### PR TITLE
Changes RestClient to allow for concurrent requests

### DIFF
--- a/DSharpPlus/AsyncManualResetEvent.cs
+++ b/DSharpPlus/AsyncManualResetEvent.cs
@@ -1,0 +1,44 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DSharpPlus
+{
+    // source: https://blogs.msdn.microsoft.com/pfxteam/2012/02/11/building-async-coordination-primitives-part-1-asyncmanualresetevent/
+    /// <summary>
+    /// Implements an async version of a <see cref="ManualResetEvent"/>
+    /// This class does currently not support Timeouts or the use of CancellationTokens
+    /// </summary>
+    internal class AsyncManualResetEvent
+    {
+        public bool IsSet => _tsc != null && _tsc.Task.IsCompleted;
+
+        private TaskCompletionSource<bool> _tsc;
+
+        public AsyncManualResetEvent() 
+            : this(false)
+        { }
+
+        public AsyncManualResetEvent(bool initialState)
+        {
+            _tsc = new TaskCompletionSource<bool>();
+
+            if (initialState)
+                _tsc.TrySetResult(true);
+        }
+
+        public Task WaitAsync() { return _tsc.Task; }
+
+        public Task Set() { return Task.Run(() => _tsc.TrySetResult(true)); }
+
+        public void Reset()
+        {
+            while (true)
+            {
+                var tsc = _tsc;
+
+                if (!tsc.Task.IsCompleted || Interlocked.CompareExchange(ref _tsc, new TaskCompletionSource<bool>(), tsc) == tsc)
+                    return;
+            }
+        }
+    }
+}

--- a/DSharpPlus/DebugLogger.cs
+++ b/DSharpPlus/DebugLogger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using DSharpPlus.EventArgs;
 
 namespace DSharpPlus
@@ -24,13 +25,21 @@ namespace DSharpPlus
         {
             if (level <= this.Level)
             {
-                message = message.Replace("\r", "");
-                var lines = new[] { message };
-                if (message.Contains('\n'))
-                    lines = message.Split('\n');
-                foreach (var line in lines)
-                    LogMessageReceived?.Invoke(this, new DebugLogMessageEventArgs { Level = level, Application = application, Message = line, Timestamp = timestamp, TimeFormatting = this.DateTimeFormat });
+                //message = message.Replace("\r", "");
+                //var lines = new[] { message };
+                //if (message.Contains('\n'))
+                //    lines = message.Split('\n');
+                //foreach (var line in lines)
+                LogMessageReceived?.Invoke(this, new DebugLogMessageEventArgs { Level = level, Application = application, Message = message, Timestamp = timestamp, TimeFormatting = this.DateTimeFormat });
             }
+        }
+
+        public void LogTaskFault(Task task, LogLevel level, string application, string message)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+
+            task.ContinueWith(t => LogMessage(level, application, message + t.Exception, DateTime.Now), TaskContinuationOptions.OnlyOnFaulted);
         }
 
         internal void LogHandler(object sender, DebugLogMessageEventArgs e)

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2251,7 +2251,7 @@ namespace DSharpPlus
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
             var request = new RestRequest(this, bucket, url, RestRequestMethod.GET, headers);
-            _ = this.ApiClient.Rest.ExecuteRequestAsync(request);
+            DebugLogger.LogTaskFault(this.ApiClient.Rest.ExecuteRequestAsync(request), LogLevel.Error, "DSharpPlus", "Error while executing request: ");
             var response = await request.WaitForCompletionAsync().ConfigureAwait(false);
 
             var jo = JObject.Parse(response.Response);

--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -100,6 +100,12 @@ namespace DSharpPlus
         public IWebProxy Proxy { internal get; set; } = null;
 
         /// <summary>
+        /// <para>Sets the timeout for HTTP requests</para>
+        /// <para>Defaults to 10 seconds. Set to <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to disable timeouts.</para>
+        /// </summary>
+        public TimeSpan HttpTimeout { internal get; set; } = TimeSpan.FromSeconds(10);
+
+        /// <summary>
         /// <para>Sets the factory method used to create instances of WebSocket clients.</para>
         /// <para>Use <see cref="WebSocketClient.CreateNew(IWebProxy)"/> and equivalents on other implementations to switch out client implementations.</para>
         /// <para>Defaults to <see cref="WebSocketClient.CreateNew(IWebProxy)"/>.</para>
@@ -160,6 +166,7 @@ namespace DSharpPlus
             this.AutomaticGuildSync = other.AutomaticGuildSync;
             this.WebSocketClientFactory = other.WebSocketClientFactory;
             this.UdpClientFactory = other.UdpClientFactory;
+            this.Proxy = other.Proxy;
         }
     }
 }

--- a/DSharpPlus/DiscordWebhookClient.cs
+++ b/DSharpPlus/DiscordWebhookClient.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
@@ -50,8 +51,17 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="proxy">Proxy to use for HTTP connections.</param>
         public DiscordWebhookClient(IWebProxy proxy)
+            : this(proxy, TimeSpan.FromSeconds(10))
+        { }
+
+        /// <summary>
+        /// Creates a new webhook client, with specified HTTP proxy and timeout settings.
+        /// </summary>
+        /// <param name="proxy">Proxy to use for HTTP connections.</param>
+        /// <param name="timeout">Timeout to use for HTTP requests. Set to <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to disable timeouts.</param>
+        public DiscordWebhookClient(IWebProxy proxy, TimeSpan timeout)
         {
-            this._apiclient = new DiscordApiClient(proxy);
+            this._apiclient = new DiscordApiClient(proxy, timeout);
             this._hooks = new List<DiscordWebhook>();
             this.Webhooks = new ReadOnlyCollection<DiscordWebhook>(this._hooks);
         }

--- a/DSharpPlus/Net/BaseRestRequest.cs
+++ b/DSharpPlus/Net/BaseRestRequest.cs
@@ -70,5 +70,8 @@ namespace DSharpPlus.Net
 
         protected internal void SetFaulted(Exception ex) 
             => this.RequestTaskSource.SetException(ex);
+
+        protected internal bool TrySetFaulted(Exception ex) 
+            => this.RequestTaskSource.TrySetException(ex);
     }
 }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -30,9 +30,9 @@ namespace DSharpPlus.Net
             this.Rest = new RestClient(client);
         }
 
-        internal DiscordApiClient(IWebProxy proxy) // This is for meta-clients, such as the webhook client
+        internal DiscordApiClient(IWebProxy proxy, TimeSpan timeout) // This is for meta-clients, such as the webhook client
         {
-            this.Rest = new RestClient(proxy);
+            this.Rest = new RestClient(proxy, timeout);
         }
 
         private static string BuildQueryString(IDictionary<string, string> values, bool post = false)
@@ -103,7 +103,7 @@ namespace DSharpPlus.Net
         private Task<RestResponse> DoRequestAsync(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, IDictionary<string, string> headers = null, string payload = null, double? ratelimit_wait_override = null)
         {
             var req = new RestRequest(client, bucket, url, method, headers, payload, ratelimit_wait_override);
-            _ = this.Rest.ExecuteRequestAsync(req);
+            Discord.DebugLogger.LogTaskFault(this.Rest.ExecuteRequestAsync(req), LogLevel.Error, "REST", "Error while executing request: ");
             return req.WaitForCompletionAsync();
         }
 
@@ -111,7 +111,7 @@ namespace DSharpPlus.Net
             IDictionary<string, Stream> files = null, double? ratelimit_wait_override = null)
         {
             var req = new MultipartWebRequest(client, bucket, url, method, headers, values, files, ratelimit_wait_override);
-            _ = this.Rest.ExecuteRequestAsync(req);
+            Discord.DebugLogger.LogTaskFault(this.Rest.ExecuteRequestAsync(req), LogLevel.Error, "REST", "Error while executing request: ");
             return req.WaitForCompletionAsync();
         }
 


### PR DESCRIPTION
# Details
- Changed Buckets from HashSet to ConcurrentDictionary (currently this can and will throw ocasionally)
- Removed the RequestSemaphore that serialized all requests
- To preserve the preemptive ratelimiting the following changes were made:
  - Decrement the remaining number of requests before the reqest is made, to allow this to happen atomically the Remaining property was changed to have a explicit backing field
  - Responses only update their ratelimit bucket when the response is for a newer interval than what the bucket currently points at. Otherwise this would push that remaining number of requests in that bucket back up when a response is received while other requests for that bucket are still pending
  - A ManualResetEvent has been added to signal that the global ratelimit has been hit and further requests should be delayed temporarily
- A HttpClientFactory has been added to allow for custom HttpClient implementation similar to how custom WebSocketClients and UdpClients are realized.

# Notes
- This should propably use a async implementation of the ManualResetEvent, but that would require additional dependencies and is only relevant in the case that the global ratelimit has been hit so I just used the framework implementation
  - the one big issue this could cause is that when spamming requests a deadlock could occour where all Threads from the TaskPool are blocked by the Wait, so that there are none left to set the event. A similar issue can occour now when a Exception is thrown while performing the request so that the Semaphore is never released
- This change will propably expose a couple of issues similar to #219 where the library assumes to be single-threaded while Tasks are in fact multi-threaded