### PR TITLE
Accept channel names starting with # in channel converter

### DIFF
--- a/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
@@ -134,7 +134,7 @@ namespace DSharpPlus.CommandsNext.Converters
             var cs = ctx.Config.CaseSensitive;
             if (!cs)
                 value = value.ToLowerInvariant();
-            if (value.StartsWith('#'))
+            if (value.Length > 0 && value[0] == '#')
                 value = value.Substring(1);
 
             var chn = ctx.Guild.Channels.FirstOrDefault(xc => (cs ? xc.Name : xc.Name.ToLowerInvariant()) == value);

--- a/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
@@ -134,6 +134,8 @@ namespace DSharpPlus.CommandsNext.Converters
             var cs = ctx.Config.CaseSensitive;
             if (!cs)
                 value = value.ToLowerInvariant();
+            if (value.StartsWith('#'))
+                value = value.Substring(1);
 
             var chn = ctx.Guild.Channels.FirstOrDefault(xc => (cs ? xc.Name : xc.Name.ToLowerInvariant()) == value);
             return Task.FromResult(chn != null ? Optional<DiscordChannel>.FromValue(chn) : Optional<DiscordChannel>.FromNoValue());


### PR DESCRIPTION
# Summary
Adds support for channel names starting with `#` in the argument converter for DiscordChannel. Where previously `#channel` (without a mention) wouldn't match, this gives the correct value. This is useful(?) for mentions of channels the current user does not have access to, so they display as plain text.

# Changes proposed
* Accept channel names starting with # in channel converter
