### PR TITLE
Fix DiscordChannel.Users exception message

### DIFF
--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -140,7 +140,7 @@ namespace DSharpPlus.Entities
             get
             {
                 if (this.Guild != null)
-                    throw new InvalidOperationException("Cannot query permissions for non-guild channels.");
+                    throw new InvalidOperationException("Cannot query users outside of guild channels.");
 
                 if (this.Type == ChannelType.Voice)
                     return Guild.Members.Where(x => x.VoiceState.ChannelId == this.Id);


### PR DESCRIPTION
# Summary
Fixes the exception message for the getter for DiscordChannel.Users.

# Details
The message seems to incorrectly say "permissions" instead of "users," which makes no sense.

# Changes proposed
* Change the exception message for the DiscordChannel.Users getter from `Cannot query permissions for non-guild channels.` to `Cannot query users outside of guild channels.`
