### PR TITLE
Fixed bad ArgumentNullException constructors

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -283,10 +283,10 @@ namespace DSharpPlus.CommandsNext
         public void RegisterCommands(Type t)
         {
             if (t == null)
-                throw new ArgumentNullException("Type cannot be null.", nameof(t));
+                throw new ArgumentNullException(nameof(t), "Type cannot be null.");
 
             if (!t.IsModuleCandidateType())
-                throw new ArgumentNullException("Type must be a class, which cannot be abstract or static.", nameof(t));
+                throw new ArgumentNullException(nameof(t), "Type must be a class, which cannot be abstract or static.");
 
             this.RegisterCommands(t, null, out var tcmds);
 
@@ -679,7 +679,7 @@ namespace DSharpPlus.CommandsNext
         public void RegisterConverter<T>(IArgumentConverter<T> converter)
         {
             if (converter == null)
-                throw new ArgumentNullException("Converter cannot be null.", nameof(converter));
+                throw new ArgumentNullException(nameof(converter), "Converter cannot be null.");
 
             var t = typeof(T);
             var ti = t.GetTypeInfo();
@@ -730,7 +730,7 @@ namespace DSharpPlus.CommandsNext
         public void RegisterUserFriendlyTypeName<T>(string value)
         {
             if (string.IsNullOrWhiteSpace(value))
-                throw new ArgumentNullException("Name cannot be null or empty.", nameof(value));
+                throw new ArgumentNullException(nameof(value), "Name cannot be null or empty.");
 
             var t = typeof(T);
             var ti = t.GetTypeInfo();


### PR DESCRIPTION
# Summary
Fixed a issue with the ArgumentNullExceptions within the CommandExtensions that resulted in weird messages such as the one below. This pull request only changes the CommandExtensions and further investigations will have to be made for the rest of the codebase.

![example](https://images-ext-1.discordapp.net/external/QUkTPRd8vdiqdKgWuhO9Dn2D47dBHYSR7ino9eD5Ekw/http/take.ms/t9Xor?width=704&height=297)

# Details
Literally just changed the ArgumentNullException constructors in DSharpPlus.CommandsNext/CommandsNextExtension.cs to match the prototype `ArgumentNullException(string paramName, string message)` as they were reversed, resulting in weird errors such as "ArgumentNullException: t".

# Notes
I have only been through the CommandsNextExtension, so there could be more hiding.