### PR TITLE
Fixes invalid if statement in DiscordChannel#Users

### DIFF
--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -139,7 +139,7 @@ namespace DSharpPlus.Entities
         {
             get
             {
-                if (this.Guild != null)
+                if (this.Guild == null)
                     throw new InvalidOperationException("Cannot query users outside of guild channels.");
 
                 if (this.Type == ChannelType.Voice)


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Makes it throw when it should throw.

# Details
Changed `if (this.Guild != null)` to `if (this.Guild == null)`

# Notes
I assume we don't want a case for `ChannelType.Group`, right?