### PR TITLE
Add fail-fast case for bots DMing each other

### DIFF
--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -216,7 +216,7 @@ namespace DSharpPlus.Entities
         /// <returns>The sent message.</returns>
         public async Task<DiscordMessage> SendMessageAsync(string content = null, bool is_tts = false, DiscordEmbed embed = null)
         {
-            if (this.IsBot && this.Client.CurrentUser.IsBot)
+            if (this.IsBot && this.Discord.CurrentUser.IsBot)
                 throw new ArgumentException("Bots cannot DM each other");
             
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
@@ -234,7 +234,7 @@ namespace DSharpPlus.Entities
         /// <returns>The sent message.</returns>
         public async Task<DiscordMessage> SendFileAsync(Stream file_data, string file_name, string content = null, bool is_tts = false, DiscordEmbed embed = null)
         {
-            if (this.IsBot && this.Client.CurrentUser.IsBot)
+            if (this.IsBot && this.Discord.CurrentUser.IsBot)
                 throw new ArgumentException("Bots cannot DM each other");
             
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -216,6 +216,9 @@ namespace DSharpPlus.Entities
         /// <returns>The sent message.</returns>
         public async Task<DiscordMessage> SendMessageAsync(string content = null, bool is_tts = false, DiscordEmbed embed = null)
         {
+            if (this.IsBot && this.Client.CurrentUser.IsBot)
+                throw new ArgumentException("Bots cannot DM each other");
+            
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
             return await chn.SendMessageAsync(content, is_tts, embed).ConfigureAwait(false);
         }
@@ -231,6 +234,9 @@ namespace DSharpPlus.Entities
         /// <returns>The sent message.</returns>
         public async Task<DiscordMessage> SendFileAsync(Stream file_data, string file_name, string content = null, bool is_tts = false, DiscordEmbed embed = null)
         {
+            if (this.IsBot && this.Client.CurrentUser.IsBot)
+                throw new ArgumentException("Bots cannot DM each other");
+            
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
             return await chn.SendFileAsync(file_data, file_name, content, is_tts, embed).ConfigureAwait(false);
         }


### PR DESCRIPTION
# Summary
Adds a fail-fast case for SendMessageAsync on a bot's DiscordMember

# Details
Currently, a bot DMing another bot will result in a difficult to debug 403 error. This PR adds a fail fast case with a pretty message in case that happens.

# Changes proposed
* Throw ArgumentException if a bot client DMs a bot member