### PR TITLE
Fix SendMessageAsync exception message when sending a message in an invalid channel

### DIFF
--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -171,7 +171,7 @@ namespace DSharpPlus.Entities
         public Task<DiscordMessage> SendMessageAsync(string content = null, bool tts = false, DiscordEmbed embed = null)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group)
-                throw new ArgumentException("Cannot send a file to a non-text channel");
+                throw new ArgumentException("Cannot send a text message to a non-text channel");
             if (string.IsNullOrWhiteSpace(content) && embed == null)
                 throw new ArgumentNullException("Must provide either content, embed or both, and content may not consist only of whitespace");
             if (content != null && content.Length > 2000)


### PR DESCRIPTION
Whew, that's a mouthful.

# Summary
Fixes the exception message in DiscordChannel.SendMessageAsync.

# Details
The exception message was crudely copied from SendFileAsync by yours truly, and the message wasn't changed to accommodate.

# Changes proposed
* Change message from `Cannot send a file to a non-text channel` to `Cannot send a text message to a non-text channel`