### PR TITLE
Fix HasPermission when checking against multiple flags

### DIFF
--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -14,7 +14,7 @@ namespace DSharpPlus
         /// <returns></returns>
         public static bool HasPermission(this Permissions p, Permissions permission)
         {
-            if ((p & permission) != 0)
+            if ((p & permission) == permission)
                 return true;
             return false;
         }


### PR DESCRIPTION
# Summary
Fixes HasPermission only checking for the presence of one flag when multiple are checked against

# Details
When checking against multiple flags, HasPermission currently only guarantees that one or more of the flags should be set for the check to pass. This changes the behavior to what it's expected to be: The result is only true if all the flags being checked against are present.

# Changes proposed
* Fix AND comparison to equal what's being compared against, instead of 0 (any compared bit set)

# Notes
Maybe add a `HasAnyPermission` method for the old behavior?