### PR TITLE
Small helper function to check if a user has a role.

### DIFF
--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -362,8 +362,8 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="role">The role to check.</param>
         /// <returns></returns>
-        public Task<bool> HasRole(DiscordRole role)
-            => Task.FromResult<bool>(this.Roles.Count(x => x.Id == role.Id) > 0);
+        public bool HasRole(DiscordRole role)
+            => this.Roles.Any(x => x.Id == role.Id);
 
         /// <summary>
         /// Bans a this member from their guild.

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -356,6 +356,15 @@ namespace DSharpPlus.Entities
         public Task ReplaceRolesAsync(IEnumerable<DiscordRole> roles, string reason = null) 
             => this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, null, roles.Select(xr => xr.Id), null, null, null, reason);
 
+
+        /// <summary>
+        /// Checks if a member has a specific role.
+        /// </summary>
+        /// <param name="role">The role to check.</param>
+        /// <returns></returns>
+        public Task<bool> HasRole(DiscordRole role)
+            => Task.FromResult<bool>(this.Roles.Count(x => x.Id == role.Id) > 0);
+
         /// <summary>
         /// Bans a this member from their guild.
         /// </summary>


### PR DESCRIPTION
# Summary
Allows for a bot developer to check if a DiscordMember has a specified DiscordRole.

# Details
Relatively small addition, could be useful for bots that need to check against roles, or grant them under certain circumstances.

# Changes proposed
* Add HasRole