### PR TITLE
Fix crash when sending embed

### DIFF
--- a/DSharpPlus/Entities/Optional.cs
+++ b/DSharpPlus/Entities/Optional.cs
@@ -37,6 +37,12 @@ namespace DSharpPlus.Entities
             this.HasValue = true;
         }
 
+        internal Optional(object value)
+        {
+            this._val = (T) value; // not a safe cast.
+            this.HasValue = true;
+        }
+
         /// <summary>
         /// Returns a string representation of this optional value.
         /// </summary>

--- a/DSharpPlus/Entities/Optional.cs
+++ b/DSharpPlus/Entities/Optional.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using DSharpPlus.Net.Serialization;
 
 namespace DSharpPlus.Entities
 {
@@ -37,6 +38,12 @@ namespace DSharpPlus.Entities
             this.HasValue = true;
         }
 
+        /// <summary>
+        /// FOR INTERNAL USE ONLY! See <see cref="OptionalJsonConverter.ReadJson"/>. Having a method that takes an
+        /// object and casts it saves a lot of time building type parameters.
+        /// <p>Creates a new <see cref="Optional{T}"/> with specified value.</p>
+        /// </summary>
+        /// <param name="value">Value of this option.</param>
         internal Optional(object value)
         {
             this._val = (T) value; // not a safe cast.

--- a/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
@@ -41,17 +41,11 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("name")]
         public Optional<string> Name { get; set; }
 
-        [JsonProperty("name")]
+        [JsonProperty("region")]
         public Optional<string> RegionId { get; set; }
-
-        [JsonProperty("splash", NullValueHandling = NullValueHandling.Include)]
+        
+        [JsonProperty("icon")]
         public Optional<string> IconBase64 { get; set; }
-
-        [JsonProperty("splash", NullValueHandling = NullValueHandling.Include)]
-        public Optional<string> SplashBase64 { get; set; }
-
-        [JsonProperty("afk_channel_id", NullValueHandling = NullValueHandling.Include)]
-        public Optional<ulong?> AfkChannelId { get; set; }
 
         [JsonProperty("verification_level")]
         public Optional<VerificationLevel> VerificationLevel { get; set; }
@@ -61,6 +55,12 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("owner_id")]
         public Optional<ulong> OwnerId { get; set; }
+
+        [JsonProperty("splash")]
+        public Optional<string> SplashBase64 { get; set; }
+
+        [JsonProperty("afk_channel_id")]
+        public Optional<ulong?> AfkChannelId { get; set; }
 
         [JsonProperty("afk_timeout")]
         public Optional<int> AfkTimeout { get; set; }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -53,7 +53,7 @@ namespace DSharpPlus.Net
         private DiscordMessage PrepareMessage(JToken msg_raw)
         {
             var author = msg_raw["author"].ToObject<TransportUser>();
-            var ret = msg_raw.ToObject<DiscordMessage>();
+            var ret = msg_raw.ToDiscordObject<DiscordMessage>();
             ret.Discord = this.Discord;
 
             var guild = ret.Channel?.Guild;

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -10,22 +10,18 @@ namespace DSharpPlus.Net.Serialization
 {
     public static class DiscordJson
     {
-        private static readonly JsonConverter[] JsonConverters =
+        private static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings
         {
-            new OptionalJsonConverter()
+            Converters = {new OptionalJsonConverter()},
+            ContractResolver = new OptionalJsonContractResolver()
         };
-        private static readonly OptionalJsonContractResolver OptionalJsonContractResolver = new OptionalJsonContractResolver();
 
         /// <summary>Serializes the specified object to a JSON string.</summary>
         /// <param name="value">The object to serialize.</param>
         /// <returns>A JSON string representation of the object.</returns>
         public static string SerializeObject(object value)
         {
-            return JsonConvert.SerializeObject(value, new JsonSerializerSettings
-            {
-                Converters = JsonConverters,
-                ContractResolver = OptionalJsonContractResolver
-            });
+            return JsonConvert.SerializeObject(value, JsonSerializerSettings);
         }
     }
 

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -31,6 +31,13 @@ namespace DSharpPlus.Net.Serialization
             return JsonConvert.SerializeObject(value, JsonSerializerSettings);
         }
         
+        /// <summary>
+        /// Converts this token into an object, passing any properties through extra <see cref="JsonConverter"/>s if
+        /// needed.
+        /// </summary>
+        /// <param name="token">The token to convert</param>
+        /// <typeparam name="T">Type to convert to</typeparam>
+        /// <returns>The converted token</returns>
         public static T ToDiscordObject<T>(this JToken token)
         {
             return token.ToObject<T>(OptionalJsonSerializer);
@@ -65,9 +72,6 @@ namespace DSharpPlus.Net.Serialization
             
             property.ShouldSerialize = instance => // instance here is the declaring (parent) type
             {
-                #if NETSTANDARD2_0
-                Console.WriteLine($"Property: {type} {property.DeclaringType}#{property.UnderlyingName} :: {optionalProp}");
-                #endif
                 // this is the Optional<T> object
                 var optionalValue = propPresent ? optionalProp.GetValue(instance) : optionalField.GetValue(instance);
                 // get the HasValue property of the Optional<T> object and cast it to a bool, and only serialize it if
@@ -105,12 +109,6 @@ namespace DSharpPlus.Net.Serialization
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
             JsonSerializer serializer)
         {
-            //if (!reader.Read()) throw new ArgumentException("Something's wrong here.");
-            
-            #if NETSTANDARD2_0
-            Console.WriteLine($"Deserializing {objectType} from {existingValue} :: {reader} / str::{reader.Value}");
-            #endif
-
             var genericType = objectType.GenericTypeArguments[0];
             
             // TODO will this crash with Single finding more than one if T happens to be object?


### PR DESCRIPTION
# Summary
Fixes the crash when receiving a message with an embed that contains a custom color.

# Details
The crash was due to the following:
1. Support for serializing Optional, but no support for deserializing it.
2. Optional serializer would assume the member being serialized is a property which it maybe not.

# Changes proposed
* Add support for Deserializing Optional<T>, and serializing Optional<T> fields
* Cache JsonSerializerSettings
* Fix guild edit payload sending incorrect data (likely due to a bad merge)

# Notes
TODO: Are the member edit payloads correct? Should double check at some point.