### PR TITLE
Fix MessageUpdated events in DMs throwing exception

### DIFF
--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -24,6 +24,7 @@ namespace DSharpPlus.Entities
             this._mentionedUsersLazy = new Lazy<IReadOnlyList<DiscordUser>>(() => new ReadOnlyCollection<DiscordUser>(this._mentionedUsers));
             this._reactionsLazy = new Lazy<IReadOnlyList<DiscordReaction>>(() => new ReadOnlyCollection<DiscordReaction>(this._reactions));
         }
+        
         internal DiscordMessage(DiscordMessage other)
             : this()
         {
@@ -31,8 +32,11 @@ namespace DSharpPlus.Entities
 
             this._attachments = other._attachments; // the attachments cannot change, thus no need to copy and reallocate.
             this._embeds = new List<DiscordEmbed>(other._embeds);
-            this._mentionedChannels = new List<DiscordChannel>(other._mentionedChannels);
-            this._mentionedRoles = new List<DiscordRole>(other._mentionedRoles);
+            
+            if (other._mentionedChannels != null) 
+                this._mentionedChannels = new List<DiscordChannel>(other._mentionedChannels);
+            if (other._mentionedRoles != null)
+                this._mentionedRoles = new List<DiscordRole>(other._mentionedRoles);
             this._mentionedUsers = new List<DiscordUser>(other._mentionedUsers);
             this._reactions = new List<DiscordReaction>(other._reactions);
 
@@ -124,6 +128,8 @@ namespace DSharpPlus.Entities
         [JsonIgnore]
         Lazy<IReadOnlyList<DiscordUser>> _mentionedUsersLazy;
 
+        // TODO this will probably throw an exception in DMs since it tries to wrap around a null List...
+        // this is probably low priority but need to find out a clean way to solve it...
         /// <summary>
         /// Gets roles mentioned by this message.
         /// </summary>
@@ -156,7 +162,7 @@ namespace DSharpPlus.Entities
             => this._attachmentsLazy.Value;
 
         [JsonProperty("attachments", NullValueHandling = NullValueHandling.Ignore)]
-        internal List<DiscordAttachment> _attachments;
+        internal List<DiscordAttachment> _attachments = new List<DiscordAttachment>();
         [JsonIgnore]
         private Lazy<IReadOnlyList<DiscordAttachment>> _attachmentsLazy;
 
@@ -168,7 +174,7 @@ namespace DSharpPlus.Entities
             => this._embedsLazy.Value;
 
         [JsonProperty("embeds", NullValueHandling = NullValueHandling.Ignore)]
-        internal List<DiscordEmbed> _embeds;
+        internal List<DiscordEmbed> _embeds = new List<DiscordEmbed>();
         [JsonIgnore]
         private Lazy<IReadOnlyList<DiscordEmbed>> _embedsLazy;
 
@@ -180,7 +186,7 @@ namespace DSharpPlus.Entities
             => this._reactionsLazy.Value;
 
         [JsonProperty("reactions", NullValueHandling = NullValueHandling.Ignore)]
-        internal List<DiscordReaction> _reactions;
+        internal List<DiscordReaction> _reactions = new List<DiscordReaction>();
         [JsonIgnore]
         private Lazy<IReadOnlyList<DiscordReaction>> _reactionsLazy;
 


### PR DESCRIPTION
# Summary
MessageUpdated events in a DM channel will trigger an exception. In previous versions this would be swallowed and ignored by the lib. As of the latest few commits the exception will be logged to console. This will not crash the client, but will cause the event to never fire and, in extreme cases, will slow down the client for a few seconds, due to all the logging.

# Details
This is a sample exception body:
```
[2018-04-05 23:50:01 +00:00] [Websocket] [Error] Socket swallowed an exception: System.ArgumentNullException: Value cannot be null.
Parameter name: collection
at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
at DSharpPlus.Entities.DiscordMessage..ctor(DiscordMessage other)
at DSharpPlus.DiscordClient.<OnMessageUpdateEventAsync>d__93.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
at DSharpPlus.DiscordClient.<HandleDispatchAsync>d__69.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at DSharpPlus.DiscordClient.<HandleSocketMessageAsync>d__68.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
at DSharpPlus.DiscordClient.<<InternalConnectAsync>g__SocketOnMessage|53_1>d.MoveNext() This is bad!!!! 
```
The error occurs due to `DiscordMessage._mentionedRoles` and `DiscordMessage._mentionedChannels` being null in DM, which is an intended feature, see here:
https://github.com/DSharpPlus/DSharpPlus/blob/6ff22ee20195cf6c5f4d5c0ff8f1eae55e9f0a11/DSharpPlus/DiscordClient.cs#L1507-L1509 
When you edit a message, inside the MessageUpdated event, the message is cloned so `_mentionedRoles` and `_mentionedChannels` are cloned:
https://github.com/DSharpPlus/DSharpPlus/blob/6ff22ee20195cf6c5f4d5c0ff8f1eae55e9f0a11/DSharpPlus/Entities/DiscordMessage.cs#L34-L35
Because the List constructor does not accept a null List, an exception is raised and it bubbles up to the try-catch for socket errors.

# Changes proposed
* Add a null check for `DiscordMessage._mentionedChannels` and `_mentionedRoles`

# Notes
Thanks to Kef on Discord for finding this issue, since it's such an absurd edge-case scenario.

Additionally, I added a note that MentionedChannels and MentionedRoles would likely throw an exception when accessed in DM, since there is a lazy ReadOnlyCollection wrapper for the internal list, which would be null. I haven't come up with a good solution for that, however it's a very low priority bug and a fix would probably be to just fail fast in that case.