### PR TITLE
Fix embeds with images causing error when message cache size is set to 0

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -1543,7 +1543,7 @@ namespace DSharpPlus
             var event_message = message;
 
             DiscordMessage oldmsg = null;
-            if (this.Configuration.MessageCacheSize > 0 && !this.MessageCache.TryGet(xm => xm.Id == event_message.Id && xm.ChannelId == event_message.ChannelId, out message))
+            if (this.Configuration.MessageCacheSize == 0 || !this.MessageCache.TryGet(xm => xm.Id == event_message.Id && xm.ChannelId == event_message.ChannelId, out message))
             {
                 message = event_message;
                 guild = message.Channel?.Guild;
@@ -1651,7 +1651,7 @@ namespace DSharpPlus
             foreach (var message_id in messageIds)
             {
                 DiscordMessage msg = null;
-                if (this.Configuration.MessageCacheSize > 0 && !this.MessageCache.TryGet(xm => xm.Id == message_id && xm.ChannelId == channel.Id, out msg))
+                if (this.Configuration.MessageCacheSize == 0 || !this.MessageCache.TryGet(xm => xm.Id == message_id && xm.ChannelId == channel.Id, out msg))
                 {
                     msg = new DiscordMessage
                     {


### PR DESCRIPTION
# Summary
Sending an embed with an image attached causes an exception when the message cache size is set to 0. The exception comes from inside the SocketOnMessage handler, so it gets swallowed and does not affect client functionality. However, with a very large amount of guilds, this can be **really annoying**.
This PR also fix a theoretical identical issue when the client receives a bulk message deletion, which with the message cache size set to 0 would call the event normally, but with an empty array instead of deleted message IDs.

# Details
This happens because of the following line of code:
https://github.com/DSharpPlus/DSharpPlus/blob/f4338d65e26e2312f3c03801d53d758b43cfdfee/DSharpPlus/DiscordClient.cs#L1556
This will execute the contents of the `else` block if the message cache is set to 0, which is already reserved case for when the `TryGet` call succeeds. Because of the obtuse use of `out` variables it's [completely unnoticeable](https://i.imgur.com/dVo0uXP.jpg) to a bystander that, when the message cache size is set to 0, the value of `message` in the `else` block is `event_message` and not a message grabbed from the cache. The contents of the `else` block look for properties that don't exist in `event_message` (since they are only sent on message create, not message update) and everything [c](https://i.imgur.com/rvywDm6.jpg)[r](https://i.imgur.com/tVWPoWO.jpg)[a](https://i.imgur.com/M44Y1At.jpg)[s](https://i.imgur.com/FOUu8Ou.jpg)[h](https://i.imgur.com/AvRlsKY.jpg)[e](https://i.imgur.com/Iflz9aw.jpg)[s](https://i.imgur.com/WuMqK5T.jpg)[ ](https://i.imgur.com/jbEWSBt.jpg)[a](https://i.imgur.com/aIEHI7f.jpg)[n](https://i.imgur.com/Y3Ee9sX.jpg)[d](https://i.imgur.com/BbKh7J7.jpg)[ ](https://i.imgur.com/fVlTd8f.jpg)[b](https://i.imgur.com/E1YXNt3.jpg)[u](https://i.imgur.com/ZyQVjXM.jpg)[r](https://i.imgur.com/Cae8cjJ.jpg)[n](https://i.imgur.com/afRyjDT.jpg)[s](https://i.imgur.com/wEa7QvP.jpg).

# Changes proposed
* Change two message cache size checks in DiscordClient to the correct form.

# Notes
This took far too long. I was very tired when I wrote this. Things might not be very correct.