### PR TITLE
Use string interpolation when possible

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2259,7 +2259,7 @@ namespace DSharpPlus
                 route += Endpoints.BOT;
             var bucket = this.ApiClient.Rest.GetBucket(RestRequestMethod.GET, route, new { }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var request = new RestRequest(this, bucket, url, RestRequestMethod.GET, headers);
             DebugLogger.LogTaskFault(this.ApiClient.Rest.ExecuteRequestAsync(request), LogLevel.Error, "DSharpPlus", "Error while executing request: ");
             var response = await request.WaitForCompletionAsync().ConfigureAwait(false);

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2256,7 +2256,7 @@ namespace DSharpPlus
 
             var route = Endpoints.GATEWAY;
             if (Configuration.TokenType == TokenType.Bot)
-                route = string.Concat(route, Endpoints.BOT);
+                route += Endpoints.BOT;
             var bucket = this.ApiClient.Rest.GetBucket(RestRequestMethod.GET, route, new { }, out var path);
 
             var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -583,12 +583,12 @@ namespace DSharpPlus.Entities
         public override string ToString()
         {
             if (this.Type == ChannelType.Category)
-                return string.Concat("Channel Category ", this.Name, " (", this.Id, ")");
+                return $"Channel Category {this.Name} ({this.Id})";
             if (this.Type == ChannelType.Text)
-                return string.Concat("Channel #", this.Name, " (", this.Id, ")");
+                return $"Channel #{this.Name} ({this.Id})";
             if (!string.IsNullOrWhiteSpace(this.Name))
-                return string.Concat("Channel ", this.Name, " (", this.Id, ")");
-            return string.Concat("Channel ", this.Id);
+                return $"Channel {this.Name} ({this.Id})";
+            return $"Channel {this.Id}";
         }
         #endregion
 

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -1548,7 +1548,7 @@ namespace DSharpPlus.Entities
         /// <returns>String representation of this guild.</returns>
         public override string ToString()
         {
-            return string.Concat("Guild ", this.Id, "; ", this.Name);
+            return $"Guild {this.Id}; {this.Name}";
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -372,7 +372,7 @@ namespace DSharpPlus.Entities
         /// <returns>String representation of this message.</returns>
         public override string ToString()
         {
-            return string.Concat("Message ", this.Id, "; Attachment count: ", this._attachments.Count, "; Embed count: ", this._embeds.Count, "; Contents: ", this.Content);
+            return $"Message {this.Id}; Attachment count: {this._attachments.Count, "; Embed count: {this._embeds.Count, "; Contents: {this.Content);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -372,7 +372,7 @@ namespace DSharpPlus.Entities
         /// <returns>String representation of this message.</returns>
         public override string ToString()
         {
-            return $"Message {this.Id}; Attachment count: {this._attachments.Count, "; Embed count: {this._embeds.Count, "; Contents: {this.Content);
+            return $"Message {this.Id}; Attachment count: {this._attachments.Count}; Embed count: {this._embeds.Count}; Contents: {this.Content}";
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordRole.cs
+++ b/DSharpPlus/Entities/DiscordRole.cs
@@ -131,7 +131,7 @@ namespace DSharpPlus.Entities
         /// <returns>String representation of this role.</returns>
         public override string ToString()
         {
-            return string.Concat("Role ", this.Id, "; ", this.Name);
+            return $"Role {this.Id}; {this.Name}";
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Optional.cs
+++ b/DSharpPlus/Entities/Optional.cs
@@ -56,7 +56,7 @@ namespace DSharpPlus.Entities
         /// <returns>String representation of this optional value.</returns>
         public override string ToString()
         {
-            return string.Concat("Optional<", typeof(T), "> (", this.HasValue ? this.Value.ToString() : "<no value>", ")");
+            return $"Optional<{typeof(T)}> ({(this.HasValue ? this.Value.ToString() : "<no value>")})";
         }
 
         /// <summary>

--- a/DSharpPlus/Formatter.cs
+++ b/DSharpPlus/Formatter.cs
@@ -78,7 +78,7 @@ namespace DSharpPlus
         /// <param name="alt_text">Alt text to display on hover.</param>
         /// <returns>Formatted url.</returns>
         public static string MaskedUrl(string text, Uri url, string alt_text = "") 
-            => string.Concat("[", text, "](", url.ToString(), !string.IsNullOrWhiteSpace(alt_text) ? $" \"{alt_text}\"" : "", ")");
+            => $"[{text}]({url}{(!string.IsNullOrWhiteSpace(alt_text) ? $" \"{alt_text}\"" : "")})";
 
         /// <summary>
         /// Escapes all markdown formatting from specified text.
@@ -86,7 +86,7 @@ namespace DSharpPlus
         /// <param name="text">Text to sanitize.</param>
         /// <returns>Sanitized text.</returns>
         public static string Sanitize(string text) 
-            => MdSanitizeRegex.Replace(text, m => string.Concat("\\", m.Groups[1].Value));
+            => MdSanitizeRegex.Replace(text, m => $"\\{m.Groups[1].Value}");
 
         /// <summary>
         /// Removes all markdown formatting from specified text.

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -41,13 +41,11 @@ namespace DSharpPlus.Net
             if (values == null || values.Count == 0)
                 return string.Empty;
 
-            var vals_collection = values.Select(xkvp => string.Concat(WebUtility.UrlEncode(xkvp.Key), "=", WebUtility.UrlEncode(xkvp.Value)));
+            var vals_collection = values.Select(xkvp => 
+                $"{WebUtility.UrlEncode(xkvp.Key)}={WebUtility.UrlEncode(xkvp.Value)}");
             var vals = string.Join("&", vals_collection);
 
-            if (!post)
-                return string.Concat("?", vals);
-            else
-                return vals;
+            return !post ? $"?{vals}" : vals;
         }
 
         private DiscordMessage PrepareMessage(JToken msg_raw)
@@ -129,10 +127,10 @@ namespace DSharpPlus.Net
                 IconBase64 = iconb64
             };
 
-            var route = string.Concat(Endpoints.GUILDS);
+            var route = $"{Endpoints.GUILDS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var json = JObject.Parse(res.Response);
@@ -146,10 +144,10 @@ namespace DSharpPlus.Net
 
         internal async Task DeleteGuildAsync(ulong guild_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE).ConfigureAwait(false);
 
             if (this.Discord is DiscordClient dc)
@@ -186,10 +184,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var json = JObject.Parse(res.Response);
@@ -205,10 +203,10 @@ namespace DSharpPlus.Net
 
         internal async Task<IReadOnlyList<DiscordBan>> GetGuildBansAsync(ulong guild_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.BANS);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.BANS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var bans_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordBan>>(res.Response).Select(xb =>
@@ -246,10 +244,10 @@ namespace DSharpPlus.Net
             if (reason != null)
                 urlparams["reason"] = reason;
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.BANS, "/:user_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.BANS}/:user_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { guild_id, user_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path, BuildQueryString(urlparams)));
+            var url = Utilities.GetApiUriFor(path, BuildQueryString(urlparams));
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT);
         }
 
@@ -259,19 +257,19 @@ namespace DSharpPlus.Net
             if (reason != null)
                 urlparams["reason"] = reason;
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.BANS, "/:user_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.BANS}/:user_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, user_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path, BuildQueryString(urlparams)));
+            var url = Utilities.GetApiUriFor(path, BuildQueryString(urlparams));
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE);
         }
 
         internal Task LeaveGuildAsync(ulong guild_id)
         {
-            var route = string.Concat(Endpoints.USERS, Endpoints.ME, Endpoints.GUILDS, "/:guild_id");
+            var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.GUILDS}/:guild_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE);
         }
 
@@ -286,10 +284,10 @@ namespace DSharpPlus.Net
                 Mute = muted
             };
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.MEMBERS, "/:user_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { guild_id, user_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var tm = JsonConvert.DeserializeObject<TransportMember>(res.Response);
@@ -305,10 +303,10 @@ namespace DSharpPlus.Net
             if (after != null)
                 urlparams["after"] = after.Value.ToString(CultureInfo.InvariantCulture);
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.MEMBERS);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path, urlparams.Any() ? BuildQueryString(urlparams) : ""));
+            var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var members_raw = JsonConvert.DeserializeObject<List<TransportMember>>(res.Response);
@@ -321,10 +319,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.MEMBERS, "/:user_id", Endpoints.ROLES, "/:role_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id{Endpoints.ROLES}/:role_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { guild_id, user_id, role_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, headers);
         }
 
@@ -334,10 +332,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.MEMBERS, "/:user_id", Endpoints.ROLES, "/:role_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id{Endpoints.ROLES}/:role_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, user_id, role_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers);
         }
 
@@ -347,10 +345,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.CHANNELS);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.CHANNELS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld));
         }
 
@@ -360,10 +358,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.ROLES);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.ROLES}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld));
         }
 
@@ -382,10 +380,10 @@ namespace DSharpPlus.Net
             if (action_type != null)
                 urlparams["action_type"] = action_type?.ToString(CultureInfo.InvariantCulture);
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.AUDIT_LOGS);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.AUDIT_LOGS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path, urlparams.Any() ? BuildQueryString(urlparams) : ""));
+            var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var audit_log_data_raw = JsonConvert.DeserializeObject<AuditLog>(res.Response);
@@ -417,10 +415,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.CHANNELS);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.CHANNELS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordChannel>(res.Response);
@@ -451,19 +449,19 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id");
+            var route = $"{Endpoints.CHANNELS}/:channel_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld));
         }
 
         internal async Task<DiscordChannel> GetChannelAsync(ulong channel_id)
         {
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id");
+            var route = $"{Endpoints.CHANNELS}/:channel_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordChannel>(res.Response);
@@ -483,19 +481,19 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id");
+            var route = $"{Endpoints.CHANNELS}/:channel_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers);
         }
 
         internal async Task<DiscordMessage> GetMessageAsync(ulong channel_id, ulong message_id)
         {
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES, "/:message_id");
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { channel_id, message_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var ret = this.PrepareMessage(JObject.Parse(res.Response));
@@ -524,10 +522,10 @@ namespace DSharpPlus.Net
                 Embed = embed
             };
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = this.PrepareMessage(JObject.Parse(res.Response));
@@ -556,10 +554,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrEmpty(content) || embed != null || tts == true)
                 values["payload_json"] = DiscordJson.SerializeObject(pld);
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, values: values, files: file).ConfigureAwait(false);
 
             var ret = this.PrepareMessage(JObject.Parse(res.Response));
@@ -587,10 +585,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(content) || embed != null || tts == true)
                 values["payload_json"] = DiscordJson.SerializeObject(pld);
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, values: values, files: files).ConfigureAwait(false);
 
             var ret = this.PrepareMessage(JObject.Parse(res.Response));
@@ -600,10 +598,10 @@ namespace DSharpPlus.Net
 
         internal async Task<IReadOnlyList<DiscordChannel>> GetGuildChannelsAsync(ulong guild_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.CHANNELS);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.CHANNELS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var channels_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordChannel>>(res.Response).Select(xc => { xc.Discord = this.Discord; return xc; });
@@ -630,10 +628,10 @@ namespace DSharpPlus.Net
             if (limit > 0)
                 urlparams["limit"] = limit.ToString(CultureInfo.InvariantCulture);
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path, urlparams.Any() ? BuildQueryString(urlparams) : ""));
+            var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var msgs_raw = JArray.Parse(res.Response);
@@ -646,10 +644,10 @@ namespace DSharpPlus.Net
 
         internal async Task<DiscordMessage> GetChannelMessageAsync(ulong channel_id, ulong message_id)
         {
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES, "/:message_id");
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { channel_id, message_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var ret = this.PrepareMessage(JObject.Parse(res.Response));
@@ -670,10 +668,10 @@ namespace DSharpPlus.Net
                 Embed = embed.HasValue ? (DiscordEmbed)embed : null
             };
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES, "/:message_id");
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { channel_id, message_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = this.PrepareMessage(JObject.Parse(res.Response));
@@ -687,10 +685,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES, "/:message_id");
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers);
         }
 
@@ -705,19 +703,19 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES, Endpoints.BULK_DELETE);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}{Endpoints.BULK_DELETE}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, DiscordJson.SerializeObject(pld));
         }
 
         internal async Task<IReadOnlyList<DiscordInvite>> GetChannelInvitesAsync(ulong channel_id)
         {
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.INVITES);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.INVITES}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var invites_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordInvite>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
@@ -739,10 +737,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.INVITES);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.INVITES}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
@@ -757,10 +755,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.PERMISSIONS, "/:overwrite_id");
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.PERMISSIONS}/:overwrite_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, overwrite_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers);
         }
 
@@ -777,28 +775,28 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.PERMISSIONS, "/:overwrite_id");
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.PERMISSIONS}/:overwrite_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { channel_id, overwrite_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, headers, DiscordJson.SerializeObject(pld));
         }
 
         internal Task TriggerTypingAsync(ulong channel_id)
         {
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.TYPING);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.TYPING}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST);
         }
 
         internal async Task<IReadOnlyList<DiscordMessage>> GetPinnedMessagesAsync(ulong channel_id)
         {
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.PINS);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.PINS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var msgs_raw = JArray.Parse(res.Response);
@@ -811,19 +809,19 @@ namespace DSharpPlus.Net
 
         internal Task PinMessageAsync(ulong channel_id, ulong message_id)
         {
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.PINS, "/:message_id");
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.PINS}/:message_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { channel_id, message_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT);
         }
 
         internal Task UnpinMessageAsync(ulong channel_id, ulong message_id)
         {
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.PINS, "/:message_id");
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.PINS}/:message_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE);
         }
 
@@ -835,19 +833,19 @@ namespace DSharpPlus.Net
                 Nickname = nickname
             };
 
-            var route = string.Concat(Endpoints.USERS, Endpoints.ME, Endpoints.CHANNELS, "/:channel_id", Endpoints.RECIPIENTS, "/:user_id");
+            var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.CHANNELS}/:channel_id{Endpoints.RECIPIENTS}/:user_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { channel_id, user_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, payload: DiscordJson.SerializeObject(pld));
         }
 
         internal Task GroupDmRemoveRecipientAsync(ulong channel_id, ulong user_id)
         {
-            var route = string.Concat(Endpoints.USERS, Endpoints.ME, Endpoints.CHANNELS, "/:channel_id", Endpoints.RECIPIENTS, "/:user_id");
+            var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.CHANNELS}/:channel_id{Endpoints.RECIPIENTS}/:user_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, user_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE);
         }
 
@@ -859,10 +857,10 @@ namespace DSharpPlus.Net
                 Nicknames = nicks
             };
 
-            var route = string.Concat(Endpoints.USERS, Endpoints.ME, Endpoints.CHANNELS);
+            var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.CHANNELS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordDmChannel>(res.Response);
@@ -878,10 +876,10 @@ namespace DSharpPlus.Net
                 Recipient = recipient_id
             };
 
-            var route = string.Concat(Endpoints.USERS, Endpoints.ME, Endpoints.CHANNELS);
+            var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.CHANNELS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordDmChannel>(res.Response);
@@ -900,10 +898,10 @@ namespace DSharpPlus.Net
 
         internal async Task<DiscordUser> GetUserAsync(string user_id)
         {
-            var route = string.Concat(Endpoints.USERS, "/:user_id");
+            var route = $"{Endpoints.USERS}/:user_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { user_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var user_raw = JsonConvert.DeserializeObject<TransportUser>(res.Response);
@@ -914,10 +912,10 @@ namespace DSharpPlus.Net
 
         internal async Task<DiscordMember> GetGuildMemberAsync(ulong guild_id, ulong user_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.MEMBERS, "/:user_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id, user_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var tm = JsonConvert.DeserializeObject<TransportMember>(res.Response);
@@ -944,10 +942,10 @@ namespace DSharpPlus.Net
             if (reason != null)
                 urlparams["reason"] = reason;
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.MEMBERS, "/:user_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, user_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path, BuildQueryString(urlparams)));
+            var url = Utilities.GetApiUriFor(path, BuildQueryString(urlparams));
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE);
         }
 
@@ -960,10 +958,10 @@ namespace DSharpPlus.Net
                 AvatarSet = base64_avatar.HasValue
             };
 
-            var route = string.Concat(Endpoints.USERS, Endpoints.ME);
+            var route = $"{Endpoints.USERS}{Endpoints.ME}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var user_raw = JsonConvert.DeserializeObject<TransportUser>(res.Response);
@@ -980,10 +978,10 @@ namespace DSharpPlus.Net
                 Before = before
             };
 
-            var route = string.Concat(Endpoints.USERS, Endpoints.ME, Endpoints.GUILDS);
+            var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.GUILDS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             if (this.Discord is DiscordClient)
@@ -1023,10 +1021,10 @@ namespace DSharpPlus.Net
                 VoiceChannelId = voice_channel_id
             };
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.MEMBERS, "/:user_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, user_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, payload: DiscordJson.SerializeObject(pld));
         }
 
@@ -1041,10 +1039,10 @@ namespace DSharpPlus.Net
                 Nickname = nick
             };
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.MEMBERS, Endpoints.ME, Endpoints.NICK);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}{Endpoints.ME}{Endpoints.NICK}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, payload: DiscordJson.SerializeObject(pld));
         }
         #endregion
@@ -1052,10 +1050,10 @@ namespace DSharpPlus.Net
         #region Roles
         internal async Task<IReadOnlyList<DiscordRole>> GetGuildRolesAsync(ulong guild_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.ROLES);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.ROLES}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var roles_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordRole>>(res.Response).Select(xr => { xr.Discord = this.Discord; xr._guild_id = guild_id; return xr; });
@@ -1065,10 +1063,10 @@ namespace DSharpPlus.Net
 
         internal async Task<DiscordGuild> GetGuildAsync(ulong guild_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var json = JObject.Parse(res.Response);
@@ -1104,10 +1102,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.ROLES, "/:role_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.ROLES}/:role_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, role_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordRole>(res.Response);
@@ -1123,10 +1121,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.ROLES, "/:role_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.ROLES}/:role_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, role_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers);
         }
 
@@ -1145,10 +1143,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.ROLES);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.ROLES}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordRole>(res.Response);
@@ -1170,10 +1168,10 @@ namespace DSharpPlus.Net
                 ["days"] = days.ToString(CultureInfo.InvariantCulture)
             };
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.PRUNE);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.PRUNE}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path, BuildQueryString(urlparams)));
+            var url = Utilities.GetApiUriFor(path, BuildQueryString(urlparams));
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var pruned = JsonConvert.DeserializeObject<RestGuildPruneResultPayload>(res.Response);
@@ -1194,10 +1192,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.PRUNE);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.PRUNE}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path, BuildQueryString(urlparams)));
+            var url = Utilities.GetApiUriFor(path, BuildQueryString(urlparams));
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST).ConfigureAwait(false);
 
             var pruned = JsonConvert.DeserializeObject<RestGuildPruneResultPayload>(res.Response);
@@ -1209,10 +1207,10 @@ namespace DSharpPlus.Net
         #region GuildVarious
         internal async Task<IReadOnlyList<DiscordIntegration>> GetGuildIntegrationsAsync(ulong guild_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.INTEGRATIONS);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.INTEGRATIONS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var integrations_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordIntegration>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
@@ -1228,10 +1226,10 @@ namespace DSharpPlus.Net
                 Id = id
             };
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.INTEGRATIONS);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.INTEGRATIONS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordIntegration>(res.Response);
@@ -1249,10 +1247,10 @@ namespace DSharpPlus.Net
                 EnableEmoticons = enable_emoticons
             };
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.INTEGRATIONS, "/:integration_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.INTEGRATIONS}/:integration_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, integration_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordIntegration>(res.Response);
@@ -1265,28 +1263,28 @@ namespace DSharpPlus.Net
         {
             var pld = integration;
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.INTEGRATIONS, "/:integration_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.INTEGRATIONS}/:integration_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, integration_id = integration.Id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, payload: DiscordJson.SerializeObject(integration));
         }
 
         internal Task SyncGuildIntegrationAsync(ulong guild_id, ulong integration_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.INTEGRATIONS, "/:integration_id", Endpoints.SYNC);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.INTEGRATIONS}/:integration_id{Endpoints.SYNC}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { guild_id, integration_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST);
         }
 
         internal async Task<DiscordGuildEmbed> GetGuildEmbedAsync(ulong guild_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.EMBED);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EMBED}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var embed = JsonConvert.DeserializeObject<DiscordGuildEmbed>(res.Response);
@@ -1298,10 +1296,10 @@ namespace DSharpPlus.Net
         {
             var pld = embed;
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.EMBED);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EMBED}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, payload: DiscordJson.SerializeObject(embed)).ConfigureAwait(false);
 
             var embed_rest = JsonConvert.DeserializeObject<DiscordGuildEmbed>(res.Response);
@@ -1311,10 +1309,10 @@ namespace DSharpPlus.Net
 
         internal async Task<IReadOnlyList<DiscordVoiceRegion>> GetGuildVoiceRegionsAsync(ulong guild_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.REGIONS);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.REGIONS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var regions_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordVoiceRegion>>(res.Response);
@@ -1324,10 +1322,10 @@ namespace DSharpPlus.Net
 
         internal async Task<IReadOnlyList<DiscordInvite>> GetGuildInvitesAsync(ulong guild_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.INVITES);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.INVITES}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var invites_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordInvite>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
@@ -1339,10 +1337,10 @@ namespace DSharpPlus.Net
         #region Invite
         internal async Task<DiscordInvite> GetInviteAsync(string invite_code)
         {
-            var route = string.Concat(Endpoints.INVITES, "/:invite_code");
+            var route = $"{Endpoints.INVITES}/:invite_code";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { invite_code }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
@@ -1357,10 +1355,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.INVITES, "/:invite_code");
+            var route = $"{Endpoints.INVITES}/:invite_code";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { invite_code }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
@@ -1376,7 +1374,7 @@ namespace DSharpPlus.Net
          * {
          *     this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "REST API", "Invite accept endpoint was used; this account is now likely unverified", DateTime.Now);
          *     
-         *     var url = new Uri(string.Concat(Utils.GetApiBaseUri(), Endpoints.INVITES, "/", invite_code));
+         *     var url = new Uri($"{Utils.GetApiBaseUri(), Endpoints.INVITES}/{invite_code));
          *     var bucket = this.Rest.GetBucket(0, MajorParameterType.Unbucketed, url, HttpRequestMethod.POST);
          *     var res = await this.DoRequestAsync(this.Discord, bucket, url, HttpRequestMethod.POST).ConfigureAwait(false);
          *     
@@ -1391,10 +1389,10 @@ namespace DSharpPlus.Net
         #region Connections
         internal async Task<IReadOnlyList<DiscordConnection>> GetUsersConnectionsAsync()
         {
-            var route = string.Concat(Endpoints.USERS, Endpoints.ME, Endpoints.CONNECTIONS);
+            var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.CONNECTIONS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var connections_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordConnection>>(res.Response).Select(xc => { xc.Discord = this.Discord; return xc; });
@@ -1406,10 +1404,10 @@ namespace DSharpPlus.Net
         #region Voice
         internal async Task<IReadOnlyList<DiscordVoiceRegion>> ListVoiceRegionsAsync()
         {
-            var route = string.Concat(Endpoints.VOICE, Endpoints.REGIONS);
+            var route = $"{Endpoints.VOICE}{Endpoints.REGIONS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var regions = JsonConvert.DeserializeObject<IEnumerable<DiscordVoiceRegion>>(res.Response);
@@ -1432,10 +1430,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.WEBHOOKS);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.WEBHOOKS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
@@ -1447,10 +1445,10 @@ namespace DSharpPlus.Net
 
         internal async Task<IReadOnlyList<DiscordWebhook>> GetChannelWebhooksAsync(ulong channel_id)
         {
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.WEBHOOKS);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.WEBHOOKS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var webhooks_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordWebhook>>(res.Response).Select(xw => { xw.Discord = this.Discord; xw.ApiClient = this; return xw; });
@@ -1460,10 +1458,10 @@ namespace DSharpPlus.Net
 
         internal async Task<IReadOnlyList<DiscordWebhook>> GetGuildWebhooksAsync(ulong guild_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.WEBHOOKS);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.WEBHOOKS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var webhooks_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordWebhook>>(res.Response).Select(xw => { xw.Discord = this.Discord; xw.ApiClient = this; return xw; });
@@ -1473,10 +1471,10 @@ namespace DSharpPlus.Net
 
         internal async Task<DiscordWebhook> GetWebhookAsync(ulong webhook_id)
         {
-            var route = string.Concat(Endpoints.WEBHOOKS, "/:webhook_id");
+            var route = $"{Endpoints.WEBHOOKS}/:webhook_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { webhook_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
@@ -1489,10 +1487,10 @@ namespace DSharpPlus.Net
         // Auth header not required
         internal async Task<DiscordWebhook> GetWebhookWithTokenAsync(ulong webhook_id, string webhook_token)
         {
-            var route = string.Concat(Endpoints.WEBHOOKS, "/:webhook_id/:webhook_token");
+            var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
@@ -1517,10 +1515,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.WEBHOOKS, "/:webhook_id");
+            var route = $"{Endpoints.WEBHOOKS}/:webhook_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { webhook_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
@@ -1542,10 +1540,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.WEBHOOKS, "/:webhook_id/:webhook_token");
+            var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
@@ -1561,10 +1559,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.WEBHOOKS, "/:webhook_id");
+            var route = $"{Endpoints.WEBHOOKS}/:webhook_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { webhook_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers);
         }
 
@@ -1574,10 +1572,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.WEBHOOKS, "/:webhook_id/:webhook_token");
+            var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers);
         }
 
@@ -1597,28 +1595,28 @@ namespace DSharpPlus.Net
                 Embeds = embeds
             };
 
-            var route = string.Concat(Endpoints.WEBHOOKS, "/:webhook_id/:webhook_token");
+            var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld));
         }
 
         internal Task ExecuteWebhookSlackAsync(ulong webhook_id, string webhook_token, string json_payload)
         {
-            var route = string.Concat(Endpoints.WEBHOOKS, "/:webhook_id/:webhook_token", Endpoints.SLACK);
+            var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.SLACK}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
         }
 
         internal Task ExecuteWebhookGithubAsync(ulong webhook_id, string webhook_token, string json_payload)
         {
-            var route = string.Concat(Endpoints.WEBHOOKS, "/:webhook_id/:webhook_token", Endpoints.GITHUB);
+            var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.GITHUB}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
         }
         #endregion
@@ -1626,19 +1624,19 @@ namespace DSharpPlus.Net
         #region Reactions
         internal Task CreateReactionAsync(ulong channel_id, ulong message_id, string emoji)
         {
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES, "/:message_id", Endpoints.REACTIONS, "/:emoji", Endpoints.ME);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}/:emoji{Endpoints.ME}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { channel_id, message_id, emoji }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, ratelimit_wait_override: 0.26);
         }
 
         internal Task DeleteOwnReactionAsync(ulong channel_id, ulong message_id, string emoji)
         {
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES, "/:message_id", Endpoints.REACTIONS, "/:emoji", Endpoints.ME);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}/:emoji{Endpoints.ME}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id, emoji }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, ratelimit_wait_override: 0.26);
         }
 
@@ -1648,19 +1646,19 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES, "/:message_id", Endpoints.REACTIONS, "/:emoji/:user_id");
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}/:emoji/:user_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id, emoji, user_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers, ratelimit_wait_override: 0.26);
         }
 
         internal async Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, string emoji)
         {
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES, "/:message_id", Endpoints.REACTIONS, "/:emoji");
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}/:emoji";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { channel_id, message_id, emoji }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var reacters_raw = JsonConvert.DeserializeObject<IEnumerable<TransportUser>>(res.Response);
@@ -1688,10 +1686,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES, "/:message_id", Endpoints.REACTIONS);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers, ratelimit_wait_override: 0.26);
         }
         #endregion
@@ -1699,10 +1697,10 @@ namespace DSharpPlus.Net
         #region Emoji
         internal async Task<IReadOnlyList<DiscordGuildEmoji>> GetGuildEmojisAsync(ulong guild_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.EMOJIS);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EMOJIS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var emojis_raw = JsonConvert.DeserializeObject<IEnumerable<JObject>>(res.Response);
@@ -1735,10 +1733,10 @@ namespace DSharpPlus.Net
 
         internal async Task<DiscordGuildEmoji> GetGuildEmojiAsync(ulong guild_id, ulong emoji_id)
         {
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.EMOJIS, "/:emoji_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EMOJIS}/:emoji_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id, emoji_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
@@ -1767,10 +1765,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.EMOJIS);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EMOJIS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
@@ -1800,10 +1798,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.EMOJIS, "/:emoji_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EMOJIS}/:emoji_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, emoji_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
@@ -1825,10 +1823,10 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.EMOJIS, "/:emoji_id");
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EMOJIS}/:emoji_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, emoji_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers);
         }
         #endregion
@@ -1842,10 +1840,10 @@ namespace DSharpPlus.Net
 
         private async Task<DiscordApplication> GetApplicationInfoAsync(string app_id)
         {
-            var route = string.Concat(Endpoints.OAUTH2, Endpoints.APPLICATIONS, "/:app_id");
+            var route = $"{Endpoints.OAUTH2}{Endpoints.APPLICATIONS}/:app_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { app_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var app = JsonConvert.DeserializeObject<DiscordApplication>(res.Response);
@@ -1856,10 +1854,10 @@ namespace DSharpPlus.Net
 
         internal async Task<IReadOnlyList<DiscordApplicationAsset>> GetApplicationAssetsAsync(DiscordApplication app)
         {
-            var route = string.Concat(Endpoints.OAUTH2, Endpoints.APPLICATIONS, "/:app_id", Endpoints.ASSETS);
+            var route = $"{Endpoints.OAUTH2}{Endpoints.APPLICATIONS}/:app_id{Endpoints.ASSETS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { app_id = app.Id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             var assets = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationAsset>>(res.Response);
@@ -1881,10 +1879,10 @@ namespace DSharpPlus.Net
                 Token = this.LastAckToken
             };
 
-            var route = string.Concat(Endpoints.CHANNELS, "/:channel_id", Endpoints.MESSAGES, "/", msg_id, Endpoints.ACK);
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/{msg_id}{Endpoints.ACK}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<AcknowledgePayload>(res.Response);
@@ -1902,10 +1900,10 @@ namespace DSharpPlus.Net
                 Token = this.LastAckToken
             };
 
-            var route = string.Concat(Endpoints.GUILDS, "/:guild_id", Endpoints.ACK);
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.ACK}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
-            var url = new Uri(string.Concat(Utilities.GetApiBaseUri(), path));
+            var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             if (res.ResponseCode != 204)

--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -48,7 +48,7 @@ namespace DSharpPlus
                 vs = v.ToString(3);
             }
 
-            VersionHeader = string.Concat("DiscordBot (https://github.com/NaamloosDT/DSharpPlus, v", vs, ")");
+            VersionHeader = $"DiscordBot (https://github.com/NaamloosDT/DSharpPlus, v{vs})";
         }
 
         internal static int CalculateIntegrity(int ping, DateTimeOffset timestamp, int heartbeat_interval)
@@ -59,6 +59,12 @@ namespace DSharpPlus
 
         internal static string GetApiBaseUri() 
             => Endpoints.BASE_URI;
+
+        internal static Uri GetApiUriFor(string path)
+            => new Uri($"{GetApiBaseUri()}{path}");
+
+        internal static Uri GetApiUriFor(string path, string queryString)
+            => new Uri($"{GetApiBaseUri()}{path}{queryString}");
 
         internal static string GetFormattedToken(BaseDiscordClient client)
         {


### PR DESCRIPTION
# Summary
Refactors the lib's code to use string interpolation instead of calls to `string.Concat`.

# Details
This should not affect lib functionality, it is a purely under-the-hood change.

If performance is a concern, please keep in mind that the compiled calls to `string.Format` are very, very likely sub-1ms and are completely negligible compared to any of the more heavyset lib operations, like sending a request or starting a task.

# Changes proposed
* Use string interpolation instead of `string.Format` in lib code

# Notes
This is the first in a series of three PRs with small improvements to lib internals, with the intention of making code more readable.