### PR TITLE
Fix HttpTimeout setting never applying

### DIFF
--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -133,10 +133,7 @@ namespace DSharpPlus
             internal get => this._udpClientFactory;
             set
             {
-                if (value == null)
-                    throw new InvalidOperationException("You need to supply a valid UDP client factory method.");
-
-                this._udpClientFactory = value;
+                this._udpClientFactory = value ?? throw new InvalidOperationException("You need to supply a valid UDP client factory method.");
             }
         }
         private UdpClientFactoryDelegate _udpClientFactory = DspUdpClient.CreateNew;
@@ -167,6 +164,7 @@ namespace DSharpPlus
             this.WebSocketClientFactory = other.WebSocketClientFactory;
             this.UdpClientFactory = other.UdpClientFactory;
             this.Proxy = other.Proxy;
+            this.HttpTimeout = other.HttpTimeout;
         }
     }
 }


### PR DESCRIPTION
# Summary
Fixes the `HttpTimeout` setting in `DiscordConfiguration` never having any effect.

# Details
The `DiscordConfiguration` object passed to the DiscordClient constructor is cloned, and the `RestClient` constructor that applies the timeout looks for the property in the cloned object, but the [clone constructor](https://github.com/DSharpPlus/DSharpPlus/blob/7381bcf489b61c2b152a107e8c751fa6a0583906/DSharpPlus/DiscordConfiguration.cs#L153-L170) does not assign the `HttpTimeout` property, so the default of 10 is always used.

# Changes proposed
* Assign `HttpTimeout` in `public DiscordConfiguration(DiscordConfiguration)` constructor

# Notes
This is all @RedworkDE's fault. [SHAME](https://github.com/DSharpPlus/DSharpPlus/blame/ba95590833074496d09a609b117288804f0a4c2a/DSharpPlus/DiscordConfiguration.cs#L106).