### PR TITLE
 Fix Optional deserializer not deserializing non-guessable types (such as Int32)

### DIFF
--- a/DSharpPlus/Entities/Optional.cs
+++ b/DSharpPlus/Entities/Optional.cs
@@ -37,19 +37,7 @@ namespace DSharpPlus.Entities
             this._val = value;
             this.HasValue = true;
         }
-
-        /// <summary>
-        /// FOR INTERNAL USE ONLY! See <see cref="OptionalJsonConverter.ReadJson"/>. Having a method that takes an
-        /// object and casts it saves a lot of time building type parameters.
-        /// <p>Creates a new <see cref="Optional{T}"/> with specified value.</p>
-        /// </summary>
-        /// <param name="value">Value of this option.</param>
-        internal Optional(object value)
-        {
-            this._val = (T) value; // not a safe cast.
-            this.HasValue = true;
-        }
-
+        
         /// <summary>
         /// Returns a string representation of this optional value.
         /// </summary>

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -110,14 +110,13 @@ namespace DSharpPlus.Net.Serialization
             JsonSerializer serializer)
         {
             var genericType = objectType.GenericTypeArguments[0];
-            
-            // TODO will this crash with Single finding more than one if T happens to be object?
+
             var constructor = objectType.GetTypeInfo().DeclaredConstructors
-                .Single(e => e.GetParameters()[0].ParameterType == typeof(object));
+                .Single(e => e.GetParameters()[0].ParameterType == genericType);
             
             try
             {
-                return constructor.Invoke(new[] {reader.Value});
+                return constructor.Invoke(new[] { Convert.ChangeType(reader.Value, genericType)});
             }
             catch
             {


### PR DESCRIPTION
# Summary
Because of an oversight ![haHAA](https://user-images.githubusercontent.com/13633343/39264111-6dd79c60-489a-11e8-9c8a-9d587bfeb13c.png) in Optional deserialization code, attempting to deserialize an integer type would fail, get catched by the try-catch and return the default value. In VS, when setting all exceptions to break, the error would pop up quite often.

# Details
I just found out that you can't directly convert between a boxed type and a different unboxed type. Json.NET always represents number values in JSON as Int64, so when deserializing the [DiscordEmbed.Color](https://github.com/DSharpPlus/DSharpPlus/blob/338161f95a7f9045e9d3e794d062e2dbc5259876/DSharpPlus/Entities/DiscordEmbed.cs#L47-L57) property, the [Optional(object)](https://github.com/DSharpPlus/DSharpPlus/blob/338161f95a7f9045e9d3e794d062e2dbc5259876/DSharpPlus/Entities/Optional.cs#L41-L51) constructor would try to convert it from `object` (boxing an `Int64`) to `Int32` and fail miserably. Because the exception is caught and silently ignored, finding the culpirit was REALLY ANNOYING.

# Changes proposed
* Fix Optional deserializer not deserializing non-guessable types (such as Int32), by preemptively converting them to the right type and using the generic constructor
* Remove now-unused [Optional(object)](https://github.com/DSharpPlus/DSharpPlus/blob/338161f95a7f9045e9d3e794d062e2dbc5259876/DSharpPlus/Entities/Optional.cs#L41-L51) constructor

# Notes
All it took was one goddamn pull request and I've never heard the end of it.