### PR TITLE
Fix #287 - Issue with GuildRoleUpdated

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -1429,7 +1429,7 @@ namespace DSharpPlus
                 IsHoisted = role_new.IsHoisted,
                 Id = role_new.Id,
                 IsManaged = role_new.IsManaged,
-                IsMentionable = role_new.IsManaged,
+                IsMentionable = role_new.IsMentionable,
                 Name = role_new.Name,
                 Permissions = role_new.Permissions,
                 Position = role_new.Position


### PR DESCRIPTION
# Summary
Fixes #287 - Issue with GuildRoleUpdated - (RoleBefore)

# Details
role_old.IsMentionable was being incorrectly set to IsManaged (which would be false most of the time)

# Changes proposed
* Assign role_old.IsMentionable to IsMentionable instead of IsManaged