### PR TITLE
Fix #280 ArgumentNullException from DiscordMessage.MentionedChannels and MentionedRoles

### DIFF
--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -19,8 +19,10 @@ namespace DSharpPlus.Entities
         {
             this._attachmentsLazy = new Lazy<IReadOnlyList<DiscordAttachment>>(() => new ReadOnlyCollection<DiscordAttachment>(this._attachments));
             this._embedsLazy = new Lazy<IReadOnlyList<DiscordEmbed>>(() => new ReadOnlyCollection<DiscordEmbed>(this._embeds));
-            this._mentionedChannelsLazy = new Lazy<IReadOnlyList<DiscordChannel>>(() => new ReadOnlyCollection<DiscordChannel>(this._mentionedChannels));
-            this._mentionedRolesLazy = new Lazy<IReadOnlyList<DiscordRole>>(() => new ReadOnlyCollection<DiscordRole>(this._mentionedRoles));
+            this._mentionedChannelsLazy = new Lazy<IReadOnlyList<DiscordChannel>>(() => 
+	        this._mentionedChannels != null ? new ReadOnlyCollection<DiscordChannel>(this._mentionedChannels) : new DiscordChannel[0]);
+            this._mentionedRolesLazy = new Lazy<IReadOnlyList<DiscordRole>>(() => 
+	        this._mentionedRoles != null ? new ReadOnlyCollection<DiscordRole>(this._mentionedRoles) : new DiscordRole[0]);
             this._mentionedUsersLazy = new Lazy<IReadOnlyList<DiscordUser>>(() => new ReadOnlyCollection<DiscordUser>(this._mentionedUsers));
             this._reactionsLazy = new Lazy<IReadOnlyList<DiscordReaction>>(() => new ReadOnlyCollection<DiscordReaction>(this._reactions));
         }

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -19,10 +19,16 @@ namespace DSharpPlus.Entities
         {
             this._attachmentsLazy = new Lazy<IReadOnlyList<DiscordAttachment>>(() => new ReadOnlyCollection<DiscordAttachment>(this._attachments));
             this._embedsLazy = new Lazy<IReadOnlyList<DiscordEmbed>>(() => new ReadOnlyCollection<DiscordEmbed>(this._embeds));
-            this._mentionedChannelsLazy = new Lazy<IReadOnlyList<DiscordChannel>>(() => 
-	        this._mentionedChannels != null ? new ReadOnlyCollection<DiscordChannel>(this._mentionedChannels) : new DiscordChannel[0]);
-            this._mentionedRolesLazy = new Lazy<IReadOnlyList<DiscordRole>>(() => 
-	        this._mentionedRoles != null ? new ReadOnlyCollection<DiscordRole>(this._mentionedRoles) : new DiscordRole[0]);
+            this._mentionedChannelsLazy = new Lazy<IReadOnlyList<DiscordChannel>>(() => {
+                if (this._mentionedChannels != null)
+                    return new ReadOnlyCollection<DiscordChannel>(this._mentionedChannels);
+                return new DiscordChannel[0];
+            });
+            this._mentionedRolesLazy = new Lazy<IReadOnlyList<DiscordRole>>(() => {
+                if (this._mentionedRoles != null)
+                    return new ReadOnlyCollection<DiscordRole>(this._mentionedRoles);
+                return new DiscordRole[0];
+            });
             this._mentionedUsersLazy = new Lazy<IReadOnlyList<DiscordUser>>(() => new ReadOnlyCollection<DiscordUser>(this._mentionedUsers));
             this._reactionsLazy = new Lazy<IReadOnlyList<DiscordReaction>>(() => new ReadOnlyCollection<DiscordReaction>(this._reactions));
         }


### PR DESCRIPTION
# Summary
Fixes #280: ArgumentNullException from DiscordMessage.MentionedChannels and MentionedRoles

# Details
The existing code wrapped a list that would be null in a DM inside a ReadOnlyCollection. The fixed version will return an empty array (which incidentally implements `IReadOnlyList` since .NET 4.5) instead.

# Changes proposed
* Make _mentionedChannelsLazy and _mentionedRolesLazy return an empty IReadOnlyList when the inner collection is empty