### PR TITLE
Don't cause an error to be logged when Discord sends a payload body the lib is not designed to handle

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -592,7 +592,11 @@ namespace DSharpPlus
 
         internal async Task HandleDispatchAsync(GatewayPayload payload)
         {
-            var dat = (JObject)payload.Data;
+            if (!(payload.Data is JObject dat))
+	        {
+                DebugLogger.LogMessage(LogLevel.Warning, "Websocket:Dispatch", $"Invalid payload body, you can probably ignore this message: {payload.OpCode}:{payload.EventName}\n{payload.Data}", DateTime.Now);
+                return;
+	        }
 
             DiscordChannel chn;
             ulong gid;
@@ -678,7 +682,7 @@ namespace DSharpPlus
                 case "guild_member_remove":
                     gid = (ulong)dat["guild_id"];
                     if (!this._guilds.ContainsKey(gid))
-                    { this.DebugLogger.LogMessage(LogLevel.Error, "DSharpPlus", $"Could not find {gid.ToString(CultureInfo.InvariantCulture)} in guild cache.", DateTime.Now); return; }
+                    { this.DebugLogger.LogMessage(LogLevel.Error, "Websocket:Dispatch", $"Could not find {gid.ToString(CultureInfo.InvariantCulture)} in guild cache.", DateTime.Now); return; }
                     await OnGuildMemberRemoveEventAsync(dat["user"].ToObject<TransportUser>(), this._guilds[gid]).ConfigureAwait(false);
                     break;
 
@@ -779,7 +783,7 @@ namespace DSharpPlus
 
                 default:
                     await OnUnknownEventAsync(payload).ConfigureAwait(false);
-                    DebugLogger.LogMessage(LogLevel.Warning, "Websocket", $"Unknown event: {payload.EventName}\n{payload.Data}", DateTime.Now);
+                    DebugLogger.LogMessage(LogLevel.Warning, "Websocket:Dispatch", $"Unknown event: {payload.EventName}\n{payload.Data}", DateTime.Now);
                     break;
             }
         }

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -593,10 +593,10 @@ namespace DSharpPlus
         internal async Task HandleDispatchAsync(GatewayPayload payload)
         {
             if (!(payload.Data is JObject dat))
-	        {
+            {
                 DebugLogger.LogMessage(LogLevel.Warning, "Websocket:Dispatch", $"Invalid payload body, you can probably ignore this message: {payload.OpCode}:{payload.EventName}\n{payload.Data}", DateTime.Now);
                 return;
-	        }
+            }
 
             DiscordChannel chn;
             ulong gid;
@@ -682,7 +682,10 @@ namespace DSharpPlus
                 case "guild_member_remove":
                     gid = (ulong)dat["guild_id"];
                     if (!this._guilds.ContainsKey(gid))
-                    { this.DebugLogger.LogMessage(LogLevel.Error, "Websocket:Dispatch", $"Could not find {gid.ToString(CultureInfo.InvariantCulture)} in guild cache.", DateTime.Now); return; }
+                    {
+                        this.DebugLogger.LogMessage(LogLevel.Error, "Websocket:Dispatch", $"Could not find {gid.ToString(CultureInfo.InvariantCulture)} in guild cache.", DateTime.Now);
+                        return;
+                    }
                     await OnGuildMemberRemoveEventAsync(dat["user"].ToObject<TransportUser>(), this._guilds[gid]).ConfigureAwait(false);
                     break;
 


### PR DESCRIPTION
# Summary
This occurs with events such as PRESENCE_REPLACE and SESSIONS_REPLACE, which are not meant to be sent to bot accounts but they are because HAHA WHY NOT

# Changes proposed
* Log a warning instead of an error when the dispatch payload data is not a JSON object

# Notes
I love this API