### PR TITLE
Fixes Channel.Users causing a NullReference

### DIFF
--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -143,7 +143,7 @@ namespace DSharpPlus.Entities
                     throw new InvalidOperationException("Cannot query users outside of guild channels.");
 
                 if (this.Type == ChannelType.Voice)
-                    return Guild.Members.Where(x => x.VoiceState?.ChannelId == this?.Id);
+                    return Guild.Members.Where(x => x.VoiceState?.ChannelId == this.Id);
 
                 return Guild.Members.Where(x => (this.PermissionsFor(x) & Permissions.AccessChannels) == Permissions.AccessChannels);
             }

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -143,7 +143,7 @@ namespace DSharpPlus.Entities
                     throw new InvalidOperationException("Cannot query users outside of guild channels.");
 
                 if (this.Type == ChannelType.Voice)
-                    return Guild.Members.Where(x => x.VoiceState.ChannelId == this.Id);
+                    return Guild.Members.Where(x => x.VoiceState?.ChannelId == this?.Id);
 
                 return Guild.Members.Where(x => (this.PermissionsFor(x) & Permissions.AccessChannels) == Permissions.AccessChannels);
             }


### PR DESCRIPTION
Fixes a bug that occurs when a user's VoiceState is null when executing Channel.Users

# Changes proposed
Switched to null-conditional operators when getting the VoiceState's ChannelId