### PR TITLE
Fixes DefaultHelpChecks not being used.

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -290,6 +290,10 @@ namespace DSharpPlus.CommandsNext
 
             this.RegisterCommands(t, null, out var tcmds);
 
+            if (t == typeof(DefaultHelpModule) && Config.DefaultHelpChecks != null)
+                foreach (var check in Config.DefaultHelpChecks)
+                    tcmds[0].WithExecutionCheck(check);
+
             if (tcmds != null)
                 foreach (var xc in tcmds)
                     this.AddToCommandDictionary(xc.Build(null));
@@ -376,8 +380,7 @@ namespace DSharpPlus.CommandsNext
                     continue;
 
                 var attrs = m.GetCustomAttributes();
-                var cattr = attrs.FirstOrDefault(xa => xa is CommandAttribute) as CommandAttribute;
-                if (cattr == null)
+                if (!(attrs.FirstOrDefault(xa => xa is CommandAttribute) is CommandAttribute cattr))
                     continue;
 
                 var cname = cattr.Name;

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -291,8 +291,12 @@ namespace DSharpPlus.CommandsNext
             this.RegisterCommands(t, null, out var tcmds);
 
             if (t == typeof(DefaultHelpModule) && Config.DefaultHelpChecks != null)
-                foreach (var check in Config.DefaultHelpChecks)
-                    tcmds[0].WithExecutionCheck(check);
+            {
+                var checks = Config.DefaultHelpChecks.ToArray();
+
+                for (int i = 0; i < tcmds.Count; i++)
+                    tcmds[i].WithExecutionChecks(checks);
+            }
 
             if (tcmds != null)
                 foreach (var xc in tcmds)

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -148,7 +148,22 @@ namespace DSharpPlus.CommandsNext
             this.Client.MessageCreated += this.HandleCommandsAsync;
 
             if (this.Config.EnableDefaultHelp)
-                this.RegisterCommands<DefaultHelpModule>();
+            {
+                this.RegisterCommands(typeof(DefaultHelpModule), null, out var tcmds);
+
+                if (this.Config.DefaultHelpChecks != null)
+                {
+                    var checks = this.Config.DefaultHelpChecks.ToArray();
+
+                    for (int i = 0; i < tcmds.Count; i++)
+                        tcmds[i].WithExecutionChecks(checks);
+                }
+
+                if (tcmds != null)
+                    foreach (var xc in tcmds)
+                        this.AddToCommandDictionary(xc.Build(null));
+            }
+
         }
         #endregion
 
@@ -289,14 +304,6 @@ namespace DSharpPlus.CommandsNext
                 throw new ArgumentNullException(nameof(t), "Type must be a class, which cannot be abstract or static.");
 
             this.RegisterCommands(t, null, out var tcmds);
-
-            if (t == typeof(DefaultHelpModule) && Config.DefaultHelpChecks != null)
-            {
-                var checks = Config.DefaultHelpChecks.ToArray();
-
-                for (int i = 0; i < tcmds.Count; i++)
-                    tcmds[i].WithExecutionChecks(checks);
-            }
 
             if (tcmds != null)
                 foreach (var xc in tcmds)


### PR DESCRIPTION
…and pattern matching, because pattern matching.

Make sure you familiarize yourself with our contributing guidelines.

# Summary
Fixes DefaultHelpChecks not being used.

# Details
Fixes DefaultHelpChecks not being used.

# Changes proposed
* merge
* this
* PR
* and make the help command great again.

# Notes
~~I could change the `foreach` to a .ToArray().~~ None.