### PR TITLE
Fix crash when changing own nickname

### DIFF
--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -320,7 +320,7 @@ namespace DSharpPlus.Entities
             {
                 await this.Discord.ApiClient.ModifyCurrentMemberNicknameAsync(this.Guild.Id, mdl.Nickname.Value,
                     mdl.AuditLogReason).ConfigureAwait(false);
-                await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, Optional.FromNoValue(),
+                await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, Optional<string>.FromNoValue(),
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
                     mdl.VoiceChannel.IfPresent(e => e.Id), mdl.AuditLogReason).ConfigureAwait(false);
             }

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -320,7 +320,7 @@ namespace DSharpPlus.Entities
             {
                 await this.Discord.ApiClient.ModifyCurrentMemberNicknameAsync(this.Guild.Id, mdl.Nickname.Value,
                     mdl.AuditLogReason).ConfigureAwait(false);
-                await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, null,
+                await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, Optional.FromNoValue(),
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
                     mdl.VoiceChannel.IfPresent(e => e.Id), mdl.AuditLogReason).ConfigureAwait(false);
             }


### PR DESCRIPTION
# Summary
Fixes a crash when a member changes their own nickname with ModifyAsync

# Details
The call to ModifyGuildMemberAsync sends a null parameter which would remove the member's nickname, but this is not possible through that endpoint (ModifyCurrentMemberNickname is to be used instead) so the call throws a 403. It shouldn't send a null parameter to begin with, instead it should ignore that property from the request body.

# Changes proposed
* Replace null parameter with empty Optional<string>

# Notes
For the future: change it so it won't make the second request if it has no data to modify