### PR TITLE
Fixed RequireBotPermissions attribute.

### DIFF
--- a/DSharpPlus.CommandsNext/Attributes/RequireBotPermissionsAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireBotPermissionsAttribute.cs
@@ -45,7 +45,7 @@ namespace DSharpPlus.CommandsNext.Attributes
             if ((pbot & Permissions.Administrator) != 0)
                 return true;
 
-            if ((pbot & this.Permissions) != 0)
+            if ((pbot & this.Permissions) == this.Permissions)
                 return true;
 
             return false;


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
It should fix the RequireBotPermissions attribute when you put at least 2 permissions. Before the change, if the bot had one of the permissions put in the attribute, the test would pass.

# Details
```if ((pbot & this.Permissions) != 0)```
became 
```if ((pbot & this.Permissions) == this.Permissions)```

It was already fixed in RequirePermissionsAttribute and RequireUserPermissionsAttribute.