### PR TITLE
 Fix Bad Request error when calling InitializeCacheAsync method on the DiscordRestClient.

### DIFF
--- a/DSharpPlus.CommandsNext/Attributes/RequireBotPermissionsAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireBotPermissionsAttribute.cs
@@ -45,7 +45,7 @@ namespace DSharpPlus.CommandsNext.Attributes
             if ((pbot & Permissions.Administrator) != 0)
                 return true;
 
-            if ((pbot & this.Permissions) != 0)
+            if ((pbot & this.Permissions) == this.Permissions)
                 return true;
 
             return false;

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -41,7 +41,7 @@ namespace DSharpPlus.Net
             if (values == null || values.Count == 0)
                 return string.Empty;
 
-            var vals_collection = values.Select(xkvp => 
+            var vals_collection = values.Select(xkvp =>
                 $"{WebUtility.UrlEncode(xkvp.Key)}={WebUtility.UrlEncode(xkvp.Value)}");
             var vals = string.Join("&", vals_collection);
 
@@ -179,7 +179,7 @@ namespace DSharpPlus.Net
                 OwnerId = owner_id,
                 SystemChannelId = systemChannelId
             };
-            
+
             var headers = Utilities.GetBaseHeaders();
             if (!string.IsNullOrWhiteSpace(reason))
                 headers.Add(REASON_HEADER_NAME, reason);
@@ -971,18 +971,17 @@ namespace DSharpPlus.Net
 
         internal async Task<IReadOnlyList<DiscordGuild>> GetCurrentUserGuildsAsync(int limit, ulong? before, ulong? after)
         {
-            var pld = new RestUserGuildListPayload
-            {
-                Limit = limit,
-                After = after,
-                Before = before
-            };
+            var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.GUILDS}?limit={limit}";
 
-            var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.GUILDS}";
+            if (before != null)
+                route += "&before=" + before;
+            if (after != null)
+                route += "&after=" + after;
+
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { }, out var path);
 
             var url = Utilities.GetApiUriFor(path);
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
             if (this.Discord is DiscordClient)
             {
@@ -993,13 +992,13 @@ namespace DSharpPlus.Net
             else
             {
                 var guilds_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordGuild>>(res.Response);
-                var glds = guilds_raw.Select(xug =>
+
+                var glds = new List<DiscordGuild>();
+                foreach (var gld in guilds_raw)
                 {
-                    xug.Discord = this.Discord;
-                    foreach (var r in xug._roles)
-                        r._guild_id = xug.Id;
-                    return xug;
-                });
+                    glds.Add(await GetGuildAsync(gld.Id));
+                }
+
                 return new ReadOnlyCollection<DiscordGuild>(new List<DiscordGuild>(glds));
             }
         }


### PR DESCRIPTION
# Summary
InitializeCacheAsync was throwing a 400 Bad Request exception when using the DiscordRestClient.

# Details
InitializeCacheAsync was trying to retrieve the guilds and the way to call the endpoint `/users/@me/guilds` was totally wrong. Now it does use the parameters limit, before and after correctly.