### PR TITLE
Fix Null ref in SendPaginatedMessage

### DIFF
--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -655,6 +655,8 @@ namespace DSharpPlus.Interactivity
 				Pages = pages,
 				Timeout = timeout
 			};
+			
+			emojis = emojis ?? new PaginationEmojis(this.Client);
 
 			await this.GeneratePaginationReactions(m, emojis).ConfigureAwait(false);
 


### PR DESCRIPTION
# Summary
Fixes the Null Reference Exception that occures in GeneratePaginationReactions. The parameter emojis in method `SendPaginatedMessage` has null value by default. If you were not passing an instance of `PaginationEmojis` it would throw when trying to call `GeneratePaginationReactions`

# Details
Simply check if `emojis` is null and instanciate it in case it's null.