### PR TITLE
Fix #307: Commands w/ body defined in abstract classes aren't registered in subclasses unless virtual & overriden

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -367,7 +367,7 @@ namespace DSharpPlus.CommandsNext
                 cgbldr = null;
 
             // candidate methods
-            var ms = ti.DeclaredMethods;
+            var ms = CommandsNextUtilities.GetAllMethods(ti);
             var cmds = new List<CommandBuilder>();
             var cblds = new Dictionary<string, CommandBuilder>();
             foreach (var m in ms)

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -335,7 +335,7 @@ namespace DSharpPlus.CommandsNext
 
                         cgbldr.WithName(mdl_name);
                         
-                        foreach (var mi in ti.DeclaredMethods.Where(x => x.IsCommandCandidate(out _) && x.GetCustomAttribute<GroupCommandAttribute>() != null))
+                        foreach (var mi in CommandsNextUtilities.GetAllMethods(ti).Where(x => x.IsCommandCandidate(out _) && x.GetCustomAttribute<GroupCommandAttribute>() != null))
                             cgbldr.WithOverload(new CommandOverloadBuilder(mi));
                         break;
 

--- a/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
@@ -382,5 +382,31 @@ namespace DSharpPlus.CommandsNext
 
             return module;
         }
+
+        // GetMethods workaround for .NET Standard 1.1
+        internal static IEnumerable<MethodInfo> GetAllMethods(TypeInfo ti)
+        {
+            var baseDefs = new HashSet<string>();
+            while (true)
+            {
+                foreach (var m in ti.DeclaredMethods)
+                {
+                    if (!baseDefs.Add(m.ToString()))
+                        continue;
+                    
+                    yield return m;
+                }
+
+                var b = ti.BaseType;
+                if (b == null) break;
+                if (b == typeof(BaseCommandModule)) break;
+                
+                ti = b.GetTypeInfo();
+
+                // only allow inheriting commands from abstract classes, since other types of classes will get picked up
+                // as regular modules by CNext
+                if (!ti.IsAbstract) break;
+            }
+        }
     }
 }


### PR DESCRIPTION
# Summary
Fixes #307. Makes modules inherit commands declared in superclasses, as long as the superclasses are abstract.

# Details
This lets you declare commands with body in an abstract module and have every module that extends it include the command. This complements existing (probably accidental) functionality that lets you declare abstract or virtual commands, complete with `Command`/`GroupCommand` attribute and implement them in your subclass.

# Changes proposed
* Changes the `ti.DeclaredMethods` bit in two RegisterCommands overloads to a call to an utility method that includes a type's methods all the way up the inheritance tree but not including BaseCommandModule.

# Notes
The functionality in this PR is extended to `GroupCommand`. Currently, all `GroupCommand`s are propagated down the inheritance tree as long as their signature is unique. Should this be changed to reflect more accurately the behavior of constructors in C#?