### PR TITLE
Account for channel pins update `last_pin_timestamp` can be null

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -1037,7 +1037,7 @@ namespace DSharpPlus
             }
         }
 
-        internal async Task OnChannelPinsUpdate(DiscordChannel channel, DateTimeOffset lastPinTimestamp)
+        internal async Task OnChannelPinsUpdate(DiscordChannel channel, DateTimeOffset? lastPinTimestamp)
         {
             if (channel == null)
                 return;

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -632,7 +632,7 @@ namespace DSharpPlus
                 case "channel_pins_update":
                     cid = (ulong)dat["channel_id"];
 		    var ts = (string)dat["last_pin_timestamp"];
-                    await this.OnChannelPinsUpdate(this.InternalGetCachedChannel(cid), ts != null ? DateTimeOffset.Parse(ts, CultureInfo.InvariantCulture) : null).ConfigureAwait(false);
+                    await this.OnChannelPinsUpdate(this.InternalGetCachedChannel(cid), ts != null ? DateTimeOffset.Parse(ts, CultureInfo.InvariantCulture) : default(DateTimeOffset?)).ConfigureAwait(false);
                     break;
 
                 case "guild_create":

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -631,7 +631,8 @@ namespace DSharpPlus
 
                 case "channel_pins_update":
                     cid = (ulong)dat["channel_id"];
-                    await this.OnChannelPinsUpdate(this.InternalGetCachedChannel(cid), DateTimeOffset.Parse((string)dat["last_pin_timestamp"], CultureInfo.InvariantCulture)).ConfigureAwait(false);
+		    var ts = (string)dat["last_pin_timestamp"];
+                    await this.OnChannelPinsUpdate(this.InternalGetCachedChannel(cid), ts != null ? DateTimeOffset.Parse(ts, CultureInfo.InvariantCulture) : null).ConfigureAwait(false);
                     break;
 
                 case "guild_create":

--- a/DSharpPlus/EventArgs/ChannelPinsUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/ChannelPinsUpdateEventArgs.cs
@@ -16,7 +16,7 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the timestamp of the latest pin.
         /// </summary>
-        public DateTimeOffset LastPinTimestamp { get; internal set; }
+        public DateTimeOffset? LastPinTimestamp { get; internal set; }
 
         internal ChannelPinsUpdateEventArgs(DiscordClient client) : base(client) { }
     }


### PR DESCRIPTION
# Summary
Fixes a rare ArgumentNullException on channel pins update.

# Details
The [last_pin_timestamp](https://discordapp.com/developers/docs/topics/gateway#channel-pins-update-channel-pins-update-event-fields) event field for the [Channel Pins Update](https://discordapp.com/developers/docs/topics/gateway#channel-pins-update) event can actually be null, but this is not accounted for in the library.

# Changes proposed
* Don't invoke DateTimeOffset.Parse if the `last_pin_timestamp` property is null.

# Notes
I would like to thank the Academy, and Kef#8576 on Discord for finding this one.