### PR TITLE
Perform cleanup when starting a Lavalink connection throws

### DIFF
--- a/DSharpPlus.Lavalink/LavalinkExtension.cs
+++ b/DSharpPlus.Lavalink/LavalinkExtension.cs
@@ -57,7 +57,15 @@ namespace DSharpPlus.Lavalink
             con.NodeDisconnected += this.Con_NodeDisconnected;
             con.Disconnected += this.Con_Disconnected;
             this.ConnectedNodes[con.NodeEndpoint] = con;
-            await con.StartAsync().ConfigureAwait(false);
+            try
+            {
+                await con.StartAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                this.Con_NodeDisconnected(con);
+                throw;
+            }
 
             return con;
         }


### PR DESCRIPTION
# Summary
Fixes #321: LavalinkNodeConnection is cached before a successful connection is made.

# Details
I use a try-catch block instead of just moving the cache code down to avoid non-deterministic behavior where Con_Disconnected could be fired without the connection being in the cache. If this is not a problem in a real-world scenario, please close this PR and just move `this.ConnectedNodes[con.NodeEndpoint] = con;` down a line.

# Changes proposed
* Catch exceptions thrown by LavalinkNodeConnection.StartAsync, remove the connection from the cache, and rethrow.

# Notes
As always, this one goes untested, in the hopes that I didn't overlook anything (again).