### PR TITLE
Added descriptions to TrackEndReason

### DIFF
--- a/DSharpPlus.Lavalink/EventArgs/TrackEventArgs.cs
+++ b/DSharpPlus.Lavalink/EventArgs/TrackEventArgs.cs
@@ -46,10 +46,29 @@
     /// </summary>
     public enum TrackEndReason
     {
+        /// <summary>
+        /// This means that the track itself emitted a terminator. This is usually caused by the track reaching the end,
+        /// however it will also be used when it ends due to an exception.
+        /// </summary>
         Finished,
+        /// <summary>
+        /// This means that the track failed to start, throwing an exception before providing any audio.
+        /// </summary>
         LoadFailed,
+        /// <summary>
+        /// The track was stopped due to the player being stopped by either calling stop() or playTrack(null).
+        /// </summary>
         Stopped,
+        /// <summary>
+        /// The track stopped playing because a new track started playing. Note that with this reason, the old track will still
+        /// play until either its buffer runs out or audio from the new track is available.
+        /// </summary>
         Replaced,
+        /// <summary>
+        /// The track was stopped because the cleanup threshold for the audio player was reached. This triggers when the amount
+        /// of time passed since the last call to AudioPlayer#provide() has reached the threshold specified in player manager
+        /// configuration. This may also indicate either a leaked audio player which was discarded, but not stopped.
+        /// </summary>
         Cleanup
     }
 


### PR DESCRIPTION
# Summary
Adds descriptions for `TrackEndReason`, so its easier to know what each one means.

# Notes
Descriptions was taken from here:
https://github.com/sedmelluq/lavaplayer/blob/b0c536098c4f92e6d03b00f19221021f8f50b19b/main/src/main/java/com/sedmelluq/discord/lavaplayer/track/AudioTrackEndReason.java#L6-L30

Just wondering, could we also implement this as an extention-method to `TrackEndReason`
![image](https://user-images.githubusercontent.com/32580874/43323436-f0433d84-91b1-11e8-8400-9835d0b6014e.png)


