### PR TITLE
Support attachments in embeds

### DIFF
--- a/DSharpPlus/DSharpPlus.csproj
+++ b/DSharpPlus/DSharpPlus.csproj
@@ -1,48 +1,61 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
+
   <Import Project="../DSharpPlus.targets" />
+
   <PropertyGroup>
     <AssemblyName>DSharpPlus</AssemblyName>
     <RootNamespace>DSharpPlus</RootNamespace>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net45;net46;net47;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
+
   <PropertyGroup>
     <Description>A C# API for Discord based off DiscordSharp, but rewritten to fit the API standards.</Description>
     <PackageTags>discord discord-api bots discord-bots chat dsharp dsharpplus csharp dotnet vb-net fsharp webhooks</PackageTags>
   </PropertyGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <Compile Remove="Net\WebSocket\WebSocketClient.cs" />
     <Compile Remove="Net\Udp\DspUdpClient.cs" />
   </ItemGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <None Include="Net\WebSocket\WebSocketClient.cs" />
     <None Include="Net\Udp\DspUdpClient.cs" />
   </ItemGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.1'">
     <Compile Remove="Net\WebSocket\WebSocketClient2.cs" />
     <Compile Remove="Net\Udp\DspUdpClient2.cs" />
   </ItemGroup>
+  
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.1'">
     <None Include="Net\WebSocket\WebSocketClient2.cs" />
     <None Include="Net\Udp\DspUdpClient2.cs" />
   </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' Or '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net47'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
+  
 </Project>

--- a/DSharpPlus/DSharpPlus.csproj
+++ b/DSharpPlus/DSharpPlus.csproj
@@ -1,61 +1,48 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
   <Import Project="../DSharpPlus.targets" />
-
   <PropertyGroup>
     <AssemblyName>DSharpPlus</AssemblyName>
     <RootNamespace>DSharpPlus</RootNamespace>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net45;net46;net47;netstandard1.1;netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
-
   <PropertyGroup>
     <Description>A C# API for Discord based off DiscordSharp, but rewritten to fit the API standards.</Description>
     <PackageTags>discord discord-api bots discord-bots chat dsharp dsharpplus csharp dotnet vb-net fsharp webhooks</PackageTags>
   </PropertyGroup>
-  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <Compile Remove="Net\WebSocket\WebSocketClient.cs" />
     <Compile Remove="Net\Udp\DspUdpClient.cs" />
   </ItemGroup>
-  
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1'">
     <None Include="Net\WebSocket\WebSocketClient.cs" />
     <None Include="Net\Udp\DspUdpClient.cs" />
   </ItemGroup>
-  
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.1'">
     <Compile Remove="Net\WebSocket\WebSocketClient2.cs" />
     <Compile Remove="Net\Udp\DspUdpClient2.cs" />
   </ItemGroup>
-  
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.1'">
     <None Include="Net\WebSocket\WebSocketClient2.cs" />
     <None Include="Net\Udp\DspUdpClient2.cs" />
   </ItemGroup>
-  
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' Or '$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net47'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-  
 </Project>

--- a/DSharpPlus/Entities/DiscordEmbedAuthor.cs
+++ b/DSharpPlus/Entities/DiscordEmbedAuthor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using DSharpPlus.Net;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
@@ -24,13 +25,13 @@ namespace DSharpPlus.Entities
         /// Gets the url of the author's icon.
         /// </summary>
         [JsonProperty("icon_url", NullValueHandling = NullValueHandling.Ignore)]
-        public Uri IconUrl { get; set; }
+        public DiscordUri IconUrl { get; set; }
 
         /// <summary>
         /// Gets the proxied url of the author's icon.
         /// </summary>
         [JsonProperty("proxy_icon_url", NullValueHandling = NullValueHandling.Ignore)]
-        public Uri ProxyIconUrl { get; internal set; }
+        public DiscordUri ProxyIconUrl { get; internal set; }
 
         internal DiscordEmbedAuthor() { }
     }

--- a/DSharpPlus/Entities/DiscordEmbedBuilder.cs
+++ b/DSharpPlus/Entities/DiscordEmbedBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using DSharpPlus.Net;
 
 namespace DSharpPlus.Entities
 {
@@ -82,15 +83,9 @@ namespace DSharpPlus.Entities
         public string ImageUrl
         {
             get { return this._image_uri?.ToString(); }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    this._image_uri = null;
-                else
-                    this._image_uri = new Uri(value);
-            }
+            set { this._image_uri = string.IsNullOrEmpty(value) ? null : new DiscordUri(value); }
         }
-        private Uri _image_uri;
+        private DiscordUri _image_uri;
 
         /// <summary>
         /// Gets or sets the thumbnail's image url.
@@ -98,15 +93,9 @@ namespace DSharpPlus.Entities
         public string ThumbnailUrl
         {
             get { return this._thumbnail_uri?.ToString(); }
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                    this._thumbnail_uri = null;
-                else
-                    this._thumbnail_uri = new Uri(value);
-            }
+            set { this._thumbnail_uri = string.IsNullOrEmpty(value) ? null : new DiscordUri(value); }
         }
-        private Uri _thumbnail_uri;
+        private DiscordUri _thumbnail_uri;
 
         /// <summary>
         /// Gets the embed's author.
@@ -276,7 +265,7 @@ namespace DSharpPlus.Entities
         /// <returns>This embed builder.</returns>
         public DiscordEmbedBuilder WithImageUrl(Uri url)
         {
-            this._image_uri = url;
+            this._image_uri = new DiscordUri(url);
             return this;
         }
 
@@ -298,7 +287,7 @@ namespace DSharpPlus.Entities
         /// <returns>This embed builder.</returns>
         public DiscordEmbedBuilder WithThumbnailUrl(Uri url)
         {
-            this._thumbnail_uri = url;
+            this._thumbnail_uri = new DiscordUri(url);
             return this;
         }
 
@@ -462,7 +451,7 @@ namespace DSharpPlus.Entities
                 embed.Footer = new DiscordEmbedFooter
                 {
                     Text = this.Footer.Text,
-                    IconUrl = this.Footer.IconUrl != null ? new Uri(this.Footer.IconUrl) : null
+                    IconUrl = this.Footer.IconUrl != null ? new DiscordUri(this.Footer.IconUrl) : null
                 };
 
             if (this.Author != null)
@@ -470,7 +459,7 @@ namespace DSharpPlus.Entities
                 {
                     Name = this.Author.Name,
                     Url = this.Author.Url != null ? new Uri(this.Author.Url) : null,
-                    IconUrl = this.Author.IconUrl != null ? new Uri(this.Author.IconUrl) : null
+                    IconUrl = this.Author.IconUrl != null ? new DiscordUri(this.Author.IconUrl) : null
                 };
 
             if (this._image_uri != null)
@@ -530,15 +519,9 @@ namespace DSharpPlus.Entities
             public string IconUrl
             {
                 get { return this._icon_uri?.ToString(); }
-                set
-                {
-                    if (string.IsNullOrEmpty(value))
-                        this._icon_uri = null;
-                    else
-                        this._icon_uri = new Uri(value);
-                }
+                set { this._icon_uri = string.IsNullOrEmpty(value) ? null : new DiscordUri(value); }
             }
-            private Uri _icon_uri;
+            private DiscordUri _icon_uri;
         }
 
         public class EmbedFooter
@@ -564,15 +547,9 @@ namespace DSharpPlus.Entities
             public string IconUrl
             {
                 get { return this._icon_uri?.ToString(); }
-                set
-                {
-                    if (string.IsNullOrEmpty(value))
-                        this._icon_uri = null;
-                    else
-                        this._icon_uri = new Uri(value);
-                }
+                set { this._icon_uri = string.IsNullOrEmpty(value) ? null : new DiscordUri(value); }
             }
-            private Uri _icon_uri;
+            private DiscordUri _icon_uri;
         }
     }
 }

--- a/DSharpPlus/Entities/DiscordEmbedFooter.cs
+++ b/DSharpPlus/Entities/DiscordEmbedFooter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using DSharpPlus.Net;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
@@ -18,13 +19,13 @@ namespace DSharpPlus.Entities
         /// Gets the url of the footer's icon.
         /// </summary>
         [JsonProperty("icon_url", NullValueHandling = NullValueHandling.Ignore)]
-        public Uri IconUrl { get; internal set; }
+        public DiscordUri IconUrl { get; internal set; }
 
         /// <summary>
         /// Gets the proxied url of the footer's icon.
         /// </summary>
         [JsonProperty("proxy_icon_url", NullValueHandling = NullValueHandling.Ignore)]
-        public Uri ProxyIconUrl { get; internal set; }
+        public DiscordUri ProxyIconUrl { get; internal set; }
 
         internal DiscordEmbedFooter() { }
     }

--- a/DSharpPlus/Entities/DiscordEmbedImage.cs
+++ b/DSharpPlus/Entities/DiscordEmbedImage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using DSharpPlus.Net;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
@@ -12,13 +13,13 @@ namespace DSharpPlus.Entities
         /// Gets the source url of the image.
         /// </summary>
         [JsonProperty("url", NullValueHandling = NullValueHandling.Ignore)]
-        public Uri Url { get; internal set; }
+        public DiscordUri Url { get; internal set; }
 
         /// <summary>
         /// Gets a proxied url of the image.
         /// </summary>
         [JsonProperty("proxy_url", NullValueHandling = NullValueHandling.Ignore)]
-        public Uri ProxyUrl { get; internal set; }
+        public DiscordUri ProxyUrl { get; internal set; }
 
         /// <summary>
         /// Gets the height of the image.

--- a/DSharpPlus/Entities/DiscordEmbedThumbnail.cs
+++ b/DSharpPlus/Entities/DiscordEmbedThumbnail.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using DSharpPlus.Net;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
@@ -12,13 +13,13 @@ namespace DSharpPlus.Entities
         /// Gets the source url of the thumbnail (only https).
         /// </summary>
         [JsonProperty("url", NullValueHandling = NullValueHandling.Ignore)]
-        public Uri Url { get; internal set; }
+        public DiscordUri Url { get; internal set; }
 
         /// <summary>
         /// Gets a proxied url of the thumbnail.
         /// </summary>
         [JsonProperty("proxy_url", NullValueHandling = NullValueHandling.Ignore)]
-        public Uri ProxyUrl { get; internal set; }
+        public DiscordUri ProxyUrl { get; internal set; }
 
         /// <summary>
         /// Gets the height of the thumbnail.

--- a/DSharpPlus/Entities/DiscordUri.cs
+++ b/DSharpPlus/Entities/DiscordUri.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Net
+{
+    /// <summary>
+    /// An URI in a Discord embed doesn't necessarily conform to the RFC 3986. If it uses the <c>attachment://</c>
+    /// protocol, it mustn't contain a trailing slash to be interpreted correctly as an embed attachment reference by
+    /// Discord.
+    /// </summary>
+    public class DiscordUri
+    {
+#if NETSTANDARD1_1
+        /// <inheritdoc />
+        /// <summary>The exception that is thrown when an invalid Uniform Resource Identifier (URI) is detected.</summary>
+        public class UriFormatException : FormatException
+        {
+            /// <inheritdoc />
+            /// <summary>Initializes a new instance of the <see cref="T:System.UriFormatException"></see> class with the specified message.</summary>
+            /// <param name="textString">The error message string.</param>
+            internal UriFormatException(string textString) : base(textString)
+            {
+            }
+        }
+#endif
+
+        private readonly object _value;
+
+        /// <summary>
+        /// The type of this URI.
+        /// </summary>
+        public DiscordUriType Type { get; }
+
+        internal DiscordUri(Uri value)
+        {
+            this._value = value ?? throw new ArgumentNullException(nameof(value));
+            this.Type = DiscordUriType.Standard;
+        }
+
+        internal DiscordUri(string value)
+        {
+            if (value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            if (IsStandard(value))
+            {
+                this._value = new Uri(value);
+                this.Type = DiscordUriType.Standard;
+            }
+            else
+            {
+                this._value = value;
+                this.Type = DiscordUriType.NonStandard;
+            }
+        }
+
+        // can be changed in future
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsStandard(string value) => !value.StartsWith("attachment://");
+
+        /// <summary>
+        /// Returns a string representation of this DiscordUri.
+        /// </summary>
+        /// <returns>This DiscordUri, as a string.</returns>
+        public override string ToString() => this._value.ToString();
+
+        /// <summary>
+        /// Converts this DiscordUri into a canonical representation of a <see cref="Uri"/> if it can be represented as
+        /// such, throwing an exception otherwise.
+        /// </summary>
+        /// <returns>A canonical representation of this DiscordUri.</returns>
+        /// <exception cref="UriFormatException">If <see cref="Type"/> is not <see cref="DiscordUriType.Standard"/>, as
+        /// that would mean creating an invalid Uri, which would result in loss of data.</exception>
+        public Uri ToUri()
+            => this.Type == DiscordUriType.Standard
+                ? this._value as Uri
+                : throw new UriFormatException(
+                    $@"DiscordUri ""{this._value}"" would be invalid as a regular URI, please the {nameof(this.Type)} property first.");
+
+        internal class DiscordUriJsonConverter : JsonConverter
+        {
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                writer.WriteValue((value as DiscordUri)._value);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
+                JsonSerializer serializer)
+            {
+                if (!(reader.Value is string s))
+                    throw new JsonReaderException("DiscordUri value invalid format! This is a bug in DSharpPlus. " +
+                                                  $"Include the value in your bug report: [[{reader.Value}]]");
+                
+                return IsStandard(s)
+                    ? new DiscordUri(new Uri(s))
+                    : new DiscordUri(s);
+            }
+
+            public override bool CanConvert(Type objectType) => objectType == typeof(DiscordUri);
+        }
+    }
+
+    public enum DiscordUriType : byte
+    {
+        /// <summary>
+        /// Represents a URI that conforms to RFC 3986, meaning it's stored internally as a <see cref="Uri"/> and will
+        /// contain a trailing slash after the domain name.
+        /// </summary>
+        Standard,
+
+        /// <summary>
+        /// Represents a URI that does not conform to RFC 3986, meaning it's stored internally as a plain string and
+        /// should be treated as one.
+        /// </summary>
+        NonStandard
+    }
+}

--- a/DSharpPlus/Entities/DiscordUri.cs
+++ b/DSharpPlus/Entities/DiscordUri.cs
@@ -89,9 +89,13 @@ namespace DSharpPlus.Net
             public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
                 JsonSerializer serializer)
             {
-                if (!(reader.Value is string s))
+                var val = reader.Value;
+                if (val == null)
+                    return null;
+                
+                if (!(val is string s))
                     throw new JsonReaderException("DiscordUri value invalid format! This is a bug in DSharpPlus. " +
-                                                  $"Include the value in your bug report: [[{reader.Value}]]");
+                                                  $"Include the type in your bug report: [[{reader.TokenType}]]");
                 
                 return IsStandard(s)
                     ? new DiscordUri(new Uri(s))


### PR DESCRIPTION
# Summary
Adds support for attachments in embeds.

This is how it looks currently:
![image](https://user-images.githubusercontent.com/13633343/43363043-44872818-92d1-11e8-878c-d464f011d3ec.png)

This is how it can, and should look:
![image](https://user-images.githubusercontent.com/13633343/43363044-51730c86-92d1-11e8-8da1-df195e3b1c61.png)

# Details
At the moment, the lib stores URLs in embeds as Uri objects. Seems reasonable, but not to Discord. Attachments in embeds are possible by using a weird non-standard `attachment://FILENAME` protocol. This is where the problems start: According to [some people pretending to own the Internet](https://www.ietf.org/rfc/rfc3986.txt), the hostname in the URI should implicitly contain a trailing slash (or something like that) and the implementation of Uri in .NET [takes this very literally](https://sharplab.io/#v2:C4LgTgrgdgNAJiA1AHwAIAYAEqCMBuAWAChUBmbHANmwCYKB2TAb2Mze3N2tQBYKAOABQBKZq3YTcATkFQApgHdMAVTABLQQCIAhsGDaAxgAsAtnKigA9JYBGAezsA6AA5QA5puHDCRCQF9iPyA=). The trailing slash added by .NET, of course, makes the image URL be silently ignored. I haven't been able to figure out why the attachments in some fields work anyway, but this makes the behavior consistent.

# Changes proposed
I've implemented a class `DiscordUri` that functions as an union of `string` (for `attachment://`) or `Uri` (for everything else). It includes a custom serializer and should function as a drop-in replacement for Uri. Of course, for efficiency's sake, I wouldn't recommend using it for anything other than the embeds.

I also cleaned up some spaghetti code in `DiscordJson` that was making it really hard to work with.

# Notes
This is the command I used to test this PR, both before and after the changes:
```cs

        [Command("test420")]
        public Task Test420(CommandContext ctx)
        {
            return ctx.RespondWithFilesAsync(embed: new DiscordEmbedBuilder
            {
                Author = new DiscordEmbedBuilder.EmbedAuthor
                {
                    IconUrl = "attachment://attachment1.png",
                    Name = "fofof"
                },
                Footer = new DiscordEmbedBuilder.EmbedFooter
                {
                    IconUrl = "attachment://attachment2.png",
                    Text = "foobar"
                },
                ImageUrl = "attachment://attachment3.png",
                ThumbnailUrl = "attachment://attachment4.png",
                Description = "hello there"
            }, files: new Dictionary<string, Stream>
            {
                ["attachment1.png"] = new FileStream(@"C:\Users\Rafael\Pictures\3.0.png", FileMode.Open, FileAccess.Read),
                ["attachment2.png"] = new FileStream(@"C:\Users\Rafael\Pictures\3.0.png", FileMode.Open, FileAccess.Read),
                ["attachment3.png"] = new FileStream(@"C:\Users\Rafael\Pictures\3.0.png", FileMode.Open, FileAccess.Read),
                ["attachment4.png"] = new FileStream(@"C:\Users\Rafael\Pictures\3.0.png", FileMode.Open, FileAccess.Read),
                ["attachment5.png"] = new FileStream(@"C:\Users\Rafael\Pictures\3.0.png", FileMode.Open, FileAccess.Read),
            });
        }
```