### PR TITLE
Fix typo in xmldoc for DiscordMember.Hierarchy

### DIFF
--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -132,7 +132,7 @@ namespace DSharpPlus.Entities
             => this.Id == this.Guild.OwnerId;
 
         /// <summary>
-        /// Gets the member's position in the role hierachy, which is the member's highest role's position. Returns <see cref="int.MaxValue"/> for guild's owner.
+        /// Gets the member's position in the role hierarchy, which is the member's highest role's position. Returns <see cref="int.MaxValue"/> for guild's owner.
         /// </summary>
         [JsonIgnore]
         public int Hierarchy


### PR DESCRIPTION
# Summary
Fixes a typo in the docs for DiscordMember.Hierarchy.

# Details
The summary for that property says hierachy instead of hierarchy.

# Changes proposed
* Change the word "hierachy" in the summary to "hierarchy."

# Notes
This PR summary is longer than the actual commit data.