### PR TITLE
DiscordEmbedBuilder (copy ctor) - Fixes #329

### DIFF
--- a/DSharpPlus/Entities/DiscordEmbedBuilder.cs
+++ b/DSharpPlus/Entities/DiscordEmbedBuilder.cs
@@ -133,7 +133,8 @@ namespace DSharpPlus.Entities
             this.Url = original.Url?.ToString();
             this.Color = original.Color;
             this.Timestamp = original.Timestamp;
-
+            this.ThumbnailUrl = original.Thumbnail?.Url?.ToString();
+            
             if (original.Author != null)
                 this.Author = new EmbedAuthor
                 {


### PR DESCRIPTION
# Summary
Fixes #329 where `ThumbnailUrl` was not copied in the ctor of `DiscordEmbedBuilder` that takes a `DiscordEmbed`

# Changes proposed
Add this line `this.ThumbnailUrl = original.Thumbnail?.Url?.ToString();`