### PR TITLE
Add an overload for GetReactionsAsync in DiscordRestClient

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -473,6 +473,9 @@ namespace DSharpPlus
 
         public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, string emoji)
             => ApiClient.GetReactionsAsync(channel_id, message_id, emoji);
+	    
+        public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, DiscordEmoji emoji)
+            => ApiClient.GetReactionsAsync(channel_id, message_id, emoji.ToReactionString());
 
         public Task DeleteAllReactionsAsync(ulong channel_id, ulong message_id, string reason)
             => ApiClient.DeleteAllReactionsAsync(channel_id, message_id, reason);


### PR DESCRIPTION
# Summary
Added an overload for the method GetReactionsAsync in DiscordRestClient that takes a DiscordEmoji to implicitly use ToReactionString method.

# Details
Added an overload for that method in DiscordRestClient.cs

*This time the pr is less trash (hello #304)*