### PR TITLE
Fix #314 - Timestamp property throws ArgumentNullException

### DIFF
--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -97,8 +97,9 @@ namespace DSharpPlus.Entities
         /// Gets the message's creation timestamp.
         /// </summary>
         [JsonIgnore]
-        public DateTimeOffset Timestamp 
-            => DateTimeOffset.Parse(this.TimestampRaw, CultureInfo.InvariantCulture);
+        public DateTimeOffset Timestamp
+            => !string.IsNullOrWhiteSpace(this.TimestampRaw) && DateTimeOffset.TryParse(this.TimestampRaw, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dto) ?
+                dto : this.CreationTimestamp;
 
         [JsonProperty("timestamp", NullValueHandling = NullValueHandling.Ignore)]
         internal string TimestampRaw { get; set; }


### PR DESCRIPTION
# Summary 
Sometimes, `TimestampRaw` is null (message not in cache?), so the method `DatetimeOffset.Parse` would throw an ArgumentNullException. But we have the property `CreationTimestamp` in `SnowflakeObject` that is set with the Id of the snowflake, so, in case `TimestampRaw` is null, we just return the value of `CreationTimestamp`, if `TimestampRaw` is not null, then we try to parse and return it.

# Details
Simply check if the property `TimestampRaw` is null, then TryParse instead of Parse (to avoid exceptions), and in cases we can't parse and the property is null, we can secure `Timestamp` property from not being null by taking `CreationTimestamp` value.