### PR TITLE
Fail fast if negative limit is passed to GetMessages, fast track if limit is zero

### DIFF
--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -367,6 +367,12 @@ namespace DSharpPlus.Entities
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group)
                 throw new ArgumentException("Cannot get the messages of a non-text channel");
 
+            if (limit < 0)
+                throw new ArgumentException("Cannot get a negative number of messages.");
+
+            if (limit == 0)
+                return Array.Empty<DiscordMessage>();
+
             //return this.Discord.ApiClient.GetChannelMessagesAsync(this.Id, limit, before, after, around);
             if (limit > 100 && around != null)
                 throw new InvalidOperationException("Cannot get more than 100 messages around specified ID.");


### PR DESCRIPTION
# Summary
Corrects a misleading exception when GetMessages is called with limit < 0, and fast-tracks when limit is 0.

# Details
Previously, passing limit < 0 would bubble up an `ArgumentOutOfRangeException` from the List constructor; this makes it throw an ArgumentException. I also made it so it returns a singleton empty array when limit is 0.

# Changes proposed
* If limit is < 0, throw an ArgumentException
* If limit is 0, return `Array.Empty<DiscordMessage>()` (a singleton empty array of DiscordMessage)