### PR TITLE
Added MayStartNext and fixed TrackExceptionEvent not being fired

### DIFF
--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -359,8 +359,8 @@ namespace DSharpPlus.Lavalink
                                 await lvl_evts.InternalTrackStuckAsync(new TrackStuckData { Track = jsonData["track"].ToString(), Threshold = (long)jsonData["thresholdMs"] }).ConfigureAwait(false);
                             break;
                         case EventType.TrackExceptionEvent:
-                            if (this.ConnectedGuilds.TryGetValue(guildId, out var lvl_evts))
-                                await lvl_evts.InternalTrackExceptionAsync(new TrackExceptionData { Track = jsonData["track"].ToString(), Error = jsonData["error"].ToString() }).ConfigureAwait(false);
+                            if (this.ConnectedGuilds.TryGetValue(guildId, out var lvl_evte))
+                                await lvl_evte.InternalTrackExceptionAsync(new TrackExceptionData { Track = jsonData["track"].ToString(), Error = jsonData["error"].ToString() }).ConfigureAwait(false);
                             break;
                     }
                     break;

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -354,10 +354,13 @@ namespace DSharpPlus.Lavalink
                             if (this.ConnectedGuilds.TryGetValue(guildId, out var lvl_evtf))
                                 await lvl_evtf.InternalPlaybackFinishedAsync(new TrackFinishData { Track = jsonData["track"].ToString(), Reason = reason }).ConfigureAwait(false);
                             break;
-
                         case EventType.TrackStuckEvent:
                             if (this.ConnectedGuilds.TryGetValue(guildId, out var lvl_evts))
                                 await lvl_evts.InternalTrackStuckAsync(new TrackStuckData { Track = jsonData["track"].ToString(), Threshold = (long)jsonData["thresholdMs"] }).ConfigureAwait(false);
+                            break;
+                        case EventType.TrackExceptionEvent:
+                            if (this.ConnectedGuilds.TryGetValue(guildId, out var lvl_evts))
+                                await lvl_evts.InternalTrackExceptionAsync(new TrackExceptionData { Track = jsonData["track"].ToString(), Error = jsonData["error"].ToString() }).ConfigureAwait(false);
                             break;
                     }
                     break;

--- a/DSharpPlus.Lavalink/LavalinkUtil.cs
+++ b/DSharpPlus.Lavalink/LavalinkUtil.cs
@@ -13,7 +13,7 @@ namespace DSharpPlus.Lavalink
         private static UTF8Encoding UTF8 { get; } = new UTF8Encoding(false);
 
         /// <summary>
-        /// Indicates whether a new track should be started on receiving this event. If this is false, either this event is
+        /// Indicates whether a new track should be started after reciving this TrackEndReason. If this is false, either this event is
         /// already triggered because another track started (REPLACED) or because the player is stopped (STOPPED, CLEANUP).
         /// </summary>
         public static bool MayStartNext(this TrackEndReason reason)

--- a/DSharpPlus.Lavalink/LavalinkUtil.cs
+++ b/DSharpPlus.Lavalink/LavalinkUtil.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using DSharpPlus.Lavalink.EventArgs;
 
 namespace DSharpPlus.Lavalink
 {
@@ -11,6 +12,13 @@ namespace DSharpPlus.Lavalink
     {
         private static UTF8Encoding UTF8 { get; } = new UTF8Encoding(false);
 
+        /// <summary>
+        /// Indicates whether a new track should be started on receiving this event. If this is false, either this event is
+        /// already triggered because another track started (REPLACED) or because the player is stopped (STOPPED, CLEANUP).
+        /// </summary>
+        public static bool MayStartNext(this TrackEndReason reason)
+            => reason == TrackEndReason.Finished || reason == TrackEndReason.LoadFailed;
+        
         /// <summary>
         /// Decodes a Lavalink track string.
         /// </summary>


### PR DESCRIPTION
# Details
Added `MayStartNext` extention method to `TrackEndReason`. (This is from [lavaplayer](https://github.com/sedmelluq/lavaplayer/blob/9889618c9ce8a08b89f091fd80084308e71b99e7/main/src/main/java/com/sedmelluq/discord/lavaplayer/track/AudioTrackEndReason.java#L36))
And fixed `TrackExceptionEvent` not being fired.

Fixes #339 

# Notes
`MayStartNext` can be helpful, just call `if (!e.Reason.MayStartNext()) return;` in the TrackFinish event.