### PR TITLE
Fix library crashing on client receive message

### DIFF
--- a/DSharpPlus/Entities/DiscordEmoji.EmojiUtils.cs
+++ b/DSharpPlus/Entities/DiscordEmoji.EmojiUtils.cs
@@ -2016,7 +2016,9 @@ namespace DSharpPlus.Entities
                 ["♡"] = "\u2764"
             };
             
-            DiscordNameLookup = UnicodeEmojis.ToDictionary(xg => xg.Value, xg => xg.Key);
+            DiscordNameLookup = UnicodeEmojis
+                .GroupBy(e => e.Value, (key, xg) => xg.FirstOrDefault())
+                .ToDictionary(xkvp => xkvp.Value, xkvp => xkvp.Key);
             
             var emojiArray = UnicodeEmojis.Values.Distinct().ToArray();
             Array.Sort(emojiArray);


### PR DESCRIPTION
# Summary
Fixes the client crashing when receiving a message

# Details
I thought `ToDictionary` would purge duplicate keys, I was very wrong

# Changes proposed
* Make sure keys are distinct before creating DiscordNameLookup dictionary

# Notes
This was a huge mistake