### PR TITLE
Fix activity game party size exploit/bug

### DIFF
--- a/DSharpPlus/Entities/DiscordActivity.cs
+++ b/DSharpPlus/Entities/DiscordActivity.cs
@@ -165,12 +165,12 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets current party size.
         /// </summary>
-        public int? CurrentPartySize { get; internal set; }
+        public long? CurrentPartySize { get; internal set; }
 
         /// <summary>
         /// Gets maximum party size.
         /// </summary>
-        public int? MaximumPartySize { get; internal set; }
+        public long? MaximumPartySize { get; internal set; }
 
         /// <summary>
         /// Gets the party ID.

--- a/DSharpPlus/Net/Abstractions/TransportActivity.cs
+++ b/DSharpPlus/Net/Abstractions/TransportActivity.cs
@@ -176,12 +176,12 @@ namespace DSharpPlus.Net.Abstractions
                 /// <summary>
                 /// Gets the current number of players in the party.
                 /// </summary>
-                public int Current { get; internal set; }
+                public long Current { get; internal set; }
 
                 /// <summary>
                 /// Gets the maximum party size.
                 /// </summary>
-                public int Maximum { get; internal set; }
+                public long Maximum { get; internal set; }
             }
         }
 

--- a/DSharpPlus/Net/Abstractions/TransportActivity.cs
+++ b/DSharpPlus/Net/Abstractions/TransportActivity.cs
@@ -250,8 +250,8 @@ namespace DSharpPlus.Net.Abstractions
             var arr = ReadArrayObject(reader, serializer);
             return new TransportActivity.GameParty.GamePartySize
             {
-                Current = (int)arr[0],
-                Maximum = (int)arr[1],
+                Current = (long)arr[0],
+                Maximum = (long)arr[1],
             };
         }
 


### PR DESCRIPTION
# Summary
Fixes an [unintuitive error](https://pastebin.com/92jVrYKU) when deserializing malformed rich presence in activity.

# Details
The error happened due to bad Discord documentation. Party size is mislabeled as "integer" in the docs, which led to the bad implementation on our side. The exception is triggered by JSON.NET trying to convert a long to int.

# Changes proposed
* Change party size Int32 => Int64
