### PR TITLE
Implement GuildBefore value in GuildUpdated event

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -1174,12 +1174,18 @@ namespace DSharpPlus
                     SystemChannelId = gld.SystemChannelId,
                     VerificationLevel = gld.VerificationLevel,
                     VoiceRegionId = gld.VoiceRegionId,
-                    _channels = gld._channels,
-                    _emojis = gld._emojis,
-                    _members = gld._members,
-                    _roles = gld._roles,
-                    _voice_states = gld._voice_states
+                    _channels = new List<DiscordChannel>(),
+                    _emojis = new List<DiscordEmoji>(),
+                    _members = new HashSet<DiscordMember>(),
+                    _roles = new List<DiscordRole>(),
+                    _voice_states = new List<DiscordVoiceState>()
                 };
+
+                guild_old._channels.AddRange(gld._channels);
+                guild_old._emojis.AddRange(gld._emojis);
+                guild_old._members.UnionWith(gld._members);
+                guild_old._roles.AddRange(gld._roles);
+                guild_old._voice_states.AddRange(gld._voice_states);
             }
 
             guild.Discord = this;

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -1139,8 +1139,48 @@ namespace DSharpPlus
 
         internal async Task OnGuildUpdateEventAsync(DiscordGuild guild, JArray rawMembers)
         {
+            DiscordGuild guild_old;
+
             if (!this._guilds.ContainsKey(guild.Id))
+            {
                 this._guilds[guild.Id] = guild;
+                guild_old = null;
+            }
+            else
+            {
+                var gld = this._guilds[guild.Id];
+
+                guild_old = new DiscordGuild
+                {
+                    Discord = gld.Discord,
+                    Name = gld.Name,
+                    AfkChannelId = gld.AfkChannelId,
+                    AfkTimeout = gld.AfkTimeout,
+                    DefaultMessageNotifications = gld.DefaultMessageNotifications,
+                    EmbedChannelId = gld.EmbedChannelId,
+                    EmbedEnabled = gld.EmbedEnabled,
+                    ExplicitContentFilter = gld.ExplicitContentFilter,
+                    Features = gld.Features,
+                    IconHash = gld.IconHash,
+                    Id = gld.Id,
+                    IsLarge = gld.IsLarge,
+                    IsSynced = gld.IsSynced,
+                    IsUnavailable = gld.IsUnavailable,
+                    JoinedAt = gld.JoinedAt,
+                    MemberCount = gld.MemberCount,
+                    MfaLevel = gld.MfaLevel,
+                    OwnerId = gld.OwnerId,
+                    SplashHash = gld.SplashHash,
+                    SystemChannelId = gld.SystemChannelId,
+                    VerificationLevel = gld.VerificationLevel,
+                    VoiceRegionId = gld.VoiceRegionId,
+                    _channels = gld._channels,
+                    _emojis = gld._emojis,
+                    _members = gld._members,
+                    _roles = gld._roles,
+                    _voice_states = gld._voice_states
+                };
+            }
 
             guild.Discord = this;
             guild.IsUnavailable = false;
@@ -1180,7 +1220,7 @@ namespace DSharpPlus
                 xr._guild_id = guild.Id;
             }
 
-            await this._guildUpdated.InvokeAsync(new GuildUpdateEventArgs(this) { Guild = guild }).ConfigureAwait(false);
+            await this._guildUpdated.InvokeAsync(new GuildUpdateEventArgs(this) { GuildBefore = guild_old, GuildAfter = guild }).ConfigureAwait(false);
         }
 
         internal async Task OnGuildDeleteEventAsync(DiscordGuild guild, JArray rawMembers)

--- a/DSharpPlus/EventArgs/GuildUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/GuildUpdateEventArgs.cs
@@ -8,9 +8,14 @@ namespace DSharpPlus.EventArgs
     public class GuildUpdateEventArgs : DiscordEventArgs
     {
         /// <summary>
-        /// Gets the guild that was updated.
+        /// Gets the guild before it was updated.
         /// </summary>
-        public DiscordGuild Guild { get; internal set; }
+        public DiscordGuild GuildBefore { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild after it was updated.
+        /// </summary>
+        public DiscordGuild GuildAfter { get; internal set; }
 
         internal GuildUpdateEventArgs(DiscordClient client) : base(client) { }
     }


### PR DESCRIPTION
# Summary
Implement GuildBefore value in GuildUpdated event.

# Details / Changes proposed
If the guild is in the cache, we just copy it in a `guild_old` variable that we pass in the event args. If the guild was not in the cache the before value will just be null.

# Notes
I kept my tests in the test project.