### PR TITLE
Fix incorrect implementation of RoleCheckMode.All

### DIFF
--- a/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
@@ -46,6 +46,9 @@ namespace DSharpPlus.CommandsNext.Attributes
             switch (this.CheckMode)
             {
                 case RoleCheckMode.All:
+                    return Task.FromResult(this.RoleNames.Count == inc);
+                    
+                case RoleCheckMode.Pure:
                     return Task.FromResult(rnc == inc);
 
                 case RoleCheckMode.None:
@@ -72,6 +75,11 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// Member is required to have all of the specified roles.
         /// </summary>
         All,
+
+        /// <summary>
+        /// Member is required to have exactly the same roles as specified; no extra roles may be present.
+        /// </summary>
+        Pure,
 
         /// <summary>
         /// Member is required to have none of the specified roles.

--- a/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
@@ -48,7 +48,7 @@ namespace DSharpPlus.CommandsNext.Attributes
                 case RoleCheckMode.All:
                     return Task.FromResult(this.RoleNames.Count == inc);
                     
-                case RoleCheckMode.Pure:
+                case RoleCheckMode.SpecifiedOnly:
                     return Task.FromResult(rnc == inc);
 
                 case RoleCheckMode.None:
@@ -79,7 +79,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <summary>
         /// Member is required to have exactly the same roles as specified; no extra roles may be present.
         /// </summary>
-        Pure,
+        SpecifiedOnly,
 
         /// <summary>
         /// Member is required to have none of the specified roles.


### PR DESCRIPTION
# Summary
Fixes RequireRoles' RoleCheckMode.All mode's implementation not matching what is implied in the docs.

# Details
The mode is incorrectly comparing that all of the member's roles exactly equal the required ones; the docs imply only that the member must have all of the roles, not that they may not have any extra ones. I've fixed the implementation for it, and introduced RoleCheckMode.Pure as a replacement containing the old implementation.

# Changes proposed
* Compare result of intersect against required roles rather than all of member's roles
* Move old behavior to new enum member RoleCheckMode.Pure
