### PR TITLE
Assign skeleton object to Target in DiscordAuditLogObjects when the target couldn't be pulled from cache

### DIFF
--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -1,6 +1,7 @@
 ﻿#pragma warning disable CS0618
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading;
@@ -60,6 +61,7 @@ namespace DSharpPlus.Test
             Discord.VoiceStateUpdated += this.Discord_VoiceStateUpdated;
             Discord.GuildDownloadCompleted += this.Discord_GuildDownloadCompleted;
             Discord.GuildUpdated += this.Discord_GuildUpdated;
+            Discord.ChannelDeleted += this.Discord_ChannelDeleted;
 
             // voice config and the voice service itself
             var vcfg = new VoiceNextConfiguration
@@ -341,6 +343,15 @@ namespace DSharpPlus.Test
             Console.WriteLine(str);
 
             return Task.CompletedTask;
+        }
+
+        private async Task Discord_ChannelDeleted(ChannelDeleteEventArgs e)
+        {
+            var logs = (await e.Guild.GetAuditLogsAsync(5, null, AuditLogActionType.ChannelDelete).ConfigureAwait(false)).Cast<DiscordAuditLogChannelEntry>();
+            foreach (var entry in logs)
+            {
+                Console.WriteLine("TargetId: " + entry.TargetId);
+            }
         }
     }
 }

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -350,7 +350,7 @@ namespace DSharpPlus.Test
             var logs = (await e.Guild.GetAuditLogsAsync(5, null, AuditLogActionType.ChannelDelete).ConfigureAwait(false)).Cast<DiscordAuditLogChannelEntry>();
             foreach (var entry in logs)
             {
-                Console.WriteLine("TargetId: " + entry.TargetId);
+                Console.WriteLine("TargetId: " + entry.Target.Id);
             }
         }
     }

--- a/DSharpPlus/Entities/DiscordAuditLogObjects.cs
+++ b/DSharpPlus/Entities/DiscordAuditLogObjects.cs
@@ -53,11 +53,6 @@ namespace DSharpPlus.Entities
         public DiscordGuild Target { get; internal set; }
 
         /// <summary>
-        /// Gets the affected guild id.
-        /// </summary>
-        public ulong TargetId { get; internal set; }
-
-        /// <summary>
         /// Gets the the description of guild name's change.
         /// </summary>
         public PropertyChange<string> NameChange { get; internal set; }
@@ -121,11 +116,6 @@ namespace DSharpPlus.Entities
         /// Gets the affected channel.
         /// </summary>
         public DiscordChannel Target { get; internal set; }
-
-        /// <summary>
-        /// Gets the affected channel id.
-        /// </summary>
-        public ulong TargetId { get; internal set; }
 
         /// <summary>
         /// Gets the description of channel's name change.
@@ -202,11 +192,6 @@ namespace DSharpPlus.Entities
         /// </summary>
         public DiscordMember Target { get; internal set; }
 
-        /// <summary>
-        /// Gets the affected member id.
-        /// </summary>
-        public ulong TargetId { get; internal set; }
-
         internal DiscordAuditLogKickEntry() { }
     }
 
@@ -232,11 +217,6 @@ namespace DSharpPlus.Entities
         /// </summary>
         public DiscordMember Target { get; internal set; }
 
-        /// <summary>
-        /// Gets the affected member id.
-        /// </summary>
-        public ulong TargetId { get; internal set; }
-
         internal DiscordAuditLogBanEntry() { }
     }
 
@@ -246,11 +226,6 @@ namespace DSharpPlus.Entities
         /// Gets the affected member.
         /// </summary>
         public DiscordMember Target { get; internal set; }
-
-        /// <summary>
-        /// Gets the affected member id.
-        /// </summary>
-        public ulong TargetId { get; internal set; }
 
         /// <summary>
         /// Gets the description of member's nickname change.
@@ -286,11 +261,6 @@ namespace DSharpPlus.Entities
         /// Gets the affected role.
         /// </summary>
         public DiscordRole Target { get; internal set; }
-
-        /// <summary>
-        /// Gets the affected role id.
-        /// </summary>
-        public ulong TargetId { get; internal set; }
 
         /// <summary>
         /// Gets the description of role's name change.
@@ -331,11 +301,6 @@ namespace DSharpPlus.Entities
         /// Gets the affected invite.
         /// </summary>
         public DiscordInvite Target { get; internal set; }
-
-        /// <summary>
-        /// Gets the affected invite id.
-        /// </summary>
-        public ulong TargetId { get; internal set; }
 
         /// <summary>
         /// Gets the description of invite's max age change.
@@ -381,11 +346,6 @@ namespace DSharpPlus.Entities
         /// Gets the affected webhook.
         /// </summary>
         public DiscordWebhook Target { get; internal set; }
-
-        /// <summary>
-        /// Gets the affected webhook id.
-        /// </summary>
-        public ulong TargetId { get; internal set; }
         
         /// <summary>
         /// Gets the description of webhook's name change.
@@ -418,11 +378,6 @@ namespace DSharpPlus.Entities
         public DiscordEmoji Target { get; internal set; }
 
         /// <summary>
-        /// Gets the affected emoji id.
-        /// </summary>
-        public ulong TargetId { get; internal set; }
-
-        /// <summary>
         /// Gets the description of emoji's name change.
         /// </summary>
         public PropertyChange<string> NameChange { get; internal set; }
@@ -436,11 +391,6 @@ namespace DSharpPlus.Entities
         /// Gets the affected message. Note that more often than not, this will only have ID specified.
         /// </summary>
         public DiscordMessage Target { get; internal set; }
-
-        /// <summary>
-        /// Gets the affected message id.
-        /// </summary>
-        public ulong TargetId { get; internal set; }
 
         /// <summary>
         /// Gets the channel in which the action occured.

--- a/DSharpPlus/Entities/DiscordAuditLogObjects.cs
+++ b/DSharpPlus/Entities/DiscordAuditLogObjects.cs
@@ -53,6 +53,11 @@ namespace DSharpPlus.Entities
         public DiscordGuild Target { get; internal set; }
 
         /// <summary>
+        /// Gets the affected guild id.
+        /// </summary>
+        public ulong TargetId { get; internal set; }
+
+        /// <summary>
         /// Gets the the description of guild name's change.
         /// </summary>
         public PropertyChange<string> NameChange { get; internal set; }
@@ -116,6 +121,11 @@ namespace DSharpPlus.Entities
         /// Gets the affected channel.
         /// </summary>
         public DiscordChannel Target { get; internal set; }
+
+        /// <summary>
+        /// Gets the affected channel id.
+        /// </summary>
+        public ulong TargetId { get; internal set; }
 
         /// <summary>
         /// Gets the description of channel's name change.
@@ -192,6 +202,11 @@ namespace DSharpPlus.Entities
         /// </summary>
         public DiscordMember Target { get; internal set; }
 
+        /// <summary>
+        /// Gets the affected member id.
+        /// </summary>
+        public ulong TargetId { get; internal set; }
+
         internal DiscordAuditLogKickEntry() { }
     }
 
@@ -217,6 +232,11 @@ namespace DSharpPlus.Entities
         /// </summary>
         public DiscordMember Target { get; internal set; }
 
+        /// <summary>
+        /// Gets the affected member id.
+        /// </summary>
+        public ulong TargetId { get; internal set; }
+
         internal DiscordAuditLogBanEntry() { }
     }
 
@@ -226,6 +246,11 @@ namespace DSharpPlus.Entities
         /// Gets the affected member.
         /// </summary>
         public DiscordMember Target { get; internal set; }
+
+        /// <summary>
+        /// Gets the affected member id.
+        /// </summary>
+        public ulong TargetId { get; internal set; }
 
         /// <summary>
         /// Gets the description of member's nickname change.
@@ -261,6 +286,11 @@ namespace DSharpPlus.Entities
         /// Gets the affected role.
         /// </summary>
         public DiscordRole Target { get; internal set; }
+
+        /// <summary>
+        /// Gets the affected role id.
+        /// </summary>
+        public ulong TargetId { get; internal set; }
 
         /// <summary>
         /// Gets the description of role's name change.
@@ -301,6 +331,11 @@ namespace DSharpPlus.Entities
         /// Gets the affected invite.
         /// </summary>
         public DiscordInvite Target { get; internal set; }
+
+        /// <summary>
+        /// Gets the affected invite id.
+        /// </summary>
+        public ulong TargetId { get; internal set; }
 
         /// <summary>
         /// Gets the description of invite's max age change.
@@ -346,6 +381,11 @@ namespace DSharpPlus.Entities
         /// Gets the affected webhook.
         /// </summary>
         public DiscordWebhook Target { get; internal set; }
+
+        /// <summary>
+        /// Gets the affected webhook id.
+        /// </summary>
+        public ulong TargetId { get; internal set; }
         
         /// <summary>
         /// Gets the description of webhook's name change.
@@ -378,6 +418,11 @@ namespace DSharpPlus.Entities
         public DiscordEmoji Target { get; internal set; }
 
         /// <summary>
+        /// Gets the affected emoji id.
+        /// </summary>
+        public ulong TargetId { get; internal set; }
+
+        /// <summary>
         /// Gets the description of emoji's name change.
         /// </summary>
         public PropertyChange<string> NameChange { get; internal set; }
@@ -391,6 +436,11 @@ namespace DSharpPlus.Entities
         /// Gets the affected message. Note that more often than not, this will only have ID specified.
         /// </summary>
         public DiscordMessage Target { get; internal set; }
+
+        /// <summary>
+        /// Gets the affected message id.
+        /// </summary>
+        public ulong TargetId { get; internal set; }
 
         /// <summary>
         /// Gets the channel in which the action occured.

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -585,7 +585,7 @@ namespace DSharpPlus.Entities
             {
                 var tms = await this.Discord.ApiClient.ListGuildMembersAsync(this.Id, 1000, last == 0 ? null : (ulong?)last).ConfigureAwait(false);
                 recd = tms.Count;
-                
+
                 foreach (var xtm in tms)
                 {
                     var usr = new DiscordUser(xtm.User) { Discord = this.Discord };
@@ -604,7 +604,7 @@ namespace DSharpPlus.Entities
                 var tm = tms.LastOrDefault();
                 last = tm?.User.Id ?? 0;
             }
-            
+
             return new ReadOnlySet<DiscordMember>(recmbr);
         }
 
@@ -615,7 +615,7 @@ namespace DSharpPlus.Entities
         {
             if (!(this.Discord is DiscordClient client))
                 throw new InvalidOperationException("This operation is only valid for regular Discord clients.");
-            
+
             var payload = new GatewayPayload
             {
                 OpCode = GatewayOpCode.RequestGuildMembers,
@@ -746,7 +746,8 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.GuildUpdate:
                         entry = new DiscordAuditLogGuildEntry
                         {
-                            Target = this
+                            Target = this,
+                            TargetId = this.Id
                         };
 
                         var entrygld = entry as DiscordAuditLogGuildEntry;
@@ -863,7 +864,8 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.ChannelUpdate:
                         entry = new DiscordAuditLogChannelEntry
                         {
-                            Target = this._channels.FirstOrDefault(xch => xch.Id == xac.TargetId.Value)
+                            Target = this._channels.FirstOrDefault(xch => xch.Id == xac.TargetId.Value),
+                            TargetId = xac.TargetId.Value
                         };
 
                         var entrychn = entry as DiscordAuditLogChannelEntry;
@@ -1002,7 +1004,8 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.Kick:
                         entry = new DiscordAuditLogKickEntry
                         {
-                            Target = amd.ContainsKey(xac.TargetId.Value) ? amd[xac.TargetId.Value] : null
+                            Target = amd.ContainsKey(xac.TargetId.Value) ? amd[xac.TargetId.Value] : null,
+                            TargetId = xac.TargetId.Value
                         };
                         break;
 
@@ -1018,7 +1021,8 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.Unban:
                         entry = new DiscordAuditLogBanEntry
                         {
-                            Target = amd.ContainsKey(xac.TargetId.Value) ? amd[xac.TargetId.Value] : null
+                            Target = amd.ContainsKey(xac.TargetId.Value) ? amd[xac.TargetId.Value] : null,
+                            TargetId = xac.TargetId.Value
                         };
                         break;
 
@@ -1026,7 +1030,8 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.MemberRoleUpdate:
                         entry = new DiscordAuditLogMemberUpdateEntry
                         {
-                            Target = amd.ContainsKey(xac.TargetId.Value) ? amd[xac.TargetId.Value] : null
+                            Target = amd.ContainsKey(xac.TargetId.Value) ? amd[xac.TargetId.Value] : null,
+                            TargetId = xac.TargetId.Value
                         };
 
                         var entrymbu = entry as DiscordAuditLogMemberUpdateEntry;
@@ -1078,7 +1083,8 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.RoleUpdate:
                         entry = new DiscordAuditLogRoleUpdateEntry
                         {
-                            Target = this._roles.FirstOrDefault(xr => xr.Id == xac.TargetId.Value)
+                            Target = this._roles.FirstOrDefault(xr => xr.Id == xac.TargetId.Value),
+                            TargetId = xac.TargetId.Value
                         };
 
                         var entryrol = entry as DiscordAuditLogRoleUpdateEntry;
@@ -1147,7 +1153,11 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.InviteCreate:
                     case AuditLogActionType.InviteDelete:
                     case AuditLogActionType.InviteUpdate:
-                        entry = new DiscordAuditLogInviteEntry();
+                        entry = new DiscordAuditLogInviteEntry
+                        {
+                            TargetId = xac.TargetId.Value
+                        };
+
                         var inv = new DiscordInvite
                         {
                             Discord = this.Discord,
@@ -1262,7 +1272,8 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.WebhookUpdate:
                         entry = new DiscordAuditLogWebhookEntry
                         {
-                            Target = ahd.ContainsKey(xac.TargetId.Value) ? ahd[xac.TargetId.Value] : null
+                            Target = ahd.ContainsKey(xac.TargetId.Value) ? ahd[xac.TargetId.Value] : null,
+                            TargetId = xac.TargetId.Value
                         };
 
                         var entrywhk = entry as DiscordAuditLogWebhookEntry;
@@ -1320,7 +1331,8 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.EmojiUpdate:
                         entry = new DiscordAuditLogEmojiEntry
                         {
-                            Target = this._emojis.FirstOrDefault(xe => xe.Id == xac.TargetId.Value)
+                            Target = this._emojis.FirstOrDefault(xe => xe.Id == xac.TargetId.Value),
+                            TargetId = xac.TargetId.Value
                         };
 
                         var entryemo = entry as DiscordAuditLogEmojiEntry;
@@ -1347,7 +1359,8 @@ namespace DSharpPlus.Entities
                         entry = new DiscordAuditLogMessageEntry
                         {
                             Channel = this._channels.FirstOrDefault(xc => xc.Id == xac.Options?.ChannelId),
-                            MessageCount = xac.Options?.MessageCount
+                            MessageCount = xac.Options?.MessageCount,
+                            TargetId = xac.TargetId.Value
                         };
 
                         var entrymsg = entry as DiscordAuditLogMessageEntry;

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -746,8 +746,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.GuildUpdate:
                         entry = new DiscordAuditLogGuildEntry
                         {
-                            Target = this,
-                            TargetId = this.Id
+                            Target = this
                         };
 
                         var entrygld = entry as DiscordAuditLogGuildEntry;
@@ -864,8 +863,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.ChannelUpdate:
                         entry = new DiscordAuditLogChannelEntry
                         {
-                            Target = this._channels.FirstOrDefault(xch => xch.Id == xac.TargetId.Value),
-                            TargetId = xac.TargetId.Value
+                            Target = this._channels.FirstOrDefault(xch => xch.Id == xac.TargetId.Value) ?? new DiscordChannel { Id = xac.TargetId.Value }
                         };
 
                         var entrychn = entry as DiscordAuditLogChannelEntry;
@@ -1004,8 +1002,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.Kick:
                         entry = new DiscordAuditLogKickEntry
                         {
-                            Target = amd.ContainsKey(xac.TargetId.Value) ? amd[xac.TargetId.Value] : null,
-                            TargetId = xac.TargetId.Value
+                            Target = amd.ContainsKey(xac.TargetId.Value) ? amd[xac.TargetId.Value] : new DiscordMember { Id = xac.TargetId.Value }
                         };
                         break;
 
@@ -1021,8 +1018,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.Unban:
                         entry = new DiscordAuditLogBanEntry
                         {
-                            Target = amd.ContainsKey(xac.TargetId.Value) ? amd[xac.TargetId.Value] : null,
-                            TargetId = xac.TargetId.Value
+                            Target = amd.ContainsKey(xac.TargetId.Value) ? amd[xac.TargetId.Value] : new DiscordMember { Id = xac.TargetId.Value }
                         };
                         break;
 
@@ -1030,8 +1026,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.MemberRoleUpdate:
                         entry = new DiscordAuditLogMemberUpdateEntry
                         {
-                            Target = amd.ContainsKey(xac.TargetId.Value) ? amd[xac.TargetId.Value] : null,
-                            TargetId = xac.TargetId.Value
+                            Target = amd.ContainsKey(xac.TargetId.Value) ? amd[xac.TargetId.Value] : new DiscordMember { Id = xac.TargetId.Value }
                         };
 
                         var entrymbu = entry as DiscordAuditLogMemberUpdateEntry;
@@ -1083,8 +1078,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.RoleUpdate:
                         entry = new DiscordAuditLogRoleUpdateEntry
                         {
-                            Target = this._roles.FirstOrDefault(xr => xr.Id == xac.TargetId.Value),
-                            TargetId = xac.TargetId.Value
+                            Target = this._roles.FirstOrDefault(xr => xr.Id == xac.TargetId.Value) ?? new DiscordRole { Id = xac.TargetId.Value }
                         };
 
                         var entryrol = entry as DiscordAuditLogRoleUpdateEntry;
@@ -1153,10 +1147,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.InviteCreate:
                     case AuditLogActionType.InviteDelete:
                     case AuditLogActionType.InviteUpdate:
-                        entry = new DiscordAuditLogInviteEntry
-                        {
-                            TargetId = xac.TargetId.Value
-                        };
+                        entry = new DiscordAuditLogInviteEntry();
 
                         var inv = new DiscordInvite
                         {
@@ -1272,8 +1263,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.WebhookUpdate:
                         entry = new DiscordAuditLogWebhookEntry
                         {
-                            Target = ahd.ContainsKey(xac.TargetId.Value) ? ahd[xac.TargetId.Value] : null,
-                            TargetId = xac.TargetId.Value
+                            Target = ahd.ContainsKey(xac.TargetId.Value) ? ahd[xac.TargetId.Value] : new DiscordWebhook { Id = xac.TargetId.Value }
                         };
 
                         var entrywhk = entry as DiscordAuditLogWebhookEntry;
@@ -1331,8 +1321,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.EmojiUpdate:
                         entry = new DiscordAuditLogEmojiEntry
                         {
-                            Target = this._emojis.FirstOrDefault(xe => xe.Id == xac.TargetId.Value),
-                            TargetId = xac.TargetId.Value
+                            Target = this._emojis.FirstOrDefault(xe => xe.Id == xac.TargetId.Value) ?? new DiscordEmoji { Id = xac.TargetId.Value }
                         };
 
                         var entryemo = entry as DiscordAuditLogEmojiEntry;
@@ -1359,8 +1348,7 @@ namespace DSharpPlus.Entities
                         entry = new DiscordAuditLogMessageEntry
                         {
                             Channel = this._channels.FirstOrDefault(xc => xc.Id == xac.Options?.ChannelId),
-                            MessageCount = xac.Options?.MessageCount,
-                            TargetId = xac.TargetId.Value
+                            MessageCount = xac.Options?.MessageCount
                         };
 
                         var entrymsg = entry as DiscordAuditLogMessageEntry;


### PR DESCRIPTION
# Summary
Right now, if the Target of the AuditLog is null, we have no way to at least have the ID of the Target. When you deal with events such as `ChannelDeleted`, we have the object, but the, if we try to get the lasts audit log entries in the current guild, the channel, at this moment, is no more in the cache, so we have no way to check if the entry in audit logs were refering to the channel in our event.

# Details
I added an ulong `TargetId` in each DiscordAuditLog object that has a `Target` value.