### PR TITLE
Fix CloneAsync in DiscordChannel that was throwing a bad request.

### DIFF
--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -31,6 +31,14 @@ namespace DSharpPlus.Test
 		//    await ctx.RespondAsync("naam check your shitcode");
 		//}
 
+	    [Command("clonechannel")]
+	    public async Task CloneChannelAsync(CommandContext ctx, DiscordChannel chan = null)
+	    {
+	        chan = chan ?? ctx.Channel;
+
+	        await chan.CloneAsync().ConfigureAwait(false);
+	    }
+
 		[Command("intext")]
 		public async Task IntExtAsync(CommandContext ctx)
 		{

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -273,7 +273,16 @@ namespace DSharpPlus.Entities
             foreach (var ovr in this._permission_overwrites)
                 ovrs.Add(await new DiscordOverwriteBuilder().FromAsync(ovr).ConfigureAwait(false));
 
-            return await this.Guild.CreateChannelAsync(this.Name, this.Type, this.Parent, this.Bitrate, this.UserLimit, ovrs, this.IsNSFW, reason).ConfigureAwait(false);
+            int? bitrate = this.Bitrate;
+            int? userLimit = this.UserLimit;
+
+            if (this.Type != ChannelType.Voice)
+            {
+                bitrate = null;
+                userLimit = null;
+            }
+
+            return await this.Guild.CreateChannelAsync(this.Name, this.Type, this.Parent, bitrate, userLimit, ovrs, this.IsNSFW, reason).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary
When we try to Clone a channel, the API will throw a 400 bad request because if the channel is a Text channel, `CloneAsync` will send `0` instead of `null` for `UserLimit` and `Bitrate` properties. Or, according to Discord API documentations, the values must only be sent in case the channel type is `Voice`.

# Details
Simply create local variables in `CloneAsync` for `Bitrate` and `UserLimit` that will become `null` if the channel is not a Voice channel.