### PR TITLE
Removed unnecessary Where condition in ModifyPositionAsync that broke it Fixes #299

### DIFF
--- a/DSharpPlus/Entities/DiscordRole.cs
+++ b/DSharpPlus/Entities/DiscordRole.cs
@@ -76,7 +76,7 @@ namespace DSharpPlus.Entities
         /// <returns></returns>
         public Task ModifyPositionAsync(int position, string reason = null)
         {
-            var roles = this.Discord.Guilds[this._guild_id].Roles.Where(xr => xr.Id != this.Id).OrderByDescending(xr => xr.Position).ToArray();
+            var roles = this.Discord.Guilds[this._guild_id].Roles.OrderByDescending(xr => xr.Position).ToArray();
             var pmds = new RestGuildRoleReorderPayload[roles.Length];
             for (var i = 0; i < roles.Length; i++)
             {


### PR DESCRIPTION
# Summary
Fixes #299 var roles in ModifyPositionAsync now actually includes the role we want to change the position of.

# Details
var roles in ModifyPositionAsync now actually includes the role we want to change the position of, instead of calling DiscordApiClient.ModifyGuildRolePosition with no changes in positions.

# Changes proposed
Remove `.Where(xr => xr.Id != this.Id)` so that we can actually modify the position of the role we want.

Also matches up with syntax for adjusting channel positions.