### PR TITLE
Fix #357 - Added check for REPLACED TrackEndReason 

### DIFF
--- a/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
@@ -240,7 +240,7 @@ namespace DSharpPlus.Lavalink
 
         internal Task InternalPlaybackFinishedAsync(TrackFinishData e)
         {
-            this.CurrentState.CurrentTrack = default;
+            if(e.Reason != TrackEndReason.Replaced) this.CurrentState.CurrentTrack = default;
 
             var ea = new TrackFinishEventArgs(this, LavalinkUtilities.DecodeTrack(e.Track), e.Reason);
             return this._playbackFinished.InvokeAsync(ea);

--- a/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
@@ -240,7 +240,8 @@ namespace DSharpPlus.Lavalink
 
         internal Task InternalPlaybackFinishedAsync(TrackFinishData e)
         {
-            if(e.Reason != TrackEndReason.Replaced) this.CurrentState.CurrentTrack = default;
+            if(e.Reason != TrackEndReason.Replaced)
+                this.CurrentState.CurrentTrack = default;
 
             var ea = new TrackFinishEventArgs(this, LavalinkUtilities.DecodeTrack(e.Track), e.Reason);
             return this._playbackFinished.InvokeAsync(ea);


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Fixes #357 
LavalinkGuildConnection#InternalPlaybackFinishedAsync now check that the TrackEndReason is not Replaced before setting the current track to default.

# Details
InternalPlaybackFinishedAsync now works properly for TrackEndReason.Replaced

# Changes proposed
Add
```csharp
if (e.Reason != TrackEndReason.Replaced) this.CurrentState.CurrentTrack = default;
```
as proposed by #357 