### PR TITLE
Fixed interactivity's TimeoutBehaviour.Ignore action

### DIFF
--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -682,7 +682,6 @@ namespace DSharpPlus.Interactivity
 				switch (timeout_behaviour)
 				{
 					case TimeoutBehaviour.Ignore:
-						await m.DeleteAllReactionsAsync().ConfigureAwait(false);
 						break;
 					case TimeoutBehaviour.DeleteMessage:
 						// deleting a message deletes all reactions anyway


### PR DESCRIPTION
# Summary
There exists a slight oversight in the `InteractivityExtension.SendPaginatedMessage` function in case `TimeoutBehaviour.Ignore` is selected. The behaviour in that case is the same as `TimeoutBehaviour.DeleteReactions` case.

# Changes proposed
Do nothing in the `TimeoutBehaviour.Ignore` case.