### PR TITLE
Explicit command name in DuplicateCommandException message

### DIFF
--- a/DSharpPlus.CommandsNext/Exceptions/DuplicateCommandException.cs
+++ b/DSharpPlus.CommandsNext/Exceptions/DuplicateCommandException.cs
@@ -17,7 +17,7 @@ namespace DSharpPlus.CommandsNext.Exceptions
         /// </summary>
         /// <param name="name">Name of the command that was taken.</param>
         public DuplicateCommandException(string name)
-            : base("A command with specified name already exists.")
+            : base($"The command {name} already exists.")
         {
             this.CommandName = name;
         }


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
As said in D API, when we're debugging and starting the bot, if you have that kind of issue, it will probably just ride up the Exception to the `new Program().MainAsync().[...]` with the rectangle displaying the `Exception` message (`A command with specified name already exists`). For some of us, debugging looks a bit harder because you cannot directly put your mouse on the variable you want to check the value of like a monkey.

# Changes proposed
Simply explicitely include the command name in the Exception's message.

# Notes
```
Emzi × Emzi 👑Today at 08:39
how much more direct can it be?
```
I guess it's a lot more direct!