### PR TITLE
Fix Lavalink sometimes not decoding tracks properly

### DIFF
--- a/DSharpPlus.Lavalink/LavalinkUtil.cs
+++ b/DSharpPlus.Lavalink/LavalinkUtil.cs
@@ -42,16 +42,16 @@ namespace DSharpPlus.Lavalink
                 var messageHeader = br.ReadInt32();
                 var messageFlags = (int) ((messageHeader & 0xC0000000L) >> 30);
                 var messageSize = messageHeader & 0x3FFFFFFF;
-                if (messageSize != raw.Length)
-                    Console.WriteLine($"Size conflict: {messageSize} but was {raw.Length}");
+                //if (messageSize != raw.Length)
+                //    Warn($"Size conflict: {messageSize} but was {raw.Length}");
                 
                 // https://github.com/sedmelluq/lavaplayer/blob/804cd1038229230052d9b1dee5e6d1741e30e284/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayerManager.java#L268
 
                 // java bytes are signed
                 // https://docs.oracle.com/javase/7/docs/api/java/io/DataInput.html#readByte()
                 var version = (messageFlags & TRACK_INFO_VERSIONED) != 0 ? (br.ReadSByte() & 0xFF) : 1;
-                if (version != TRACK_INFO_VERSION)
-                    Console.WriteLine($"Version conflict: Expected {TRACK_INFO_VERSION} but got {version}");
+                //if (version != TRACK_INFO_VERSION)
+                //    Warn($"Version conflict: Expected {TRACK_INFO_VERSION} but got {version}");
 
                 decoded.Title = br.ReadJavaUtf8();
 

--- a/DSharpPlus.Lavalink/LavalinkUtil.cs
+++ b/DSharpPlus.Lavalink/LavalinkUtil.cs
@@ -10,8 +10,6 @@ namespace DSharpPlus.Lavalink
     /// </summary>
     public static class LavalinkUtilities
     {
-        private static UTF8Encoding UTF8 { get; } = new UTF8Encoding(false);
-
         /// <summary>
         /// Indicates whether a new track should be started after reciving this TrackEndReason. If this is false, either this event is
         /// already triggered because another track started (REPLACED) or because the player is stopped (STOPPED, CLEANUP).
@@ -26,55 +24,50 @@ namespace DSharpPlus.Lavalink
         /// <returns>Decoded Lavalink track.</returns>
         public static LavalinkTrack DecodeTrack(string track)
         {
-            var raw = Convert.FromBase64String(track);
+            // https://github.com/sedmelluq/lavaplayer/blob/804cd1038229230052d9b1dee5e6d1741e30e284/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayerManager.java#L63-L64
+            const int TRACK_INFO_VERSIONED = 1;
+            const int TRACK_INFO_VERSION = 2;
 
-            var msgval = BitConverter.ToInt32(raw, 0);
-            msgval = (int)SwapEndianness((uint)msgval);
-            var msgFlags = (int)((msgval & 0xC0000000L) >> 30);
-            var msgSize = msgval & 0x3FFFFFFF;
+            var raw = Convert.FromBase64String(track);
 
             var decoded = new LavalinkTrack
             {
                 TrackString = track
             };
-
-            using (var ms = new MemoryStream(msgSize))
+            
+            using (var ms = new MemoryStream(raw))
+            using (var br = new JavaBinaryReader(ms))
             {
-                ms.Write(raw, 4, msgSize);
-                ms.Position = 0;
+                // https://github.com/sedmelluq/lavaplayer/blob/b0c536098c4f92e6d03b00f19221021f8f50b19b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/MessageInput.java#L37-L39
+                var messageHeader = br.ReadInt32();
+                var messageFlags = (int) ((messageHeader & 0xC0000000L) >> 30);
+                var messageSize = messageHeader & 0x3FFFFFFF;
+                if (messageSize != raw.Length)
+                    Console.WriteLine($"Size conflict: {messageSize} but was {raw.Length}");
+                
+                // https://github.com/sedmelluq/lavaplayer/blob/804cd1038229230052d9b1dee5e6d1741e30e284/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayerManager.java#L268
 
-                using (var br = new BinaryReader(ms))
-                {
-                    var version = (msgFlags & 1) == 1 ? br.ReadByte() & 0xFF : 1;
+                // java bytes are signed
+                // https://docs.oracle.com/javase/7/docs/api/java/io/DataInput.html#readByte()
+                var version = (messageFlags & TRACK_INFO_VERSIONED) != 0 ? (br.ReadSByte() & 0xFF) : 1;
+                if (version != TRACK_INFO_VERSION)
+                    Console.WriteLine($"Version conflict: Expected {TRACK_INFO_VERSION} but got {version}");
 
-                    var len = br.ReadInt16();
-                    len = SwapEndianness(len);
-                    raw = br.ReadBytes(len);
-                    decoded.Title = UTF8.GetString(raw, 0, len);
+                decoded.Title = br.ReadJavaUtf8();
 
-                    len = br.ReadInt16();
-                    len = SwapEndianness(len);
-                    raw = br.ReadBytes(len);
-                    decoded.Author = UTF8.GetString(raw, 0, len);
+                decoded.Author = br.ReadJavaUtf8();
 
-                    decoded._length = (long)SwapEndianness((ulong)br.ReadInt64());
+                decoded._length = br.ReadInt64();
 
-                    len = br.ReadInt16();
-                    len = SwapEndianness(len);
-                    raw = br.ReadBytes(len);
-                    decoded.Identifier = UTF8.GetString(raw, 0, len);
+                decoded.Identifier = br.ReadJavaUtf8();
 
-                    decoded.IsStream = br.ReadBoolean();
+                decoded.IsStream = br.ReadBoolean();
 
-                    var isthere = br.ReadBoolean();
-                    if (isthere)
-                    {
-                        len = br.ReadInt16();
-                        len = SwapEndianness(len);
-                        raw = br.ReadBytes(len);
-                        decoded.Uri = version >= 2 ? new Uri(UTF8.GetString(raw, 0, len)) : null;
-                    }
-                }
+                var uri = br.ReadNullableString();
+                if (uri != null && version >= 2)
+                    decoded.Uri = new Uri(uri);
+                else
+                    decoded.Uri = null;
             }
 
             return decoded;
@@ -97,5 +90,140 @@ namespace DSharpPlus.Lavalink
             v = ((v & 0xFFFF0000FFFF0000) >> 16) | ((v & 0x0000FFFF0000FFFF) << 16);
             return ((v & 0xFF00FF00FF00FF00) >> 8) | ((v & 0x00FF00FF00FF00FF) << 8);
         }
+    }
+
+    /// <inheritdoc />
+    /// <summary>
+    /// Java's DataOutputStream always uses big-endian, while BinaryReader always uses little-endian.
+    /// This class converts a big-endian stream to little-endian, and includes some helper methods
+    /// for interacting with Lavaplayer/Lavalink.
+    /// </summary>
+    internal class JavaBinaryReader : BinaryReader
+    {
+        private static readonly Encoding Utf8NoBom = new UTF8Encoding();
+
+        public JavaBinaryReader(Stream ms) : base(ms, Utf8NoBom)
+        {
+        }
+
+        // https://docs.oracle.com/javase/7/docs/api/java/io/DataInput.html#readUTF()
+        public string ReadJavaUtf8()
+        {
+            var length = ReadUInt16(); // string size in bytes
+            var bytes = new byte[length];
+            var amountRead = Read(bytes, 0, length);
+            if (amountRead < length)
+                throw new InvalidDataException("EOS unexpected");
+
+            var output = new char[length];
+            var strlen = 0;
+
+            // i'm gonna blindly assume here that the javadocs had the correct endianness
+
+            for (var i = 0; i < length; i++)
+            {
+                var value1 = bytes[i];
+                if ((value1 & 0b10000000) == 0) // highest bit 1 is false
+                {
+                    output[strlen++] = (char) value1;
+                    continue;
+                }
+
+                // remember to skip one byte for every extra byte
+                var value2 = bytes[++i];
+                if ((value1 & 0b00100000) == 0 && // highest bit 3 is false
+                    (value1 & 0b11000000) != 0 && // highest bit 1 and 2 are true
+                    (value2 & 0b01000000) == 0 && // highest bit 2 is false
+                    (value2 & 0b10000000) != 0) //   highest bit 1 is true
+                {
+                    var value1Chop = (value1 & 0b00011111) << 6;
+                    var value2Chop = (value2 & 0b00111111);
+                    output[strlen++] = (char) (value1Chop | value2Chop);
+                    continue;
+                }
+                
+                var value3 = bytes[++i];
+                if ((value1 & 0b00010000) == 0 && // highest bit 4 is false
+                    (value1 & 0b11100000) != 0 && // highest bit 1,2,3 are true
+                    (value2 & 0b01000000) == 0 && // highest bit 2 is false
+                    (value2 & 0b10000000) != 0 && // highest bit 1 is true
+                    (value3 & 0b01000000) == 0 && // highest bit 2 is false
+                    (value3 & 0b10000000) != 0) //   highest bit 1 is true
+                {
+                    var value1Chop = (value1 & 0b00001111) << 12;
+                    var value2Chop = (value2 & 0b00111111) << 6;
+                    var value3Chop = (value3 & 0b00111111);
+                    output[strlen++] = (char) (value1Chop | value2Chop | value3Chop);
+                    continue;
+                }
+            }
+            
+            return new string(output, 0, strlen);
+        }
+
+        // https://github.com/sedmelluq/lavaplayer/blob/b0c536098c4f92e6d03b00f19221021f8f50b19b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/DataFormatTools.java#L114-L125
+        public string ReadNullableString()
+        {
+            return ReadBoolean() ? ReadJavaUtf8() : null;
+        }
+
+        // swap endianness
+		public override decimal ReadDecimal()
+		{
+            throw new MissingMethodException("This method does not have a Java equivalent");
+		}
+
+        // from https://github.com/Zoltu/Zoltu.EndianAwareBinaryReaderWriter under CC0
+		public override float ReadSingle() => Read(4, BitConverter.ToSingle);
+
+        public override double ReadDouble() => Read(8, BitConverter.ToDouble);
+
+        public override short ReadInt16() => Read(2, BitConverter.ToInt16);
+
+        public override int ReadInt32() => Read(4, BitConverter.ToInt32);
+
+        public override long ReadInt64() => Read(8, BitConverter.ToInt64);
+
+        public override ushort ReadUInt16() => Read(2, BitConverter.ToUInt16);
+
+        public override uint ReadUInt32() => Read(4, BitConverter.ToUInt32);
+
+        public override ulong ReadUInt64() => Read(8, BitConverter.ToUInt64);
+
+        private T Read<T>(int size, Func<byte[], int, T> converter) where T : struct
+		{
+			//Contract.Requires(size >= 0);
+			//Contract.Requires(converter != null);
+
+			var bytes = GetNextBytesNativeEndian(size);
+			return converter(bytes, 0);
+		}
+
+		private byte[] GetNextBytesNativeEndian(int count)
+		{
+			//Contract.Requires(count >= 0);
+			//Contract.Ensures(Contract.Result<Byte[]>() != null);
+			//Contract.Ensures(Contract.Result<Byte[]>().Length == count);
+
+			var bytes = GetNextBytes(count);
+			if (BitConverter.IsLittleEndian)
+				Array.Reverse(bytes);
+			return bytes;
+		}
+
+		private byte[] GetNextBytes(int count)
+		{
+			//Contract.Requires(count >= 0);
+			//Contract.Ensures(Contract.Result<Byte[]>() != null);
+			//Contract.Ensures(Contract.Result<Byte[]>().Length == count);
+
+			var buffer = new byte[count];
+			var bytesRead = BaseStream.Read(buffer, 0, count);
+
+			if (bytesRead != count)
+				throw new EndOfStreamException();
+
+			return buffer;
+		}
     }
 }

--- a/DSharpPlus.Lavalink/LavalinkUtil.cs
+++ b/DSharpPlus.Lavalink/LavalinkUtil.cs
@@ -168,13 +168,13 @@ namespace DSharpPlus.Lavalink
         }
 
         // swap endianness
-		public override decimal ReadDecimal()
-		{
+        public override decimal ReadDecimal()
+        {
             throw new MissingMethodException("This method does not have a Java equivalent");
-		}
+        }
 
         // from https://github.com/Zoltu/Zoltu.EndianAwareBinaryReaderWriter under CC0
-		public override float ReadSingle() => Read(4, BitConverter.ToSingle);
+        public override float ReadSingle() => Read(4, BitConverter.ToSingle);
 
         public override double ReadDouble() => Read(8, BitConverter.ToDouble);
 
@@ -191,39 +191,39 @@ namespace DSharpPlus.Lavalink
         public override ulong ReadUInt64() => Read(8, BitConverter.ToUInt64);
 
         private T Read<T>(int size, Func<byte[], int, T> converter) where T : struct
-		{
-			//Contract.Requires(size >= 0);
-			//Contract.Requires(converter != null);
+        {
+            //Contract.Requires(size >= 0);
+            //Contract.Requires(converter != null);
 
-			var bytes = GetNextBytesNativeEndian(size);
-			return converter(bytes, 0);
-		}
+            var bytes = GetNextBytesNativeEndian(size);
+            return converter(bytes, 0);
+        }
 
-		private byte[] GetNextBytesNativeEndian(int count)
-		{
-			//Contract.Requires(count >= 0);
-			//Contract.Ensures(Contract.Result<Byte[]>() != null);
-			//Contract.Ensures(Contract.Result<Byte[]>().Length == count);
+        private byte[] GetNextBytesNativeEndian(int count)
+        {
+            //Contract.Requires(count >= 0);
+            //Contract.Ensures(Contract.Result<Byte[]>() != null);
+            //Contract.Ensures(Contract.Result<Byte[]>().Length == count);
 
-			var bytes = GetNextBytes(count);
-			if (BitConverter.IsLittleEndian)
-				Array.Reverse(bytes);
-			return bytes;
-		}
+            var bytes = GetNextBytes(count);
+            if (BitConverter.IsLittleEndian)
+                Array.Reverse(bytes);
+            return bytes;
+        }
 
-		private byte[] GetNextBytes(int count)
-		{
-			//Contract.Requires(count >= 0);
-			//Contract.Ensures(Contract.Result<Byte[]>() != null);
-			//Contract.Ensures(Contract.Result<Byte[]>().Length == count);
+        private byte[] GetNextBytes(int count)
+        {
+            //Contract.Requires(count >= 0);
+            //Contract.Ensures(Contract.Result<Byte[]>() != null);
+            //Contract.Ensures(Contract.Result<Byte[]>().Length == count);
 
-			var buffer = new byte[count];
-			var bytesRead = BaseStream.Read(buffer, 0, count);
+            var buffer = new byte[count];
+            var bytesRead = BaseStream.Read(buffer, 0, count);
 
-			if (bytesRead != count)
-				throw new EndOfStreamException();
+            if (bytesRead != count)
+                throw new EndOfStreamException();
 
-			return buffer;
-		}
+            return buffer;
+        }
     }
 }


### PR DESCRIPTION
# Summary
Fixes DSharpPlus.Lavalink not being able to handle some tracks, triggering an exception on track finish.

# Details
Lavaplayer (and thus Lavalink) encodes tracks with DataOutputStream, which is a Very Bad Idea™️ for interoperability (as was once said by Jon Skeet himself). The main problem caused by this is the need to swap the endianness when reading data provided by it, which the lib accounts for. However, one sneakier problem is that the strings are [not encoded with real UTF-8](https://docs.oracle.com/javase/7/docs/api/java/io/DataInput.html#modified-utf-8), which the lib does not account for. This doesn't cause any problems when the tracks being decoded only contain characters in the range `\u0001` to `\u007F`, so it went unnoticed. The solution was to implement my own decoder for Java's arcane UTF-8, since copying and pasting code from the JDK would be a licensing nightmare.

# Changes proposed
* Rewrite LavalinkUtilities.DecodeTrack
* Create a JavaBinaryReader class designed to handle data from DataOutputStream

# Notes
This was actually a pretty fun bug to fix. I've tested the decoding with normal strings, strings containing special characters, and the strings reported to cause issues by thegiggitybyte#8099 on Discord.