### PR TITLE
Remove unnecessary guild redownloading (#383)

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -656,7 +656,7 @@ namespace DSharpPlus
         /// <param name="before">Gets guild before id</param>
         /// <param name="after">Gets guilds after id</param>
         /// <returns></returns>
-        public Task<IReadOnlyList<DiscordGuild>> GetCurrentUserGuildsAsync(int limit, ulong? before, ulong? after)
+        public Task<IReadOnlyList<DiscordGuild>> GetCurrentUserGuildsAsync(int limit = 100, ulong? before = null, ulong? after = null)
             => ApiClient.GetCurrentUserGuildsAsync(limit, before, after);
 
         /// <summary>

--- a/DSharpPlus/BaseDiscordClient.cs
+++ b/DSharpPlus/BaseDiscordClient.cs
@@ -115,10 +115,10 @@ namespace DSharpPlus
                 this.UserCache.AddOrUpdate(this.CurrentUser.Id, this.CurrentUser, (id, xu) => this.CurrentUser);
             }
 
-            if (this.Configuration.TokenType != TokenType.User && this.CurrentApplication == null)
+            if (this.Configuration.TokenType == TokenType.Bot && this.CurrentApplication == null)
                 this.CurrentApplication = await this.GetCurrentApplicationAsync().ConfigureAwait(false);
 
-            if (this.InternalVoiceRegions.Count == 0)
+            if (this.Configuration.TokenType != TokenType.Bearer && this.InternalVoiceRegions.Count == 0)
             {
                 var vrs = await this.ListVoiceRegionsAsync().ConfigureAwait(false);
                 foreach (var xvr in vrs)

--- a/DSharpPlus/Entities/DiscordUser.cs
+++ b/DSharpPlus/Entities/DiscordUser.cs
@@ -86,10 +86,10 @@ namespace DSharpPlus.Entities
         public virtual string Email { get; internal set; }
 
         /// <summary>
-        /// Gets the user's email address.
+        /// Gets the user's premium type.
         /// </summary>
         [JsonProperty("premium_type", NullValueHandling = NullValueHandling.Ignore)]
-        public virtual int? PremiumType { get; internal set; }
+        public virtual PremiumType? PremiumType { get; internal set; }
 
         /// <summary>
         /// Gets the user's mention string.

--- a/DSharpPlus/Entities/DiscordUser.cs
+++ b/DSharpPlus/Entities/DiscordUser.cs
@@ -22,6 +22,7 @@ namespace DSharpPlus.Entities
             this.MfaEnabled = transport.MfaEnabled;
             this.Verified = transport.Verified;
             this.Email = transport.Email;
+            this.PremiumType = transport.PremiumType;
         }
 
         /// <summary>
@@ -83,6 +84,12 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("email", NullValueHandling = NullValueHandling.Ignore)]
         public virtual string Email { get; internal set; }
+
+        /// <summary>
+        /// Gets the user's email address.
+        /// </summary>
+        [JsonProperty("premium_type", NullValueHandling = NullValueHandling.Ignore)]
+        public virtual int? PremiumType { get; internal set; }
 
         /// <summary>
         /// Gets the user's mention string.

--- a/DSharpPlus/Enums/PremiumType.cs
+++ b/DSharpPlus/Enums/PremiumType.cs
@@ -3,7 +3,8 @@
     /// <summary>
     /// The type of Nitro subscription on a user's account.
     /// </summary>
-    public enum PremiumType {
+    public enum PremiumType
+    {
         /// <summary>
         /// Includes app perks like animated emojis and avatars, but not games.
         /// </summary>

--- a/DSharpPlus/Enums/PremiumType.cs
+++ b/DSharpPlus/Enums/PremiumType.cs
@@ -1,0 +1,16 @@
+﻿namespace DSharpPlus
+{
+    /// <summary>
+    /// The type of Nitro subscription on a user's account.
+    /// </summary>
+    public enum PremiumType {
+        /// <summary>
+        /// Includes app perks like animated emojis and avatars, but not games.
+        /// </summary>
+        NitroClassic = 1,
+        /// <summary>
+        /// Includes app perks as well as the games subscription service.
+        /// </summary>
+        Nitro = 2
+    }
+}

--- a/DSharpPlus/Net/Abstractions/TransportUser.cs
+++ b/DSharpPlus/Net/Abstractions/TransportUser.cs
@@ -28,6 +28,9 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("email", NullValueHandling = NullValueHandling.Ignore)]
         public string Email { get; internal set; }
 
+        [JsonProperty("premium_type", NullValueHandling = NullValueHandling.Ignore)]
+        public int PremiumType { get; internal set; }
+
         internal TransportUser() { }
 
         internal TransportUser(TransportUser other)
@@ -40,6 +43,7 @@ namespace DSharpPlus.Net.Abstractions
             this.MfaEnabled = other.MfaEnabled;
             this.Verified = other.Verified;
             this.Email = other.Email;
+            this.PremiumType = other.PremiumType;
         }
     }
 }

--- a/DSharpPlus/Net/Abstractions/TransportUser.cs
+++ b/DSharpPlus/Net/Abstractions/TransportUser.cs
@@ -29,7 +29,7 @@ namespace DSharpPlus.Net.Abstractions
         public string Email { get; internal set; }
 
         [JsonProperty("premium_type", NullValueHandling = NullValueHandling.Ignore)]
-        public int PremiumType { get; internal set; }
+        public PremiumType? PremiumType { get; internal set; }
 
         internal TransportUser() { }
 

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1009,7 +1009,7 @@ namespace DSharpPlus.Net
             }
             else
             {
-                return new ReadOnlyCollection<DiscordGuild>(new List<DiscordGuild>(JsonConvert.DeserializeObject<IEnumerable<DiscordGuild>>(res.Response)));
+                return new ReadOnlyCollection<DiscordGuild>(JsonConvert.DeserializeObject<List<DiscordGuild>>(res.Response));
             }
         }
 

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -987,7 +987,7 @@ namespace DSharpPlus.Net
             return user_raw;
         }
 
-        internal async Task<IReadOnlyList<DiscordGuild>> GetCurrentUserGuildsAsync(int limit, ulong? before, ulong? after)
+        internal async Task<IReadOnlyList<DiscordGuild>> GetCurrentUserGuildsAsync(int limit = 100, ulong? before = null, ulong? after = null)
         {
             var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.GUILDS}?limit={limit}";
 
@@ -1009,15 +1009,7 @@ namespace DSharpPlus.Net
             }
             else
             {
-                var guilds_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordGuild>>(res.Response);
-
-                var glds = new List<DiscordGuild>();
-                foreach (var gld in guilds_raw)
-                {
-                    glds.Add(await GetGuildAsync(gld.Id).ConfigureAwait(false));
-                }
-
-                return new ReadOnlyCollection<DiscordGuild>(new List<DiscordGuild>(glds));
+                return new ReadOnlyCollection<DiscordGuild>(new List<DiscordGuild>(JsonConvert.DeserializeObject<IEnumerable<DiscordGuild>>(res.Response)));
             }
         }
 


### PR DESCRIPTION
# Summary
Fixes #383 

# Details
Repair #383, while not breaking #275, removing unnecessary guild downloads that only slow down the entire request. Even Kiritsu doesn't know why he wrote it now.