### PR TITLE
Add Locale property to DiscordUser/DiscordMember

### DIFF
--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -205,6 +205,12 @@ namespace DSharpPlus.Entities
             get { return this.User.Verified; }
             internal set { this.User.Verified = value; }
         }
+
+        public override string Locale
+        {
+            get { return this.User.Locale; }
+            internal set { this.User.Locale = value; }
+        }
         #endregion
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -206,6 +206,9 @@ namespace DSharpPlus.Entities
             internal set { this.User.Verified = value; }
         }
 
+        /// <summary>
+        /// Gets the user's chosen language
+        /// </summary>
         public override string Locale
         {
             get { return this.User.Locale; }

--- a/DSharpPlus/Entities/DiscordUser.cs
+++ b/DSharpPlus/Entities/DiscordUser.cs
@@ -23,6 +23,7 @@ namespace DSharpPlus.Entities
             this.Verified = transport.Verified;
             this.Email = transport.Email;
             this.PremiumType = transport.PremiumType;
+            this.Locale = transport.Locale;
         }
 
         /// <summary>
@@ -91,6 +92,12 @@ namespace DSharpPlus.Entities
         [JsonProperty("premium_type", NullValueHandling = NullValueHandling.Ignore)]
         public virtual PremiumType? PremiumType { get; internal set; }
 
+        /// <summary>
+        /// Gets the user's chosen language
+        /// </summary>
+        [JsonProperty("locale", NullValueHandling = NullValueHandling.Ignore)]
+        public virtual string Locale { get; internal set; }
+        
         /// <summary>
         /// Gets the user's mention string.
         /// </summary>

--- a/DSharpPlus/Net/Abstractions/TransportUser.cs
+++ b/DSharpPlus/Net/Abstractions/TransportUser.cs
@@ -31,6 +31,9 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("premium_type", NullValueHandling = NullValueHandling.Ignore)]
         public PremiumType? PremiumType { get; internal set; }
 
+        [JsonProperty("locale", NullValueHandling = NullValueHandling.Ignore)]
+        public string Locale { get; internal set; }
+
         internal TransportUser() { }
 
         internal TransportUser(TransportUser other)
@@ -44,6 +47,7 @@ namespace DSharpPlus.Net.Abstractions
             this.Verified = other.Verified;
             this.Email = other.Email;
             this.PremiumType = other.PremiumType;
+            this.Locale = other.Locale;
         }
     }
 }


### PR DESCRIPTION
# Summary
Fixes #387

# Details
Adds the locale property defined by Discord's documentation to the `DiscordUser` object.

# Notes
This isn't super useful right now as it's only sent for the current user (`DiscordClient#CurrentUser`), but who knows what Discord's gonna do with this eventually.