### PR TITLE
Add missing bot-to-bot DM sanity checks

### DIFF
--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -268,6 +268,9 @@ namespace DSharpPlus.Entities
         /// <returns>The sent message.</returns>
         public async Task<DiscordMessage> SendFileAsync(FileStream fileData, string content = null, bool is_tts = false, DiscordEmbed embed = null)
         {
+            if (this.IsBot && this.Discord.CurrentUser.IsBot)
+                throw new ArgumentException("Bots cannot DM each other");
+
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
             return await chn.SendFileAsync(fileData, content, is_tts, embed).ConfigureAwait(false);
         }
@@ -282,6 +285,9 @@ namespace DSharpPlus.Entities
         /// <returns>The sent message.</returns>
         public async Task<DiscordMessage> SendFileAsync(string filePath, string content = null, bool is_tts = false, DiscordEmbed embed = null)
         {
+            if (this.IsBot && this.Discord.CurrentUser.IsBot)
+                throw new ArgumentException("Bots cannot DM each other");
+
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
             return await chn.SendFileAsync(filePath, content, is_tts, embed).ConfigureAwait(false);
         }
@@ -297,6 +303,9 @@ namespace DSharpPlus.Entities
         /// <returns>The sent message.</returns>
         public async Task<DiscordMessage> SendMultipleFilesAsync(Dictionary<string, Stream> files, string content = null, bool is_tts = false, DiscordEmbed embed = null)
         {
+            if (this.IsBot && this.Discord.CurrentUser.IsBot)
+                throw new ArgumentException("Bots cannot DM each other");
+
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
             return await chn.SendMultipleFilesAsync(files, content, is_tts, embed).ConfigureAwait(false);
         }


### PR DESCRIPTION
# Summary
I noticed these were missing when looking over the code. This makes the rest of the DiscordMember direct message methods fail fast when a bot attempts to DM another bot.

# Details
Simply copied the checks from the methods that had them, to the methods that didn't.

# Changes proposed
* Assert that the current user and the target member are not both bots in DiscordMember.SendFileAsync and SendMultipleFilesAsync.

# Notes
I didn't test this PR.