### PR TITLE
Fixes #392 - DmHelp property

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
@@ -122,6 +122,7 @@ namespace DSharpPlus.CommandsNext
             this.UseDefaultCommandHandler = other.UseDefaultCommandHandler;
             this.Services = other.Services;
             this.StringPrefixes = other.StringPrefixes?.ToArray();
+            this.DmHelp = other.DmHelp;
         }
     }
 }


### PR DESCRIPTION
DmHelp property was not copied in the CommandsNextConfiguration copy constructor.

# Summary
Fixes #392 where DmHelp property was kept correctly and was always false.