### PR TITLE
Fast-track getting a channel's parent if it does not exist

### DIFF
--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -32,7 +32,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public DiscordChannel Parent 
-            => ParentId.HasValue ? this.Guild.Channels.FirstOrDefault(xc => xc.Id == this.ParentId) : null;
+            => this.ParentId.HasValue ? this.Guild.Channels.FirstOrDefault(xc => xc.Id == this.ParentId) : null;
 
         /// <summary>
         /// Gets the name of this channel.

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -32,7 +32,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public DiscordChannel Parent 
-            => this.Guild.Channels.FirstOrDefault(xc => xc.Id == this.ParentId);
+            => ParentId.HasValue ? this.Guild.Channels.FirstOrDefault(xc => xc.Id == this.ParentId) : null;
 
         /// <summary>
         /// Gets the name of this channel.


### PR DESCRIPTION
# Summary
Skips the enumeration through Guild.Channels when getting a channel's parent category if it does not have one.

# Details
Currently the enumeration will always return null, but this might not always be the case. Also, avoiding the enumeration I guess is faster and reduces the chance of it happening while the collection is being modified. I don't know, I'm really grasping at straws here.

# Changes proposed
* Skips the enumeration through Guild.Channels when getting a channel's parent category if it does not have one.

# Notes
Untested, but if there is a bug in this single line of code then I might just retire and never code again.