### PR TITLE
Make extensions disposable

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2372,10 +2372,16 @@ namespace DSharpPlus
             DisconnectAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             this.CurrentUser = null;
 
+            var extensions = _extensions; // prevent _extensions being modified during dispose
+            _extensions = null;
+            foreach (var extension in extensions)
+            {
+                if (extension is IDisposable disposable) disposable.Dispose();
+            }
+
             _cancelTokenSource?.Cancel();
             _guilds = null;
             _heartbeatTask = null;
-            _extensions = null;
             _privateChannels = null;
             _webSocketClient.DisconnectAsync(null).ConfigureAwait(false).GetAwaiter().GetResult();
             _webSocketClient.Dispose();


### PR DESCRIPTION
# Summary
Allows client extensions to be disposable.

# Details
I needed this to properly deal with a daemon thread. The implementation simply disposes all the extensions on a call to `DiscordClient.Dispose()`.

# Changes proposed
* Check and dispose DiscordClient extensions that implement IDisposable.

# Notes
I haven't tested this PR, but I'm about to do so very soon. You can wait until I do if you want.