### PR TITLE
Fix GetMessagesAsync (and possibly others) returning messages with no channel

### DIFF
--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -48,11 +48,14 @@ namespace DSharpPlus.Net
             return !post ? $"?{vals}" : vals;
         }
 
-        private DiscordMessage PrepareMessage(JToken msg_raw)
+        private DiscordMessage PrepareMessage(JToken msgRaw, ulong channelId)
         {
-            var author = msg_raw["author"].ToObject<TransportUser>();
-            var ret = msg_raw.ToDiscordObject<DiscordMessage>();
+            var author = msgRaw["author"].ToObject<TransportUser>();
+            var ret = msgRaw.ToDiscordObject<DiscordMessage>();
             ret.Discord = this.Discord;
+
+            if (ret.ChannelId == 0) // not all rest requests will provide a channel, so we have to set a default
+                ret.ChannelId = channelId;
 
             var guild = ret.Channel?.Guild;
 
@@ -69,27 +72,27 @@ namespace DSharpPlus.Net
                 ret.Author = usr;
             }
 
-            var mentioned_users = new List<DiscordUser>();
-            var mentioned_roles = guild != null ? new List<DiscordRole>() : null;
-            var mentioned_channels = guild != null ? new List<DiscordChannel>() : null;
+            var mentionedUsers = new List<DiscordUser>();
+            var mentionedRoles = guild != null ? new List<DiscordRole>() : null;
+            var mentionedChannels = guild != null ? new List<DiscordChannel>() : null;
 
             if (!string.IsNullOrWhiteSpace(ret.Content))
             {
                 if (guild != null)
                 {
-                    mentioned_users = Utilities.GetUserMentions(ret).Select(xid => guild._members.FirstOrDefault(xm => xm.Id == xid)).Cast<DiscordUser>().ToList();
-                    mentioned_roles = Utilities.GetRoleMentions(ret).Select(xid => guild._roles.FirstOrDefault(xr => xr.Id == xid)).ToList();
-                    mentioned_channels = Utilities.GetChannelMentions(ret).Select(xid => guild._channels.FirstOrDefault(xc => xc.Id == xid)).ToList();
+                    mentionedUsers = Utilities.GetUserMentions(ret).Select(xid => guild._members.FirstOrDefault(xm => xm.Id == xid)).Cast<DiscordUser>().ToList();
+                    mentionedRoles = Utilities.GetRoleMentions(ret).Select(xid => guild._roles.FirstOrDefault(xr => xr.Id == xid)).ToList();
+                    mentionedChannels = Utilities.GetChannelMentions(ret).Select(xid => guild._channels.FirstOrDefault(xc => xc.Id == xid)).ToList();
                 }
                 else
                 {
-                    mentioned_users = Utilities.GetUserMentions(ret).Select(this.Discord.InternalGetCachedUser).ToList();
+                    mentionedUsers = Utilities.GetUserMentions(ret).Select(this.Discord.InternalGetCachedUser).ToList();
                 }
             }
 
-            ret._mentionedUsers = mentioned_users;
-            ret._mentionedRoles = mentioned_roles;
-            ret._mentionedChannels = mentioned_channels;
+            ret._mentionedUsers = mentionedUsers;
+            ret._mentionedRoles = mentionedRoles;
+            ret._mentionedChannels = mentionedChannels;
 
             if (ret._reactions == null)
                 ret._reactions = new List<DiscordReaction>();
@@ -508,7 +511,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(JObject.Parse(res.Response));
+            var ret = this.PrepareMessage(JObject.Parse(res.Response), channel_id);
 
             return ret;
         }
@@ -540,7 +543,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(JObject.Parse(res.Response));
+            var ret = this.PrepareMessage(JObject.Parse(res.Response), channel_id);
 
             return ret;
         }
@@ -572,7 +575,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, values: values, files: file).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(JObject.Parse(res.Response));
+            var ret = this.PrepareMessage(JObject.Parse(res.Response), channel_id);
 
             return ret;
         }
@@ -603,7 +606,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, values: values, files: files).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(JObject.Parse(res.Response));
+            var ret = this.PrepareMessage(JObject.Parse(res.Response), channel_id);
 
             return ret;
         }
@@ -649,7 +652,7 @@ namespace DSharpPlus.Net
             var msgs_raw = JArray.Parse(res.Response);
             var msgs = new List<DiscordMessage>();
             foreach (var xj in msgs_raw)
-                msgs.Add(this.PrepareMessage(xj));
+                msgs.Add(this.PrepareMessage(xj, channel_id));
 
             return new ReadOnlyCollection<DiscordMessage>(new List<DiscordMessage>(msgs));
         }
@@ -662,7 +665,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(JObject.Parse(res.Response));
+            var ret = this.PrepareMessage(JObject.Parse(res.Response), channel_id);
 
             return ret;
         }
@@ -686,7 +689,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(JObject.Parse(res.Response));
+            var ret = this.PrepareMessage(JObject.Parse(res.Response), channel_id);
 
             return ret;
         }
@@ -814,7 +817,7 @@ namespace DSharpPlus.Net
             var msgs_raw = JArray.Parse(res.Response);
             var msgs = new List<DiscordMessage>();
             foreach (var xj in msgs_raw)
-                msgs.Add(this.PrepareMessage(xj));
+                msgs.Add(this.PrepareMessage(xj, channel_id));
 
             return new ReadOnlyCollection<DiscordMessage>(new List<DiscordMessage>(msgs));
         }


### PR DESCRIPTION
# Summary
Fixes GetMessagesAsync (and potentially other methods that do similar things) returning messages with no channel ID, which would raise an exception when calling a method such as `GetReactionsAsync`.

# Details
The REST API does not always provide messages with channel IDs, for some reason. However, on all calls to PrepareMessage, we already know the channel's ID, so there's no reason that we can't force a default if one is not provided by Discord.

# Changes proposed
* Add an additional parameter to DiscordApiClient.PrepareMessage used as a backup when the raw message's channel ID does not get deserialized
* Fix naming of the variables and parameters in DiscordApiClient.PrepareMessage. You said you were going to do this incrementally as needed, so I took the opportunity to fix it now.

# Notes
This was reported by Paulo on Discord. I haven't had the opportunity to test this yet since I'm currently developing in a branch and my test bot is not in a working state at the moment.