### PR TITLE
Fix documentation for UserUpdated...

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2742,9 +2742,9 @@ namespace DSharpPlus
         /// <summary>
         /// Fired when properties about the current user change.
         /// </summary>
-	/// <remarks>
-	/// NB: This event only applies for changes to the <b>current user</c>, the client that is connected to Discord.
-	/// </remarks>
+        /// <remarks>
+        /// NB: This event only applies for changes to the <b>current user</b>, the client that is connected to Discord.
+        /// </remarks>
         public event AsyncEventHandler<UserUpdateEventArgs> UserUpdated
         {
             add { this._userUpdated.Register(value); }


### PR DESCRIPTION
# Summary
I do not understand how I managed to mess up a documentation fix so badly.

# Details
Use tabs instead of spaces and fix the remarks tag in the docs for DiscordClient.UserUpdated

# Changes proposed
* Fix documentation for UserUpdated

# Notes
This is why I don't have push access