### PR TITLE
Use property/event expression body style wherever possible

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2384,8 +2384,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ClientErrorEventArgs> ClientErrored
         {
-            add { this._clientErrored.Register(value); }
-            remove { this._clientErrored.Unregister(value); }
+            add => this._clientErrored.Register(value);
+            remove => this._clientErrored.Unregister(value);
         }
         private AsyncEvent<ClientErrorEventArgs> _clientErrored;
 
@@ -2394,8 +2394,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<SocketErrorEventArgs> SocketErrored
         {
-            add { this._socketErrored.Register(value); }
-            remove { this._socketErrored.Unregister(value); }
+            add => this._socketErrored.Register(value);
+            remove => this._socketErrored.Unregister(value);
         }
         private AsyncEvent<SocketErrorEventArgs> _socketErrored;
 
@@ -2404,8 +2404,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler SocketOpened
         {
-            add { this._socketOpened.Register(value); }
-            remove { this._socketOpened.Unregister(value); }
+            add => this._socketOpened.Register(value);
+            remove => this._socketOpened.Unregister(value);
         }
         private AsyncEvent _socketOpened;
 
@@ -2414,8 +2414,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<SocketCloseEventArgs> SocketClosed
         {
-            add { this._socketClosed.Register(value); }
-            remove { this._socketClosed.Unregister(value); }
+            add => this._socketClosed.Register(value);
+            remove => this._socketClosed.Unregister(value);
         }
         private AsyncEvent<SocketCloseEventArgs> _socketClosed;
 
@@ -2424,8 +2424,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ReadyEventArgs> Ready
         {
-            add { this._ready.Register(value); }
-            remove { this._ready.Unregister(value); }
+            add => this._ready.Register(value);
+            remove => this._ready.Unregister(value);
         }
         private AsyncEvent<ReadyEventArgs> _ready;
 
@@ -2434,8 +2434,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ReadyEventArgs> Resumed
         {
-            add { this._resumed.Register(value); }
-            remove { this._resumed.Unregister(value); }
+            add => this._resumed.Register(value);
+            remove => this._resumed.Unregister(value);
         }
         private AsyncEvent<ReadyEventArgs> _resumed;
 
@@ -2444,8 +2444,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ChannelCreateEventArgs> ChannelCreated
         {
-            add { this._channelCreated.Register(value); }
-            remove { this._channelCreated.Unregister(value); }
+            add => this._channelCreated.Register(value);
+            remove => this._channelCreated.Unregister(value);
         }
         private AsyncEvent<ChannelCreateEventArgs> _channelCreated;
 
@@ -2454,8 +2454,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<DmChannelCreateEventArgs> DmChannelCreated
         {
-            add { this._dmChannelCreated.Register(value); }
-            remove { this._dmChannelCreated.Unregister(value); }
+            add => this._dmChannelCreated.Register(value);
+            remove => this._dmChannelCreated.Unregister(value);
         }
         private AsyncEvent<DmChannelCreateEventArgs> _dmChannelCreated;
 
@@ -2464,8 +2464,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ChannelUpdateEventArgs> ChannelUpdated
         {
-            add { this._channelUpdated.Register(value); }
-            remove { this._channelUpdated.Unregister(value); }
+            add => this._channelUpdated.Register(value);
+            remove => this._channelUpdated.Unregister(value);
         }
         private AsyncEvent<ChannelUpdateEventArgs> _channelUpdated;
 
@@ -2474,8 +2474,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ChannelDeleteEventArgs> ChannelDeleted
         {
-            add { this._channelDeleted.Register(value); }
-            remove { this._channelDeleted.Unregister(value); }
+            add => this._channelDeleted.Register(value);
+            remove => this._channelDeleted.Unregister(value);
         }
         private AsyncEvent<ChannelDeleteEventArgs> _channelDeleted;
 
@@ -2484,8 +2484,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<DmChannelDeleteEventArgs> DmChannelDeleted
         {
-            add { this._dmChannelDeleted.Register(value); }
-            remove { this._dmChannelDeleted.Unregister(value); }
+            add => this._dmChannelDeleted.Register(value);
+            remove => this._dmChannelDeleted.Unregister(value);
         }
         private AsyncEvent<DmChannelDeleteEventArgs> _dmChannelDeleted;
 
@@ -2494,8 +2494,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ChannelPinsUpdateEventArgs> ChannelPinsUpdated
         {
-            add { this._channelPinsUpdated.Register(value); }
-            remove { this._channelPinsUpdated.Unregister(value); }
+            add => this._channelPinsUpdated.Register(value);
+            remove => this._channelPinsUpdated.Unregister(value);
         }
         private AsyncEvent<ChannelPinsUpdateEventArgs> _channelPinsUpdated;
 
@@ -2504,8 +2504,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildCreateEventArgs> GuildCreated
         {
-            add { this._guildCreated.Register(value); }
-            remove { this._guildCreated.Unregister(value); }
+            add => this._guildCreated.Register(value);
+            remove => this._guildCreated.Unregister(value);
         }
         private AsyncEvent<GuildCreateEventArgs> _guildCreated;
 
@@ -2514,8 +2514,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildCreateEventArgs> GuildAvailable
         {
-            add { this._guildAvailable.Register(value); }
-            remove { this._guildAvailable.Unregister(value); }
+            add => this._guildAvailable.Register(value);
+            remove => this._guildAvailable.Unregister(value);
         }
         private AsyncEvent<GuildCreateEventArgs> _guildAvailable;
 
@@ -2524,8 +2524,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildUpdateEventArgs> GuildUpdated
         {
-            add { this._guildUpdated.Register(value); }
-            remove { this._guildUpdated.Unregister(value); }
+            add => this._guildUpdated.Register(value);
+            remove => this._guildUpdated.Unregister(value);
         }
         private AsyncEvent<GuildUpdateEventArgs> _guildUpdated;
 
@@ -2534,8 +2534,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildDeleteEventArgs> GuildDeleted
         {
-            add { this._guildDeleted.Register(value); }
-            remove { this._guildDeleted.Unregister(value); }
+            add => this._guildDeleted.Register(value);
+            remove => this._guildDeleted.Unregister(value);
         }
         private AsyncEvent<GuildDeleteEventArgs> _guildDeleted;
 
@@ -2544,8 +2544,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildDeleteEventArgs> GuildUnavailable
         {
-            add { this._guildUnavailable.Register(value); }
-            remove { this._guildUnavailable.Unregister(value); }
+            add => this._guildUnavailable.Register(value);
+            remove => this._guildUnavailable.Unregister(value);
         }
         private AsyncEvent<GuildDeleteEventArgs> _guildUnavailable;
 
@@ -2554,8 +2554,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildDownloadCompletedEventArgs> GuildDownloadCompleted
         {
-            add { this._guildDownloadCompletedEv.Register(value); }
-            remove { this._guildDownloadCompletedEv.Unregister(value); }
+            add => this._guildDownloadCompletedEv.Register(value);
+            remove => this._guildDownloadCompletedEv.Unregister(value);
         }
         private AsyncEvent<GuildDownloadCompletedEventArgs> _guildDownloadCompletedEv;
 
@@ -2564,8 +2564,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageCreateEventArgs> MessageCreated
         {
-            add { this._messageCreated.Register(value); }
-            remove { this._messageCreated.Unregister(value); }
+            add => this._messageCreated.Register(value);
+            remove => this._messageCreated.Unregister(value);
         }
         private AsyncEvent<MessageCreateEventArgs> _messageCreated;
 
@@ -2574,8 +2574,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<PresenceUpdateEventArgs> PresenceUpdated
         {
-            add { this._presenceUpdated.Register(value); }
-            remove { this._presenceUpdated.Unregister(value); }
+            add => this._presenceUpdated.Register(value);
+            remove => this._presenceUpdated.Unregister(value);
         }
         private AsyncEvent<PresenceUpdateEventArgs> _presenceUpdated;
 
@@ -2584,8 +2584,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildBanAddEventArgs> GuildBanAdded
         {
-            add { this._guildBanAdded.Register(value); }
-            remove { this._guildBanAdded.Unregister(value); }
+            add => this._guildBanAdded.Register(value);
+            remove => this._guildBanAdded.Unregister(value);
         }
         private AsyncEvent<GuildBanAddEventArgs> _guildBanAdded;
 
@@ -2594,8 +2594,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildBanRemoveEventArgs> GuildBanRemoved
         {
-            add { this._guildBanRemoved.Register(value); }
-            remove { this._guildBanRemoved.Unregister(value); }
+            add => this._guildBanRemoved.Register(value);
+            remove => this._guildBanRemoved.Unregister(value);
         }
         private AsyncEvent<GuildBanRemoveEventArgs> _guildBanRemoved;
 
@@ -2604,8 +2604,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildEmojisUpdateEventArgs> GuildEmojisUpdated
         {
-            add { this._guildEmojisUpdated.Register(value); }
-            remove { this._guildEmojisUpdated.Unregister(value); }
+            add => this._guildEmojisUpdated.Register(value);
+            remove => this._guildEmojisUpdated.Unregister(value);
         }
         private AsyncEvent<GuildEmojisUpdateEventArgs> _guildEmojisUpdated;
 
@@ -2614,8 +2614,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildIntegrationsUpdateEventArgs> GuildIntegrationsUpdated
         {
-            add { this._guildIntegrationsUpdated.Register(value); }
-            remove { this._guildIntegrationsUpdated.Unregister(value); }
+            add => this._guildIntegrationsUpdated.Register(value);
+            remove => this._guildIntegrationsUpdated.Unregister(value);
         }
         private AsyncEvent<GuildIntegrationsUpdateEventArgs> _guildIntegrationsUpdated;
 
@@ -2624,8 +2624,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildMemberAddEventArgs> GuildMemberAdded
         {
-            add { this._guildMemberAdded.Register(value); }
-            remove { this._guildMemberAdded.Unregister(value); }
+            add => this._guildMemberAdded.Register(value);
+            remove => this._guildMemberAdded.Unregister(value);
         }
         private AsyncEvent<GuildMemberAddEventArgs> _guildMemberAdded;
 
@@ -2634,8 +2634,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildMemberRemoveEventArgs> GuildMemberRemoved
         {
-            add { this._guildMemberRemoved.Register(value); }
-            remove { this._guildMemberRemoved.Unregister(value); }
+            add => this._guildMemberRemoved.Register(value);
+            remove => this._guildMemberRemoved.Unregister(value);
         }
         private AsyncEvent<GuildMemberRemoveEventArgs> _guildMemberRemoved;
 
@@ -2644,8 +2644,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildMemberUpdateEventArgs> GuildMemberUpdated
         {
-            add { this._guildMemberUpdated.Register(value); }
-            remove { this._guildMemberUpdated.Unregister(value); }
+            add => this._guildMemberUpdated.Register(value);
+            remove => this._guildMemberUpdated.Unregister(value);
         }
         private AsyncEvent<GuildMemberUpdateEventArgs> _guildMemberUpdated;
 
@@ -2654,8 +2654,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildRoleCreateEventArgs> GuildRoleCreated
         {
-            add { this._guildRoleCreated.Register(value); }
-            remove { this._guildRoleCreated.Unregister(value); }
+            add => this._guildRoleCreated.Register(value);
+            remove => this._guildRoleCreated.Unregister(value);
         }
         private AsyncEvent<GuildRoleCreateEventArgs> _guildRoleCreated;
 
@@ -2664,8 +2664,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildRoleUpdateEventArgs> GuildRoleUpdated
         {
-            add { this._guildRoleUpdated.Register(value); }
-            remove { this._guildRoleUpdated.Unregister(value); }
+            add => this._guildRoleUpdated.Register(value);
+            remove => this._guildRoleUpdated.Unregister(value);
         }
         private AsyncEvent<GuildRoleUpdateEventArgs> _guildRoleUpdated;
 
@@ -2674,8 +2674,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildRoleDeleteEventArgs> GuildRoleDeleted
         {
-            add { this._guildRoleDeleted.Register(value); }
-            remove { this._guildRoleDeleted.Unregister(value); }
+            add => this._guildRoleDeleted.Register(value);
+            remove => this._guildRoleDeleted.Unregister(value);
         }
         private AsyncEvent<GuildRoleDeleteEventArgs> _guildRoleDeleted;
 
@@ -2684,8 +2684,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageAcknowledgeEventArgs> MessageAcknowledged
         {
-            add { this._messageAcknowledged.Register(value); }
-            remove { this._messageAcknowledged.Unregister(value); }
+            add => this._messageAcknowledged.Register(value);
+            remove => this._messageAcknowledged.Unregister(value);
         }
         private AsyncEvent<MessageAcknowledgeEventArgs> _messageAcknowledged;
 
@@ -2694,8 +2694,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageUpdateEventArgs> MessageUpdated
         {
-            add { this._messageUpdated.Register(value); }
-            remove { this._messageUpdated.Unregister(value); }
+            add => this._messageUpdated.Register(value);
+            remove => this._messageUpdated.Unregister(value);
         }
         private AsyncEvent<MessageUpdateEventArgs> _messageUpdated;
 
@@ -2704,8 +2704,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageDeleteEventArgs> MessageDeleted
         {
-            add { this._messageDeleted.Register(value); }
-            remove { this._messageDeleted.Unregister(value); }
+            add => this._messageDeleted.Register(value);
+            remove => this._messageDeleted.Unregister(value);
         }
         private AsyncEvent<MessageDeleteEventArgs> _messageDeleted;
 
@@ -2714,8 +2714,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageBulkDeleteEventArgs> MessagesBulkDeleted
         {
-            add { this._messagesBulkDeleted.Register(value); }
-            remove { this._messagesBulkDeleted.Unregister(value); }
+            add => this._messagesBulkDeleted.Register(value);
+            remove => this._messagesBulkDeleted.Unregister(value);
         }
         private AsyncEvent<MessageBulkDeleteEventArgs> _messagesBulkDeleted;
 
@@ -2724,8 +2724,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<TypingStartEventArgs> TypingStarted
         {
-            add { this._typingStarted.Register(value); }
-            remove { this._typingStarted.Unregister(value); }
+            add => this._typingStarted.Register(value);
+            remove => this._typingStarted.Unregister(value);
         }
         private AsyncEvent<TypingStartEventArgs> _typingStarted;
 
@@ -2734,8 +2734,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<UserSettingsUpdateEventArgs> UserSettingsUpdated
         {
-            add { this._userSettingsUpdated.Register(value); }
-            remove { this._userSettingsUpdated.Unregister(value); }
+            add => this._userSettingsUpdated.Register(value);
+            remove => this._userSettingsUpdated.Unregister(value);
         }
         private AsyncEvent<UserSettingsUpdateEventArgs> _userSettingsUpdated;
 
@@ -2747,8 +2747,8 @@ namespace DSharpPlus
 	/// </remarks>
         public event AsyncEventHandler<UserUpdateEventArgs> UserUpdated
         {
-            add { this._userUpdated.Register(value); }
-            remove { this._userUpdated.Unregister(value); }
+            add => this._userUpdated.Register(value);
+            remove => this._userUpdated.Unregister(value);
         }
         private AsyncEvent<UserUpdateEventArgs> _userUpdated;
 
@@ -2757,8 +2757,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<VoiceStateUpdateEventArgs> VoiceStateUpdated
         {
-            add { this._voiceStateUpdated.Register(value); }
-            remove { this._voiceStateUpdated.Unregister(value); }
+            add => this._voiceStateUpdated.Register(value);
+            remove => this._voiceStateUpdated.Unregister(value);
         }
         private AsyncEvent<VoiceStateUpdateEventArgs> _voiceStateUpdated;
 
@@ -2767,8 +2767,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<VoiceServerUpdateEventArgs> VoiceServerUpdated
         {
-            add { this._voiceServerUpdated.Register(value); }
-            remove { this._voiceServerUpdated.Unregister(value); }
+            add => this._voiceServerUpdated.Register(value);
+            remove => this._voiceServerUpdated.Unregister(value);
         }
         private AsyncEvent<VoiceServerUpdateEventArgs> _voiceServerUpdated;
 
@@ -2777,8 +2777,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildMembersChunkEventArgs> GuildMembersChunked
         {
-            add { this._guildMembersChunked.Register(value); }
-            remove { this._guildMembersChunked.Unregister(value); }
+            add => this._guildMembersChunked.Register(value);
+            remove => this._guildMembersChunked.Unregister(value);
         }
         private AsyncEvent<GuildMembersChunkEventArgs> _guildMembersChunked;
 
@@ -2787,8 +2787,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<UnknownEventArgs> UnknownEvent
         {
-            add { this._unknownEvent.Register(value); }
-            remove { this._unknownEvent.Unregister(value); }
+            add => this._unknownEvent.Register(value);
+            remove => this._unknownEvent.Unregister(value);
         }
         private AsyncEvent<UnknownEventArgs> _unknownEvent;
 
@@ -2797,8 +2797,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageReactionAddEventArgs> MessageReactionAdded
         {
-            add { this._messageReactionAdded.Register(value); }
-            remove { this._messageReactionAdded.Unregister(value); }
+            add => this._messageReactionAdded.Register(value);
+            remove => this._messageReactionAdded.Unregister(value);
         }
         private AsyncEvent<MessageReactionAddEventArgs> _messageReactionAdded;
 
@@ -2807,8 +2807,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageReactionRemoveEventArgs> MessageReactionRemoved
         {
-            add { this._messageReactionRemoved.Register(value); }
-            remove { this._messageReactionRemoved.Unregister(value); }
+            add => this._messageReactionRemoved.Register(value);
+            remove => this._messageReactionRemoved.Unregister(value);
         }
         private AsyncEvent<MessageReactionRemoveEventArgs> _messageReactionRemoved;
 
@@ -2817,8 +2817,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageReactionsClearEventArgs> MessageReactionsCleared
         {
-            add { this._messageReactionsCleared.Register(value); }
-            remove { this._messageReactionsCleared.Unregister(value); }
+            add => this._messageReactionsCleared.Register(value);
+            remove => this._messageReactionsCleared.Unregister(value);
         }
         private AsyncEvent<MessageReactionsClearEventArgs> _messageReactionsCleared;
 
@@ -2827,8 +2827,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<WebhooksUpdateEventArgs> WebhooksUpdated
         {
-            add { this._webhooksUpdated.Register(value); }
-            remove { this._webhooksUpdated.Unregister(value); }
+            add => this._webhooksUpdated.Register(value);
+            remove => this._webhooksUpdated.Unregister(value);
         }
         private AsyncEvent<WebhooksUpdateEventArgs> _webhooksUpdated;
 
@@ -2837,8 +2837,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<HeartbeatEventArgs> Heartbeated
         {
-            add { this._heartbeated.Register(value); }
-            remove { this._heartbeated.Unregister(value); }
+            add => this._heartbeated.Register(value);
+            remove => this._heartbeated.Unregister(value);
         }
         private AsyncEvent<HeartbeatEventArgs> _heartbeated;
 

--- a/DSharpPlus/DiscordShardedClient.cs
+++ b/DSharpPlus/DiscordShardedClient.cs
@@ -24,8 +24,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ClientErrorEventArgs> ClientErrored
         {
-            add { this._clientErrored.Register(value); }
-            remove { this._clientErrored.Unregister(value); }
+            add => this._clientErrored.Register(value);
+            remove => this._clientErrored.Unregister(value);
         }
         private AsyncEvent<ClientErrorEventArgs> _clientErrored;
 
@@ -34,8 +34,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<SocketErrorEventArgs> SocketErrored
         {
-            add { this._socketErrored.Register(value); }
-            remove { this._socketErrored.Unregister(value); }
+            add => this._socketErrored.Register(value);
+            remove => this._socketErrored.Unregister(value);
         }
         private AsyncEvent<SocketErrorEventArgs> _socketErrored;
 
@@ -44,8 +44,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler SocketOpened
         {
-            add { this._socketOpened.Register(value); }
-            remove { this._socketOpened.Unregister(value); }
+            add => this._socketOpened.Register(value);
+            remove => this._socketOpened.Unregister(value);
         }
         private AsyncEvent _socketOpened;
 
@@ -54,8 +54,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<SocketCloseEventArgs> SocketClosed
         {
-            add { this._socketClosed.Register(value); }
-            remove { this._socketClosed.Unregister(value); }
+            add => this._socketClosed.Register(value);
+            remove => this._socketClosed.Unregister(value);
         }
         private AsyncEvent<SocketCloseEventArgs> _socketClosed;
 
@@ -64,8 +64,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ReadyEventArgs> Ready
         {
-            add { this._ready.Register(value); }
-            remove { this._ready.Unregister(value); }
+            add => this._ready.Register(value);
+            remove => this._ready.Unregister(value);
         }
         private AsyncEvent<ReadyEventArgs> _ready;
 
@@ -74,8 +74,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ReadyEventArgs> Resumed
         {
-            add { this._resumed.Register(value); }
-            remove { this._resumed.Unregister(value); }
+            add => this._resumed.Register(value);
+            remove => this._resumed.Unregister(value);
         }
         private AsyncEvent<ReadyEventArgs> _resumed;
 
@@ -84,8 +84,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ChannelCreateEventArgs> ChannelCreated
         {
-            add { this._channelCreated.Register(value); }
-            remove { this._channelCreated.Unregister(value); }
+            add => this._channelCreated.Register(value);
+            remove => this._channelCreated.Unregister(value);
         }
         private AsyncEvent<ChannelCreateEventArgs> _channelCreated;
 
@@ -94,8 +94,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<DmChannelCreateEventArgs> DmChannelCreated
         {
-            add { this._dmChannelCreated.Register(value); }
-            remove { this._dmChannelCreated.Unregister(value); }
+            add => this._dmChannelCreated.Register(value);
+            remove => this._dmChannelCreated.Unregister(value);
         }
         private AsyncEvent<DmChannelCreateEventArgs> _dmChannelCreated;
 
@@ -104,8 +104,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ChannelUpdateEventArgs> ChannelUpdated
         {
-            add { this._channelUpdated.Register(value); }
-            remove { this._channelUpdated.Unregister(value); }
+            add => this._channelUpdated.Register(value);
+            remove => this._channelUpdated.Unregister(value);
         }
         private AsyncEvent<ChannelUpdateEventArgs> _channelUpdated;
 
@@ -114,8 +114,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ChannelDeleteEventArgs> ChannelDeleted
         {
-            add { this._channelDeleted.Register(value); }
-            remove { this._channelDeleted.Unregister(value); }
+            add => this._channelDeleted.Register(value);
+            remove => this._channelDeleted.Unregister(value);
         }
         private AsyncEvent<ChannelDeleteEventArgs> _channelDeleted;
 
@@ -124,8 +124,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<DmChannelDeleteEventArgs> DmChannelDeleted
         {
-            add { this._dmChannelDeleted.Register(value); }
-            remove { this._dmChannelDeleted.Unregister(value); }
+            add => this._dmChannelDeleted.Register(value);
+            remove => this._dmChannelDeleted.Unregister(value);
         }
         private AsyncEvent<DmChannelDeleteEventArgs> _dmChannelDeleted;
 
@@ -134,8 +134,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<ChannelPinsUpdateEventArgs> ChannelPinsUpdated
         {
-            add { this._channelPinsUpdated.Register(value); }
-            remove { this._channelPinsUpdated.Unregister(value); }
+            add => this._channelPinsUpdated.Register(value);
+            remove => this._channelPinsUpdated.Unregister(value);
         }
         private AsyncEvent<ChannelPinsUpdateEventArgs> _channelPinsUpdated;
 
@@ -144,8 +144,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildCreateEventArgs> GuildCreated
         {
-            add { this._guildCreated.Register(value); }
-            remove { this._guildCreated.Unregister(value); }
+            add => this._guildCreated.Register(value);
+            remove => this._guildCreated.Unregister(value);
         }
         private AsyncEvent<GuildCreateEventArgs> _guildCreated;
 
@@ -154,8 +154,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildCreateEventArgs> GuildAvailable
         {
-            add { this._guildAvailable.Register(value); }
-            remove { this._guildAvailable.Unregister(value); }
+            add => this._guildAvailable.Register(value);
+            remove => this._guildAvailable.Unregister(value);
         }
         private AsyncEvent<GuildCreateEventArgs> _guildAvailable;
 
@@ -164,8 +164,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildUpdateEventArgs> GuildUpdated
         {
-            add { this._guildUpdated.Register(value); }
-            remove { this._guildUpdated.Unregister(value); }
+            add => this._guildUpdated.Register(value);
+            remove => this._guildUpdated.Unregister(value);
         }
         private AsyncEvent<GuildUpdateEventArgs> _guildUpdated;
 
@@ -174,8 +174,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildDeleteEventArgs> GuildDeleted
         {
-            add { this._guildDeleted.Register(value); }
-            remove { this._guildDeleted.Unregister(value); }
+            add => this._guildDeleted.Register(value);
+            remove => this._guildDeleted.Unregister(value);
         }
         private AsyncEvent<GuildDeleteEventArgs> _guildDeleted;
 
@@ -184,8 +184,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildDeleteEventArgs> GuildUnavailable
         {
-            add { this._guildUnavailable.Register(value); }
-            remove { this._guildUnavailable.Unregister(value); }
+            add => this._guildUnavailable.Register(value);
+            remove => this._guildUnavailable.Unregister(value);
         }
         private AsyncEvent<GuildDeleteEventArgs> _guildUnavailable;
 
@@ -194,8 +194,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildDownloadCompletedEventArgs> GuildDownloadCompleted
         {
-            add { this._guildDownloadCompleted.Register(value); }
-            remove { this._guildDownloadCompleted.Unregister(value); }
+            add => this._guildDownloadCompleted.Register(value);
+            remove => this._guildDownloadCompleted.Unregister(value);
         }
         private AsyncEvent<GuildDownloadCompletedEventArgs> _guildDownloadCompleted;
 
@@ -204,8 +204,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageCreateEventArgs> MessageCreated
         {
-            add { this._messageCreated.Register(value); }
-            remove { this._messageCreated.Unregister(value); }
+            add => this._messageCreated.Register(value);
+            remove => this._messageCreated.Unregister(value);
         }
         private AsyncEvent<MessageCreateEventArgs> _messageCreated;
 
@@ -214,8 +214,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<PresenceUpdateEventArgs> PresenceUpdated
         {
-            add { this._presenceUpdated.Register(value); }
-            remove { this._presenceUpdated.Unregister(value); }
+            add => this._presenceUpdated.Register(value);
+            remove => this._presenceUpdated.Unregister(value);
         }
         private AsyncEvent<PresenceUpdateEventArgs> _presenceUpdated;
 
@@ -224,8 +224,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildBanAddEventArgs> GuildBanAdded
         {
-            add { this._guildBanAdded.Register(value); }
-            remove { this._guildBanAdded.Unregister(value); }
+            add => this._guildBanAdded.Register(value);
+            remove => this._guildBanAdded.Unregister(value);
         }
         private AsyncEvent<GuildBanAddEventArgs> _guildBanAdded;
 
@@ -234,8 +234,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildBanRemoveEventArgs> GuildBanRemoved
         {
-            add { this._guildBanRemoved.Register(value); }
-            remove { this._guildBanRemoved.Unregister(value); }
+            add => this._guildBanRemoved.Register(value);
+            remove => this._guildBanRemoved.Unregister(value);
         }
         private AsyncEvent<GuildBanRemoveEventArgs> _guildBanRemoved;
 
@@ -244,8 +244,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildEmojisUpdateEventArgs> GuildEmojisUpdated
         {
-            add { this._guildEmojisUpdated.Register(value); }
-            remove { this._guildEmojisUpdated.Unregister(value); }
+            add => this._guildEmojisUpdated.Register(value);
+            remove => this._guildEmojisUpdated.Unregister(value);
         }
         private AsyncEvent<GuildEmojisUpdateEventArgs> _guildEmojisUpdated;
 
@@ -254,8 +254,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildIntegrationsUpdateEventArgs> GuildIntegrationsUpdated
         {
-            add { this._guildIntegrationsUpdated.Register(value); }
-            remove { this._guildIntegrationsUpdated.Unregister(value); }
+            add => this._guildIntegrationsUpdated.Register(value);
+            remove => this._guildIntegrationsUpdated.Unregister(value);
         }
         private AsyncEvent<GuildIntegrationsUpdateEventArgs> _guildIntegrationsUpdated;
 
@@ -264,8 +264,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildMemberAddEventArgs> GuildMemberAdded
         {
-            add { this._guildMemberAdded.Register(value); }
-            remove { this._guildMemberAdded.Unregister(value); }
+            add => this._guildMemberAdded.Register(value);
+            remove => this._guildMemberAdded.Unregister(value);
         }
         private AsyncEvent<GuildMemberAddEventArgs> _guildMemberAdded;
 
@@ -274,8 +274,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildMemberRemoveEventArgs> GuildMemberRemoved
         {
-            add { this._guildMemberRemoved.Register(value); }
-            remove { this._guildMemberRemoved.Unregister(value); }
+            add => this._guildMemberRemoved.Register(value);
+            remove => this._guildMemberRemoved.Unregister(value);
         }
         private AsyncEvent<GuildMemberRemoveEventArgs> _guildMemberRemoved;
 
@@ -284,8 +284,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildMemberUpdateEventArgs> GuildMemberUpdated
         {
-            add { this._guildMemberUpdated.Register(value); }
-            remove { this._guildMemberUpdated.Unregister(value); }
+            add => this._guildMemberUpdated.Register(value);
+            remove => this._guildMemberUpdated.Unregister(value);
         }
         private AsyncEvent<GuildMemberUpdateEventArgs> _guildMemberUpdated;
 
@@ -294,8 +294,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildRoleCreateEventArgs> GuildRoleCreated
         {
-            add { this._guildRoleCreated.Register(value); }
-            remove { this._guildRoleCreated.Unregister(value); }
+            add => this._guildRoleCreated.Register(value);
+            remove => this._guildRoleCreated.Unregister(value);
         }
         private AsyncEvent<GuildRoleCreateEventArgs> _guildRoleCreated;
 
@@ -304,8 +304,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildRoleUpdateEventArgs> GuildRoleUpdated
         {
-            add { this._guildRoleUpdated.Register(value); }
-            remove { this._guildRoleUpdated.Unregister(value); }
+            add => this._guildRoleUpdated.Register(value);
+            remove => this._guildRoleUpdated.Unregister(value);
         }
         private AsyncEvent<GuildRoleUpdateEventArgs> _guildRoleUpdated;
 
@@ -314,8 +314,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildRoleDeleteEventArgs> GuildRoleDeleted
         {
-            add { this._guildRoleDeleted.Register(value); }
-            remove { this._guildRoleDeleted.Unregister(value); }
+            add => this._guildRoleDeleted.Register(value);
+            remove => this._guildRoleDeleted.Unregister(value);
         }
         private AsyncEvent<GuildRoleDeleteEventArgs> _guildRoleDeleted;
 
@@ -324,8 +324,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageUpdateEventArgs> MessageUpdated
         {
-            add { this._messageUpdated.Register(value); }
-            remove { this._messageUpdated.Unregister(value); }
+            add => this._messageUpdated.Register(value);
+            remove => this._messageUpdated.Unregister(value);
         }
         private AsyncEvent<MessageUpdateEventArgs> _messageUpdated;
 
@@ -334,8 +334,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageDeleteEventArgs> MessageDeleted
         {
-            add { this._messageDeleted.Register(value); }
-            remove { this._messageDeleted.Unregister(value); }
+            add => this._messageDeleted.Register(value);
+            remove => this._messageDeleted.Unregister(value);
         }
         private AsyncEvent<MessageDeleteEventArgs> _messageDeleted;
 
@@ -344,8 +344,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageBulkDeleteEventArgs> MessagesBulkDeleted
         {
-            add { this._messageBulkDeleted.Register(value); }
-            remove { this._messageBulkDeleted.Unregister(value); }
+            add => this._messageBulkDeleted.Register(value);
+            remove => this._messageBulkDeleted.Unregister(value);
         }
         private AsyncEvent<MessageBulkDeleteEventArgs> _messageBulkDeleted;
 
@@ -354,8 +354,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<TypingStartEventArgs> TypingStarted
         {
-            add { this._typingStarted.Register(value); }
-            remove { this._typingStarted.Unregister(value); }
+            add => this._typingStarted.Register(value);
+            remove => this._typingStarted.Unregister(value);
         }
         private AsyncEvent<TypingStartEventArgs> _typingStarted;
 
@@ -364,8 +364,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<UserSettingsUpdateEventArgs> UserSettingsUpdated
         {
-            add { this._userSettingsUpdated.Register(value); }
-            remove { this._userSettingsUpdated.Unregister(value); }
+            add => this._userSettingsUpdated.Register(value);
+            remove => this._userSettingsUpdated.Unregister(value);
         }
         private AsyncEvent<UserSettingsUpdateEventArgs> _userSettingsUpdated;
 
@@ -374,8 +374,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<UserUpdateEventArgs> UserUpdated
         {
-            add { this._userUpdated.Register(value); }
-            remove { this._userUpdated.Unregister(value); }
+            add => this._userUpdated.Register(value);
+            remove => this._userUpdated.Unregister(value);
         }
         private AsyncEvent<UserUpdateEventArgs> _userUpdated;
 
@@ -384,8 +384,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<VoiceStateUpdateEventArgs> VoiceStateUpdated
         {
-            add { this._voiceStateUpdated.Register(value); }
-            remove { this._voiceStateUpdated.Unregister(value); }
+            add => this._voiceStateUpdated.Register(value);
+            remove => this._voiceStateUpdated.Unregister(value);
         }
         private AsyncEvent<VoiceStateUpdateEventArgs> _voiceStateUpdated;
 
@@ -394,8 +394,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<VoiceServerUpdateEventArgs> VoiceServerUpdated
         {
-            add { this._voiceServerUpdated.Register(value); }
-            remove { this._voiceServerUpdated.Unregister(value); }
+            add => this._voiceServerUpdated.Register(value);
+            remove => this._voiceServerUpdated.Unregister(value);
         }
         private AsyncEvent<VoiceServerUpdateEventArgs> _voiceServerUpdated;
 
@@ -404,8 +404,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<GuildMembersChunkEventArgs> GuildMembersChunked
         {
-            add { this._guildMembersChunk.Register(value); }
-            remove { this._guildMembersChunk.Unregister(value); }
+            add => this._guildMembersChunk.Register(value);
+            remove => this._guildMembersChunk.Unregister(value);
         }
         private AsyncEvent<GuildMembersChunkEventArgs> _guildMembersChunk;
 
@@ -414,8 +414,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<UnknownEventArgs> UnknownEvent
         {
-            add { this._unknownEvent.Register(value); }
-            remove { this._unknownEvent.Unregister(value); }
+            add => this._unknownEvent.Register(value);
+            remove => this._unknownEvent.Unregister(value);
         }
         private AsyncEvent<UnknownEventArgs> _unknownEvent;
 
@@ -424,8 +424,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageReactionAddEventArgs> MessageReactionAdded
         {
-            add { this._messageReactionAdded.Register(value); }
-            remove { this._messageReactionAdded.Unregister(value); }
+            add => this._messageReactionAdded.Register(value);
+            remove => this._messageReactionAdded.Unregister(value);
         }
         private AsyncEvent<MessageReactionAddEventArgs> _messageReactionAdded;
 
@@ -434,8 +434,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageReactionRemoveEventArgs> MessageReactionRemoved
         {
-            add { this._messageReactionRemoved.Register(value); }
-            remove { this._messageReactionRemoved.Unregister(value); }
+            add => this._messageReactionRemoved.Register(value);
+            remove => this._messageReactionRemoved.Unregister(value);
         }
         private AsyncEvent<MessageReactionRemoveEventArgs> _messageReactionRemoved;
 
@@ -444,8 +444,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<MessageReactionsClearEventArgs> MessageReactionsCleared
         {
-            add { this._messageReactionsCleared.Register(value); }
-            remove { this._messageReactionsCleared.Unregister(value); }
+            add => this._messageReactionsCleared.Register(value);
+            remove => this._messageReactionsCleared.Unregister(value);
         }
         private AsyncEvent<MessageReactionsClearEventArgs> _messageReactionsCleared;
 
@@ -454,8 +454,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<WebhooksUpdateEventArgs> WebhooksUpdated
         {
-            add { this._webhooksUpdated.Register(value); }
-            remove { this._webhooksUpdated.Unregister(value); }
+            add => this._webhooksUpdated.Register(value);
+            remove => this._webhooksUpdated.Unregister(value);
         }
         private AsyncEvent<WebhooksUpdateEventArgs> _webhooksUpdated;
 
@@ -464,8 +464,8 @@ namespace DSharpPlus
         /// </summary>
         public event AsyncEventHandler<HeartbeatEventArgs> Heartbeated
         {
-            add { this._heartbeated.Register(value); }
-            remove { this._heartbeated.Unregister(value); }
+            add => this._heartbeated.Register(value);
+            remove => this._heartbeated.Unregister(value);
         }
         private AsyncEvent<HeartbeatEventArgs> _heartbeated;
 

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -148,8 +148,8 @@ namespace DSharpPlus.Entities
         /// </summary>
         public override string Username
         {
-            get { return this.User.Username; }
-            internal set { this.User.Username = value; }
+            get => this.User.Username;
+            internal set => this.User.Username = value;
         }
 
         /// <summary>
@@ -157,8 +157,8 @@ namespace DSharpPlus.Entities
         /// </summary>
         public override string Discriminator
         {
-            get { return this.User.Discriminator; }
-            internal set { this.User.Discriminator = value; }
+            get => this.User.Discriminator;
+            internal set => this.User.Discriminator = value;
         }
 
         /// <summary>
@@ -166,8 +166,8 @@ namespace DSharpPlus.Entities
         /// </summary>
         public override string AvatarHash
         {
-            get { return this.User.AvatarHash; }
-            internal set { this.User.AvatarHash = value; }
+            get => this.User.AvatarHash;
+            internal set => this.User.AvatarHash = value;
         }
 
         /// <summary>
@@ -175,8 +175,8 @@ namespace DSharpPlus.Entities
         /// </summary>
         public override bool IsBot
         {
-            get { return this.User.IsBot; }
-            internal set { this.User.IsBot = value; }
+            get => this.User.IsBot;
+            internal set => this.User.IsBot = value;
         }
 
         /// <summary>
@@ -184,8 +184,8 @@ namespace DSharpPlus.Entities
         /// </summary>
         public override string Email
         {
-            get { return this.User.Email; }
-            internal set { this.User.Email = value; }
+            get => this.User.Email;
+            internal set => this.User.Email = value;
         }
 
         /// <summary>
@@ -193,8 +193,8 @@ namespace DSharpPlus.Entities
         /// </summary>
         public override bool? MfaEnabled
         {
-            get { return this.User.MfaEnabled; }
-            internal set { this.User.MfaEnabled = value; }
+            get => this.User.MfaEnabled;
+            internal set => this.User.MfaEnabled = value;
         }
 
         /// <summary>
@@ -202,8 +202,8 @@ namespace DSharpPlus.Entities
         /// </summary>
         public override bool? Verified
         {
-            get { return this.User.Verified; }
-            internal set { this.User.Verified = value; }
+            get => this.User.Verified;
+            internal set => this.User.Verified = value;
         }
 
         /// <summary>
@@ -211,8 +211,8 @@ namespace DSharpPlus.Entities
         /// </summary>
         public override string Locale
         {
-            get { return this.User.Locale; }
-            internal set { this.User.Locale = value; }
+            get => this.User.Locale;
+            internal set => this.User.Locale = value;
         }
         #endregion
 

--- a/DSharpPlus/Net/Abstractions/TransportActivity.cs
+++ b/DSharpPlus/Net/Abstractions/TransportActivity.cs
@@ -53,11 +53,8 @@ namespace DSharpPlus.Net.Abstractions
         [JsonIgnore]
         public ulong? ApplicationId
         {
-            get { return this.ApplicationIdStr != null ? (ulong?)ulong.Parse(this.ApplicationIdStr, CultureInfo.InvariantCulture) : null; }
-            internal set
-            {
-                this.ApplicationIdStr = value?.ToString(CultureInfo.InvariantCulture);
-            }
+            get => this.ApplicationIdStr != null ? (ulong?)ulong.Parse(this.ApplicationIdStr, CultureInfo.InvariantCulture) : null;
+            internal set => this.ApplicationIdStr = value?.ToString(CultureInfo.InvariantCulture);
         }
 
         [JsonProperty("application_id", NullValueHandling = NullValueHandling.Ignore)]

--- a/DSharpPlus/Net/WebSocket/WebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient.cs
@@ -274,8 +274,8 @@ namespace DSharpPlus.Net.WebSocket
         /// </summary>
         public override event AsyncEventHandler Connected
         {
-            add { this._connected.Register(value); }
-            remove { this._connected.Unregister(value); }
+            add => this._connected.Register(value);
+            remove => this._connected.Unregister(value);
         }
         private AsyncEvent _connected;
 
@@ -284,8 +284,8 @@ namespace DSharpPlus.Net.WebSocket
         /// </summary>
         public override event AsyncEventHandler<SocketCloseEventArgs> Disconnected
         {
-            add { this._disconnected.Register(value); }
-            remove { this._disconnected.Unregister(value); }
+            add => this._disconnected.Register(value);
+            remove => this._disconnected.Unregister(value);
         }
         private AsyncEvent<SocketCloseEventArgs> _disconnected;
 
@@ -294,8 +294,8 @@ namespace DSharpPlus.Net.WebSocket
         /// </summary>
         public override event AsyncEventHandler<SocketMessageEventArgs> MessageReceived
         {
-            add { this._messageReceived.Register(value); }
-            remove { this._messageReceived.Unregister(value); }
+            add => this._messageReceived.Register(value);
+            remove => this._messageReceived.Unregister(value);
         }
         private AsyncEvent<SocketMessageEventArgs> _messageReceived;
 
@@ -304,8 +304,8 @@ namespace DSharpPlus.Net.WebSocket
         /// </summary>
         public override event AsyncEventHandler<SocketErrorEventArgs> Errored
         {
-            add { this._errored.Register(value); }
-            remove { this._errored.Unregister(value); }
+            add => this._errored.Register(value);
+            remove => this._errored.Unregister(value);
         }
         private AsyncEvent<SocketErrorEventArgs> _errored;
 

--- a/DSharpPlus/Net/WebSocket/WebSocketClient2.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient2.cs
@@ -84,8 +84,8 @@ namespace DSharpPlus.Net.WebSocket
         /// </summary>
         public override event AsyncEventHandler Connected
         {
-            add { this._connected.Register(value); }
-            remove { this._connected.Unregister(value); }
+            add => this._connected.Register(value);
+            remove => this._connected.Unregister(value);
         }
         private AsyncEvent _connected;
 
@@ -94,8 +94,8 @@ namespace DSharpPlus.Net.WebSocket
         /// </summary>
         public override event AsyncEventHandler<SocketCloseEventArgs> Disconnected
         {
-            add { this._disconnected.Register(value); }
-            remove { this._disconnected.Unregister(value); }
+            add => this._disconnected.Register(value);
+            remove => this._disconnected.Unregister(value);
         }
         private AsyncEvent<SocketCloseEventArgs> _disconnected;
 
@@ -104,8 +104,8 @@ namespace DSharpPlus.Net.WebSocket
         /// </summary>
         public override event AsyncEventHandler<SocketMessageEventArgs> MessageReceived
         {
-            add { this._messageReceived.Register(value); }
-            remove { this._messageReceived.Unregister(value); }
+            add => this._messageReceived.Register(value);
+            remove => this._messageReceived.Unregister(value);
         }
         private AsyncEvent<SocketMessageEventArgs> _messageReceived;
 
@@ -114,8 +114,8 @@ namespace DSharpPlus.Net.WebSocket
         /// </summary>
         public override event AsyncEventHandler<SocketErrorEventArgs> Errored
         {
-            add { this._errored.Register(value); }
-            remove { this._errored.Unregister(value); }
+            add => this._errored.Register(value);
+            remove => this._errored.Unregister(value);
         }
         private AsyncEvent<SocketErrorEventArgs> _errored;
 #pragma warning restore 649


### PR DESCRIPTION
# Summary
Switches from statement body to expression body for property get/set and event add/remove wherever possible in the main project.

# Details
According to Emzi, this was previously not used due to a bug in VS. It's been two years since then, so I think that might not apply anymore.

# Changes proposed
* Fix body style in DiscordClient, DiscordShardedClient, DiscordMember, TransportActivity, WebSocketClient2 and WebSocketClient (every instance of statement body style that can be expression body in the main DSharpPlus project)

# Notes
This conversion was performed by a robot.