### PR TITLE
Optional<T> API do-over

### DIFF
--- a/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
@@ -25,7 +25,7 @@ namespace DSharpPlus.CommandsNext.Converters
             if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var uid))
             {
                 var result = await ctx.Client.GetUserAsync(uid).ConfigureAwait(false);
-                var ret = result != null ? Optional<DiscordUser>.FromValue(result) : Optional<DiscordUser>.FromNoValue();
+                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordUser>();
                 return ret;
             }
 
@@ -33,7 +33,7 @@ namespace DSharpPlus.CommandsNext.Converters
             if (m.Success && ulong.TryParse(m.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out uid))
             {
                 var result = await ctx.Client.GetUserAsync(uid).ConfigureAwait(false);
-                var ret = result != null ? Optional<DiscordUser>.FromValue(result) : Optional<DiscordUser>.FromNoValue();
+                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordUser>();
                 return ret;
             }
 
@@ -50,7 +50,7 @@ namespace DSharpPlus.CommandsNext.Converters
                 .Where(xm => (cs ? xm.Username : xm.Username.ToLowerInvariant()) == un && ((dv != null && xm.Discriminator == dv) || dv == null));
             
             var usr = us.FirstOrDefault();
-            return usr != null ? Optional<DiscordUser>.FromValue(usr) : Optional<DiscordUser>.FromNoValue();
+            return usr != null ? Optional.FromValue<DiscordUser>(usr) : Optional.FromNoValue<DiscordUser>();
         }
     }
 
@@ -70,12 +70,12 @@ namespace DSharpPlus.CommandsNext.Converters
         public async Task<Optional<DiscordMember>> ConvertAsync(string value, CommandContext ctx)
         {
             if (ctx.Guild == null)
-                return Optional<DiscordMember>.FromNoValue();
+                return Optional.FromNoValue<DiscordMember>();
 
             if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var uid))
             {
                 var result = await ctx.Guild.GetMemberAsync(uid).ConfigureAwait(false);
-                var ret = result != null ? Optional<DiscordMember>.FromValue(result) : Optional<DiscordMember>.FromNoValue();
+                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordMember>();
                 return ret;
             }
 
@@ -83,7 +83,7 @@ namespace DSharpPlus.CommandsNext.Converters
             if (m.Success && ulong.TryParse(m.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out uid))
             {
                 var result = await ctx.Guild.GetMemberAsync(uid).ConfigureAwait(false);
-                var ret = result != null ? Optional<DiscordMember>.FromValue(result) : Optional<DiscordMember>.FromNoValue();
+                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordMember>();
                 return ret;
             }
 
@@ -100,7 +100,7 @@ namespace DSharpPlus.CommandsNext.Converters
                           || (cs ? xm.Nickname : xm.Nickname?.ToLowerInvariant()) == value);
 
             var mbr = us.FirstOrDefault();
-            return mbr != null ? Optional<DiscordMember>.FromValue(mbr) : Optional<DiscordMember>.FromNoValue();
+            return mbr != null ? Optional.FromValue(mbr) : Optional.FromNoValue<DiscordMember>();
         }
     }
 
@@ -122,7 +122,7 @@ namespace DSharpPlus.CommandsNext.Converters
             if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var cid))
             {
                 var result = await ctx.Client.GetChannelAsync(cid).ConfigureAwait(false);
-                var ret = result != null ? Optional<DiscordChannel>.FromValue(result) : Optional<DiscordChannel>.FromNoValue();
+                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordChannel>();
                 return ret;
             }
 
@@ -130,7 +130,7 @@ namespace DSharpPlus.CommandsNext.Converters
             if (m.Success && ulong.TryParse(m.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out cid))
             {
                 var result = await ctx.Client.GetChannelAsync(cid).ConfigureAwait(false);
-                var ret = result != null ? Optional<DiscordChannel>.FromValue(result) : Optional<DiscordChannel>.FromNoValue();
+                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordChannel>();
                 return ret;
             }
 
@@ -139,7 +139,7 @@ namespace DSharpPlus.CommandsNext.Converters
                 value = value.ToLowerInvariant();
 
             var chn = ctx.Guild?.Channels.FirstOrDefault(xc => (cs ? xc.Name : xc.Name.ToLowerInvariant()) == value);
-            return chn != null ? Optional<DiscordChannel>.FromValue(chn) : Optional<DiscordChannel>.FromNoValue();
+            return chn != null ? Optional.FromValue(chn) : Optional.FromNoValue<DiscordChannel>();
         }
     }
 
@@ -159,12 +159,12 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<DiscordRole>> ConvertAsync(string value, CommandContext ctx)
         {
             if (ctx.Guild == null)
-                return Task.FromResult(Optional<DiscordRole>.FromNoValue());
+                return Task.FromResult(Optional.FromNoValue<DiscordRole>());
 
             if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var rid))
             {
                 var result = ctx.Guild.Roles.FirstOrDefault(xr => xr.Id == rid);
-                var ret = result != null ? Optional<DiscordRole>.FromValue(result) : Optional<DiscordRole>.FromNoValue();
+                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordRole>();
                 return Task.FromResult(ret);
             }
 
@@ -172,7 +172,7 @@ namespace DSharpPlus.CommandsNext.Converters
             if (m.Success && ulong.TryParse(m.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out rid))
             {
                 var result = ctx.Guild.Roles.FirstOrDefault(xr => xr.Id == rid);
-                var ret = result != null ? Optional<DiscordRole>.FromValue(result) : Optional<DiscordRole>.FromNoValue();
+                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordRole>();
                 return Task.FromResult(ret);
             }
 
@@ -181,7 +181,7 @@ namespace DSharpPlus.CommandsNext.Converters
                 value = value.ToLowerInvariant();
 
             var rol = ctx.Guild.Roles.FirstOrDefault(xr => (cs ? xr.Name : xr.Name.ToLowerInvariant()) == value);
-            return Task.FromResult(rol != null ? Optional<DiscordRole>.FromValue(rol) : Optional<DiscordRole>.FromNoValue());
+            return Task.FromResult(rol != null ? Optional.FromValue(rol) : Optional.FromNoValue<DiscordRole>());
         }
     }
 
@@ -192,9 +192,9 @@ namespace DSharpPlus.CommandsNext.Converters
             if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var gid))
             {
                 if (ctx.Client.Guilds.TryGetValue(gid, out var result))
-                    return Task.FromResult(Optional<DiscordGuild>.FromValue(result));
+                    return Task.FromResult(Optional.FromValue(result));
                 else
-                    return Task.FromResult(Optional<DiscordGuild>.FromNoValue());
+                    return Task.FromResult(Optional.FromNoValue<DiscordGuild>());
             }
 
             var cs = ctx.Config.CaseSensitive;
@@ -202,7 +202,7 @@ namespace DSharpPlus.CommandsNext.Converters
                 value = value?.ToLowerInvariant();
 
             var gld = ctx.Client.Guilds.Values.FirstOrDefault(xg => (cs ? xg.Name : xg.Name.ToLowerInvariant()) == value);
-            return Task.FromResult(gld != null ? Optional<DiscordGuild>.FromValue(gld) : Optional<DiscordGuild>.FromNoValue());
+            return Task.FromResult(gld != null ? Optional.FromValue(gld) : Optional.FromNoValue<DiscordGuild>());
         }
     }
 
@@ -213,11 +213,11 @@ namespace DSharpPlus.CommandsNext.Converters
             if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var mid))
             {
                 var result = await ctx.Channel.GetMessageAsync(mid).ConfigureAwait(false);
-                var ret = result != null ? Optional<DiscordMessage>.FromValue(result) : Optional<DiscordMessage>.FromNoValue();
+                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordMessage>();
                 return ret;
             }
 
-            return Optional<DiscordMessage>.FromNoValue();
+            return Optional.FromNoValue<DiscordMessage>();
         }
     }
 
@@ -239,7 +239,7 @@ namespace DSharpPlus.CommandsNext.Converters
             if (DiscordEmoji.UnicodeEmojiList.Contains(value))
             {
                 var result = DiscordEmoji.FromUnicode(ctx.Client, value);
-                var ret = result != null ? Optional<DiscordEmoji>.FromValue(result) : Optional<DiscordEmoji>.FromNoValue();
+                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordEmoji>();
                 return Task.FromResult(ret);
             }
 
@@ -251,17 +251,17 @@ namespace DSharpPlus.CommandsNext.Converters
                 var anim = m.Groups["animated"].Success;
 
                 if (!ulong.TryParse(sid, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
-                    return Task.FromResult(Optional<DiscordEmoji>.FromNoValue());
+                    return Task.FromResult(Optional.FromNoValue<DiscordEmoji>());
 
                 try
                 {
                     var e = DiscordEmoji.FromGuildEmote(ctx.Client, id);
-                    return Task.FromResult(Optional<DiscordEmoji>.FromValue(e));
+                    return Task.FromResult(Optional.FromValue(e));
                 }
                 catch (KeyNotFoundException)
                 { }
 
-                return Task.FromResult(Optional<DiscordEmoji>.FromValue(new DiscordEmoji
+                return Task.FromResult(Optional.FromValue(new DiscordEmoji
                 {
                     Discord = ctx.Client,
                     Id = id,
@@ -272,7 +272,7 @@ namespace DSharpPlus.CommandsNext.Converters
                 }));
             }
 
-            return Task.FromResult(Optional<DiscordEmoji>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<DiscordEmoji>());
         }
     }
 
@@ -296,7 +296,7 @@ namespace DSharpPlus.CommandsNext.Converters
         {
             var m = ColorRegexHex.Match(value);
             if (m.Success && int.TryParse(m.Groups[1].Value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var clr))
-                return Task.FromResult(Optional<DiscordColor>.FromValue(clr));
+                return Task.FromResult(Optional.FromValue<DiscordColor>(clr));
 
             m = ColorRegexRgb.Match(value);
             if (m.Success)
@@ -306,12 +306,12 @@ namespace DSharpPlus.CommandsNext.Converters
                 var p3 = byte.TryParse(m.Groups[3].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var b);
 
                 if (!(p1 && p2 && p3))
-                    return Task.FromResult(Optional<DiscordColor>.FromNoValue());
+                    return Task.FromResult(Optional.FromNoValue<DiscordColor>());
                 
-                return Task.FromResult(Optional<DiscordColor>.FromValue(new DiscordColor(r, g, b)));
+                return Task.FromResult(Optional.FromValue(new DiscordColor(r, g, b)));
             }
 
-            return Task.FromResult(Optional<DiscordColor>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<DiscordColor>());
         }
     }
 }

--- a/DSharpPlus.CommandsNext/Converters/EnumConverter.cs
+++ b/DSharpPlus.CommandsNext/Converters/EnumConverter.cs
@@ -18,10 +18,10 @@ namespace DSharpPlus.CommandsNext.Converters
             if (!ti.IsEnum)
                 throw new InvalidOperationException("Cannot convert non-enum value to an enum.");
 
-            if (Enum.TryParse<T>(value, !ctx.Config.CaseSensitive, out T ev))
-                return Task.FromResult(Optional<T>.FromValue(ev));
+            if (Enum.TryParse(value, !ctx.Config.CaseSensitive, out T ev))
+                return Task.FromResult(Optional.FromValue(ev));
 
-            return Task.FromResult(Optional<T>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<T>());
         }
     }
 }

--- a/DSharpPlus.CommandsNext/Converters/NullableConverter.cs
+++ b/DSharpPlus.CommandsNext/Converters/NullableConverter.cs
@@ -12,16 +12,16 @@ namespace DSharpPlus.CommandsNext.Converters
                 value = value.ToLowerInvariant();
 
             if (value == "null")
-                return Optional<Nullable<T>>.FromValue(null);
+                return Optional.FromValue<Nullable<T>>(null);
 
             if (ctx.CommandsNext.ArgumentConverters.TryGetValue(typeof(T), out var cv))
             {
                 var cvx = cv as IArgumentConverter<T>;
                 var val = await cvx.ConvertAsync(value, ctx).ConfigureAwait(false);
-                return val.HasValue ? Optional<Nullable<T>>.FromValue(val.Value) : Optional<Nullable<T>>.FromNoValue();
+                return val.HasValue ? Optional.FromValue<Nullable<T>>(val.Value) : Optional.FromNoValue<Nullable<T>>();
             }
 
-            return Optional<Nullable<T>>.FromNoValue();
+            return Optional.FromNoValue<Nullable<T>>();
         }
     }
 }

--- a/DSharpPlus.CommandsNext/Converters/NumericConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/NumericConverters.cs
@@ -9,9 +9,9 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<bool>> ConvertAsync(string value, CommandContext ctx)
         {
             if (bool.TryParse(value, out var result))
-                return Task.FromResult(Optional<bool>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
-            return Task.FromResult(Optional<bool>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<bool>());
         }
     }
 
@@ -20,9 +20,9 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<sbyte>> ConvertAsync(string value, CommandContext ctx)
         {
             if (sbyte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional<sbyte>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
-            return Task.FromResult(Optional<sbyte>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<sbyte>());
         }
     }
 
@@ -31,9 +31,9 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<byte>> ConvertAsync(string value, CommandContext ctx)
         {
             if (byte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional<byte>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
-            return Task.FromResult(Optional<byte>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<byte>());
         }
     }
 
@@ -42,9 +42,9 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<short>> ConvertAsync(string value, CommandContext ctx)
         {
             if (short.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional<short>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
-            return Task.FromResult(Optional<short>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<short>());
         }
     }
 
@@ -53,9 +53,9 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<ushort>> ConvertAsync(string value, CommandContext ctx)
         {
             if (ushort.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional<ushort>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
-            return Task.FromResult(Optional<ushort>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<ushort>());
         }
     }
 
@@ -64,9 +64,9 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<int>> ConvertAsync(string value, CommandContext ctx)
         {
             if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional<int>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
-            return Task.FromResult(Optional<int>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<int>());
         }
     }
 
@@ -75,9 +75,9 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<uint>> ConvertAsync(string value, CommandContext ctx)
         {
             if (uint.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional<uint>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
-            return Task.FromResult(Optional<uint>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<uint>());
         }
     }
 
@@ -86,9 +86,9 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<long>> ConvertAsync(string value, CommandContext ctx)
         {
             if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional<long>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
-            return Task.FromResult(Optional<long>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<long>());
         }
     }
 
@@ -97,9 +97,9 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<ulong>> ConvertAsync(string value, CommandContext ctx)
         {
             if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional<ulong>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
-            return Task.FromResult(Optional<ulong>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<ulong>());
         }
     }
 
@@ -108,9 +108,9 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<float>> ConvertAsync(string value, CommandContext ctx)
         {
             if (float.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional<float>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
-            return Task.FromResult(Optional<float>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<float>());
         }
     }
 
@@ -119,9 +119,9 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<double>> ConvertAsync(string value, CommandContext ctx)
         {
             if (double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional<double>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
-            return Task.FromResult(Optional<double>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<double>());
         }
     }
 
@@ -130,9 +130,9 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<decimal>> ConvertAsync(string value, CommandContext ctx)
         {
             if (decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional<decimal>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
-            return Task.FromResult(Optional<decimal>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<decimal>());
         }
     }
 }

--- a/DSharpPlus.CommandsNext/Converters/StringConverter.cs
+++ b/DSharpPlus.CommandsNext/Converters/StringConverter.cs
@@ -7,7 +7,7 @@ namespace DSharpPlus.CommandsNext.Converters
     public class StringConverter : IArgumentConverter<string>
     {
         public Task<Optional<string>> ConvertAsync(string value, CommandContext ctx)
-            => Task.FromResult(Optional<string>.FromValue(value));
+            => Task.FromResult(Optional.FromValue(value));
     }
 
     public class UriConverter : IArgumentConverter<Uri>
@@ -19,11 +19,11 @@ namespace DSharpPlus.CommandsNext.Converters
                 if (value.StartsWith("<") && value.EndsWith(">"))
                     value = value.Substring(1, value.Length - 2);
 
-                return Task.FromResult(Optional<Uri>.FromValue(new Uri(value)));
+                return Task.FromResult(Optional.FromValue(new Uri(value)));
             }
             catch
             {
-                return Task.FromResult(Optional<Uri>.FromNoValue());
+                return Task.FromResult(Optional.FromNoValue<Uri>());
             }
         }
     }

--- a/DSharpPlus.CommandsNext/Converters/TimeConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/TimeConverters.cs
@@ -13,7 +13,7 @@ namespace DSharpPlus.CommandsNext.Converters
             if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result))
                 return Task.FromResult(new Optional<DateTime>(result));
 
-            return Task.FromResult(Optional<DateTime>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<DateTime>());
         }
     }
 
@@ -22,9 +22,9 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<DateTimeOffset>> ConvertAsync(string value, CommandContext ctx)
         {
             if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result))
-                return Task.FromResult(Optional<DateTimeOffset>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
-            return Task.FromResult(Optional<DateTimeOffset>.FromNoValue());
+            return Task.FromResult(Optional.FromNoValue<DateTimeOffset>());
         }
     }
 
@@ -44,21 +44,21 @@ namespace DSharpPlus.CommandsNext.Converters
         public Task<Optional<TimeSpan>> ConvertAsync(string value, CommandContext ctx)
         {
             if (value == "0")
-                return Task.FromResult(Optional<TimeSpan>.FromValue(TimeSpan.Zero));
+                return Task.FromResult(Optional.FromValue(TimeSpan.Zero));
 
             if (int.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out _))
-                return Task.FromResult(Optional<TimeSpan>.FromNoValue());
+                return Task.FromResult(Optional.FromNoValue<TimeSpan>());
 
             if (!ctx.Config.CaseSensitive)
                 value = value.ToLowerInvariant();
 
             if (TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional<TimeSpan>.FromValue(result));
+                return Task.FromResult(Optional.FromValue(result));
 
             var gps = new string[] { "days", "hours", "minutes", "seconds" };
             var mtc = TimeSpanRegex.Match(value);
             if (!mtc.Success)
-                return Task.FromResult(Optional<TimeSpan>.FromNoValue());
+                return Task.FromResult(Optional.FromNoValue<TimeSpan>());
 
             var d = 0;
             var h = 0;
@@ -92,7 +92,7 @@ namespace DSharpPlus.CommandsNext.Converters
                 }
             }
             result = new TimeSpan(d, h, m, s);
-            return Task.FromResult(Optional<TimeSpan>.FromValue(result));
+            return Task.FromResult(Optional.FromValue(result));
         }
     }
 }

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -104,14 +104,14 @@ namespace DSharpPlus
                 if (mdl.AfkChannel.Value.Type != ChannelType.Voice)
                     throw new ArgumentException("AFK channel needs to be a voice channel!");
 
-            var iconb64 = Optional<string>.FromNoValue();
+            var iconb64 = Optional.FromNoValue<string>();
             if (mdl.Icon.HasValue && mdl.Icon.Value != null)
                 using (var imgtool = new ImageTool(mdl.Icon.Value))
                     iconb64 = imgtool.GetBase64();
             else if (mdl.Icon.HasValue)
                 iconb64 = null;
 
-            var splashb64 = Optional<string>.FromNoValue();
+            var splashb64 = Optional.FromNoValue<string>();
             if (mdl.Splash.HasValue && mdl.Splash.Value != null)
                 using (var imgtool = new ImageTool(mdl.Splash.Value))
                     splashb64 = imgtool.GetBase64();
@@ -695,7 +695,7 @@ namespace DSharpPlus
             {
                 await this.ApiClient.ModifyCurrentMemberNicknameAsync(guild_id, mdl.Nickname.Value,
                     mdl.AuditLogReason).ConfigureAwait(false);
-                await this.ApiClient.ModifyGuildMemberAsync(guild_id, member_id, Optional<string>.FromNoValue(),
+                await this.ApiClient.ModifyGuildMemberAsync(guild_id, member_id, Optional.FromNoValue<string>(),
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
                     mdl.VoiceChannel.IfPresent(e => e.Id), mdl.AuditLogReason).ConfigureAwait(false);
             }

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -440,7 +440,7 @@ namespace DSharpPlus
         public Task<DiscordGuild> CreateGuildAsync(string name, string region = null, Optional<Stream> icon = default, VerificationLevel? verificationLevel = null,
             DefaultMessageNotifications? defaultMessageNotifications = null)
         {
-            var iconb64 = Optional<string>.FromNoValue();
+            var iconb64 = Optional.FromNoValue<string>();
             if (icon.HasValue && icon.Value != null)
                 using (var imgtool = new ImageTool(icon.Value))
                     iconb64 = imgtool.GetBase64();
@@ -525,7 +525,7 @@ namespace DSharpPlus
         /// <returns></returns>
         public async Task<DiscordUser> UpdateCurrentUserAsync(string username = null, Optional<Stream> avatar = default)
         {
-            var av64 = Optional<string>.FromNoValue();
+            var av64 = Optional.FromNoValue<string>();
             if (avatar.HasValue && avatar.Value != null)
                 using (var imgtool = new ImageTool(avatar.Value))
                     av64 = imgtool.GetBase64();

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -291,7 +291,7 @@ namespace DSharpPlus.Entities
             }
             if (this.Type != ChannelType.Text)
             {
-                perUserRateLimit = Optional<int?>.FromNoValue();
+                perUserRateLimit = Optional.FromNoValue<int?>();
             }
 
             return await this.Guild.CreateChannelAsync(this.Name, this.Type, this.Parent, bitrate, userLimit, ovrs, this.IsNSFW, perUserRateLimit, reason).ConfigureAwait(false);

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -540,7 +540,7 @@ namespace DSharpPlus.Entities
         /// <returns></returns>
         public async Task<DiscordWebhook> CreateWebhookAsync(string name, Optional<Stream> avatar = default, string reason = null)
         {
-            var av64 = Optional<string>.FromNoValue();
+            var av64 = Optional.FromNoValue<string>();
             if (avatar.HasValue && avatar.Value != null)
                 using (var imgtool = new ImageTool(avatar.Value))
                     av64 = imgtool.GetBase64();

--- a/DSharpPlus/Entities/DiscordEmbed.cs
+++ b/DSharpPlus/Entities/DiscordEmbed.cs
@@ -95,7 +95,7 @@ namespace DSharpPlus.Entities
 
         internal DiscordEmbed()
         {
-            this._colorLazy = new Lazy<Optional<DiscordColor>>(() => this._color.HasValue ? Optional<DiscordColor>.FromValue(this._color.Value) : Optional<DiscordColor>.FromNoValue());
+            this._colorLazy = new Lazy<Optional<DiscordColor>>(() => this._color.HasValue ? Optional.FromValue<DiscordColor>(this._color.Value) : Optional.FromNoValue<DiscordColor>());
         }
     }
 }

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -419,7 +419,7 @@ namespace DSharpPlus.Entities
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The newly-created channel category.</returns>
         public Task<DiscordChannel> CreateChannelCategoryAsync(string name, IEnumerable<DiscordOverwriteBuilder> overwrites = null, string reason = null)
-            => this.CreateChannelAsync(name, ChannelType.Category, null, null, null, overwrites, null, Optional<int?>.FromNoValue(), reason);
+            => this.CreateChannelAsync(name, ChannelType.Category, null, null, null, overwrites, null, Optional.FromNoValue<int?>(), reason);
 
         /// <summary>
         /// Creates a new voice channel in this guild.
@@ -432,7 +432,7 @@ namespace DSharpPlus.Entities
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The newly-created channel.</returns>
         public Task<DiscordChannel> CreateVoiceChannelAsync(string name, DiscordChannel parent = null, int? bitrate = null, int? user_limit = null, IEnumerable<DiscordOverwriteBuilder> overwrites = null, string reason = null)
-            => this.CreateChannelAsync(name, ChannelType.Voice, parent, bitrate, user_limit, overwrites, null, Optional<int?>.FromNoValue(), reason);
+            => this.CreateChannelAsync(name, ChannelType.Voice, parent, bitrate, user_limit, overwrites, null, Optional.FromNoValue<int?>(), reason);
 
         /// <summary>
         /// Creates a new channel in this guild.

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -326,14 +326,14 @@ namespace DSharpPlus.Entities
             if (mdl.AfkChannel.HasValue && mdl.AfkChannel.Value.Type != ChannelType.Voice)
                 throw new ArgumentException("AFK channel needs to be a voice channel.");
 
-            var iconb64 = Optional<string>.FromNoValue();
+            var iconb64 = Optional.FromNoValue<string>();
             if (mdl.Icon.HasValue && mdl.Icon.Value != null)
                 using (var imgtool = new ImageTool(mdl.Icon.Value))
                     iconb64 = imgtool.GetBase64();
             else if (mdl.Icon.HasValue)
                 iconb64 = null;
 
-            var splashb64 = Optional<string>.FromNoValue();
+            var splashb64 = Optional.FromNoValue<string>();
             if (mdl.Splash.HasValue && mdl.Splash.Value != null)
                 using (var imgtool = new ImageTool(mdl.Splash.Value))
                     splashb64 = imgtool.GetBase64();

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -345,7 +345,7 @@ namespace DSharpPlus.Entities
             {
                 await this.Discord.ApiClient.ModifyCurrentMemberNicknameAsync(this.Guild.Id, mdl.Nickname.Value,
                     mdl.AuditLogReason).ConfigureAwait(false);
-                await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, Optional<string>.FromNoValue(),
+                await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, Optional.FromNoValue<string>(),
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
                     mdl.VoiceChannel.IfPresent(e => e.Id), mdl.AuditLogReason).ConfigureAwait(false);
             }

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -66,7 +66,7 @@ namespace DSharpPlus.Entities
         /// <returns>The modified webhook.</returns>
         public Task<DiscordWebhook> ModifyAsync(string name = null, Optional<Stream> avatar = default)
         {
-            var avatarb64 = Optional<string>.FromNoValue();
+            var avatarb64 = Optional.FromNoValue<string>();
             if (avatar.HasValue && avatar.Value != null)
                 using (var imgtool = new ImageTool(avatar.Value))
                     avatarb64 = imgtool.GetBase64();

--- a/DSharpPlus/Entities/Optional.cs
+++ b/DSharpPlus/Entities/Optional.cs
@@ -4,10 +4,37 @@ using DSharpPlus.Net.Serialization;
 namespace DSharpPlus.Entities
 {
     /// <summary>
-    /// Represents a value which may or may not have a value.
+    /// Helper methods for instantiating an <see cref="Optional{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// This class only serves to allow type parameter inference on calls to <see cref="FromValue{T}"/> or
+    /// <see cref="FromNoValue{T}"/>.
+    /// </remarks>
+    public static class Optional
+    {
+        /// <summary>
+        /// Creates a new <see cref="Optional{T}"/> with specified value and valid state.
+        /// </summary>
+        /// <param name="value">Value to populate the optional with.</param>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <returns>Created optional.</returns>
+        public static Optional<T> FromValue<T>(T value)
+            => new Optional<T>(value);
+
+        /// <summary>
+        /// Creates a new empty <see cref="Optional{T}"/> with no value and invalid state.
+        /// </summary>
+        /// <typeparam name="T">The type that the created instance is wrapping around.</typeparam>
+        /// <returns>Created optional.</returns>
+        public static Optional<T> FromNoValue<T>()
+            => default;
+    }
+    
+    /// <summary>
+    /// Represents a wrapper which may or may not have a value.
     /// </summary>
     /// <typeparam name="T">Type of the value.</typeparam>
-    public struct Optional<T> : IEquatable<Optional<T>>, IEquatable<T>
+    public readonly struct Optional<T> : IEquatable<Optional<T>>, IEquatable<T>
     {
         /// <summary>
         /// Gets whether this <see cref="Optional{T}"/> has a value.
@@ -17,16 +44,10 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the value of this <see cref="Optional{T}"/>.
         /// </summary>
-        public T Value
-        {
-            get
-            {
-                if (!this.HasValue)
-                    throw new InvalidOperationException("Value is not set.");
-                return this._val;
-            }
-        }
-        private T _val;
+        /// <exception cref="InvalidOperationException">If this <see cref="Optional{T}"/> has no value.</exception>
+        public T Value => this.HasValue ? this._val : throw new InvalidOperationException("Value is not set.");
+
+        private readonly T _val;
 
         /// <summary>
         /// Creates a new <see cref="Optional{T}"/> with specified value.
@@ -54,13 +75,15 @@ namespace DSharpPlus.Entities
         /// <returns>Whether the object is equal to this <see cref="Optional{T}"/> or its value.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is T t)
-                return this.Equals(t);
-
-            if (obj is Optional<T> opt)
-                return this.Equals(opt);
-
-            return false;
+            switch (obj)
+            {
+                case T t:
+                    return this.Equals(t);
+                case Optional<T> opt:
+                    return this.Equals(opt);
+                default:
+                    return false;
+            }
         }
 
         /// <summary>
@@ -73,10 +96,7 @@ namespace DSharpPlus.Entities
             if (!this.HasValue && !e.HasValue)
                 return true;
 
-            if (this.HasValue != e.HasValue)
-                return false;
-
-            return this.Value.Equals(e.Value);
+            return this.HasValue == e.HasValue && this.Value.Equals(e.Value);
         }
 
         /// <summary>
@@ -84,37 +104,15 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="e">Object to compare to.</param>
         /// <returns>Whether the object is equal to the value of this <see cref="Optional{T}"/>.</returns>
-        public bool Equals(T e)
-        {
-            if (!this.HasValue)
-                return false;
-
-            return ReferenceEquals(this.Value, e);
-        }
+        public bool Equals(T e) 
+            => this.HasValue && ReferenceEquals(this.Value, e);
 
         /// <summary>
         /// Gets the hash code for this <see cref="Optional{T}"/>.
         /// </summary>
         /// <returns>The hash code for this <see cref="Optional{T}"/>.</returns>
-        public override int GetHashCode()
-        {
-            return this.HasValue ? this.Value.GetHashCode() : 0;
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="Optional{T}"/> with specified value and valid state.
-        /// </summary>
-        /// <param name="value">Value to populate the optional with.</param>
-        /// <returns>Created optional.</returns>
-        public static Optional<T> FromValue(T value)
-            => new Optional<T>(value);
-
-        /// <summary>
-        /// Creates a new empty <see cref="Optional{T}"/> with no value and invalid state.
-        /// </summary>
-        /// <returns>Created optional.</returns>
-        public static Optional<T> FromNoValue()
-            => default;
+        public override int GetHashCode() 
+            => this.HasValue ? this.Value.GetHashCode() : 0;
 
         public static implicit operator Optional<T>(T val) 
             => new Optional<T>(val);
@@ -134,6 +132,18 @@ namespace DSharpPlus.Entities
         public static bool operator !=(Optional<T> opt, T t) 
             => !opt.Equals(t);
 
+        /// <summary>
+        /// Performs a mapping operation on the current <see cref="Optional{T}"/>, turning it into an Optional holding a
+        /// <typeparamref name="TTarget"/> instance if the source optional contains a value; otherwise, returns an
+        /// <see cref="Optional{T}"/> of that same type with no value.
+        /// </summary>
+        /// <param name="mapper">The mapping function to apply on the current value if it exists</param>
+        /// <typeparam name="TTarget">The type of the target value returned by <paramref name="mapper"/></typeparam>
+        /// <returns>
+        /// An <see cref="Optional{T}"/> containing a value denoted by calling <paramref name="mapper"/> if the current
+        /// <see cref="Optional{T}"/> contains a value; otherwise, an empty <see cref="Optional{T}"/> of the target
+        /// type.
+        /// </returns>
         public Optional<TTarget> IfPresent<TTarget>(Func<T, TTarget> mapper)
         {
             return HasValue ? new Optional<TTarget>(mapper(Value)) : default;


### PR DESCRIPTION
# Summary
I never noticed that the Optional&lt;T> APIs were all public, which has now made me a bit ashamed of adding to it without writing documentation. So I decided to clean up minor things and just make it more betterer.

# Details
I documented all of the public-facing APIs for Optional and extracted the FromValue/FromNoValue methods into a static class so that the type parameters could be inferred by the compiler ... some of the time. That last part is what turned this PR so huge.

The changes to outside Optional.cs were all made by a robot.

All in all, after looking through all the processed code, I'm not 100% sure if I like the new pattern or not, so I'll leave that for you to decide.

# Changes proposed
* Document Optional&lt;T>.IfPresent
* Squish (technical term) Optional&lt;T>.Equals
* Squish Optional&lt;T>.Value
* Make Optional&lt;T>._val read-only (it should have been from the start)
* Move Optional&lt;T>.FromValue and FromNoValue to separate static utility classes that use the type parameters in the method signature rather than the class signature, allowing for type inference when the compiler decides it
  * This required changes to every class that used it

# Notes
I will actually get to fixing bugs in the lib and doing other important things ... in the near future. PS am tired and started writing this PR 5 hours ago but will actually test things now if I still got time (probably not) or tomorrow