### PR TITLE
Properly dispose WS4NetCore client

### DIFF
--- a/DSharpPlus.WebSocket.WebSocket4NetCore/WebSocket4NetCoreClient.cs
+++ b/DSharpPlus.WebSocket.WebSocket4NetCore/WebSocket4NetCoreClient.cs
@@ -204,5 +204,12 @@ namespace DSharpPlus.Net.WebSocket
                 this._error.InvokeAsync(new SocketErrorEventArgs(null) { Exception = ex }).ConfigureAwait(false).GetAwaiter().GetResult();
         }
         #endregion
+
+        public override void Dispose()
+        {
+            this._socket.Dispose();
+            this._socket = null;
+            base.Dispose();
+        }
     }
 }


### PR DESCRIPTION
# Summary
Fixes the WS4NetCore websocket client not being disposed when the client is disposed.

# Details
In the present behavior, the socket connection does not terminate immediately (even though it's supposed to) and causes awkward exceptions. This patch gets rid of the socket immediately during dispose.

# Changes proposed
* Call socket.Dispose in the Dispose method for WebSocket4NetCoreClient

# Notes
I didn't touch the other websocket clients because I have no means to run them properly and I can't be bothered to actually set them up. You might want to fix them as well. Also, I wrote this a few days ago, so I have to test this again to make sure it does what I think it does.