### PR TITLE
Fix GetResult call on async method in an async context.

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -34,7 +34,7 @@ namespace DSharpPlus
         {
             await base.InitializeAsync().ConfigureAwait(false);
             _guilds_lazy = new Lazy<IReadOnlyDictionary<ulong, DiscordGuild>>(() => new ReadOnlyDictionary<ulong, DiscordGuild>(_guilds));
-            var gs = ApiClient.GetCurrentUserGuildsAsync(100, null, null).ConfigureAwait(false).GetAwaiter().GetResult();
+            var gs = await ApiClient.GetCurrentUserGuildsAsync(100, null, null).ConfigureAwait(false);
             foreach (DiscordGuild g in gs)
             {
                 _guilds[g.Id] = g;


### PR DESCRIPTION
# Summary
Changes the DSharpPlus.Rest.DiscordRestClient to use await where it can, rather than GetAwaiter().GetResult() in an async context.

# Details
In the current code, this line blocks. So instead of doing that, it should be `await`ed to avoid deadlocking.

# Changes proposed
* `await` [this line](https://github.com/DSharpPlus/DSharpPlus/blob/master/DSharpPlus.Rest/DiscordRestClient.cs#L37).