### PR TITLE
Holy shit, it's voice receive.

### DIFF
--- a/DSharpPlus.Test/TestBotVoiceCommands.cs
+++ b/DSharpPlus.Test/TestBotVoiceCommands.cs
@@ -29,10 +29,10 @@ namespace DSharpPlus.Test
                 this._ssrcFilemap[e.SSRC] = File.Create($"{e.SSRC} ({e.AudioFormat.ChannelCount}).pcm");
             var fs = this._ssrcFilemap[e.SSRC];
 
-            //e.Client.DebugLogger.LogMessage(LogLevel.Debug, "VNEXT RX", $"{e.User?.Username ?? "Unknown user"} sent voice data.", DateTime.Now);
+            // e.Client.DebugLogger.LogMessage(LogLevel.Debug, "VNEXT RX", $"{e.User?.Username ?? "Unknown user"} sent voice data. {e.AudioFormat.ChannelCount}", DateTime.Now);
             var buff = e.PcmData.ToArray();
             await fs.WriteAsync(buff, 0, buff.Length).ConfigureAwait(false);
-            //await fs.FlushAsync().ConfigureAwait(false);
+            // await fs.FlushAsync().ConfigureAwait(false);
         }
         private Task OnUserSpeaking(UserSpeakingEventArgs e)
         {

--- a/DSharpPlus.VoiceNext/Codec/Opus.cs
+++ b/DSharpPlus.VoiceNext/Codec/Opus.cs
@@ -68,9 +68,7 @@ namespace DSharpPlus.VoiceNext.Codec
             outputFormat = this.AudioFormat.ChannelCount != channels ? new AudioFormat(this.AudioFormat.SampleRate, channels, this.AudioFormat.VoiceApplication) : this.AudioFormat;
 
             if (decoder.AudioFormat.ChannelCount != channels)
-            {
                 decoder.Initialize(outputFormat);
-            }
 
             var sampleCount = Interop.OpusDecode(decoder.Decoder, opus, frameSize, target, useFec);
 
@@ -155,10 +153,8 @@ namespace DSharpPlus.VoiceNext.Codec
         /// <param name="outputFormat"></param>
         internal void Initialize(AudioFormat outputFormat)
         {
-            if(Decoder != IntPtr.Zero)
-            {
+            if (Decoder != IntPtr.Zero)
                 Interop.OpusDestroyDecoder(Decoder);
-            }
 
             AudioFormat = outputFormat;
 

--- a/DSharpPlus.VoiceNext/Codec/Opus.cs
+++ b/DSharpPlus.VoiceNext/Codec/Opus.cs
@@ -65,9 +65,15 @@ namespace DSharpPlus.VoiceNext.Codec
             //    throw new ArgumentException("PCM target buffer size needs to be equal to maximum buffer size for specified audio format.", nameof(target));
 
             Interop.OpusGetPacketMetrics(opus, this.AudioFormat.SampleRate, out var channels, out var frames, out var samplesPerFrame, out var frameSize);
+            outputFormat = this.AudioFormat.ChannelCount != channels ? new AudioFormat(this.AudioFormat.SampleRate, channels, this.AudioFormat.VoiceApplication) : this.AudioFormat;
+
+            if (decoder.AudioFormat.ChannelCount != channels)
+            {
+                decoder.Initialize(outputFormat);
+            }
+
             var sampleCount = Interop.OpusDecode(decoder.Decoder, opus, frameSize, target, useFec);
 
-            outputFormat = this.AudioFormat.ChannelCount != channels ? new AudioFormat(this.AudioFormat.SampleRate, channels, this.AudioFormat.VoiceApplication) : this.AudioFormat;
             var sampleSize = outputFormat.SampleCountToSampleSize(sampleCount);
             target = target.Slice(0, sampleSize);
         }
@@ -87,8 +93,7 @@ namespace DSharpPlus.VoiceNext.Codec
         {
             lock (this.ManagedDecoders)
             {
-                var decoder = Interop.OpusCreateDecoder(this.AudioFormat);
-                var managedDecoder = new OpusDecoder(decoder, this);
+                var managedDecoder = new OpusDecoder(this);
                 this.ManagedDecoders.Add(managedDecoder);
                 return managedDecoder;
             }
@@ -130,17 +135,34 @@ namespace DSharpPlus.VoiceNext.Codec
         /// <summary>
         /// Gets the audio format produced by this decoder.
         /// </summary>
-        public AudioFormat AudioFormat 
-            => this.Opus.AudioFormat;
+        public AudioFormat AudioFormat { get; private set; }
 
-        internal IntPtr Decoder { get; }
         internal Opus Opus { get; }
+        internal IntPtr Decoder { get; private set; }
+
         private volatile bool _isDisposed = false;
 
-        internal OpusDecoder(IntPtr decoder, Opus managedOpus)
+        internal OpusDecoder(Opus managedOpus)
         {
-            this.Decoder = decoder;
             this.Opus = managedOpus;
+        }
+
+        /// <summary>
+        /// Used to lazily initialize the decoder to make sure we're
+        /// using the correct output format, this way we don't end up
+        /// creating more decoders than we need.
+        /// </summary>
+        /// <param name="outputFormat"></param>
+        internal void Initialize(AudioFormat outputFormat)
+        {
+            if(Decoder != IntPtr.Zero)
+            {
+                Interop.OpusDestroyDecoder(Decoder);
+            }
+
+            AudioFormat = outputFormat;
+
+            Decoder = Interop.OpusCreateDecoder(outputFormat);
         }
 
         /// <summary>

--- a/DSharpPlus.VoiceNext/EventArgs/VoiceReceiveEventArgs.cs
+++ b/DSharpPlus.VoiceNext/EventArgs/VoiceReceiveEventArgs.cs
@@ -31,6 +31,9 @@ namespace DSharpPlus.VoiceNext.EventArgs
 
         /// <summary>
         /// Gets the format of the received PCM data.
+        /// <para>
+        /// Important: This isn't always the format set in <see cref="VoiceNextConfiguration.AudioFormat"/>, and depends on the audio data recieved.
+        /// </para>
         /// </summary>
         public AudioFormat AudioFormat { get; internal set; }
 

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -1,14 +1,4 @@
-﻿using DSharpPlus.Entities;
-using DSharpPlus.EventArgs;
-using DSharpPlus.Net;
-using DSharpPlus.Net.Udp;
-using DSharpPlus.Net.WebSocket;
-using DSharpPlus.VoiceNext.Codec;
-using DSharpPlus.VoiceNext.Entities;
-using DSharpPlus.VoiceNext.EventArgs;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
@@ -20,6 +10,16 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
+using DSharpPlus.Net;
+using DSharpPlus.Net.Udp;
+using DSharpPlus.Net.WebSocket;
+using DSharpPlus.VoiceNext.Codec;
+using DSharpPlus.VoiceNext.Entities;
+using DSharpPlus.VoiceNext.EventArgs;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.VoiceNext
 {

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -530,7 +530,7 @@ namespace DSharpPlus.VoiceNext
                         PcmData = pcmFiller,
                         OpusData = new byte[0].AsMemory(),
                         AudioFormat = audioFormat,
-                        AudioDuration = this.AudioFormat.CalculateSampleDuration(pcmFiller.Length)
+                        AudioDuration = audioFormat.CalculateSampleDuration(pcmFiller.Length)
                     }).ConfigureAwait(false);
 
                 await this._voiceReceived.InvokeAsync(new VoiceReceiveEventArgs(this.Discord)
@@ -540,7 +540,7 @@ namespace DSharpPlus.VoiceNext
                     PcmData = pcmMem,
                     OpusData = opusMem,
                     AudioFormat = audioFormat,
-                    AudioDuration = this.AudioFormat.CalculateSampleDuration(pcmMem.Length)
+                    AudioDuration = audioFormat.CalculateSampleDuration(pcmMem.Length)
                 }).ConfigureAwait(false);
             }
             catch (Exception ex)


### PR DESCRIPTION
# Summary
Fixes receiving and decoding voice data. 

# Details
Previously, the `OpusDecoder` was configured using the audio format specified in `VoiceNextConfiguration`, however, as it turns out, this isn't always the format incoming voice uses. This PR changes the way decoders are initialized, ensuring they have the correct channel count.

# Changes proposed
* Lazily initialize OpusDecoders
* Allow channel count to change depending on input

# Notes
*wew*