### PR TITLE
Implemented voice kick via ModifyAsync

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -674,7 +674,7 @@ namespace DSharpPlus
         /// <returns></returns>
         public Task ModifyGuildMemberAsync(ulong guild_id, ulong user_id, Optional<string> nick,
             Optional<IEnumerable<ulong>> role_ids, Optional<bool> mute, Optional<bool> deaf,
-            Optional<ulong> voice_channel_id, string reason)
+            Optional<ulong?> voice_channel_id, string reason)
             => ApiClient.ModifyGuildMemberAsync(guild_id, user_id, nick, role_ids, mute, deaf, voice_channel_id, reason);
 
         /// <summary>
@@ -689,7 +689,7 @@ namespace DSharpPlus
             var mdl = new MemberEditModel();
             action(mdl);
 
-            if (mdl.VoiceChannel.HasValue && mdl.VoiceChannel.Value.Type != ChannelType.Voice)
+            if (mdl.VoiceChannel.HasValue && mdl.VoiceChannel.Value != null && mdl.VoiceChannel.Value.Type != ChannelType.Voice)
                 throw new ArgumentException("Given channel is not a voice channel.", nameof(mdl.VoiceChannel));
 
             if (mdl.Nickname.HasValue && this.CurrentUser.Id == member_id)
@@ -698,13 +698,13 @@ namespace DSharpPlus
                     mdl.AuditLogReason).ConfigureAwait(false);
                 await this.ApiClient.ModifyGuildMemberAsync(guild_id, member_id, Optional.FromNoValue<string>(),
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
-                    mdl.VoiceChannel.IfPresent(e => e.Id), mdl.AuditLogReason).ConfigureAwait(false);
+                    mdl.VoiceChannel.IfPresent(e => e?.Id ?? null), mdl.AuditLogReason).ConfigureAwait(false);
             }
             else
             {
                 await this.ApiClient.ModifyGuildMemberAsync(guild_id, member_id, mdl.Nickname,
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
-                    mdl.VoiceChannel.IfPresent(e => e.Id), mdl.AuditLogReason).ConfigureAwait(false);
+                    mdl.VoiceChannel.IfPresent(e => e?.Id ?? null), mdl.AuditLogReason).ConfigureAwait(false);
             }
         }
 

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -698,13 +698,13 @@ namespace DSharpPlus
                     mdl.AuditLogReason).ConfigureAwait(false);
                 await this.ApiClient.ModifyGuildMemberAsync(guild_id, member_id, Optional.FromNoValue<string>(),
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
-                    mdl.VoiceChannel.IfPresent(e => e?.Id ?? null), mdl.AuditLogReason).ConfigureAwait(false);
+                    mdl.VoiceChannel.IfPresent(e => e?.Id), mdl.AuditLogReason).ConfigureAwait(false);
             }
             else
             {
                 await this.ApiClient.ModifyGuildMemberAsync(guild_id, member_id, mdl.Nickname,
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
-                    mdl.VoiceChannel.IfPresent(e => e?.Id ?? null), mdl.AuditLogReason).ConfigureAwait(false);
+                    mdl.VoiceChannel.IfPresent(e => e?.Id), mdl.AuditLogReason).ConfigureAwait(false);
             }
         }
 

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -223,6 +223,12 @@ namespace DSharpPlus.Test
             await member.ModifyAsync(u => u.VoiceChannel = null);
         }
 
+        [Command("vmove")]
+        public async Task VoiceKickAsync(CommandContext ctx, DiscordMember member, DiscordChannel channel)
+        {
+            await member.ModifyAsync(u => u.VoiceChannel = channel);
+        }
+
         /*
 		[Command("testpoll")]
 		public async Task TestPollAsync(CommandContext ctx, [RemainingText]string question)

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -215,7 +215,13 @@ namespace DSharpPlus.Test
 				await ctx.RespondAsync("voice state is not null, channel is null");
 			else
 				await ctx.RespondAsync($"connected to channel {ctx.Member.VoiceState.Channel.Name}");
-		}
+        }
+
+        [Command("vkick")]
+        public async Task VoiceKickAsync(CommandContext ctx, DiscordMember member)
+        {
+            await member.ModifyAsync(u => u.VoiceChannel = null);
+        }
 
         /*
 		[Command("testpoll")]
@@ -242,7 +248,7 @@ namespace DSharpPlus.Test
 			ctx.Client.DebugLogger.LogMessage(LogLevel.Debug, "interactivity-test", "sent results", DateTime.Now);
 		}*/
 
-		[Command("testmodify"), RequireOwner]
+        [Command("testmodify"), RequireOwner]
 		public async Task TestModifyAsync(CommandContext ctx, DiscordMember m)
 		{
 			await ctx.Channel.ModifyAsync(x =>

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -338,22 +338,23 @@ namespace DSharpPlus.Entities
             var mdl = new MemberEditModel();
             action(mdl);
 
-            if (mdl.VoiceChannel.HasValue && mdl.VoiceChannel.Value.Type != ChannelType.Voice)
+            if (mdl.VoiceChannel.HasValue && mdl.VoiceChannel.Value != null && mdl.VoiceChannel.Value.Type != ChannelType.Voice)
                 throw new ArgumentException("Given channel is not a voice channel.", nameof(mdl.VoiceChannel));
 
             if (mdl.Nickname.HasValue && this.Discord.CurrentUser.Id == this.Id)
             {
                 await this.Discord.ApiClient.ModifyCurrentMemberNicknameAsync(this.Guild.Id, mdl.Nickname.Value,
                     mdl.AuditLogReason).ConfigureAwait(false);
+
                 await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, Optional.FromNoValue<string>(),
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
-                    mdl.VoiceChannel.IfPresent(e => e.Id), mdl.AuditLogReason).ConfigureAwait(false);
+                    mdl.VoiceChannel.IfPresent(e => e?.Id ?? null), mdl.AuditLogReason).ConfigureAwait(false);
             }
             else
             {
                 await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, mdl.Nickname,
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
-                    mdl.VoiceChannel.IfPresent(e => e.Id), mdl.AuditLogReason).ConfigureAwait(false);
+                    mdl.VoiceChannel.IfPresent(e => e?.Id ?? null), mdl.AuditLogReason).ConfigureAwait(false);
             }
         }
 

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -348,13 +348,13 @@ namespace DSharpPlus.Entities
 
                 await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, Optional.FromNoValue<string>(),
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
-                    mdl.VoiceChannel.IfPresent(e => e?.Id ?? null), mdl.AuditLogReason).ConfigureAwait(false);
+                    mdl.VoiceChannel.IfPresent(e => e?.Id), mdl.AuditLogReason).ConfigureAwait(false);
             }
             else
             {
                 await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, mdl.Nickname,
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
-                    mdl.VoiceChannel.IfPresent(e => e?.Id ?? null), mdl.AuditLogReason).ConfigureAwait(false);
+                    mdl.VoiceChannel.IfPresent(e => e?.Id), mdl.AuditLogReason).ConfigureAwait(false);
             }
         }
 

--- a/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
@@ -126,7 +126,7 @@ namespace DSharpPlus.Net.Abstractions
         public Optional<bool> Deafen { get; set; }
 
         [JsonProperty("channel_id")]
-        public Optional<ulong> VoiceChannelId { get; set; }
+        public Optional<ulong?> VoiceChannelId { get; set; }
     }
 
     internal sealed class RestGuildRolePayload

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1017,7 +1017,7 @@ namespace DSharpPlus.Net
 
         internal Task ModifyGuildMemberAsync(ulong guild_id, ulong user_id, Optional<string> nick,
             Optional<IEnumerable<ulong>> role_ids, Optional<bool> mute, Optional<bool> deaf,
-            Optional<ulong> voice_channel_id, string reason)
+            Optional<ulong?> voice_channel_id, string reason)
         {
             var headers = Utilities.GetBaseHeaders();
             if (!string.IsNullOrWhiteSpace(reason))

--- a/DSharpPlus/Net/Models/MemberEditModel.cs
+++ b/DSharpPlus/Net/Models/MemberEditModel.cs
@@ -26,7 +26,7 @@ namespace DSharpPlus.Net.Models
         /// </summary>
         public Optional<bool> Deafened { internal get; set; }
         /// <summary>
-        /// Voice channel to move this user to
+        /// Voice channel to move this user to, set to null to kick
         /// </summary>
         public Optional<DiscordChannel> VoiceChannel { internal get; set; }
         


### PR DESCRIPTION
# Summary
Now Discord supports kicking users by setting `channel_id` to null when modifying users, this PR makes sure D#+ supports that via `ModifyAsync` on both the REST and Socket clients

# Details
Made VoiceChannelId an `Optional<ulong?>` rather than `Optional<ulong>` and added nullchecks to the tests

# Changes proposed
* `ulong?`
* null checking
* add commands to the test bot to test this

# Notes
This feels really hacky on Discord's part...