### PR TITLE
Fix for #425 (Session expected to be closed in OnInvalidateSessionAsync, while it is always open)

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2178,7 +2178,7 @@ namespace DSharpPlus
                 await this.SendResumeAsync().ConfigureAwait(false);
         }
 
-        private async void ReadyTimeoutBackgroundTask()
+        private async Task ReadyTimeoutBackgroundTask()
         {
             try
             {

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -33,6 +33,7 @@ namespace DSharpPlus
 
         internal CancellationTokenSource _cancelTokenSource;
         internal CancellationToken _cancelToken;
+        private CancellationTokenSource _readyTimeoutSource = new CancellationTokenSource();
 
         internal List<BaseExtension> _extensions = new List<BaseExtension>();
 
@@ -843,6 +844,15 @@ namespace DSharpPlus
         #region Events
         internal async Task OnReadyEventAsync(ReadyPayload ready, JArray rawGuilds, JArray rawDmChannels)
         {
+            var readyTimeoutSource = Interlocked.Exchange(ref this._readyTimeoutSource, new CancellationTokenSource());
+            try
+            {
+                readyTimeoutSource.Cancel();
+            }
+            finally // Cancel can throw when already disposed so let's be safe
+            {
+                readyTimeoutSource.Dispose();
+            }
             //ready.CurrentUser.Discord = this;
 
             var rusr = ready.CurrentUser;
@@ -2150,15 +2160,41 @@ namespace DSharpPlus
                 return;
             }
 
-            Interlocked.CompareExchange(ref this._skippedHeartbeats, 0, 0);
             this._heartbeatInterval = hello.HeartbeatInterval;
             this._heartbeatTask = new Task(StartHeartbeating, _cancelToken, TaskCreationOptions.LongRunning);
             this._heartbeatTask.Start();
 
+            _ = ReadyTimeoutBackgroundTask();
+
             if (this._sessionId == "")
-                await SendIdentifyAsync(_status).ConfigureAwait(false);
+                await this.SendIdentifyAsync(_status).ConfigureAwait(false);
             else
-                await SendResumeAsync().ConfigureAwait(false);
+                await this.SendResumeAsync().ConfigureAwait(false);
+        }
+
+        private async void ReadyTimeoutBackgroundTask()
+        {
+            try
+            {
+                using (var linkedSource = CancellationTokenSource.CreateLinkedTokenSource(this._cancelToken, this._readyTimeoutSource.Token))
+                {
+                    await Task.Delay(15_000, linkedSource.Token);
+                    this.DebugLogger.LogMessage(LogLevel.Critical, "DSharpPlus", "Remote did not issue Ready within 15 seconds of resume or identify. Issuing reconnect.", DateTime.Now);
+                    await this.ReconnectAsync().ConfigureAwait(false);
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                // empty
+            }
+            catch (OperationCanceledException)
+            {
+                // empty
+            }
+            catch (Exception ex)
+            {
+                this.DebugLogger.LogMessage(LogLevel.Critical, "DSharpPlus", $"Ready timeout handler failed with {ex.GetType()}: {ex.Message}", DateTime.Now, ex);
+            }
         }
 
         internal async Task OnHeartbeatAckAsync()

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2109,17 +2109,14 @@ namespace DSharpPlus
 
         internal async Task OnInvalidateSessionAsync(bool data)
         {
+            // begin a session if one is not open already
             if (this.SessionLock.Wait(0))
-            {
                 this.SessionLock.Reset();
-                var socketLock = this.GetSocketLock();
-                await socketLock.LockAsync().ConfigureAwait(false);
-                socketLock.UnlockAfter(TimeSpan.FromSeconds(5));
-            }
-            else
-            {
-                return;
-            }
+
+            // we are sending a fresh resume/identify, so lock the socket
+            var socketLock = this.GetSocketLock();
+            await socketLock.LockAsync().ConfigureAwait(false);
+            socketLock.UnlockAfter(TimeSpan.FromSeconds(5));
 
             if (data)
             {

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2178,7 +2178,7 @@ namespace DSharpPlus
                 await this.SendResumeAsync().ConfigureAwait(false);
         }
 
-        private async Task ReadyTimeoutBackgroundTask()
+        private async void ReadyTimeoutBackgroundTask()
         {
             try
             {


### PR DESCRIPTION
# Summary
Fixes #425 (misleadingly titled "Bot Stays offline in Discord after it Reconnects due to Discord Cloudfare reboot")

# Details
The cited issue is a result of Emzi's ported deadlock fix code (ironically).

When Discord sends an Opcode 9 Invalid Session payload, SessionLock will (likely always) be in nonsignaled (blocking) state (as is set in the HELLO handler), but the OP9 handler expects it to be open, returning otherwise. The only situation where that behavior would be useful would be if the WebSocket payload was received _twice in succession_, which isn't all that great considering the design of the session lock means it'll discard the payload every time...

Anyway, if you discard this seemingly impossible edge case, the most reasonable behavior would be to _never_ return early from OnInvalidateSessionAsync. Instead, my implementation ensures there is always a session running (so that further user-induced session starts will be discarded, as they should), and maintains the previous behavior of locking the socket (as we're effectively starting a new session).

As you may have gathered, and as others have told, this bug has nothing to do with Discord's CloudFlare proxy rebooting. It will happen in any situation where a reconnect results in an OP9 instead of READY/RESUMED.

# Changes proposed
* Consume the SessionLock in OnInvalidateSessionAsync without returning and deadlocking the client

# Notes
Thanks dearly to @WamWooWamWooWamWooWamWooWamWooWam for finding out that it was the locking code that was causing the deadlock and not any of the incredibly absurd things I had thought.

I haven't tested this completely yet, either. I will do that in a moment.

## Other possible solutions
* A proper system to handle locking for both session connect and session establish so that duplicate OP9s get handled. Because I can't imagine such a thing can happen, I think this would be wholly unnecessary and confusing.