### PR TITLE
Add NullValueHandling.Ignore to PremiumSubscriptionCount as it's an optional struct property

### DIFF
--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -291,7 +291,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the amount of members that boosted this guild.
         /// </summary>
-        [JsonProperty("premium_subscription_count")]
+        [JsonProperty("premium_subscription_count", NullValueHandling.Ignore)]
         public int? PremiumSubscriptionCount { get; internal set; }
         // Seriously discord?
 

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -291,7 +291,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the amount of members that boosted this guild.
         /// </summary>
-        [JsonProperty("premium_subscription_count", NullValueHandling.Ignore)]
+        [JsonProperty("premium_subscription_count", NullValueHandling = NullValueHandling.Ignore)]
         public int? PremiumSubscriptionCount { get; internal set; }
         // Seriously discord?
 


### PR DESCRIPTION
# Summary
I've added NullValueHandling.Ignore to the JsonProperty attribute for PremiumSubscriptionCount to align with other optional value type properties (almost all at the moment, save for I think DiscordEmbed.Color, which uses Optional).

# Details
This change should not affect functionality in any way, as it only affects serialization (and this property does not exist in the update endpoints); it is purely a style fix for consistency.

# Changes proposed
* Add NullValueHandling.Ignore to DiscordGuild.PremiumSubscriptionCount

# Notes
In the future, optional properties should be updated to use Optional<T>, and NullValueHandling.Ignore will most likely no longer be used. However, that would be a chore to update, and require a fair bit of testing, so I'm favoring consistency until the opportunity to do a full pass on entities arises.