### PR TITLE
Adds support for message object returned by the api when executing a webhook.

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1078,7 +1078,7 @@ namespace DSharpPlus
         /// <param name="file_name">Name of the file to attach to this webhook</param>
         /// <param name="file_data">Stream data of the file to attach to this webhook</param>
         /// <returns></returns>
-        public Task ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, string username, string avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, string file_name, Stream file_data)
+        public Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, string username, string avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, string file_name, Stream file_data)
             => ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, content, username, avatar_url, tts, embeds, file_name, file_data);
 
         /// <summary>
@@ -1093,7 +1093,7 @@ namespace DSharpPlus
         /// <param name="embeds">Embeds to attach to this webhook</param>
         /// <param name="files">Files to attach to this webhook</param>
         /// <returns></returns>
-        public Task ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, string username, string avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, Dictionary<string, Stream> files)
+        public Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, string username, string avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, Dictionary<string, Stream> files)
             => ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, content, username, avatar_url, tts, embeds, files);
         #endregion
 

--- a/DSharpPlus/DiscordWebhookClient.cs
+++ b/DSharpPlus/DiscordWebhookClient.cs
@@ -210,8 +210,8 @@ namespace DSharpPlus
         /// <param name="avatar_override">Avatar URL to use for this broadcast.</param>
         /// <param name="file_name">Name of the file to broadcast.</param>
         /// <param name="file_data">Content of the file to broadcast.</param>
-        /// <returns></returns>
-        public Task BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, string file_name = null, Stream file_data = null)
+        /// <returns>A dictionary of each message object associated with its webhook.</returns>
+        public Task<Dictionary<DiscordWebhook, DiscordMessage>> BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, string file_name = null, Stream file_data = null)
         {
             return BroadcastMessageAsync(content, embeds, tts, username_override, avatar_override, new Dictionary<string, Stream> { { file_name, file_data } });
         }
@@ -225,24 +225,30 @@ namespace DSharpPlus
         /// <param name="username_override">Username to use for this broadcast.</param>
         /// <param name="avatar_override">Avatar URL to use for this broadcast.</param>
         /// <param name="files">Files to broadcast.</param>
-        /// <returns></returns>
-        public async Task BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, Dictionary<string, Stream> files = null)
+        /// <returns>A dictionary of each message object associated with its webhook.</returns>
+        public async Task<Dictionary<DiscordWebhook, DiscordMessage>> BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, Dictionary<string, Stream> files = null)
         {
             var deadhooks = new List<DiscordWebhook>();
+            var messages = new Dictionary<DiscordWebhook, DiscordMessage>();
+
             foreach (var hook in _hooks)
             {
                 try
                 {
-                    await hook.ExecuteAsync(content, username_override ?? this.Username, avatar_override ?? this.AvatarUrl, tts, embeds, files).ConfigureAwait(false);
+                    var msg = await hook.ExecuteAsync(content, username_override ?? this.Username, avatar_override ?? this.AvatarUrl, tts, embeds, files).ConfigureAwait(false);
+                    messages.Add(hook, msg);
                 }
                 catch (NotFoundException)
                 {
                     deadhooks.Add(hook);
                 }
             }
+
             // Removing dead webhooks from collection
             foreach (var xwh in deadhooks)
                 _hooks.Remove(xwh);
+
+            return messages;
         }
     }
 }

--- a/DSharpPlus/DiscordWebhookClient.cs
+++ b/DSharpPlus/DiscordWebhookClient.cs
@@ -211,7 +211,7 @@ namespace DSharpPlus
         /// <param name="file_name">Name of the file to broadcast.</param>
         /// <param name="file_data">Content of the file to broadcast.</param>
         /// <returns>A dictionary of each message object associated with its webhook.</returns>
-        public Task<Dictionary<DiscordWebhook, DiscordMessage>> BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, string file_name = null, Stream file_data = null)
+        public Task<IReadOnlyDictionary<DiscordWebhook, DiscordMessage>> BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, string file_name = null, Stream file_data = null)
         {
             return BroadcastMessageAsync(content, embeds, tts, username_override, avatar_override, new Dictionary<string, Stream> { { file_name, file_data } });
         }

--- a/DSharpPlus/DiscordWebhookClient.cs
+++ b/DSharpPlus/DiscordWebhookClient.cs
@@ -226,7 +226,7 @@ namespace DSharpPlus
         /// <param name="avatar_override">Avatar URL to use for this broadcast.</param>
         /// <param name="files">Files to broadcast.</param>
         /// <returns>A dictionary of each message object associated with its webhook.</returns>
-        public async Task<Dictionary<DiscordWebhook, DiscordMessage>> BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, Dictionary<string, Stream> files = null)
+        public async Task<IReadOnlyDictionary<DiscordWebhook, DiscordMessage>> BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, Dictionary<string, Stream> files = null)
         {
             var deadhooks = new List<DiscordWebhook>();
             var messages = new Dictionary<DiscordWebhook, DiscordMessage>();

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -94,7 +94,7 @@ namespace DSharpPlus.Entities
         /// <param name="file_name">Name of the file to attach to the message being sent.</param>
         /// <param name="file_data">Content of the file to attach to the message being sent.</param>
         /// <returns></returns>
-        public Task ExecuteAsync(string content = null, string username = null, string avatar_url = null, bool tts = false, IEnumerable<DiscordEmbed> embeds = null, string file_name = null, Stream file_data = null) 
+        public Task<DiscordMessage> ExecuteAsync(string content = null, string username = null, string avatar_url = null, bool tts = false, IEnumerable<DiscordEmbed> embeds = null, string file_name = null, Stream file_data = null) 
             => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookAsync(Id, Token, content, username, avatar_url, tts, embeds, file_name, file_data);
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace DSharpPlus.Entities
         /// <param name="embeds">Embeds to attach to the message being sent.</param>
         /// <param name="files">Files to attach to the message being sent.</param>
         /// <returns></returns>
-        public Task ExecuteAsync(string content = null, string username = null, string avatar_url = null, bool tts = false, IEnumerable<DiscordEmbed> embeds = null, Dictionary<string, Stream> files = null)
+        public Task<DiscordMessage> ExecuteAsync(string content = null, string username = null, string avatar_url = null, bool tts = false, IEnumerable<DiscordEmbed> embeds = null, Dictionary<string, Stream> files = null)
             => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookAsync(Id, Token, content, username, avatar_url, tts, embeds, files);
 
         /// <summary>

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1629,7 +1629,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = Utilities.GetApiUriFor(path, "?wait=true");
+            var url = Utilities.PatchQueryString(Utilities.GetApiUriFor(path), new Dictionary<string, string> { ["wait"] = "true" });
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, values: values, files: files).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
@@ -1640,8 +1640,8 @@ namespace DSharpPlus.Net
         {
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.SLACK}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
-            
-            var url = Utilities.GetApiUriFor(path, "?wait=true");
+
+            var url = Utilities.PatchQueryString(Utilities.GetApiUriFor(path), new Dictionary<string, string> { ["wait"] = "true" });
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
@@ -1653,7 +1653,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.GITHUB}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = Utilities.GetApiUriFor(path, "?wait=true");
+            var url = Utilities.PatchQueryString(Utilities.GetApiUriFor(path), new Dictionary<string, string> { ["wait"] = "true" });
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1629,9 +1629,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            path += "?wait=true";
-
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(path, "?wait=true");
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, values: values, files: files).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
@@ -1642,10 +1640,8 @@ namespace DSharpPlus.Net
         {
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.SLACK}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
-
-            path += "?wait=true";
-
-            var url = Utilities.GetApiUriFor(path);
+            
+            var url = Utilities.GetApiUriFor(path, "?wait=true");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
@@ -1657,9 +1653,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.GITHUB}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            path += "?wait=true";
-
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(path, "?wait=true");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1643,6 +1643,8 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.SLACK}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
+            path += "?wait=true";
+
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
@@ -1654,6 +1656,8 @@ namespace DSharpPlus.Net
         {
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.GITHUB}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
+
+            path += "?wait=true";
 
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);

--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -66,6 +66,23 @@ namespace DSharpPlus
         internal static Uri GetApiUriFor(string path, string queryString)
             => new Uri($"{GetApiBaseUri()}{path}{queryString}");
 
+        internal static Uri PatchQueryString(Uri url, IDictionary<string, string> queryArgs)
+        {
+            var ub = new UriBuilder(url);
+
+            var existingQuery = string.IsNullOrWhiteSpace(ub.Query)
+                ? new Dictionary<string, string>()
+                : ub.Query.Split('&')
+                    .Select(x => x.Split('='))
+                    .ToDictionary(x => x[0], x => x[1]);
+
+            foreach (var kvp in queryArgs)
+                existingQuery[kvp.Key] = kvp.Value;
+
+            ub.Query = string.Join("&", queryArgs.Select(x => $"{x.Key}={x.Value}"));
+            return ub.Uri;
+        }
+
         internal static string GetFormattedToken(BaseDiscordClient client)
         {
             return GetFormattedToken(client.Configuration);


### PR DESCRIPTION
# Summary
It was not possible to get the message object when you execute a webhook.

# Details
As told in the official discord docs, it is possible to add the querystring parameter `wait` to get as a response, the message object after the execution of the webhook.

This pull request also fixes the fact that when you pass a null file_name (default param) to one of the overloads, it was trying to add a null key to a dictionary.

# Notes
It was tested and worked.