### PR TITLE
Prevent DiscordClient from being inherited

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -25,7 +25,7 @@ namespace DSharpPlus
     /// <summary>
     /// A Discord api wrapper
     /// </summary>
-    public class DiscordClient : BaseDiscordClient
+    public sealed class DiscordClient : BaseDiscordClient
     {
         #region Internal Variables
         internal static UTF8Encoding UTF8 = new UTF8Encoding(false);


### PR DESCRIPTION
# Summary
Fixes an InvalidOperationException in the EventWaiter&lt;T> constructor by disallowing something which should have never been allowed to begin with.

# Details
This is the exception:
![](https://cdn.discordapp.com/attachments/379378610412191753/595133438244290582/unknown.png)
It is caused by enumerating DeclaredFields looking for an event field. When you inherit DiscordClient, all the event fields will be in the superclass, so DeclaredFields will not return anything useful. The only way around it would be really annoying, especially when you could just mark DiscordClient as `sealed` and call it a day.

# Changes proposed
* Add `sealed` modifier to DiscordClient

# Notes
Untested