### PR TITLE
Fix swallowed NRE when receiving some types of events in an uncached DM channel

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -1979,7 +1979,7 @@ namespace DSharpPlus
                     : new DiscordMember(usr) { Discord = this, _guild_id = channel.GuildId };
 
             if (channel == null || this.Configuration.MessageCacheSize == 0 ||
-                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channel.Id, out var msg))
+                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
             {
                 msg = new DiscordMessage
                 {
@@ -2030,7 +2030,7 @@ namespace DSharpPlus
                     : new DiscordMember(usr) { Discord = this, _guild_id = channel.GuildId };
 
             if (channel == null || this.Configuration.MessageCacheSize == 0 ||
-                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channel.Id, out var msg))
+                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
             {
                 msg = new DiscordMessage
                 {
@@ -2069,7 +2069,7 @@ namespace DSharpPlus
             var channel = this.InternalGetCachedChannel(channelId);
 
             if (channel == null || this.Configuration.MessageCacheSize == 0 ||
-                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channel.Id, out var msg))
+                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
             {
                 msg = new DiscordMessage
                 {

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -813,18 +813,15 @@ namespace DSharpPlus
                     break;
 
                 case "message_reaction_add":
-                    cid = (ulong)dat["channel_id"];
-                    await OnMessageReactionAddAsync((ulong)dat["user_id"], (ulong)dat["message_id"], this.InternalGetCachedChannel(cid), dat["emoji"].ToObject<DiscordEmoji>()).ConfigureAwait(false);
+                    await OnMessageReactionAddAsync((ulong)dat["user_id"], (ulong)dat["message_id"], (ulong)dat["channel_id"], dat["emoji"].ToObject<DiscordEmoji>()).ConfigureAwait(false);
                     break;
 
                 case "message_reaction_remove":
-                    cid = (ulong)dat["channel_id"];
-                    await OnMessageReactionRemoveAsync((ulong)dat["user_id"], (ulong)dat["message_id"], this.InternalGetCachedChannel(cid), dat["emoji"].ToObject<DiscordEmoji>()).ConfigureAwait(false);
+                    await OnMessageReactionRemoveAsync((ulong)dat["user_id"], (ulong)dat["message_id"], (ulong)dat["channel_id"], dat["emoji"].ToObject<DiscordEmoji>()).ConfigureAwait(false);
                     break;
 
                 case "message_reaction_remove_all":
-                    cid = (ulong)dat["channel_id"];
-                    await OnMessageReactionRemoveAllAsync((ulong)dat["message_id"], this.InternalGetCachedChannel(cid)).ConfigureAwait(false);
+                    await OnMessageReactionRemoveAllAsync((ulong)dat["message_id"], (ulong)dat["channel_id"]).ConfigureAwait(false);
                     break;
 
                 case "webhooks_update":
@@ -1962,24 +1959,27 @@ namespace DSharpPlus
             await this._unknownEvent.InvokeAsync(ea).ConfigureAwait(false);
         }
 
-        internal async Task OnMessageReactionAddAsync(ulong userId, ulong messageId, DiscordChannel channel, DiscordEmoji emoji)
+        internal async Task OnMessageReactionAddAsync(ulong userId, ulong messageId, ulong channelId, DiscordEmoji emoji)
         {
+            var channel = this.InternalGetCachedChannel(channelId);
+
             emoji.Discord = this;
 
             if (!this.UserCache.TryGetValue(userId, out var usr))
                 usr = new DiscordUser { Id = userId, Discord = this };
 
-            if (channel.Guild != null)
+            if (channel?.Guild != null)
                 usr = channel.Guild.Members.TryGetValue(userId, out var member)
                     ? member
                     : new DiscordMember(usr) { Discord = this, _guild_id = channel.GuildId };
 
-            if (this.Configuration.MessageCacheSize == 0 || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channel.Id, out var msg))
+            if (channel == null || this.Configuration.MessageCacheSize == 0 ||
+                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channel.Id, out var msg))
             {
                 msg = new DiscordMessage
                 {
                     Id = messageId,
-                    ChannelId = channel.Id,
+                    ChannelId = channelId,
                     Discord = this,
                     _reactions = new List<DiscordReaction>()
                 };
@@ -2005,31 +2005,34 @@ namespace DSharpPlus
             {
                 Message = msg,
                 Channel = channel,
+                ChannelId = channelId,
                 User = usr,
                 Emoji = emoji
             };
             await this._messageReactionAdded.InvokeAsync(ea).ConfigureAwait(false);
         }
 
-        internal async Task OnMessageReactionRemoveAsync(ulong userId, ulong messageId, DiscordChannel channel, DiscordEmoji emoji)
+        internal async Task OnMessageReactionRemoveAsync(ulong userId, ulong messageId, ulong channelId, DiscordEmoji emoji)
         {
+            var channel = this.InternalGetCachedChannel(channelId);
+
             emoji.Discord = this;
 
             if (!this.UserCache.TryGetValue(userId, out var usr))
                 usr = new DiscordUser { Id = userId, Discord = this };
 
-            if (channel.Guild != null)
+            if (channel?.Guild != null)
                 usr = channel.Guild.Members.TryGetValue(userId, out var member)
                     ? member
                     : new DiscordMember(usr) { Discord = this, _guild_id = channel.GuildId };
 
-            if (this.Configuration.MessageCacheSize == 0 ||
+            if (channel == null || this.Configuration.MessageCacheSize == 0 ||
                 !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channel.Id, out var msg))
             {
                 msg = new DiscordMessage
                 {
                     Id = messageId,
-                    ChannelId = channel.Id,
+                    ChannelId = channelId,
                     Discord = this
                 };
             }
@@ -2053,22 +2056,24 @@ namespace DSharpPlus
             {
                 Message = msg,
                 Channel = channel,
+                ChannelId = channelId,
                 User = usr,
                 Emoji = emoji
             };
             await this._messageReactionRemoved.InvokeAsync(ea).ConfigureAwait(false);
         }
 
-        internal async Task OnMessageReactionRemoveAllAsync(ulong messageId, DiscordChannel channel)
+        internal async Task OnMessageReactionRemoveAllAsync(ulong messageId, ulong channelId)
         {
-            DiscordMessage msg = null;
-            if (this.Configuration.MessageCacheSize == 0 ||
-                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channel.Id, out msg))
+            var channel = this.InternalGetCachedChannel(channelId);
+
+            if (channel == null || this.Configuration.MessageCacheSize == 0 ||
+                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channel.Id, out var msg))
             {
                 msg = new DiscordMessage
                 {
                     Id = messageId,
-                    ChannelId = channel.Id,
+                    ChannelId = channelId,
                     Discord = this
                 };
             }
@@ -2078,7 +2083,8 @@ namespace DSharpPlus
             var ea = new MessageReactionsClearEventArgs(this)
             {
                 Message = msg,
-                Channel = channel
+                Channel = channel,
+                ChannelId = channelId
             };
             await this._messageReactionsCleared.InvokeAsync(ea).ConfigureAwait(false);
         }

--- a/DSharpPlus/EventArgs/MessageReactionAddEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageReactionAddEventArgs.cs
@@ -15,7 +15,17 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the channel to which this message belongs.
         /// </summary>
+        /// <remarks>
+        /// This will be <c>null</c> for an uncached channel, which will usually happen for when this event triggers on
+        /// DM channels in which no prior messages were received or sent.
+        /// </remarks>
         public DiscordChannel Channel { get; internal set; }
+        
+        /// <summary>
+        /// Gets the ID of the channel to which this message belongs. This property can be used even when
+        /// <see cref="Channel"/> is <c>null</c>.
+        /// </summary>
+        public ulong ChannelId { get; internal set; }
 
         /// <summary>
         /// Gets the user who created the reaction.

--- a/DSharpPlus/EventArgs/MessageReactionAddEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageReactionAddEventArgs.cs
@@ -19,14 +19,9 @@ namespace DSharpPlus.EventArgs
         /// This will be <c>null</c> for an uncached channel, which will usually happen for when this event triggers on
         /// DM channels in which no prior messages were received or sent.
         /// </remarks>
-        public DiscordChannel Channel { get; internal set; }
+        public DiscordChannel Channel
+            => Message.Channel;
         
-        /// <summary>
-        /// Gets the ID of the channel to which this message belongs. This property can be used even when
-        /// <see cref="Channel"/> is <c>null</c>.
-        /// </summary>
-        public ulong ChannelId { get; internal set; }
-
         /// <summary>
         /// Gets the user who created the reaction.
         /// </summary>

--- a/DSharpPlus/EventArgs/MessageReactionRemoveEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageReactionRemoveEventArgs.cs
@@ -19,13 +19,8 @@ namespace DSharpPlus.EventArgs
         /// This will be <c>null</c> for an uncached channel, which will usually happen for when this event triggers on
         /// DM channels in which no prior messages were received or sent.
         /// </remarks>
-        public DiscordChannel Channel { get; internal set; }
-
-        /// <summary>
-        /// Gets the ID of the channel to which this message belongs. This property can be used even when
-        /// <see cref="Channel"/> is <c>null</c>.
-        /// </summary>
-        public ulong ChannelId { get; internal set; }
+        public DiscordChannel Channel
+            => Message.Channel;
 
         /// <summary>
         /// Gets the users whose reaction was removed.

--- a/DSharpPlus/EventArgs/MessageReactionRemoveEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageReactionRemoveEventArgs.cs
@@ -15,7 +15,17 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the channel to which this message belongs.
         /// </summary>
+        /// <remarks>
+        /// This will be <c>null</c> for an uncached channel, which will usually happen for when this event triggers on
+        /// DM channels in which no prior messages were received or sent.
+        /// </remarks>
         public DiscordChannel Channel { get; internal set; }
+
+        /// <summary>
+        /// Gets the ID of the channel to which this message belongs. This property can be used even when
+        /// <see cref="Channel"/> is <c>null</c>.
+        /// </summary>
+        public ulong ChannelId { get; internal set; }
 
         /// <summary>
         /// Gets the users whose reaction was removed.

--- a/DSharpPlus/EventArgs/MessageReactionsClearEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageReactionsClearEventArgs.cs
@@ -15,13 +15,12 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the channel to which this message belongs.
         /// </summary>
-        public DiscordChannel Channel { get; internal set; }
-
-        /// <summary>
-        /// Gets the ID of the channel to which this message belongs. This property can be used even when
-        /// <see cref="Channel"/> is <c>null</c>.
-        /// </summary>
-        public ulong ChannelId { get; internal set; }
+        /// <remarks>
+        /// This will be <c>null</c> for an uncached channel, which will usually happen for when this event triggers on
+        /// DM channels in which no prior messages were received or sent.
+        /// </remarks>
+        public DiscordChannel Channel
+            => Message.Channel;
 
         internal MessageReactionsClearEventArgs(DiscordClient client) : base(client) { }
     }

--- a/DSharpPlus/EventArgs/MessageReactionsClearEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageReactionsClearEventArgs.cs
@@ -17,6 +17,12 @@ namespace DSharpPlus.EventArgs
         /// </summary>
         public DiscordChannel Channel { get; internal set; }
 
+        /// <summary>
+        /// Gets the ID of the channel to which this message belongs. This property can be used even when
+        /// <see cref="Channel"/> is <c>null</c>.
+        /// </summary>
+        public ulong ChannelId { get; internal set; }
+
         internal MessageReactionsClearEventArgs(DiscordClient client) : base(client) { }
     }
 }


### PR DESCRIPTION
# Summary
This PR fixes the following exception when an external client adds/removes/clears a reaction to any message, or deletes a message, or bulk deletes a message (OAuth only), in a DM channel that isn't cached, among others:

```cs
[2019-07-02 19:19:52 -05:00] [Websocket] [Error] Socket swallowed an exception:
System.NullReferenceException: Object reference not set to an instance of an object.
   at DSharpPlus.DiscordClient.<OnMessageReactionAddAsync>d__110.MoveNext() in D:\Code\DSharpPlus\DSharpPlus\DiscordClient.cs:line 1977
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at DSharpPlus.DiscordClient.<HandleDispatchAsync>d__76.MoveNext() in D:\Code\DSharpPlus\DSharpPlus\DiscordClient.cs:line 817
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at DSharpPlus.DiscordClient.<HandleSocketMessageAsync>d__75.MoveNext() in D:\Code\DSharpPlus\DSharpPlus\DiscordClient.cs:line 612
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at DSharpPlus.DiscordClient.<<InternalConnectAsync>g__SocketOnMessage|60_1>d.MoveNext() in D:\Code\DSharpPlus\DSharpPlus\DiscordClient.cs:line 380
```

# Details
Discord only sends Channel Create events for DMs alongside Message Receive events. This means that you can receive events for messages when the client doesn't even know about the channel! The client, of course, safely handles missing message cache entries, but not missing channel cache entries, since they don't happen outside of DMs. This causes the NRE to be thrown.

I also had to alter the event args for the reaction events as the channel not being cached would also mean no way to get its ID to request it manually. I don't know if a skeleton entity would be preferable in this scenario.

# Changes proposed
* Change OnMessageReactionAddAsync, OnMessageReactionRemoveAsync, OnMessageReactionRemoveAllAsync, OnMessageDeleteEventAsync and OnMessageBulkDeleteEventAsync to support channels not in cache.
* Change the Channel properties in MessageReactionAddEventArgs, MessageReactionRemoveEventArgs and MessageReactionsClearEventArgs to use `Message.Channel` like the other event args do.

# Notes
Message Delete and Message Bulk Delete are untested. The rest of this PR was tested, but was forward-ported from an old version of the library. I tried to be surgical, but if there are any sneaky regressions as a result of the patch, feel free to blame me.

Thanks to Becca on Discord for finding and reporting this issue. Just the line number was enough for me to deduce what the problem was, which made debugging it really easy!