### PR TITLE
Query string overhaul, add wait=true for webhooks

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1078,7 +1078,7 @@ namespace DSharpPlus
         /// <param name="file_name">Name of the file to attach to this webhook</param>
         /// <param name="file_data">Stream data of the file to attach to this webhook</param>
         /// <returns></returns>
-        public Task ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, string username, string avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, string file_name, Stream file_data)
+        public Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, string username, string avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, string file_name, Stream file_data)
             => ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, content, username, avatar_url, tts, embeds, file_name, file_data);
 
         /// <summary>
@@ -1093,7 +1093,7 @@ namespace DSharpPlus
         /// <param name="embeds">Embeds to attach to this webhook</param>
         /// <param name="files">Files to attach to this webhook</param>
         /// <returns></returns>
-        public Task ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, string username, string avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, Dictionary<string, Stream> files)
+        public Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, string username, string avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, Dictionary<string, Stream> files)
             => ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, content, username, avatar_url, tts, embeds, files);
         #endregion
 

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -363,12 +363,14 @@ namespace DSharpPlus
             _webSocketClient.MessageReceived += SocketOnMessage;
             _webSocketClient.Errored += SocketOnError;
 
-            var gwuri = new UriBuilder(this._gatewayUri)
-            {
-                Query = this.Configuration.GatewayCompressionLevel == GatewayCompressionLevel.Stream ? "v=6&encoding=json&compress=zlib-stream" : "v=6&encoding=json"
-            };
-            
-            await _webSocketClient.ConnectAsync(gwuri.Uri).ConfigureAwait(false);
+            var gwuri = new QueryUriBuilder(this._gatewayUri)
+                .AddParameter("v", "6")
+                .AddParameter("encoding", "json");
+
+            if (this.Configuration.GatewayCompressionLevel == GatewayCompressionLevel.Stream)
+                gwuri.AddParameter("compress", "zlib-stream");
+
+            await _webSocketClient.ConnectAsync(gwuri.Build()).ConfigureAwait(false);
 
             Task SocketOnConnect()
                 => this._socketOpened.InvokeAsync();

--- a/DSharpPlus/DiscordWebhookClient.cs
+++ b/DSharpPlus/DiscordWebhookClient.cs
@@ -210,8 +210,8 @@ namespace DSharpPlus
         /// <param name="avatar_override">Avatar URL to use for this broadcast.</param>
         /// <param name="file_name">Name of the file to broadcast.</param>
         /// <param name="file_data">Content of the file to broadcast.</param>
-        /// <returns></returns>
-        public Task BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, string file_name = null, Stream file_data = null)
+        /// <returns>A dictionary of each message object associated with its webhook.</returns>
+        public Task<Dictionary<DiscordWebhook, DiscordMessage>> BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, string file_name = null, Stream file_data = null)
         {
             return BroadcastMessageAsync(content, embeds, tts, username_override, avatar_override, new Dictionary<string, Stream> { { file_name, file_data } });
         }
@@ -225,24 +225,30 @@ namespace DSharpPlus
         /// <param name="username_override">Username to use for this broadcast.</param>
         /// <param name="avatar_override">Avatar URL to use for this broadcast.</param>
         /// <param name="files">Files to broadcast.</param>
-        /// <returns></returns>
-        public async Task BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, Dictionary<string, Stream> files = null)
+        /// <returns>A dictionary of each message object associated with its webhook.</returns>
+        public async Task<Dictionary<DiscordWebhook, DiscordMessage>> BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, Dictionary<string, Stream> files = null)
         {
             var deadhooks = new List<DiscordWebhook>();
+            var messages = new Dictionary<DiscordWebhook, DiscordMessage>();
+
             foreach (var hook in _hooks)
             {
                 try
                 {
-                    await hook.ExecuteAsync(content, username_override ?? this.Username, avatar_override ?? this.AvatarUrl, tts, embeds, files).ConfigureAwait(false);
+                    var msg = await hook.ExecuteAsync(content, username_override ?? this.Username, avatar_override ?? this.AvatarUrl, tts, embeds, files).ConfigureAwait(false);
+                    messages.Add(hook, msg);
                 }
                 catch (NotFoundException)
                 {
                     deadhooks.Add(hook);
                 }
             }
+
             // Removing dead webhooks from collection
             foreach (var xwh in deadhooks)
                 _hooks.Remove(xwh);
+
+            return messages;
         }
     }
 }

--- a/DSharpPlus/DiscordWebhookClient.cs
+++ b/DSharpPlus/DiscordWebhookClient.cs
@@ -211,7 +211,7 @@ namespace DSharpPlus
         /// <param name="file_name">Name of the file to broadcast.</param>
         /// <param name="file_data">Content of the file to broadcast.</param>
         /// <returns>A dictionary of each message object associated with its webhook.</returns>
-        public Task<Dictionary<DiscordWebhook, DiscordMessage>> BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, string file_name = null, Stream file_data = null)
+        public Task<IReadOnlyDictionary<DiscordWebhook, DiscordMessage>> BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, string file_name = null, Stream file_data = null)
         {
             return BroadcastMessageAsync(content, embeds, tts, username_override, avatar_override, new Dictionary<string, Stream> { { file_name, file_data } });
         }

--- a/DSharpPlus/DiscordWebhookClient.cs
+++ b/DSharpPlus/DiscordWebhookClient.cs
@@ -226,7 +226,7 @@ namespace DSharpPlus
         /// <param name="avatar_override">Avatar URL to use for this broadcast.</param>
         /// <param name="files">Files to broadcast.</param>
         /// <returns>A dictionary of each message object associated with its webhook.</returns>
-        public async Task<Dictionary<DiscordWebhook, DiscordMessage>> BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, Dictionary<string, Stream> files = null)
+        public async Task<IReadOnlyDictionary<DiscordWebhook, DiscordMessage>> BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, Dictionary<string, Stream> files = null)
         {
             var deadhooks = new List<DiscordWebhook>();
             var messages = new Dictionary<DiscordWebhook, DiscordMessage>();

--- a/DSharpPlus/Entities/DiscordApplication.cs
+++ b/DSharpPlus/Entities/DiscordApplication.cs
@@ -147,10 +147,12 @@ namespace DSharpPlus.Entities
         public string GenerateBotOAuth(Permissions permissions = Permissions.None)
         {
             permissions &= PermissionMethods.FULL_PERMS;
-            // Split it up so it isn't annoying and blue
-            // 
-            // :blobthonkang: -emzi
-            return "https://" + $"discordapp.com/oauth2/authorize?client_id={this.Id.ToString(CultureInfo.InvariantCulture)}&scope=bot&permissions={((long)permissions).ToString(CultureInfo.InvariantCulture)}";
+            // hey look, it's not all annoying and blue :P
+            return new QueryUriBuilder("https://discordapp.com/oauth2/authorize")
+                .AddParameter("client_id", this.Id.ToString(CultureInfo.InvariantCulture))
+                .AddParameter("scope", "bot")
+                .AddParameter("permissions", ((long) permissions).ToString(CultureInfo.InvariantCulture))
+                .ToString();
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -94,7 +94,7 @@ namespace DSharpPlus.Entities
         /// <param name="file_name">Name of the file to attach to the message being sent.</param>
         /// <param name="file_data">Content of the file to attach to the message being sent.</param>
         /// <returns></returns>
-        public Task ExecuteAsync(string content = null, string username = null, string avatar_url = null, bool tts = false, IEnumerable<DiscordEmbed> embeds = null, string file_name = null, Stream file_data = null) 
+        public Task<DiscordMessage> ExecuteAsync(string content = null, string username = null, string avatar_url = null, bool tts = false, IEnumerable<DiscordEmbed> embeds = null, string file_name = null, Stream file_data = null) 
             => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookAsync(Id, Token, content, username, avatar_url, tts, embeds, file_name, file_data);
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace DSharpPlus.Entities
         /// <param name="embeds">Embeds to attach to the message being sent.</param>
         /// <param name="files">Files to attach to the message being sent.</param>
         /// <returns></returns>
-        public Task ExecuteAsync(string content = null, string username = null, string avatar_url = null, bool tts = false, IEnumerable<DiscordEmbed> embeds = null, Dictionary<string, Stream> files = null)
+        public Task<DiscordMessage> ExecuteAsync(string content = null, string username = null, string avatar_url = null, bool tts = false, IEnumerable<DiscordEmbed> embeds = null, Dictionary<string, Stream> files = null)
             => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookAsync(Id, Token, content, username, avatar_url, tts, embeds, files);
 
         /// <summary>

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1629,7 +1629,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = Utilities.GetApiUriFor(path, "?wait=true");
+            var url = Utilities.PatchQueryString(Utilities.GetApiUriFor(path), new Dictionary<string, string> { ["wait"] = "true" });
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, values: values, files: files).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
@@ -1640,8 +1640,8 @@ namespace DSharpPlus.Net
         {
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.SLACK}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
-            
-            var url = Utilities.GetApiUriFor(path, "?wait=true");
+
+            var url = Utilities.PatchQueryString(Utilities.GetApiUriFor(path), new Dictionary<string, string> { ["wait"] = "true" });
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
@@ -1653,7 +1653,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.GITHUB}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = Utilities.GetApiUriFor(path, "?wait=true");
+            var url = Utilities.PatchQueryString(Utilities.GetApiUriFor(path), new Dictionary<string, string> { ["wait"] = "true" });
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -991,17 +991,19 @@ namespace DSharpPlus.Net
 
         internal async Task<IReadOnlyList<DiscordGuild>> GetCurrentUserGuildsAsync(int limit = 100, ulong? before = null, ulong? after = null)
         {
-            var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.GUILDS}?limit={limit}";
-
-            if (before != null)
-                route += "&before=" + before;
-            if (after != null)
-                route += "&after=" + after;
+            var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.GUILDS}";
 
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
+            var url = Utilities.GetApiUriBuilderFor(path)
+                .AddParameter($"limit", limit.ToString(CultureInfo.InvariantCulture));
+            
+            if (before != null)
+                url.AddParameter("before", before.Value.ToString(CultureInfo.InvariantCulture));
+            if (after != null)
+                url.AddParameter("after", after.Value.ToString(CultureInfo.InvariantCulture));
+
+            var res = await this.DoRequestAsync(this.Discord, bucket, url.Build(), RestRequestMethod.GET).ConfigureAwait(false);
 
             if (this.Discord is DiscordClient)
             {
@@ -1629,7 +1631,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = Utilities.PatchQueryString(Utilities.GetApiUriFor(path), new Dictionary<string, string> { ["wait"] = "true" });
+            var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, values: values, files: files).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
@@ -1641,7 +1643,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.SLACK}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = Utilities.PatchQueryString(Utilities.GetApiUriFor(path), new Dictionary<string, string> { ["wait"] = "true" });
+            var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
@@ -1653,7 +1655,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.GITHUB}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = Utilities.PatchQueryString(Utilities.GetApiUriFor(path), new Dictionary<string, string> { ["wait"] = "true" });
+            var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1629,9 +1629,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            path += "?wait=true";
-
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(path, "?wait=true");
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, values: values, files: files).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
@@ -1642,10 +1640,8 @@ namespace DSharpPlus.Net
         {
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.SLACK}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
-
-            path += "?wait=true";
-
-            var url = Utilities.GetApiUriFor(path);
+            
+            var url = Utilities.GetApiUriFor(path, "?wait=true");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
@@ -1657,9 +1653,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.GITHUB}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            path += "?wait=true";
-
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(path, "?wait=true");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1643,6 +1643,8 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.SLACK}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
+            path += "?wait=true";
+
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
@@ -1654,6 +1656,8 @@ namespace DSharpPlus.Net
         {
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.GITHUB}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
+
+            path += "?wait=true";
 
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: json_payload);

--- a/DSharpPlus/QueryUriBuilder.cs
+++ b/DSharpPlus/QueryUriBuilder.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DSharpPlus
+{
+    internal class QueryUriBuilder
+    {
+        public Uri SourceUri { get; }
+
+        public IReadOnlyList<KeyValuePair<string, string>> QueryParameters => this._queryParams;
+        private readonly List<KeyValuePair<string, string>> _queryParams = new List<KeyValuePair<string, string>>();
+
+        public QueryUriBuilder(string uri)
+        {
+            if (uri == null)
+                throw new ArgumentNullException(nameof(uri));
+            
+            this.SourceUri = new Uri(uri);
+        }
+
+        public QueryUriBuilder(Uri uri)
+        {
+            if (uri == null)
+                throw new ArgumentNullException(nameof(uri));
+            
+            this.SourceUri = uri;
+        }
+
+        public QueryUriBuilder AddParameter(string key, string value)
+        {
+            this._queryParams.Add(new KeyValuePair<string, string>(key, value));
+            return this;
+        }
+
+        public Uri Build()
+        {
+            return new UriBuilder(this.SourceUri)
+            {
+                Query = string.Join("&",
+                    _queryParams.Select(e => Uri.EscapeDataString(e.Key) + '=' + Uri.EscapeDataString(e.Value)))
+            }.Uri;
+        }
+
+        public override string ToString()
+        {
+            return Build().ToString();
+        }
+    }
+}

--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -66,22 +66,8 @@ namespace DSharpPlus
         internal static Uri GetApiUriFor(string path, string queryString)
             => new Uri($"{GetApiBaseUri()}{path}{queryString}");
 
-        internal static Uri PatchQueryString(Uri url, IDictionary<string, string> queryArgs)
-        {
-            var ub = new UriBuilder(url);
-
-            var existingQuery = string.IsNullOrWhiteSpace(ub.Query)
-                ? new Dictionary<string, string>()
-                : ub.Query.Split('&')
-                    .Select(x => x.Split('='))
-                    .ToDictionary(x => x[0], x => x[1]);
-
-            foreach (var kvp in queryArgs)
-                existingQuery[kvp.Key] = kvp.Value;
-
-            ub.Query = string.Join("&", queryArgs.Select(x => $"{x.Key}={x.Value}"));
-            return ub.Uri;
-        }
+        internal static QueryUriBuilder GetApiUriBuilderFor(string path)
+            => new QueryUriBuilder($"{GetApiBaseUri()}{path}");
 
         internal static string GetFormattedToken(BaseDiscordClient client)
         {

--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -66,6 +66,23 @@ namespace DSharpPlus
         internal static Uri GetApiUriFor(string path, string queryString)
             => new Uri($"{GetApiBaseUri()}{path}{queryString}");
 
+        internal static Uri PatchQueryString(Uri url, IDictionary<string, string> queryArgs)
+        {
+            var ub = new UriBuilder(url);
+
+            var existingQuery = string.IsNullOrWhiteSpace(ub.Query)
+                ? new Dictionary<string, string>()
+                : ub.Query.Split('&')
+                    .Select(x => x.Split('='))
+                    .ToDictionary(x => x[0], x => x[1]);
+
+            foreach (var kvp in queryArgs)
+                existingQuery[kvp.Key] = kvp.Value;
+
+            ub.Query = string.Join("&", queryArgs.Select(x => $"{x.Key}={x.Value}"));
+            return ub.Uri;
+        }
+
         internal static string GetFormattedToken(BaseDiscordClient client)
         {
             return GetFormattedToken(client.Configuration);


### PR DESCRIPTION
# Summary
This supercedes #440.

# Details
I modified Allan's PR and introduced QueryUriBuilder class instead of the dictionary mess. In addition, that dictionary mess was incredibly inconsistent - there were loads of places in the lib where query strings were hardwired. I replaced all these with QueryUriBuilder usages, which for the most part just makes them more readable. It also saves quite a few Dictionary allocations for the webhook endpoints.

The only places where hardcoded query strings still remain are when the library simply returns a link, say, to an image. For instance:

https://github.com/DSharpPlus/DSharpPlus/blob/5d0fc812ed31b5f5cdab0d1c6e6d55057c43f3b4/DSharpPlus/Entities/DiscordGuild.cs#L841-L842

I left these as-is since there are _so many_ of them and they seem to be very purposefully hardcoded. If you want these to use the query URI builder, let me know.

Additionally, I fixed a bug in `GetCurrentUserGuildsAsync` where the rest ratelimit bucket was dependant on the query parameters. I don't know if the original behavior was intentional, please let me know if so.

I want to hear your opinions, so I'm leaving this PR as a draft for now.

# Changes proposed
* Create QueryUriBuilder
* Patch up hardcoded query URIs into the nicer, cleaner builder format
* Make the parameters of `GetCurrentUserGuildsAsync` not part of the ratelimit bucket

# Notes
Credits to @Kiritsu for doing the hard part.