### PR TITLE
Make the setter of DiscordChannel.Position internal

### DIFF
--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -50,7 +50,7 @@ namespace DSharpPlus.Entities
         /// Gets the position of this channel.
         /// </summary>
         [JsonProperty("position", NullValueHandling = NullValueHandling.Ignore)]
-        public int Position { get; set; }
+        public int Position { get; internal set; }
 
         /// <summary>
         /// Gets whether this channel is a DM channel.


### PR DESCRIPTION
# Summary
Make the setter of DiscordChannel.Position internal. Someone dun fucked up.

# Details
This is a breaking change. Yes, very breaking.

# Changes proposed
* Change `public int Position { get; set; }` to `public int Position { get; internal set; }`. What do you expect me to write here?
