### PR TITLE
Add overload for bulk delete to use just ids

### DIFF
--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -453,6 +453,29 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// Deletes multiple messages
+        /// </summary>
+        /// <param name="messages"></param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns></returns>
+        public async Task DeleteMessagesAsync(IEnumerable<ulong> messages, string reason = null)
+        {
+            // Discord does the filtering too
+            var msgs = messages.ToArray();
+            if (messages == null || !msgs.Any())
+                throw new ArgumentException("You need to specify at least one message to delete.");
+
+            if (msgs.Count() < 2) 
+            {
+                await this.Discord.ApiClient.DeleteMessageAsync(this.Id, msgs.Single(), reason).ConfigureAwait(false);
+                return;
+            }
+
+            for (var i = 0; i < msgs.Count(); i += 100)
+                await this.Discord.ApiClient.DeleteMessagesAsync(this.Id, msgs.Skip(i).Take(100), reason).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Deletes a message
         /// </summary>
         /// <param name="message"></param>


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Add functionality to run bulk delete using only a collection of ids

# Details
Instead of having a large collection where you need to actually go through and find the messages themselves just run it with the id's and make discord handle that crap

# Changes proposed
Add an admittedly simple overload for DiscordChannel#DeleteMessagesAsync that takes a collection of ulong instead of DiscordMessage

# Notes
Whether the filtering in the original method is there to fail-fast or just avoid sending invalid ids to discord I dunno but I think it would be a little silly if it grabbed all of the message objects itself and then just ran like the original method so figured it'd be fine to just drop it.