### PR TITLE
Add Trace log level.

### DIFF
--- a/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
@@ -139,8 +139,7 @@ namespace DSharpPlus.Lavalink
                     Muted = false
                 }
             };
-            var vsj = JsonConvert.SerializeObject(vsd, Formatting.None);
-            (this.Channel.Discord as DiscordClient)._webSocketClient.SendMessage(vsj);
+            (this.Channel.Discord as DiscordClient).SendWebsocketMessage(vsd);
         }
 
         /// <summary>

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -38,7 +38,7 @@ namespace DSharpPlus.Test
             {
                 AutoReconnect = true,
                 LargeThreshold = 250,
-                LogLevel = LogLevel.Debug,
+                LogLevel = LogLevel.Trace,
                 Token = this.Config.Token,
                 TokenType = TokenType.Bot,
                 UseInternalLogHandler = false,
@@ -142,6 +142,10 @@ namespace DSharpPlus.Test
 
                 case LogLevel.Debug:
                     Console.ForegroundColor = ConsoleColor.Magenta;
+                    break;
+
+                case LogLevel.Trace:
+                    Console.ForegroundColor = ConsoleColor.DarkMagenta;
                     break;
                     
                 default:

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -298,7 +298,7 @@ namespace DSharpPlus.VoiceNext
         private void SendWebsocketMessage(object obj)
         {
             var payload = JsonConvert.SerializeObject(obj, Formatting.None);
-            this.Discord.DebugLogger.LogMessage(LogLevel.Trace, "VoiceNext ↑", payload, DateTime.Now);
+            this.Discord.DebugLogger.LogMessage(LogLevel.Trace, "VNext WS ↑", payload, DateTime.Now);
             this.VoiceWs.SendMessage(payload);
         }
 
@@ -999,7 +999,7 @@ namespace DSharpPlus.VoiceNext
 
         private Task VoiceWS_SocketMessage(SocketMessageEventArgs e)
         {
-            this.Discord.DebugLogger.LogMessage(LogLevel.Trace, "VoiceNext ↓", e.Message, DateTime.Now);
+            this.Discord.DebugLogger.LogMessage(LogLevel.Trace, "VNext WS ↓", e.Message, DateTime.Now);
             return this.HandleDispatch(JObject.Parse(e.Message));
         }
 

--- a/DSharpPlus.VoiceNext/VoiceNextExtension.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextExtension.cs
@@ -88,8 +88,8 @@ namespace DSharpPlus.VoiceNext
                     Muted = false
                 }
             };
-            var vsj = JsonConvert.SerializeObject(vsd, Formatting.None);
-            (channel.Discord as DiscordClient)._webSocketClient.SendMessage(vsj);
+
+            (channel.Discord as DiscordClient).SendWebsocketMessage(vsd);
             
             var vstu = await vstut.Task.ConfigureAwait(false);
             var vstup = new VoiceStateUpdatePayload
@@ -141,8 +141,8 @@ namespace DSharpPlus.VoiceNext
                     ChannelId = null
                 }
             };
-            var vsj = JsonConvert.SerializeObject(vsd, Formatting.None);
-            (guild.Discord as DiscordClient)._webSocketClient.SendMessage(vsj);
+
+            (guild.Discord as DiscordClient).SendWebsocketMessage(vsd);
         }
 
         private Task Client_VoiceStateUpdate(VoiceStateUpdateEventArgs e)

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -651,8 +651,8 @@ namespace DSharpPlus.Entities
                 OpCode = GatewayOpCode.RequestGuildMembers,
                 Data = new GatewayRequestGuildMembers(this)
             };
-            var payloadStr = JsonConvert.SerializeObject(payload, Formatting.None);
-            client._webSocketClient.SendMessage(payloadStr);
+
+            client.SendWebsocketMessage(payload);
         }
 
         /// <summary>

--- a/DSharpPlus/Enums/LogLevel.cs
+++ b/DSharpPlus/Enums/LogLevel.cs
@@ -6,6 +6,11 @@
     public enum LogLevel
     {
         /// <summary>
+        /// Signifies a trace-level message.
+        /// </summary>
+        Trace       = 16,
+
+        /// <summary>
         /// Signifies a debug-level message.
         /// </summary>
         Debug       = 8,


### PR DESCRIPTION
# Summary
Adds a trace log level that writes all incoming and outgoing WebSocket messages to the DebugLogger.

# Details
In the past, we've had one or two recurring bugs that could've been fixed much more easily if we could view the WebSocket traffic going to and from Discord. Previously, in order to do this we'd have to use Fiddler or Wireshark, and disable socket compression, which isn't a great solution. This PR adds a new log level called `Trace`, which outputs all WebSocket traffic to the DebugLogger.

# Changes proposed
* Add `LogLevel.Trace`.
* Move all instances of `BaseWebSocketClient#SendMessage` into wrapper functions that also write the payload to `DiscordClient#DebugLogger` .
* Add a warning to discourage use of `LogLevel.Trace` outside of specific debugging scenarios. 

# Notes
I'm not too happy with the wrapper functions, but I also don't see a great way around the problem.

I also don't sanitise output in any way, to do so would add an extra JSON Deserialization step, hurting performance more and adding an extra layer to debug, so it's almost certain the logged data will contain personal information. 

Would it not also be beneficial to include the response payloads from REST requests? Just in case? They're less likely to cause problems, but might be useful nonetheless.  