### PR TITLE
Added suppress embeds method + new Lavalink event

### DIFF
--- a/DSharpPlus.Lavalink/EventArgs/StatsReceivedEventArgs.cs
+++ b/DSharpPlus.Lavalink/EventArgs/StatsReceivedEventArgs.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DSharpPlus.Lavalink.Entities;
+
+namespace DSharpPlus.Lavalink.EventArgs
+{
+    public sealed class StatsReceivedEventArgs : AsyncEventArgs
+    {
+        /// <summary>
+        /// Gets the Lavalink statistics received.
+        /// </summary>
+        public LavalinkStatistics Statistics { get; }
+
+
+        public StatsReceivedEventArgs(LavalinkStatistics stats)
+        {
+            this.Statistics = stats;
+        }
+    }
+}

--- a/DSharpPlus.Lavalink/EventArgs/StatsReceivedEventArgs.cs
+++ b/DSharpPlus.Lavalink/EventArgs/StatsReceivedEventArgs.cs
@@ -7,6 +7,9 @@ using DSharpPlus.Lavalink.Entities;
 
 namespace DSharpPlus.Lavalink.EventArgs
 {
+    /// <summary>
+    /// Represents arguments for Lavalink statistics received.
+    /// </summary>
     public sealed class StatsReceivedEventArgs : AsyncEventArgs
     {
         /// <summary>
@@ -15,7 +18,7 @@ namespace DSharpPlus.Lavalink.EventArgs
         public LavalinkStatistics Statistics { get; }
 
 
-        public StatsReceivedEventArgs(LavalinkStatistics stats)
+        internal StatsReceivedEventArgs(LavalinkStatistics stats)
         {
             this.Statistics = stats;
         }

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -49,6 +49,16 @@ namespace DSharpPlus.Lavalink
         private AsyncEvent<NodeDisconnectedEventArgs> _disconnected;
 
         /// <summary>
+        /// Triggered when this node receives a statistics update.
+        /// </summary>
+        public event AsyncEventHandler<StatsReceivedEventArgs> StatisticsReceived
+        {
+            add { this._statsReceived.Register(value); }
+            remove { this._statsReceived.Unregister(value); }
+        }
+        private AsyncEvent<StatsReceivedEventArgs> _statsReceived;
+
+        /// <summary>
         /// Triggered whenever any of the players on this node is updated.
         /// </summary>
         public event AsyncEventHandler<PlayerUpdateEventArgs> PlayerUpdated
@@ -125,6 +135,7 @@ namespace DSharpPlus.Lavalink
 
             this._lavalinkSocketError = new AsyncEvent<SocketErrorEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_SOCKET_ERROR");
             this._disconnected = new AsyncEvent<NodeDisconnectedEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_NODE_DISCONNECTED");
+            this._statsReceived = new AsyncEvent<StatsReceivedEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_STATS_RECEIVED");
             this._playerUpdated = new AsyncEvent<PlayerUpdateEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_PLAYER_UPDATED");
             this._playbackFinished = new AsyncEvent<TrackFinishEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_PLAYBACK_FINISHED");
             this._trackStuck = new AsyncEvent<TrackStuckEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_TRACK_STUCK");
@@ -360,6 +371,7 @@ namespace DSharpPlus.Lavalink
                 case "stats":
                     var statsRaw = jsonData.ToObject<LavalinkStats>();
                     this.Statistics.Update(statsRaw);
+                    await this._statsReceived.InvokeAsync(new StatsReceivedEventArgs(this.Statistics)).ConfigureAwait(false);
                     break;
 
                 case "event":

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -255,7 +255,7 @@ namespace DSharpPlus.Entities
         /// <param name="embed">New embed.</param>
         /// <returns></returns>
         public Task<DiscordMessage> ModifyAsync(Optional<string> content = default, Optional<DiscordEmbed> embed = default) 
-            => this.Discord.ApiClient.EditMessageAsync(ChannelId, Id, content, embed);
+            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, embed);
 
         /// <summary>
         /// Deletes the message.
@@ -263,6 +263,13 @@ namespace DSharpPlus.Entities
         /// <returns></returns>
         public Task DeleteAsync(string reason = null) 
             => this.Discord.ApiClient.DeleteMessageAsync(this.ChannelId, this.Id, reason);
+
+        /// <summary>
+        /// Removes all embeds in the message.
+        /// </summary>
+        /// <returns></returns>
+        public Task SuppressEmbedsAsync()
+            => this.Discord.ApiClient.SuppressEmbedsAsync(this.ChannelId, this.Id);
 
         /// <summary>
         /// Pins the message in its channel.

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -267,9 +267,10 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Removes all embeds in the message.
         /// </summary>
+        /// <param name="suppress">Whether to suppress all embeds.</param>
         /// <returns></returns>
-        public Task SuppressEmbedsAsync()
-            => this.Discord.ApiClient.SuppressEmbedsAsync(this.ChannelId, this.Id);
+        public Task SuppressEmbedsAsync(bool suppress = true)
+            => this.Discord.ApiClient.SuppressEmbedsAsync(suppress, this.ChannelId, this.Id);
 
         /// <summary>
         /// Pins the message in its channel.

--- a/DSharpPlus/Net/Abstractions/RestChannelPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/RestChannelPayloads.cs
@@ -106,6 +106,12 @@ namespace DSharpPlus.Net.Abstractions
         public IEnumerable<ulong> Messages { get; set; }
     }
 
+    internal sealed class RestChannelMessageSuppressEmbedsPayload
+    {
+        [JsonProperty("suppress", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? Suppress { get; set; }
+    }
+
     internal sealed class RestChannelInviteCreatePayload
     {
         [JsonProperty("max_age", NullValueHandling = NullValueHandling.Ignore)]

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -661,7 +661,7 @@ namespace DSharpPlus.Net
 
             return new ReadOnlyCollection<DiscordMessage>(new List<DiscordMessage>(msgs));
         }
-
+        
         internal async Task<DiscordMessage> GetChannelMessageAsync(ulong channel_id, ulong message_id)
         {
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id";
@@ -675,13 +675,13 @@ namespace DSharpPlus.Net
             return ret;
         }
 
-        internal Task SuppressEmbedsAsync(ulong channel_id, ulong message_id)
+        internal Task SuppressEmbedsAsync(bool suppress, ulong channel_id, ulong message_id)
         {
             var pld = new RestChannelMessageSuppressEmbedsPayload
             {
-                Suppress = true
+                Suppress = suppress
             };
-
+            
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.SUPPRESS_EMBEDS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id, message_id }, out var path);
 

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -675,6 +675,20 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        internal Task SuppressEmbedsAsync(ulong channel_id, ulong message_id)
+        {
+            var pld = new RestChannelMessageSuppressEmbedsPayload
+            {
+                Suppress = true
+            };
+
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.SUPPRESS_EMBEDS}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id, message_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, payload: DiscordJson.SerializeObject(pld));
+        }
+
         internal async Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, Optional<string> content, Optional<DiscordEmbed> embed)
         {
             if (embed.HasValue && embed.Value != null && embed.Value.Timestamp != null)

--- a/DSharpPlus/Net/Endpoints.cs
+++ b/DSharpPlus/Net/Endpoints.cs
@@ -43,5 +43,6 @@
         public const string NICK = "/nick";
         public const string ASSETS = "/assets";
         public const string EMOJIS = "/emojis";
+        public const string SUPPRESS_EMBEDS = "/suppress-embeds";
     }
 }


### PR DESCRIPTION
# Summary
Implemented support for the new Suppress embeds endpoint, and also created a new event when a Lavalink stats op is received.

# Details
The suppress embeds support was attached as a new method to the DiscordMessage class, which resolves issue #434. Also added `this.` to the parameters in `ApiClient#ModifyAsync()` in `DiscordMessage.cs` because they were missing. In addition, I felt that having the Lavalink stats emitted is important for debugging, and can give the user additional control when it comes to managing Lavalink nodes. 

# Changes proposed
* Added `StatsReceivedEventArgs.cs` as a new Event Argument with a property of `Statistics`, which are the lavalink stats sent.
* Added support for the event in `LavalinkNodeConnection.cs`, invoked in `LavalinkNodeConnection#WebSocket_OnMessage` after the statistics are updated.
* Added `.this` to the parameters of `ApiClient.EditMessageAsync() in `DiscordMessage.cs`
* Added the SuppressEmbeds method for both `DiscordMessage.cs` and `DiscordApiClient.cs` and created a new endpoint constant and payload class. The payload class has a boolean property, which is assigned to true to suppress embeds.
