### PR TITLE
Add lavalink soundcloud search support.

### DIFF
--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -257,25 +257,25 @@ namespace DSharpPlus.Lavalink
         public LavalinkGuildConnection GetConnection(DiscordGuild guild)
             => this.ConnectedGuilds.TryGetValue(guild.Id, out LavalinkGuildConnection lgc) && lgc.IsConnected ? lgc : null;
 
-		/// <summary>
-		/// Searches for specified terms.
-		/// </summary>
-		/// <param name="searchQuery">What to search for.</param>
-		/// <param name="type">What platform will search for.</param>
-		/// <returns>A collection of tracks matching the criteria.</returns>
-		public Task<LavalinkLoadResult> GetTracksAsync(string searchQuery, LavalinkSearchType type = LavalinkSearchType.Youtube)
+        /// <summary>
+        /// Searches for specified terms.
+        /// </summary>
+        /// <param name="searchQuery">What to search for.</param>
+        /// <param name="type">What platform will search for.</param>
+        /// <returns>A collection of tracks matching the criteria.</returns>
+        public Task<LavalinkLoadResult> GetTracksAsync(string searchQuery, LavalinkSearchType type = LavalinkSearchType.Youtube)
         {
-			string prefix;
-			if (type == LavalinkSearchType.Youtube)
-				prefix = "ytsearch";
-			else
-				prefix = "scsearch";
+            string prefix;
+            if (type == LavalinkSearchType.Youtube)
+                prefix = "ytsearch";
+            else
+                prefix = "scsearch";
 
             var str = WebUtility.UrlEncode($"{prefix}:{searchQuery}");
             var tracksUri = new Uri($"http://{this.Configuration.RestEndpoint}/loadtracks?identifier={str}");
             return this.InternalResolveTracksAsync(tracksUri);
         }
-        
+
         /// <summary>
         /// Loads tracks from specified URL.
         /// </summary>

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -256,15 +256,22 @@ namespace DSharpPlus.Lavalink
         /// <returns>Channel connection, which allows for playback control.</returns>
         public LavalinkGuildConnection GetConnection(DiscordGuild guild)
             => this.ConnectedGuilds.TryGetValue(guild.Id, out LavalinkGuildConnection lgc) && lgc.IsConnected ? lgc : null;
-        
-        /// <summary>
-        /// Searches YouTube for specified terms.
-        /// </summary>
-        /// <param name="searchQuery">What to search for.</param>
-        /// <returns>A collection of tracks matching the criteria.</returns>
-        public Task<LavalinkLoadResult> GetTracksAsync(string searchQuery)
+
+		/// <summary>
+		/// Searches for specified terms.
+		/// </summary>
+		/// <param name="searchQuery">What to search for.</param>
+		/// <param name="type">What platform will search for.</param>
+		/// <returns>A collection of tracks matching the criteria.</returns>
+		public Task<LavalinkLoadResult> GetTracksAsync(string searchQuery, LavalinkSearchType type = LavalinkSearchType.Youtube)
         {
-            var str = WebUtility.UrlEncode($"ytsearch:{searchQuery}");
+			string prefix;
+			if (type == LavalinkSearchType.Youtube)
+				prefix = "ytsearch";
+			else
+				prefix = "scsearch";
+
+            var str = WebUtility.UrlEncode($"{prefix}:{searchQuery}");
             var tracksUri = new Uri($"http://{this.Configuration.RestEndpoint}/loadtracks?identifier={str}");
             return this.InternalResolveTracksAsync(tracksUri);
         }

--- a/DSharpPlus.Lavalink/LavalinkSearchType.cs
+++ b/DSharpPlus.Lavalink/LavalinkSearchType.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace DSharpPlus.Lavalink
+﻿namespace DSharpPlus.Lavalink
 {
     public enum LavalinkSearchType
     {

--- a/DSharpPlus.Lavalink/LavalinkSearchType.cs
+++ b/DSharpPlus.Lavalink/LavalinkSearchType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DSharpPlus.Lavalink
+{
+    public enum LavalinkSearchType
+    {
+        SoundCloud,
+		Youtube
+    }
+}

--- a/DSharpPlus.Lavalink/LavalinkSearchType.cs
+++ b/DSharpPlus.Lavalink/LavalinkSearchType.cs
@@ -9,6 +9,6 @@ namespace DSharpPlus.Lavalink
     public enum LavalinkSearchType
     {
         SoundCloud,
-		Youtube
+        Youtube
     }
 }

--- a/DSharpPlus.Test/TestBotLavaCommands.cs
+++ b/DSharpPlus.Test/TestBotLavaCommands.cs
@@ -92,7 +92,7 @@ namespace DSharpPlus.Test
         {
             if (this.ContextChannel == null)
                 return;
-            
+
             await this.ContextChannel.SendMessageAsync($"Playback of {Formatter.Bold(Formatter.Sanitize(e.Track.Title))} by {Formatter.Bold(Formatter.Sanitize(e.Track.Author))} finished.").ConfigureAwait(false);
             this.ContextChannel = null;
         }
@@ -136,18 +136,18 @@ namespace DSharpPlus.Test
             await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.").ConfigureAwait(false);
         }
 
-		[Command, Description("Queues track for playback.")]
-		public async Task PlaySoundCloudAsync(CommandContext ctx, string search)
-		{
-			if (this.Lavalink == null)
-				return;
+        [Command, Description("Queues track for playback.")]
+        public async Task PlaySoundCloudAsync(CommandContext ctx, string search)
+        {
+            if (this.Lavalink == null)
+                return;
 
-			var result = await this.Lavalink.GetTracksAsync(search, LavalinkSearchType.SoundCloud);
-			var track = result.Tracks.First();
-			this.LavalinkVoice.Play(track);
+            var result = await this.Lavalink.GetTracksAsync(search, LavalinkSearchType.SoundCloud);
+            var track = result.Tracks.First();
+            this.LavalinkVoice.Play(track);
 
-			await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.");
-		}
+            await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.");
+        }
 
         [Command, Description("Queues tracks for playback.")]
         public async Task PlayPartialAsync(CommandContext ctx, TimeSpan start, TimeSpan stop, [RemainingText] Uri uri)

--- a/DSharpPlus.Test/TestBotLavaCommands.cs
+++ b/DSharpPlus.Test/TestBotLavaCommands.cs
@@ -136,6 +136,19 @@ namespace DSharpPlus.Test
             await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.").ConfigureAwait(false);
         }
 
+		[Command, Description("Queues track for playback.")]
+		public async Task PlaySoundCloudAsync(CommandContext ctx, string search)
+		{
+			if (this.Lavalink == null)
+				return;
+
+			var result = await this.Lavalink.GetTracksAsync(search, LavalinkSearchType.SoundCloud);
+			var track = result.Tracks.First();
+			this.LavalinkVoice.Play(track);
+
+			await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.");
+		}
+
         [Command, Description("Queues tracks for playback.")]
         public async Task PlayPartialAsync(CommandContext ctx, TimeSpan start, TimeSpan stop, [RemainingText] Uri uri)
         {


### PR DESCRIPTION
# Summary
Fixes #380

# Details
Implemented support to search specific audio source (youtube and soundcloud). Defaults to: Youtube.

# Notes 
[SoundCloudAudioSourceManager](https://github.com/sedmelluq/lavaplayer/blob/master/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudAudioSourceManager.java#L72)

- <i>Add .editorconfig file to force VS/VSCode/VSMac/Any .NET IDE use specific project pattern like Spaces intead of tabs, and full qualification on method, property, field and event.</i>