### PR TITLE
Added RespondWithDmAsync method to CommandContext

### DIFF
--- a/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
@@ -160,7 +160,7 @@ namespace DSharpPlus.CommandsNext
         /// <param name="embed">Embed to attach.</param>
         /// <returns></returns>
         public Task<DiscordMessage> RespondWithDmAsync(string content = null, bool isTTS = false, DiscordEmbed embed = null)
-            => Member != null ? Member.SendMessageAsync(content, isTTS, embed) : RespondAsync(content, isTTS, embed);
+            => this.Member != null ? this.Member.SendMessageAsync(content, isTTS, embed) : this.RespondAsync(content, isTTS, embed);
 
         /// <summary>
         /// Triggers typing in the channel containing the message that triggered the command.

--- a/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
@@ -153,6 +153,16 @@ namespace DSharpPlus.CommandsNext
             => this.Message.RespondWithFilesAsync(files, content, isTTS, embed);
 
         /// <summary>
+        /// Quickly respond to the message with a direct message.
+        /// </summary>
+        /// <param name="content">Message to respond with.</param>
+        /// <param name="isTTS">Whether the message is to be spoken aloud.</param>
+        /// <param name="embed">Embed to attach.</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> RespondWithDmAsync(string content = null, bool isTTS = false, DiscordEmbed embed = null)
+            => Member != null ? Member.SendMessageAsync(content, isTTS, embed) : RespondAsync(content, isTTS, embed);
+
+        /// <summary>
         /// Triggers typing in the channel containing the message that triggered the command.
         /// </summary>
         /// <returns></returns>

--- a/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
# Summary
Implemented a simple function in CommandContext that allows us quickly respond to a message with a DM to the author of the message.

# Details
Method `CommandContext.RespondWithDmAsync` checks for us, if the user sent a command/message over a channel or as a DM to the bot and uses the right function to respond in a DM to the user.
```csharp
if (this.Member != null)
{
	this.Member.SendMessageAsync(...);
}
else
{
	this.RespondAsync(...);
}
```

# Changes proposed
* Added method `RespondWithDmAsync` to the class `CommandContext`

# Notes
This is just a simple "quality of life improvement". I'm using it a lot in my bot to send sensitive data to the user.