### PR TITLE
Make PermissionsFor properly support administrator

### DIFF
--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -604,11 +604,6 @@ namespace DSharpPlus.Entities
 
             // roles that member is in
             var mbRoles = mbr.Roles.Where(xr => xr.Id != everyoneRole.Id).ToArray();
-            // channel overrides for roles that member is in
-            var mbRoleOverrides = mbRoles
-                .Select(xr => this._permissionOverwrites.FirstOrDefault(xo => xo.Id == xr.Id))
-                .Where(xo => xo != null)
-                .ToList();
 
             // assign permissions from member's roles (in order)
             perms |= mbRoles.Aggregate(Permissions.None, (c, role) => c | role.Permissions);
@@ -616,6 +611,12 @@ namespace DSharpPlus.Entities
             // Adminstrator grants all permissions and cannot be overridden
             if ((perms & Permissions.Administrator) == Permissions.Administrator)
                 return PermissionMethods.FULL_PERMS;
+
+            // channel overrides for roles that member is in
+            var mbRoleOverrides = mbRoles
+                .Select(xr => this._permissionOverwrites.FirstOrDefault(xo => xo.Id == xr.Id))
+                .Where(xo => xo != null)
+                .ToList();
             
             // assign channel permission overwrites for @everyone pseudo-role
             var everyoneOverwrites = this._permissionOverwrites.FirstOrDefault(xo => xo.Id == everyoneRole.Id);

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -612,6 +612,10 @@ namespace DSharpPlus.Entities
 
             // assign permissions from member's roles (in order)
             perms |= mbRoles.Aggregate(Permissions.None, (c, role) => c | role.Permissions);
+
+            // Adminstrator grants all permissions and cannot be overridden
+            if ((perms & Permissions.Administrator) == Permissions.Administrator)
+                return PermissionMethods.FULL_PERMS;
             
             // assign channel permission overwrites for @everyone pseudo-role
             var everyoneOverwrites = this._permissionOverwrites.FirstOrDefault(xo => xo.Id == everyoneRole.Id);


### PR DESCRIPTION
# Summary
Fixes #474 also returns full permissions when the member has administrator.

# Notes
Dunno if this is the correct behavior expected from this method but looking at some of the other stuff that uses it elsewhere in dsp it makes sense to me.