### PR TITLE
Fix #477 and fix #431: Prevent static constructor from being called by Dictionary deserializer

### DIFF
--- a/DSharpPlus/Net/Serialization/SnowflakeArrayAsDictionaryJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/SnowflakeArrayAsDictionaryJsonConverter.cs
@@ -35,7 +35,7 @@ namespace DSharpPlus.Net.Serialization
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             var constructor = objectType.GetTypeInfo().DeclaredConstructors
-                .FirstOrDefault(e => e.GetParameters().Length == 0);
+                .FirstOrDefault(e => !e.IsStatic && e.GetParameters().Length == 0);
 
             var dict = constructor.Invoke(new object[] {});
 


### PR DESCRIPTION
# Summary
Fixes #477: DiscordGuild.GetRole returns null on .net core 3.0 linux arm

Fixes #431: `System.MemberAccessException` on initial startup with .NET Core 3.0 Preview builds

# Details
As discussed in #431, this is caused by the addition of a static constructor in the Dictionary (or ConcurrentDictionary?) class in the BCL that only shows up in ARM64.

# Changes proposed
* Add a static constructor check to the instantiation procedure in SnowflakeArrayAsDictionaryJsonConverter.ReadJson