### PR TITLE
Fix constant attempts to reconnect after a voice kick

### DIFF
--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -981,7 +981,9 @@ namespace DSharpPlus.VoiceNext
                 this.VoiceWs.Disconnected += this.VoiceWS_SocketClosed;
                 this.VoiceWs.MessageReceived += this.VoiceWS_SocketMessage;
                 this.VoiceWs.Connected += this.VoiceWS_SocketOpened;
-                await this.ConnectAsync().ConfigureAwait(false);
+
+                if(this.Resume) // emzi you dipshit
+                    await this.ConnectAsync().ConfigureAwait(false);
             }
         }
 

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -982,7 +982,7 @@ namespace DSharpPlus.VoiceNext
                 this.VoiceWs.MessageReceived += this.VoiceWS_SocketMessage;
                 this.VoiceWs.Connected += this.VoiceWS_SocketOpened;
 
-                if(this.Resume) // emzi you dipshit
+                if (this.Resume) // emzi you dipshit
                     await this.ConnectAsync().ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
# Summary
Fixes a bug where VoiceNext will continually attempt to reconnect if kicked from the voice channel by Discord, causing hundreds of invalid session errors.

# Details
This PR adds a check to ensure we're actually supposed to be resuming before trying to reconnect the WebSocket.

# Changes proposed
* See Above

# Notes
A `Disconnected` event probably wouldn't go amiss here, but I felt that was out of the scope of this simple bugfix.