### PR TITLE
Exposing PacketQueue count

### DIFF
--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -179,6 +179,11 @@ namespace DSharpPlus.VoiceNext
         /// </summary>
         public DiscordChannel Channel { get; internal set; }
 
+        /// <summary>
+        /// Gets the current amount of VoicePackets in the Queue.
+        /// </summary>
+        public int PacketQueueCount { get => PacketQueue.Count; }
+
         internal VoiceNextConnection(DiscordClient client, DiscordGuild guild, DiscordChannel channel, VoiceNextConfiguration config, VoiceServerUpdatePayload server, VoiceStateUpdatePayload state)
         {
             this.Discord = client;


### PR DESCRIPTION
# Summary
Exposes the PacketQueue count to help with implementing pause functions

# Details
Adds an integer that returns the current PacketQueue size to help with not "flooding" VNexts queue when wrting to the TransmitStream and makes it generally easier to "stop sending audio" for pausing

# Changes proposed
Just an integer that returns the PacketQueue size