### PR TITLE
Added support for message flags

### DIFF
--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -258,6 +258,12 @@ namespace DSharpPlus.Entities
             => (this._reference.HasValue) ? this?.InternalBuildMessageReference() : null;
 
         /// <summary>
+        /// Gets the bitwise flags for this message.
+        /// </summary>
+        [JsonProperty("flags", NullValueHandling = NullValueHandling.Ignore)]
+        public MessageFlags? Flags { get; internal set; }
+
+        /// <summary>
         /// Gets whether the message originated from a webhook.
         /// </summary>
         [JsonIgnore]
@@ -341,12 +347,12 @@ namespace DSharpPlus.Entities
             => this.Discord.ApiClient.DeleteMessageAsync(this.ChannelId, this.Id, reason);
 
         /// <summary>
-        /// Removes all embeds in the message.
+        /// Modifes the visibility of embeds in this message.
         /// </summary>
-        /// <param name="suppress">Whether to suppress all embeds.</param>
+        /// <param name="hideEmbeds">Whether to hide all embeds.</param>
         /// <returns></returns>
-        public Task SuppressEmbedsAsync(bool suppress = true)
-            => this.Discord.ApiClient.SuppressEmbedsAsync(suppress, this.ChannelId, this.Id);
+        public Task ModifyEmbedSuppressionAsync(bool hideEmbeds)
+            => this.Discord.ApiClient.ModifyEmbedSuppressionAsync(hideEmbeds, this.ChannelId, this.Id);
 
         /// <summary>
         /// Pins the message in its channel.

--- a/DSharpPlus/Enums/MessageActivityType.cs
+++ b/DSharpPlus/Enums/MessageActivityType.cs
@@ -21,7 +21,7 @@
         Listen = 3,
 
         /// <summary>
-        /// Allows user to request to join.
+        /// Allows the user to request to join.
         /// </summary>
         JoinRequest = 4
     }

--- a/DSharpPlus/Enums/MessageFlag.cs
+++ b/DSharpPlus/Enums/MessageFlag.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace DSharpPlus.Enums
+{
+    public static class MessageFlagExtensions
+    {
+        /// <summary>
+        /// Calculates whether these message flags contain a specific flag.
+        /// </summary>
+        /// <param name="f">The existing bitwise flags.</param>
+        /// <param name="flag">The flags to search for.</param>
+        /// <returns></returns>
+        public static bool HasMessageFlag(this MessageFlags f, MessageFlags flag) => (f & flag) == flag;
+    }
+
+    /// <summary>
+    /// Represents additional features of a message.
+    /// </summary>
+    [Flags]
+    public enum MessageFlags
+    {
+        /// <summary>
+        /// Whether this message is the original message that was published from a news channel to subscriber channels.
+        /// </summary>
+        Crossposted = 1 << 0,
+
+        /// <summary>
+        /// Whether this message is crossposted (automatically posted in a subscriber channel).
+        /// </summary>
+        IsCrosspost = 1 << 1,
+
+        /// <summary>
+        /// Whether any embeds in the message are hidden.
+        /// </summary>
+        SuppressedEmbeds = 1 << 2
+    }
+}

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -675,7 +675,7 @@ namespace DSharpPlus.Net
             return ret;
         }
 
-        internal Task SuppressEmbedsAsync(bool suppress, ulong channel_id, ulong message_id)
+        internal Task ModifyEmbedSuppressionAsync(bool suppress, ulong channel_id, ulong message_id)
         {
             var pld = new RestChannelMessageSuppressEmbedsPayload
             {


### PR DESCRIPTION
# Summary
Implemented initial support for Message Flags, documented here: https://discordapp.com/developers/docs/resources/channel#message-object-message-flags. Also changed a few things with the `SuppressEmbeds` method.

# Details
The flags were implemented as an enum of bitwise flags. I also implemented an extension method similar to the `Permissions` enum, which allows a user to check if a particular flag exists in the sent flags. 

Furthermore, I wanted to change the `SuppressEmbeds` method in both name and in parameter because I did not fully realize what it did when I implemented it. It's now changed to where it can suppress, or unsuppress a message, with a required boolean parameter to determine whether to suppress versus unsuppress.

# Changes proposed
* Implemented the `MessageFlags` enum, along with the property in `DiscordMessage`.
* Added an extension method to make it more efficient to check for a certain Message Flag.
* Modified the `SuppressEmbeds` method to better reflect its functionality.