### PR TITLE
Allow interactivity page set values to property setters.

### DIFF
--- a/DSharpPlus.Interactivity/EventHandling/Requests/PaginationRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/PaginationRequest.cs
@@ -210,9 +210,9 @@ namespace DSharpPlus.Interactivity
 
     public class Page
     {
-        public string Content { get; private set; }
-        public DiscordEmbed Embed { get; private set; }
-
+        public string Content { get; set; }
+        public DiscordEmbed Embed { get; set; }
+        
         public Page(string content = "", DiscordEmbedBuilder embed = null)
         {
             this.Content = content;


### PR DESCRIPTION
Allow interactivity page construction values to be set direcly from setter instead using class constructor like in embed builder.