### PR TITLE
Implemented guild subscriptions

### DIFF
--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -45,7 +45,8 @@ namespace DSharpPlus.Test
                 ShardId = shardid,
                 ShardCount = this.Config.ShardCount,
                 MessageCacheSize = 2048,
-                DateTimeFormat = "dd-MM-yyyy HH:mm:ss zzz"
+                DateTimeFormat = "dd-MM-yyyy HH:mm:ss zzz",
+                HandleGuildSubscriptions = true
             };
             Discord = new DiscordClient(dcfg);
 

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2271,17 +2271,17 @@ namespace DSharpPlus
             if (!this.Configuration.HandleGuildSubscriptions)
                 this.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", "Guild subscriptions are set to not be sent to this client. This may cause cache incoherence problems.", DateTime.Now);
 	    
-	    var identify = new GatewayIdentify
-	    {
-		Token = Utilities.GetFormattedToken(this),
-		Compress = this.Configuration.GatewayCompressionLevel == GatewayCompressionLevel.Payload,
-		LargeThreshold = this.Configuration.LargeThreshold,
-		ShardInfo = new ShardInfo
-		{
-		    ShardId = this.Configuration.ShardId,
-		    ShardCount = this.Configuration.ShardCount
-		},
-		Presence = status,
+	        var identify = new GatewayIdentify
+	        {
+		        Token = Utilities.GetFormattedToken(this),
+		        Compress = this.Configuration.GatewayCompressionLevel == GatewayCompressionLevel.Payload,
+		        LargeThreshold = this.Configuration.LargeThreshold,
+		        ShardInfo = new ShardInfo
+		        {
+		            ShardId = this.Configuration.ShardId,
+		            ShardCount = this.Configuration.ShardCount
+		        },
+		        Presence = status,
                 GuildSubscriptions = this.Configuration.HandleGuildSubscriptions
             };
             var payload = new GatewayPayload

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2270,18 +2270,18 @@ namespace DSharpPlus
         {
             if (!this.Configuration.HandleGuildSubscriptions)
                 this.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", "Guild subscriptions are set to not be sent to this client. This may cause cache incoherence problems.", DateTime.Now);
-
-			var identify = new GatewayIdentify
-			{
-				Token = Utilities.GetFormattedToken(this),
-				Compress = this.Configuration.GatewayCompressionLevel == GatewayCompressionLevel.Payload,
-				LargeThreshold = this.Configuration.LargeThreshold,
-				ShardInfo = new ShardInfo
-				{
-					ShardId = this.Configuration.ShardId,
-					ShardCount = this.Configuration.ShardCount
-				},
-				Presence = status,
+	    
+	    var identify = new GatewayIdentify
+	    {
+		Token = Utilities.GetFormattedToken(this),
+		Compress = this.Configuration.GatewayCompressionLevel == GatewayCompressionLevel.Payload,
+		LargeThreshold = this.Configuration.LargeThreshold,
+		ShardInfo = new ShardInfo
+		{
+		    ShardId = this.Configuration.ShardId,
+		    ShardCount = this.Configuration.ShardCount
+		},
+		Presence = status,
                 GuildSubscriptions = this.Configuration.HandleGuildSubscriptions
             };
             var payload = new GatewayPayload

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2268,6 +2268,9 @@ namespace DSharpPlus
 
         internal Task SendIdentifyAsync(StatusUpdate status)
         {
+            if (!this.Configuration.HandleGuildSubscriptions)
+                this.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", "Guild subscriptions are set to not be sent to this client. This may cause cache incoherence problems.", DateTime.Now);
+
 			var identify = new GatewayIdentify
 			{
 				Token = Utilities.GetFormattedToken(this),
@@ -2278,7 +2281,8 @@ namespace DSharpPlus
 					ShardId = this.Configuration.ShardId,
 					ShardCount = this.Configuration.ShardCount
 				},
-				Presence = status
+				Presence = status,
+                GuildSubscriptions = this.Configuration.HandleGuildSubscriptions
             };
             var payload = new GatewayPayload
             {

--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -108,6 +108,13 @@ namespace DSharpPlus
         public bool ReconnectIndefinitely { internal get; set; } = false;
 
         /// <summary>
+        /// <para>Determines whether guild subscription events should be sent from the gateway.</para>
+        /// <para>Setting this to false will disable typing and presence events from being sent to the client. This typically reduces bandwidth and memory usage.</para>
+        /// <para>Defaults to true.</para>
+        /// </summary>
+        public bool HandleGuildSubscriptions { internal get; set; } = true;
+
+        /// <summary>
         /// <para>Sets the factory method used to create instances of WebSocket clients.</para>
         /// <para>Use <see cref="WebSocketClient.CreateNew(IWebProxy)"/> and equivalents on other implementations to switch out client implementations.</para>
         /// <para>Defaults to <see cref="WebSocketClient.CreateNew(IWebProxy)"/>.</para>
@@ -167,6 +174,7 @@ namespace DSharpPlus
             this.Proxy = other.Proxy;
             this.HttpTimeout = other.HttpTimeout;
             this.ReconnectIndefinitely = other.ReconnectIndefinitely;
+            this.HandleGuildSubscriptions = other.HandleGuildSubscriptions;
         }
     }
 }

--- a/DSharpPlus/Net/Abstractions/GatewayIdentifyResume.cs
+++ b/DSharpPlus/Net/Abstractions/GatewayIdentifyResume.cs
@@ -38,9 +38,15 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("shard")]
         public ShardInfo ShardInfo { get; set; }
 
-		[JsonProperty("presence", NullValueHandling = NullValueHandling.Ignore)]
-		public StatusUpdate Presence { get; set; } = null;
+	/// <summary>
+        /// Gets or sets the presence for this connection.
+        /// </summary>
+	[JsonProperty("presence", NullValueHandling = NullValueHandling.Ignore)]
+	public StatusUpdate Presence { get; set; } = null;
 
+	/// <summary>
+        /// Gets or sets whether to handle guild subscriptions for this connection.
+        /// </summary>
         [JsonProperty("guild_subscriptions")]
         public bool GuildSubscriptions { get; set; }
     }

--- a/DSharpPlus/Net/Abstractions/GatewayIdentifyResume.cs
+++ b/DSharpPlus/Net/Abstractions/GatewayIdentifyResume.cs
@@ -40,6 +40,9 @@ namespace DSharpPlus.Net.Abstractions
 
 		[JsonProperty("presence", NullValueHandling = NullValueHandling.Ignore)]
 		public StatusUpdate Presence { get; set; } = null;
+
+        [JsonProperty("guild_subscriptions")]
+        public bool GuildSubscriptions { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
# Summary
Implemented guild subscriptions, fixes #487.

# Details
This would allow clients to decide whether to allow typing and presence events to be sent over the gateway, which as discussed in issue #487 not only can improve bandwidth, but also can significantly reduce memory usage due to not caching those event objects.

# Changes proposed
* Added this as a new boolean property to `DiscordConfiguration`, which defaults to true.
* Made the debug logger post a warning about setting this property to false, which could cause cache issues.
* Internally added this property to be sent in the identify payload.