### PR TITLE
Reapplying status hotfix

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -405,10 +405,14 @@ namespace DSharpPlus
                 if (Configuration.AutoReconnect)
                 {
                     DebugLogger.LogMessage(LogLevel.Critical, "Websocket", $"Socket connection terminated ({e.CloseCode.ToString(CultureInfo.InvariantCulture)}, '{e.CloseMessage}'). Reconnecting.", DateTime.Now);
-                    if (this._status.IdleSince.HasValue)
-                        await this.ConnectAsync(this._status._activity, this._status.Status, Utilities.GetDateTimeOffset(this._status.IdleSince.Value)).ConfigureAwait(false);
+
+                    if (this._status == null)
+                        await this.ConnectAsync().ConfigureAwait(false);
                     else
-                        await this.ConnectAsync(this._status._activity, this._status.Status).ConfigureAwait(false);
+                        if (this._status.IdleSince.HasValue)
+                            await this.ConnectAsync(this._status._activity, this._status.Status, Utilities.GetDateTimeOffset(this._status.IdleSince.Value)).ConfigureAwait(false);
+                        else
+                            await this.ConnectAsync(this._status._activity, this._status.Status).ConfigureAwait(false);
                 }
             }
         }


### PR DESCRIPTION
# Summary
Fixes a NRE being thrown when trying to reconnect without a status/activity.

# Details
In my original PR, I forgot to handle when a user connects without a custom activity and presence. If this occurs, it will throw a NRE when checking [here](https://github.com/DSharpPlus/DSharpPlus/blob/9fcd57b4fc4282e77d16d3d4967b8750afee5777/DSharpPlus/DiscordClient.cs#L408), if the status is null, and not reconnect the client. This PR should correct that.

# Changes proposed
* Added a conditional which checks if `this._status` is null, and if so just reconnects without the status arguments.