### PR TITLE
Fixed a couple DiscordPresence properties returning null

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -1078,7 +1078,14 @@ namespace DSharpPlus
                 foreach (var xp in presences)
                 {
                     xp.Discord = this;
+                    xp.GuildId = guild.Id;
                     xp.Activity = new DiscordActivity(xp.RawActivity);
+                    if (xp.RawActivities != null)
+                    {
+                        xp.InternalActivities = new DiscordActivity[xp.RawActivities.Length];
+                        for (int i = 0; i < xp.RawActivities.Length; i++)
+                            xp.InternalActivities[i] = new DiscordActivity(xp.RawActivities[i]);
+                    }
                     this._presences[xp.InternalUser.Id] = xp;
                 }
             }


### PR DESCRIPTION
# Summary
This PR fixes #496.

# Details
I discovered that that both `DiscordPresence.Activities` and `DiscordPresence.GuildId` were not initialized during the internal guild create handler, and were only set after a presence update. This PR should fix that.

# Changes proposed
* Made both the `DiscordPresence.Activities` and `DiscordPresence.GuildId` initialize during the guild create handler.

# Notes
On an unrelated note I found that the properties `Activity` and `Activities` somewhat confusing, and I feel that `Activity` should be renamed to `CurrentActivity` or something similar. Let me know your opinions on this.