### PR TITLE
Implemented custom statuses

### DIFF
--- a/DSharpPlus/Entities/DiscordActivity.cs
+++ b/DSharpPlus/Entities/DiscordActivity.cs
@@ -122,6 +122,11 @@ namespace DSharpPlus.Entities
         public DiscordRichPresence RichPresence { get; internal set; }
 
         /// <summary>
+        /// Gets the custom status of this activity, if present.
+        /// </summary>
+        public DiscordCustomStatus CustomStatus { get; internal set; }
+
+        /// <summary>
         /// Creates a new, empty instance of a <see cref="DiscordActivity"/>.
         /// </summary>
         public DiscordActivity()
@@ -161,6 +166,7 @@ namespace DSharpPlus.Entities
             this.ActivityType = other.ActivityType;
             this.StreamUrl = other.StreamUrl;
             this.RichPresence = new DiscordRichPresence(other.RichPresence);
+            this.CustomStatus = new DiscordCustomStatus(other.CustomStatus);
         }
 
         internal void UpdateWith(TransportActivity rawActivity)
@@ -175,6 +181,47 @@ namespace DSharpPlus.Entities
                 this.RichPresence = new DiscordRichPresence(rawActivity);
             else
                 this.RichPresence = null;
+
+            if (rawActivity?.IsCustomStatus() == true && this.CustomStatus != null)
+                this.CustomStatus.UpdateWith(rawActivity.State, rawActivity.Emoji);
+            else if (rawActivity?.IsCustomStatus() == true)
+                this.CustomStatus = new DiscordCustomStatus
+                {
+                    Name = rawActivity.State,
+                    Emoji = rawActivity.Emoji
+                };
+            else
+                this.CustomStatus = null;
+        }
+    }
+
+    /// <summary>
+    /// Represents details for a custom status activity, attached to a <see cref="DiscordActivity"/>.
+    /// </summary>
+    public sealed class DiscordCustomStatus
+    {
+        /// <summary>
+        /// Gets the name of this custom status.
+        /// </summary>
+        public string Name { get; internal set; }
+
+        /// <summary>
+        /// Gets the emoji of this custom status, if any.
+        /// </summary>
+        public DiscordEmoji Emoji { get; internal set; }
+
+        internal DiscordCustomStatus() { }
+
+        internal DiscordCustomStatus(DiscordCustomStatus other)
+        {
+            this.Name = other.Name;
+            this.Emoji = other.Emoji;
+        }
+
+        internal void UpdateWith(string state, DiscordEmoji emoji)
+        {
+            this.Name = state;
+            this.Emoji = emoji;
         }
     }
 
@@ -184,7 +231,7 @@ namespace DSharpPlus.Entities
     public sealed class DiscordRichPresence
     {
         /// <summary>
-        /// Gets the details.
+        /// Gets the details of this presence.
         /// </summary>
         public string Details { get; internal set; }
 
@@ -199,12 +246,12 @@ namespace DSharpPlus.Entities
         public DiscordApplication Application { get; internal set; }
 
         /// <summary>
-        /// Gets instance status.
+        /// Gets the instance status.
         /// </summary>
         public bool? Instance { get; internal set; }
 
         /// <summary>
-        /// Gets large image for the rich presence.
+        /// Gets the large image for the rich presence.
         /// </summary>
         public DiscordAsset LargeImage { get; internal set; }
 
@@ -214,7 +261,7 @@ namespace DSharpPlus.Entities
         public string LargeImageText { get; internal set; }
 
         /// <summary>
-        /// Gets small image for the rich presence.
+        /// Gets the small image for the rich presence.
         /// </summary>
         public DiscordAsset SmallImage { get; internal set; }
 
@@ -224,12 +271,12 @@ namespace DSharpPlus.Entities
         public string SmallImageText { get; internal set; }
 
         /// <summary>
-        /// Gets current party size.
+        /// Gets the current party size.
         /// </summary>
         public long? CurrentPartySize { get; internal set; }
 
         /// <summary>
-        /// Gets maximum party size.
+        /// Gets the maximum party size.
         /// </summary>
         public long? MaximumPartySize { get; internal set; }
 
@@ -353,6 +400,11 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Indicates the user is watching something.
         /// </summary>
-        Watching = 3
+        Watching = 3,
+
+        /// <summary>
+        /// Indicates the current activity is a custom status.
+        /// </summary>
+        Custom = 4
     }
 }

--- a/DSharpPlus/Net/Abstractions/TransportActivity.cs
+++ b/DSharpPlus/Net/Abstractions/TransportActivity.cs
@@ -32,7 +32,7 @@ namespace DSharpPlus.Net.Abstractions
         /// <summary>
         /// Gets or sets the details.
         /// 
-        /// This is a component of the rich presence, and, as such, can only be used by regular users.
+        /// <para>This is a component of the rich presence, and, as such, can only be used by regular users.</para>
         /// </summary>
         [JsonProperty("details", NullValueHandling = NullValueHandling.Ignore)]
         public string Details { get; internal set; }
@@ -40,10 +40,16 @@ namespace DSharpPlus.Net.Abstractions
         /// <summary>
         /// Gets or sets game state.
         /// 
-        /// This is a component of the rich presence, and, as such, can only be used by regular users.
+        /// <para>This is a component of the rich presence, and, as such, can only be used by regular users.</para>
         /// </summary>
         [JsonProperty("state", NullValueHandling = NullValueHandling.Ignore)]
         public string State { get; internal set; }
+
+        /// <summary>
+        /// Gets the emoji details for a custom status, if any.
+        /// </summary>
+        [JsonProperty("emoji", NullValueHandling = NullValueHandling.Ignore)]
+        public DiscordEmoji Emoji { get; internal set; }
 
         /// <summary>
         /// Gets ID of the application for which this rich presence is for.
@@ -115,6 +121,11 @@ namespace DSharpPlus.Net.Abstractions
         public bool IsRichPresence()
         {
             return this.Details != null || this.State != null || this.ApplicationId != null || this.Instance != null || this.Party != null || this.Assets != null || this.Secrets != null || this.Timestamps != null;
+        }
+
+        public bool IsCustomStatus()
+        {
+            return this.Name == "Custom Status";
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary
Implemented support for interpreting user custom statuses. This fixes #451.

# Details
I modeled this similarly to `DiscordRichPresence` in terms of initializing and the UpdateWith method. I also added a new json property `emoji` to capture the emoji of the status as well as add the custom status a new enum to `ActivityType`.

# Changes proposed
* Added the `emoji` property to `TransportActivity`.
* Added custom as a new activity type in `ActivityType`.
* Added the `DiscordCustomStatus` class, with name and emoji properties as well as an update method.
* Modified the `DiscordActivity.UpdateWith()` method to properly update the custom status property.
* Minor grammar corrections.

# Notes
Bots are not able to implement this as of now.