### PR TITLE
Fix NRE when ReactionCollectRequest is disposed more than once

### DIFF
--- a/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
@@ -198,10 +198,11 @@ namespace DSharpPlus.Interactivity.EventHandling
 
         public void Dispose()
         {
+            GC.SuppressFinalize(this);
             this._ct.Dispose();
             this._tcs = null;
             this.message = null;
-            this._collected.Clear();
+            this._collected?.Clear();
             this._collected = null;
         }
     }


### PR DESCRIPTION
# Summary
Fixes a NRE when ReactionCollectRequest is disposed more than once. A type in C# must never throw when disposing it more than once.

# Details
This issue is caused by calling Clear on _collected, which is set to null the first time the object is disposed.

# Changes proposed
* Add a null-check to `this._collected.Clear();`

# Notes
This issue was reported by Sakray#1428 on Discord.