### PR TITLE
Add client method to create DM channel

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -472,6 +472,14 @@ namespace DSharpPlus
             => this.ApiClient.CreateMessageAsync(channel.Id, content, isTTS, embed);
 
         /// <summary>
+        /// Creates a direct message channel to the specified user ID.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>Direct message channel to to the specified user ID.</returns>
+        public Task<DiscordDmChannel> CreateDmChannelAsync(ulong id)
+            => this.ApiClient.CreateDmAsync(id);
+
+        /// <summary>
         /// Creates a guild. This requires the bot to be in less than 10 guilds total.
         /// </summary>
         /// <param name="name">Name of the guild.</param>


### PR DESCRIPTION
# Summary
Add the ability to easily open DM channels from the client by using only the ID of a user.

# Details
This change add a method to the client in order to easily open DM channels by the ID of a user. This change is the result of not wanting to also use a REST client alongside a normal client just to open DMs easily.

# Changes proposed
- Add the method CreateDmChannelAsync(ulong id) to the DiscordClient class