### PR TITLE
Implemented support for Lavalink resuming

### DIFF
--- a/DSharpPlus.Lavalink/Entities/LavalinkCommands.cs
+++ b/DSharpPlus.Lavalink/Entities/LavalinkCommands.cs
@@ -4,6 +4,22 @@ using Newtonsoft.Json;
 
 namespace DSharpPlus.Lavalink.Entities
 {
+    internal sealed class LavalinkConfigureResume : LavalinkPayload
+    {
+        [JsonProperty("key")]
+        public string Key { get; }
+
+        [JsonProperty("timeout")]
+        public int Timeout { get; }
+
+        public LavalinkConfigureResume(string key, int timeout)
+            : base("configureResuming")
+        {
+            this.Key = key;
+            this.Timeout = timeout;
+        }
+    }
+
     internal sealed class LavalinkDestroy : LavalinkPayload
     {
         public LavalinkDestroy(LavalinkGuildConnection lvl)

--- a/DSharpPlus.Lavalink/Entities/LavalinkPayload.cs
+++ b/DSharpPlus.Lavalink/Entities/LavalinkPayload.cs
@@ -7,8 +7,11 @@ namespace DSharpPlus.Lavalink.Entities
         [JsonProperty("op")]
         public string Operation { get; }
 
-        [JsonProperty("guildId")]
+        [JsonProperty("guildId", NullValueHandling = NullValueHandling.Ignore)]
         public string GuildId { get; }
+
+        internal LavalinkPayload(string opcode)
+            => this.Operation = opcode;
 
         internal LavalinkPayload(string opcode, string guildId)
         {

--- a/DSharpPlus.Lavalink/LavalinkConfiguration.cs
+++ b/DSharpPlus.Lavalink/LavalinkConfiguration.cs
@@ -9,18 +9,33 @@ namespace DSharpPlus.Lavalink
     {
         /// <summary>
         /// Sets the endpoint for Lavalink REST.
+        /// <para>Defaults to 127.0.0.1 on port 2333.</para>
         /// </summary>
         public ConnectionEndpoint RestEndpoint { internal get; set; } = new ConnectionEndpoint("127.0.0.1", 2333);
 
         /// <summary>
-        /// Sets the endpoint for Lavalink Websocket connection.
+        /// Sets the endpoint for the Lavalink Websocket connection.
+        /// <para>Defaults to 127.0.0.1 on port 2333.</para>
         /// </summary>
         public ConnectionEndpoint SocketEndpoint { internal get; set; } = new ConnectionEndpoint("127.0.0.1", 2333);
 
         /// <summary>
-        /// Sets the password for Lavalink connection.
+        /// Sets the password for the Lavalink connection.
+        /// <para>Defaults to "youshallnotpass".</para>
         /// </summary>
         public string Password { internal get; set; } = "youshallnotpass";
+
+        /// <summary>
+        /// Sets the resume key for the Lavalink connection.
+        /// <para>This will allow existing voice sessions to continue for a certain time after the client is disconnected.</para>
+        /// </summary>
+        public string ResumeKey { internal get; set; }
+
+        /// <summary>
+        /// Sets the time in seconds when all voice sessions are closed after the client disconnects.
+        /// <para>Defaults to 60 seconds.</para>
+        /// </summary>
+        public int ResumeTimeout { internal get; set; } = 60;
 
         /// <summary>
         /// Creates a new instance of <see cref="LavalinkConfiguration"/>.
@@ -44,6 +59,8 @@ namespace DSharpPlus.Lavalink
                 Port = other.SocketEndpoint.Port
             };
             this.Password = other.Password;
+            this.ResumeKey = other.ResumeKey;
+            this.ResumeTimeout = other.ResumeTimeout;
         }
     }
 }

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -180,12 +180,17 @@ namespace DSharpPlus.Lavalink
             if (this.Discord?.CurrentUser?.Id == null || this.Discord?.ShardCount == null)
                 throw new InvalidOperationException("This operation requires the Discord client to be fully initialized.");
 
-            return this.WebSocket.ConnectAsync(new Uri($"ws://{this.Configuration.SocketEndpoint}/"), new Dictionary<string, string>()
+            var headers = new Dictionary<string, string>()
             {
                 ["Authorization"] = this.Configuration.Password,
                 ["Num-Shards"] = this.Discord.ShardCount.ToString(CultureInfo.InvariantCulture),
                 ["User-Id"] = this.Discord.CurrentUser.Id.ToString(CultureInfo.InvariantCulture)
-            });
+            };
+
+            if (this.Configuration.ResumeKey != null)
+                headers.Add("Resume-Key", this.Configuration.ResumeKey);
+
+            return this.WebSocket.ConnectAsync(new Uri($"ws://{this.Configuration.SocketEndpoint}/"), headers);
         }
 
         /// <summary>
@@ -470,6 +475,9 @@ namespace DSharpPlus.Lavalink
         private Task WebSocket_OnConnect()
         {
             this.Discord.DebugLogger.LogMessage(LogLevel.Info, "Lavalink", "Connection established", DateTime.Now);
+
+            if (this.Configuration.ResumeKey != null)
+                this.SendPayload(new LavalinkConfigureResume(this.Configuration.ResumeKey, this.Configuration.ResumeTimeout));
 
             return Task.Delay(0);
         }


### PR DESCRIPTION
# Summary
Implemented lavalink resuming as described [here](https://github.com/Frederikam/Lavalink/blob/master/IMPLEMENTATION.md#resuming-lavalink-sessions).

# Details
As mentioned in Lavalink, this will allow the resuming of sessions after a client is disconnected. The user can specify the key and timeout in the lavalink configuration, and I made the op send when the client first connects as well specify the key in the initial handshake headers.

# Changes proposed
* Added `key` and `timeout` properties to `LavalinkConfiguration`.
* Added `Resume-Key` as an additional header sent when connecting. 
* Added and changed a couple internal payload classes to better support it (since this op does not take a guild id).
* Made a couple grammar corrections as well as give more detail for other configuration properties.