### PR TITLE
Add Write(ReadOnlySpan<byte>) to VoiceTransmitStream

### DIFF
--- a/DSharpPlus.VoiceNext/VoiceTransmitStream.cs
+++ b/DSharpPlus.VoiceNext/VoiceTransmitStream.cs
@@ -123,10 +123,24 @@ namespace DSharpPlus.VoiceNext
         /// <param name="count">Number of bytes from the buffer.</param>
         public override void Write(byte[] buffer, int offset, int count)
         {
+            Write(new ReadOnlySpan<byte>(buffer, offset, count));
+        }
+
+
+        /// <summary>
+        /// Writes PCM data to the stream. The data is prepared for transmission, and enqueued.
+        /// </summary>
+        /// <param name="buffer">PCM data buffer to send.</param>
+#if NETSTANDARD2_1
+        public override void Write(ReadOnlySpan<byte> buffer)
+#else
+        public void Write(ReadOnlySpan<byte> buffer)
+#endif
+        {
             lock (this.PcmBuffer)
             {
-                var remaining = count;
-                var buffSpan = buffer.AsSpan().Slice(offset, count);
+                var remaining = buffer.Length;
+                var buffSpan = buffer;
                 var pcmSpan = this.PcmMemory.Span;
 
                 while (remaining > 0)


### PR DESCRIPTION
# Summary
Add an overload accepting ReadOnlySpan<byte> to Write in VoiceTransmitStream.

# Details
n/a, Summary and Changes proposed explain everything.

# Changes proposed
Copied the existing code into the new overload, changing the buffer.AsSpan to just use the provided ReadOnlySpan.
Made the old Write use the new overload.

# Notes
Since in .Net Standard 2.1 streams have a virtual Write with ReadOnlySpan i've made it override it there when NETSTANDARD2_1 is defined in case of the library updating to it.