### PR TITLE
Lavalink RoutePlanner support

### DIFF
--- a/DSharpPlus.Lavalink/Entities/LavalinkRouteStatusPayload.cs
+++ b/DSharpPlus.Lavalink/Entities/LavalinkRouteStatusPayload.cs
@@ -141,13 +141,13 @@ namespace DSharpPlus.Lavalink.Entities
         public string Address { get; internal set; }
 
         /// <summary>
-        /// Gets the failing timestamp in miliseconds
+        /// Gets the failing timestamp in miliseconds.
         /// </summary>
         [JsonProperty("failingTimestamp", NullValueHandling = NullValueHandling.Ignore)]
         public ulong FailingTimestamp { get; internal set; }
 
         /// <summary>
-        /// Gets the DateTime format of the failing address 
+        /// Gets the DateTime format of the failing address.
         /// </summary>
         [JsonProperty("failingTime", NullValueHandling = NullValueHandling.Ignore)]
         public string FailingTime { get; internal set; }

--- a/DSharpPlus.Lavalink/Entities/LavalinkRouteStatusPayload.cs
+++ b/DSharpPlus.Lavalink/Entities/LavalinkRouteStatusPayload.cs
@@ -1,0 +1,155 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Lavalink.Entities
+{
+    public class LavalinkRouteStatus
+    {
+        /// <summary>
+        /// Gets the route planner type.
+        /// </summary>
+        [JsonIgnore]
+        public RoutePlannerType? Class
+            => this.GetRoutePlannerType(_class);
+
+        /// <summary>
+        /// Gets the details of the route planner.
+        /// </summary>
+        [JsonProperty("details", NullValueHandling = NullValueHandling.Ignore)]
+        public LavalinkRouteStatusDetails Details { get; internal set; }
+
+        [JsonProperty("class", NullValueHandling = NullValueHandling.Ignore)]
+        internal string _class { get; set; }
+
+        private RoutePlannerType? GetRoutePlannerType(string type)
+        {
+            switch(type)
+            {
+                case "RotatingIpRoutePlanner":
+                    return RoutePlannerType.RotatingIpRoutePlanner;
+
+                case "BalancingIpRoutePlanner":
+                    return RoutePlannerType.BalancingIpRoutePlanner;
+
+                case "NanoIpRoutePlanner":
+                    return RoutePlannerType.NanoIpRoutePlanner;
+
+                case "RotatingNanoIpRoutePlanner":
+                    return RoutePlannerType.RotatingNanoIpRoutePlanner;
+
+                default:
+                    return null;
+            }
+        }
+    }
+
+    public class LavalinkRouteStatusDetails
+    {
+        /// <summary>
+        /// Gets the details for the current IP block.
+        /// </summary>
+        [JsonProperty("ipBlock", NullValueHandling = NullValueHandling.Ignore)]
+        public LavalinkIpBlock IpBlock { get; internal set; }
+
+        /// <summary>
+        /// Gets the collection of failed addresses.
+        /// </summary>
+        [JsonProperty("failingAddresses", NullValueHandling = NullValueHandling.Ignore)]
+        public IEnumerable<LavalinkFailedAddress> FailedAddresses { get; internal set; }
+
+        /// <summary>
+        /// Gets the number of rotations since the restart of Lavalink.
+        /// <para>Only present in the <see cref="RoutePlannerType.RotatingIpRoutePlanner"/>.</para>
+        /// </summary>
+        [JsonProperty("rotateIndex", NullValueHandling = NullValueHandling.Ignore)]
+        public string RotateIndex { get; internal set; }
+
+        /// <summary>
+        /// Gets the current offset of the IP block.
+        /// <para>Only present in the <see cref="RoutePlannerType.RotatingIpRoutePlanner"/>.</para>
+        /// </summary>
+        [JsonProperty("ipIndex", NullValueHandling = NullValueHandling.Ignore)]
+        public string IpIndex { get; internal set; }
+
+        /// <summary>
+        /// Gets the current IP Address used by the planner.
+        /// <para>Only present in the <see cref="RoutePlannerType.RotatingIpRoutePlanner"/>.</para>
+        /// </summary>
+        [JsonProperty("currentAddress", NullValueHandling = NullValueHandling.Ignore)]
+        public string CurrentAddress { get; internal set; }
+
+        /// <summary>
+        /// Gets the current offset of the IP block.
+        /// <para>Only present in the <see cref="RoutePlannerType.NanoIpRoutePlanner"/> and the <see cref="RoutePlannerType.RotatingNanoIpRoutePlanner"/>.</para>
+        /// </summary>
+        [JsonProperty("currentAddressIndex", NullValueHandling = NullValueHandling.Ignore)]
+        public long CurrentAddressIndex { get; internal set; }
+
+        /// <summary>
+        /// Gets the information in which /64 block ips are chosen. This number increases on each ban.
+        /// <para>Only present in the <see cref="RoutePlannerType.RotatingNanoIpRoutePlanner"/>.</para>
+        /// </summary>
+        [JsonProperty("blockIndex", NullValueHandling = NullValueHandling.Ignore)]
+        public string BlockIndex { get; internal set; }
+    }
+
+    public enum RoutePlannerType
+    {
+        /// <summary>
+        /// Route planner that switches the IP on ban.
+        /// </summary>
+        RotatingIpRoutePlanner = 1,
+
+        /// <summary>
+        /// Route planner that selects random IP addresses from the given block.
+        /// </summary>
+        BalancingIpRoutePlanner = 2,
+
+        /// <summary>
+        /// Route planner that switches the IP on every clock update.
+        /// </summary>
+        NanoIpRoutePlanner = 3,
+
+        /// <summary>
+        /// Route planner that switches the IP on every clock update and rotates to next IP block on a ban as a fallback. 
+        /// </summary>
+        RotatingNanoIpRoutePlanner = 4
+    }
+
+
+    public struct LavalinkIpBlock
+    {
+        /// <summary>
+        /// Gets the type of the IP block.
+        /// </summary>
+        [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]
+        public string Type { get; internal set; }
+
+        /// <summary>
+        /// Gets the size of the IP block.
+        /// </summary>
+        [JsonProperty("size", NullValueHandling = NullValueHandling.Ignore)]
+        public string Size { get; internal set; }
+    }
+
+    public struct LavalinkFailedAddress
+    {
+        /// <summary>
+        /// Gets the failed address IP.
+        /// </summary>
+        [JsonProperty("address", NullValueHandling = NullValueHandling.Ignore)]
+        public string Address { get; internal set; }
+
+        /// <summary>
+        /// Gets the failing timestamp in miliseconds
+        /// </summary>
+        [JsonProperty("failingTimestamp", NullValueHandling = NullValueHandling.Ignore)]
+        public ulong FailingTimestamp { get; internal set; }
+
+        /// <summary>
+        /// Gets the DateTime format of the failing address 
+        /// </summary>
+        [JsonProperty("failingTime", NullValueHandling = NullValueHandling.Ignore)]
+        public string FailingTime { get; internal set; }
+    }
+}

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -114,6 +114,11 @@ namespace DSharpPlus.Lavalink
         /// </summary>
         public LavalinkStatistics Statistics { get; }
 
+        /// <summary>
+        /// Gets the route planner for this connection, if present.
+        /// </summary>
+        public LavalinkRoutePlanner RoutePlanner { get; }
+
         internal DiscordClient Discord { get; }
         private LavalinkConfiguration Configuration { get; }
         private ConcurrentDictionary<ulong, LavalinkGuildConnection> ConnectedGuilds { get; }
@@ -159,6 +164,9 @@ namespace DSharpPlus.Lavalink
             {
                 BaseAddress = new Uri($"http://{this.Configuration.RestEndpoint}/loadtracks")
             };
+
+            this.RoutePlanner = new LavalinkRoutePlanner(this.Configuration, client);
+
             this.Rest.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", $"DSharpPlus.LavaLink/{client.VersionString}");
             this.Rest.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", this.Configuration.Password);
 

--- a/DSharpPlus.Lavalink/LavalinkRoutePlanner.cs
+++ b/DSharpPlus.Lavalink/LavalinkRoutePlanner.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Lavalink.Entities
+{
+    public class LavalinkRoutePlanner
+    {
+        private HttpClient Rest;
+
+        private LavalinkConfiguration Configuration;
+
+        private DebugLogger Logger;
+
+        private static UTF8Encoding UTF8 { get; } = new UTF8Encoding(false);
+
+        internal LavalinkRoutePlanner(LavalinkConfiguration config, DiscordClient client)
+        {
+            this.Configuration = config;
+            this.Logger = client.DebugLogger;
+
+            var httphandler = new HttpClientHandler
+            {
+                UseCookies = false,
+                AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip,
+                UseProxy = client.Configuration.Proxy != null
+            };
+            if (httphandler.UseProxy) 
+                httphandler.Proxy = client.Configuration.Proxy;
+
+            this.Rest = new HttpClient(httphandler);
+            
+            this.Rest.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", $"DSharpPlus.LavaLink/{client.VersionString}");
+            this.Rest.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", config.Password);
+        }
+
+        /// <summary>
+        /// Retrieves statistics from the route planner.
+        /// </summary>
+        /// <returns>The status (<see cref="LavalinkRouteStatus"/>) details.</returns>
+        public Task<LavalinkRouteStatus> GetStatusAsync()
+        {
+            var routeStatusUri = new Uri($"http://{this.Configuration.RestEndpoint}/routeplanner/status");
+            return this.InternalGetStatusAsync(routeStatusUri);
+        }
+
+        /// <summary>
+        /// Unmarks a failed route planner IP Address.
+        /// </summary>
+        /// <param name="address">The IP address name to unmark.</param>
+        /// <returns></returns>
+        public Task FreeAddressAsync(string address)
+        {
+            var routeFreeAddressUri = new Uri($"http://{this.Configuration.RestEndpoint}/routeplanner/free/address");
+            return this.InternalFreeAddressAsync(routeFreeAddressUri, address);
+        }
+
+        /// <summary>
+        /// Unmarks all failed route planner IP Addresses.
+        /// </summary>
+        /// <returns></returns>
+        public Task FreeAllAddressesAsync()
+        {
+            var routeFreeAddressUri = new Uri($"http://{this.Configuration.RestEndpoint}/routeplanner/free/all");
+            return this.InternalFreeAllAddressesAsync(routeFreeAddressUri);
+        }
+
+        internal async Task<LavalinkRouteStatus> InternalGetStatusAsync(Uri uri)
+        {
+            using (var req = await this.Rest.GetAsync(uri).ConfigureAwait(false))
+            using (var res = await req.Content.ReadAsStreamAsync().ConfigureAwait(false))
+            using (var sr = new StreamReader(res, UTF8))
+            {
+                var json = await sr.ReadToEndAsync().ConfigureAwait(false);
+                var status = JsonConvert.DeserializeObject<LavalinkRouteStatus>(json);
+                return status;
+            }
+        }
+
+        internal async Task InternalFreeAddressAsync(Uri uri, string address)
+        {
+            var payload = new StringContent(address, UTF8, "application/json");
+            using (var req = await this.Rest.PostAsync(uri, payload).ConfigureAwait(false))
+                if (req.StatusCode == HttpStatusCode.InternalServerError)
+                    this.Logger.LogMessage(LogLevel.Warning, "Lavalink", $"Request to {uri.ToString()} returned an internal server error. This likely indicates that the server route planner configuration is incorrect.", DateTime.Now);
+             
+        }
+
+        internal async Task InternalFreeAllAddressesAsync(Uri uri)
+        {
+            var httpReq = new HttpRequestMessage(HttpMethod.Post, uri);
+            using (var req = await this.Rest.SendAsync(httpReq).ConfigureAwait(false))
+                if (req.StatusCode == HttpStatusCode.InternalServerError)
+                    this.Logger.LogMessage(LogLevel.Warning, "Lavalink", $"Request to {uri.ToString()} returned an internal server error. This likely indicates that the server route planner configuration is incorrect.", DateTime.Now);
+        }
+    }
+}

--- a/DSharpPlus.Lavalink/LavalinkRoutePlanner.cs
+++ b/DSharpPlus.Lavalink/LavalinkRoutePlanner.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;


### PR DESCRIPTION
# Summary
Implements route planner support for Lavalink as described [here](https://github.com/Frederikam/Lavalink/blob/master/IMPLEMENTATION.md#routeplanner-api).

# Details
With the recent IP bans YouTube has been issuing against music bots, Lavaplayer implemented this strategy of switching IPs to counter it. Lavalink implemented support for this as well, and has added several new endpoints to its API. 

I created a RoutePlanner class to handle the requests to Lavalink, and I also made several payload handlers to decode the responses in `LavalinkRouteStatusPayload.cs`. The endpoints serve to get the status of the route planner, as well as either freeing a single banned address, or every banned address.

Further details about the route planners can be found [here](https://github.com/Frederikam/Lavalink/blob/master/ROUTEPLANNERS.md).

# Changes proposed
* Created `LavalinkRoutePlanner`, which was added as a property to `LavalinkNodeConnection` and serves to make route planner requests to Lavalink.
* Created `LavalinkRouteStatusPayload`, which are entities used to get information from the route planner status endpoint.