### PR TITLE
Ignore GIFT_CODE_UPDATE event

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -658,6 +658,9 @@ namespace DSharpPlus
                     await this.OnChannelPinsUpdate((ulong?)dat["guild_id"], this.InternalGetCachedChannel(cid), ts != null ? DateTimeOffset.Parse(ts, CultureInfo.InvariantCulture) : default(DateTimeOffset?)).ConfigureAwait(false);
                     break;
 
+                case "gift_code_update": //Not supposed to be dispatched to bots
+                    break;
+
                 case "guild_create":
                     await OnGuildCreateEventAsync(dat.ToObject<DiscordGuild>(), (JArray)dat["members"], dat["presences"].ToObject<IEnumerable<DiscordPresence>>()).ConfigureAwait(false);
                     break;


### PR DESCRIPTION
# Summary
Ignores the gift code update event from dispatch. Fixes #506.

# Details
As per discordapp/discord-api-docs#803, this event is not supposed to be dispatched to bots, and is also not documented in Discord API docs. 