### PR TITLE
Add webhook request builder and use new querystring request system

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1074,33 +1074,10 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="webhook_id">Webhook id</param>
         /// <param name="webhook_token">Webhook token</param>
-        /// <param name="content">Webhook message content</param>
-        /// <param name="username">Webhook username</param>
-        /// <param name="avatar_url">Webhook avatar url</param>
-        /// <param name="tts">Whether this message should be text-to-speech</param>
-        /// <param name="embeds">Embeds to attach to this webhook</param>
-        /// <param name="file_name">Name of the file to attach to this webhook</param>
-        /// <param name="file_data">Stream data of the file to attach to this webhook</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
+        /// <param name="builder">Webhook builder filled with data to send.</param>
         /// <returns></returns>
-        public Task ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, string username, string avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, string file_name, Stream file_data, IEnumerable<IMention> mentions = null)
-            => ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, content, username, avatar_url, tts, embeds, file_name, file_data, mentions);
-
-        /// <summary>
-        /// Sends a message to a webhook
-        /// </summary>
-        /// <param name="webhook_id">Webhook id</param>
-        /// <param name="webhook_token">Webhook token</param>
-        /// <param name="content">Webhook message content</param>
-        /// <param name="username">Webhook username</param>
-        /// <param name="avatar_url">Webhook avatar url</param>
-        /// <param name="tts">Whether this message should be text-to-speech</param>
-        /// <param name="embeds">Embeds to attach to this webhook</param>
-        /// <param name="files">Files to attach to this webhook</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
-        /// <returns></returns>
-        public Task ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, string username, string avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, Dictionary<string, Stream> files, IEnumerable<IMention> mentions = null)
-            => ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, content, username, avatar_url, tts, embeds, files, mentions);
+        public Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, DiscordWebhookBuilder builder)
+            => ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, builder.Content, builder.Username, builder.AvatarUrl, builder.IsTTS, builder.Embeds, builder.Files);
         #endregion
 
         #region Reactions

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1077,7 +1077,7 @@ namespace DSharpPlus
         /// <param name="builder">Webhook builder filled with data to send.</param>
         /// <returns></returns>
         public Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, DiscordWebhookBuilder builder)
-            => ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, builder.Content, builder.Username, builder.AvatarUrl, builder.IsTTS, builder.Embeds, builder.Files);
+            => ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, builder.Content, builder.Username, builder.AvatarUrl, builder.IsTTS, builder.Embeds, builder.Files, builder.Mentions);
         #endregion
 
         #region Reactions

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -370,12 +370,14 @@ namespace DSharpPlus
             this._webSocketClient.MessageReceived += SocketOnMessage;
             this._webSocketClient.ExceptionThrown += SocketOnException;
 
-            var gwuri = new UriBuilder(this._gatewayUri)
-            {
-                Query = this.Configuration.GatewayCompressionLevel == GatewayCompressionLevel.Stream ? "v=6&encoding=json&compress=zlib-stream" : "v=6&encoding=json"
-            };
+            var gwuri = new QueryUriBuilder(this._gatewayUri)
+                .AddParameter("v", "6")
+                .AddParameter("encoding", "json");
 
-            await this._webSocketClient.ConnectAsync(gwuri.Uri).ConfigureAwait(false);
+            if (this.Configuration.GatewayCompressionLevel == GatewayCompressionLevel.Stream)
+                gwuri.AddParameter("compress", "zlib-stream");
+
+            await this._webSocketClient.ConnectAsync(gwuri.Build()).ConfigureAwait(false);
 
             Task SocketOnConnect()
                 => this._socketOpened.InvokeAsync();

--- a/DSharpPlus/DiscordWebhookClient.cs
+++ b/DSharpPlus/DiscordWebhookClient.cs
@@ -205,23 +205,28 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="builder">Webhook builder filled with data to send.</param>
         /// <returns></returns>
-        public async Task BroadcastMessageAsync(DiscordWebhookBuilder builder)
+        public async Task<Dictionary<DiscordWebhook, DiscordMessage>> BroadcastMessageAsync(DiscordWebhookBuilder builder)
         {
             var deadhooks = new List<DiscordWebhook>();
+            var messages = new Dictionary<DiscordWebhook, DiscordMessage>();
+
             foreach (var hook in _hooks)
             {
                 try
                 {
-                    await hook.ExecuteAsync(builder).ConfigureAwait(false);
+                    messages.Add(hook, await hook.ExecuteAsync(builder).ConfigureAwait(false));
                 }
                 catch (NotFoundException)
                 {
                     deadhooks.Add(hook);
                 }
             }
+
             // Removing dead webhooks from collection
             foreach (var xwh in deadhooks)
                 _hooks.Remove(xwh);
+
+            return messages;
         }
     }
 }

--- a/DSharpPlus/DiscordWebhookClient.cs
+++ b/DSharpPlus/DiscordWebhookClient.cs
@@ -203,37 +203,16 @@ namespace DSharpPlus
         /// <summary>
         /// Broadcasts a message to all registered webhooks.
         /// </summary>
-        /// <param name="content">Contents of the message to broadcast.</param>
-        /// <param name="embeds">Embeds to send with the messages.</param>
-        /// <param name="tts">Whether the messages should be read aloud using TTS engine.</param>
-        /// <param name="username_override">Username to use for this broadcast.</param>
-        /// <param name="avatar_override">Avatar URL to use for this broadcast.</param>
-        /// <param name="file_name">Name of the file to broadcast.</param>
-        /// <param name="file_data">Content of the file to broadcast.</param>
+        /// <param name="builder">Webhook builder filled with data to send.</param>
         /// <returns></returns>
-        public Task BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, string file_name = null, Stream file_data = null)
-        {
-            return BroadcastMessageAsync(content, embeds, tts, username_override, avatar_override, new Dictionary<string, Stream> { { file_name, file_data } });
-        }
-
-        /// <summary>
-        /// Broadcasts a message to all registered webhooks.
-        /// </summary>
-        /// <param name="content">Contents of the message to broadcast.</param>
-        /// <param name="embeds">Embeds to send with the messages.</param>
-        /// <param name="tts">Whether the messages should be read aloud using TTS engine.</param>
-        /// <param name="username_override">Username to use for this broadcast.</param>
-        /// <param name="avatar_override">Avatar URL to use for this broadcast.</param>
-        /// <param name="files">Files to broadcast.</param>
-        /// <returns></returns>
-        public async Task BroadcastMessageAsync(string content = null, List<DiscordEmbed> embeds = null, bool tts = false, string username_override = null, string avatar_override = null, Dictionary<string, Stream> files = null)
+        public async Task BroadcastMessageAsync(DiscordWebhookBuilder builder)
         {
             var deadhooks = new List<DiscordWebhook>();
             foreach (var hook in _hooks)
             {
                 try
                 {
-                    await hook.ExecuteAsync(content, username_override ?? this.Username, avatar_override ?? this.AvatarUrl, tts, embeds, files).ConfigureAwait(false);
+                    await hook.ExecuteAsync(builder).ConfigureAwait(false);
                 }
                 catch (NotFoundException)
                 {

--- a/DSharpPlus/Entities/DiscordApplication.cs
+++ b/DSharpPlus/Entities/DiscordApplication.cs
@@ -140,10 +140,12 @@ namespace DSharpPlus.Entities
         public string GenerateBotOAuth(Permissions permissions = Permissions.None)
         {
             permissions &= PermissionMethods.FULL_PERMS;
-            // Split it up so it isn't annoying and blue
-            // 
-            // :blobthonkang: -emzi
-            return "https://" + $"discordapp.com/oauth2/authorize?client_id={this.Id.ToString(CultureInfo.InvariantCulture)}&scope=bot&permissions={((long)permissions).ToString(CultureInfo.InvariantCulture)}";
+            // hey look, it's not all annoying and blue :P
+            return new QueryUriBuilder("https://discordapp.com/oauth2/authorize")
+                .AddParameter("client_id", this.Id.ToString(CultureInfo.InvariantCulture))
+                .AddParameter("scope", "bot")
+                .AddParameter("permissions", ((long) permissions).ToString(CultureInfo.InvariantCulture))
+                .ToString();
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -91,7 +91,7 @@ namespace DSharpPlus.Entities
         public Task<DiscordMessage> ExecuteAsync(DiscordWebhookBuilder builder)
             => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookAsync(this.Id, this.Token, builder.Content,
                 builder.Username.HasValue ? builder.Username.Value : this.Name, builder.AvatarUrl.HasValue ? builder.AvatarUrl.Value : this.AvatarUrl, 
-                builder.IsTTS, builder.Embeds, builder.Files);
+                builder.IsTTS, builder.Embeds, builder.Files, builder.Mentions);
 
         /// <summary>
         /// Executes this webhook in Slack compatibility mode.

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using DSharpPlus.Net;
 using Newtonsoft.Json;
+using System.Linq;
 
 namespace DSharpPlus.Entities
 {
@@ -84,33 +85,13 @@ namespace DSharpPlus.Entities
             => this.Discord.ApiClient.DeleteWebhookAsync(this.Id, Token);
 
         /// <summary>
-        /// Executes this webhook.
+        /// Executes this webhook with the given <see cref="DiscordWebhookBuilder"/>.
         /// </summary>
-        /// <param name="content">The contents of the message to send.</param>
-        /// <param name="username">Username to use for this message.</param>
-        /// <param name="avatar_url">Url of the avatar to use for this message.</param>
-        /// <param name="tts">Whether the message is to be spoken aloud.</param>
-        /// <param name="embeds">Embeds to attach to the message being sent.</param>
-        /// <param name="file_name">Name of the file to attach to the message being sent.</param>
-        /// <param name="file_data">Content of the file to attach to the message being sent.</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
-        /// <returns></returns>
-        public Task ExecuteAsync(string content = null, string username = null, string avatar_url = null, bool tts = false, IEnumerable<DiscordEmbed> embeds = null, string file_name = null, Stream file_data = null, IEnumerable<IMention> mentions = null) 
-            => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookAsync(Id, Token, content, username, avatar_url, tts, embeds, file_name, file_data, mentions);
-
-        /// <summary>
-        /// Executes this webhook.
-        /// </summary>
-        /// <param name="content">The contents of the message to send.</param>
-        /// <param name="username">Username to use for this message.</param>
-        /// <param name="avatar_url">Url of the avatar to use for this message.</param>
-        /// <param name="tts">Whether the message is to be spoken aloud.</param>
-        /// <param name="embeds">Embeds to attach to the message being sent.</param>
-        /// <param name="files">Files to attach to the message being sent.</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
-        /// <returns></returns>
-        public Task ExecuteAsync(string content = null, string username = null, string avatar_url = null, bool tts = false, IEnumerable<DiscordEmbed> embeds = null, Dictionary<string, Stream> files = null, IEnumerable<IMention> mentions = null)
-            => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookAsync(Id, Token, content, username, avatar_url, tts, embeds, files, mentions);
+        /// <param name="builder">Webhook builder filled with data to send.</param>
+        public Task<DiscordMessage> ExecuteAsync(DiscordWebhookBuilder builder)
+            => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookAsync(this.Id, this.Token, builder.Content,
+                builder.Username.HasValue ? builder.Username.Value : this.Name, builder.AvatarUrl.HasValue ? builder.AvatarUrl.Value : this.AvatarUrl, 
+                builder.IsTTS, builder.Embeds, builder.Files);
 
         /// <summary>
         /// Executes this webhook in Slack compatibility mode.

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -52,6 +52,9 @@ namespace DSharpPlus.Entities
         public IReadOnlyDictionary<string, Stream> Files { get; }
         private readonly Dictionary<string, Stream> _files = new Dictionary<string, Stream>();
 
+        public IEnumerable<IMention> Mentions { get; }
+        private readonly List<IMention> _mentions = new List<IMention>();
+
         /// <summary>
         /// Constructs a new empty webhook request builder.
         /// </summary>
@@ -59,6 +62,7 @@ namespace DSharpPlus.Entities
         {
             this.Embeds = new ReadOnlyCollection<DiscordEmbed>(this._embeds);
             this.Files = new ReadOnlyDictionary<string, Stream>(this._files);
+            this.Mentions = new ReadOnlyCollection<IMention>(this._mentions);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -52,6 +52,9 @@ namespace DSharpPlus.Entities
         public IReadOnlyDictionary<string, Stream> Files { get; }
         private readonly Dictionary<string, Stream> _files = new Dictionary<string, Stream>();
 
+        /// <summary>
+        /// Mentions to send on this webhook request.
+        /// </summary>
         public IEnumerable<IMention> Mentions { get; }
         private readonly List<IMention> _mentions = new List<IMention>();
 
@@ -146,6 +149,26 @@ namespace DSharpPlus.Entities
             {
                 this._files[file.Key] = file.Value;
             }
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the mention to the mentions to parse, etc. at the execution of the webhook.
+        /// </summary>
+        /// <param name="mention">Mention to add.</param>
+        public DiscordWebhookBuilder AddMention(IMention mention)
+        {
+            this._mentions.Add(mention);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the mentions to the mentions to parse, etc. at the execution of the webhook.
+        /// </summary>
+        /// <param name="mentions">Mentions to add.</param>
+        public DiscordWebhookBuilder AddMentions(IEnumerable<IMention> mentions)
+        {
+            this._mentions.AddRange(mentions);
             return this;
         }
     }

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -1,0 +1,137 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+
+namespace DSharpPlus.Entities
+{
+    /// <summary>
+    /// Constructs ready-to-send webhook requests.
+    /// </summary>
+    public sealed class DiscordWebhookBuilder
+    {
+        /// <summary>
+        /// Username to use for this webhook request.
+        /// </summary>
+        public Optional<string> Username { get; set; }
+        
+        /// <summary>
+        /// Avatar url to use for this webhook request.
+        /// </summary>
+        public Optional<string> AvatarUrl { get; set; }
+        
+        /// <summary>
+        /// Whether this webhook request is text-to-speech.
+        /// </summary>
+        public bool IsTTS { get; set; }
+
+        /// <summary>
+        /// Message to send on this webhook request.
+        /// </summary>
+        public string Content { get; set; }
+        
+        /// <summary>
+        /// Embeds to send on this webhook request.
+        /// </summary>
+        public IReadOnlyList<DiscordEmbed> Embeds { get; }
+        private readonly List<DiscordEmbed> _embeds = new List<DiscordEmbed>();
+
+        /// <summary>
+        /// Files to send on this webhook request.
+        /// </summary>
+        public IReadOnlyDictionary<string, Stream> Files { get; }
+        private readonly Dictionary<string, Stream> _files = new Dictionary<string, Stream>();
+
+        /// <summary>
+        /// Constructs a new empty webhook request builder.
+        /// </summary>
+        public DiscordWebhookBuilder()
+        {
+            this.Embeds = new ReadOnlyCollection<DiscordEmbed>(this._embeds);
+            this.Files = new ReadOnlyDictionary<string, Stream>(this._files);
+        }
+
+        /// <summary>
+        /// Sets the username for this webhook builder.
+        /// </summary>
+        /// <param name="username">Username of the webhook</param>
+        public DiscordWebhookBuilder WithUsername(string username)
+        {
+            this.Username = username;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the avatar of this webhook builder from its url.
+        /// </summary>
+        /// <param name="avatarUrl">Avatar url of the webhook</param>
+        public DiscordWebhookBuilder WithAvatarUrl(string avatarUrl)
+        {
+            this.AvatarUrl = avatarUrl;
+            return this;
+        }
+
+        /// <summary>
+        /// Indicates if the webhook must use text-to-speech.
+        /// </summary>
+        /// <param name="tts">Text-to-speech</param>
+        public DiscordWebhookBuilder WithTTS(bool tts)
+        {
+            this.IsTTS = tts;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the message to send at the execution of the webhook.
+        /// </summary>
+        /// <param name="content">Message to send.</param>
+        public DiscordWebhookBuilder WithContent(string content)
+        {
+            this.Content = content;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an embed to send at the execution of the webhook.
+        /// </summary>
+        /// <param name="embed">Embed to add.</param>
+        public DiscordWebhookBuilder AddEmbed(DiscordEmbed embed)
+        {
+            this._embeds.Add(embed);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the given embeds to send at the execution of the webhook.
+        /// </summary>
+        /// <param name="embeds">Embeds to add.</param>
+        public DiscordWebhookBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
+        {
+            this._embeds.AddRange(embeds);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a file to send at the execution of the webhook.
+        /// </summary>
+        /// <param name="filename">Name of the file.</param>
+        /// <param name="data">File data.</param>
+        public DiscordWebhookBuilder AddFile(string filename, Stream data)
+        {
+            this._files[filename] = data;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the given files to send at the execution of the webhook.
+        /// </summary>
+        /// <param name="files">Dictionary of file name and file data.</param>
+        public DiscordWebhookBuilder AddFiles(Dictionary<string, Stream> files)
+        {
+            foreach (var file in files)
+            {
+                this._files[file.Key] = file.Value;
+            }
+            return this;
+        }
+    }
+}

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 
@@ -27,7 +28,17 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Message to send on this webhook request.
         /// </summary>
-        public string Content { get; set; }
+        public string Content
+        {
+            get => this._content;
+            set
+            {
+                if (value != null && value.Length > 2000)
+                    throw new ArgumentException("Content length cannot exceed 2000 characters.", nameof(value));
+                this._content = value;
+            }
+        }
+        private string _content;
         
         /// <summary>
         /// Embeds to send on this webhook request.

--- a/DSharpPlus/Net/BaseRestRequest.cs
+++ b/DSharpPlus/Net/BaseRestRequest.cs
@@ -48,7 +48,7 @@ namespace DSharpPlus.Net
         /// <param name="method">Method to use for this request,</param>
         /// <param name="headers">Additional headers for this request.</param>
         /// <param name="ratelimitWaitOverride">Override for ratelimit bucket wait time.</param>
-        internal BaseRestRequest(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, IDictionary<string, string> headers = null, double? ratelimitWaitOverride = null)
+        internal BaseRestRequest(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, IReadOnlyDictionary<string, string> headers = null, double? ratelimitWaitOverride = null)
         {
             this.Discord = client;
             this.RateLimitBucket = bucket;
@@ -61,7 +61,7 @@ namespace DSharpPlus.Net
             {
                 headers = headers.Select(x => new KeyValuePair<string, string>(x.Key, Uri.EscapeDataString(x.Value)))
                     .ToDictionary(x => x.Key, x => x.Value);
-                this.Headers = new ReadOnlyDictionary<string, string>(headers);
+                this.Headers = headers;
             }
         }
 

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -100,7 +100,7 @@ namespace DSharpPlus.Net
             return ret;
         }
 
-        private Task<RestResponse> DoRequestAsync(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, IDictionary<string, string> headers = null, string payload = null, double? ratelimitWaitOverride = null)
+        private Task<RestResponse> DoRequestAsync(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, IReadOnlyDictionary<string, string> headers = null, string payload = null, double? ratelimitWaitOverride = null)
         {
             var req = new RestRequest(client, bucket, url, method, headers, payload, ratelimitWaitOverride);
 
@@ -112,8 +112,8 @@ namespace DSharpPlus.Net
             return req.WaitForCompletionAsync();
         }
 
-        private Task<RestResponse> DoMultipartAsync(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, IDictionary<string, string> headers = null, IDictionary<string, string> values = null,
-            IDictionary<string, Stream> files = null, double? ratelimitWaitOverride = null)
+        private Task<RestResponse> DoMultipartAsync(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, IReadOnlyDictionary<string, string> headers = null, IReadOnlyDictionary<string, string> values = null,
+            IReadOnlyDictionary<string, Stream> files = null, double? ratelimitWaitOverride = null)
         {
             var req = new MultipartWebRequest(client, bucket, url, method, headers, values, files, ratelimitWaitOverride);
 
@@ -1647,14 +1647,7 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers);
         }
 
-        internal Task ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, string username, string avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, string file_name, Stream file_data, IEnumerable<IMention> mentions)
-        {
-            var file = new Dictionary<string, Stream> { { file_name, file_data } };
-
-            return this.ExecuteWebhookAsync(webhook_id, webhook_token, content, username, avatar_url, tts, embeds, file, mentions);
-        }
-
-        internal async Task ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, string username, string avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, Dictionary<string, Stream> files, IEnumerable<IMention> mentions)
+        internal async Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, Optional<string> username, Optional<string> avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, IReadOnlyDictionary<string, Stream> files, IEnumerable<IMention> mentions)
         {
             if (files?.Count == 0 && string.IsNullOrEmpty(content) && embeds == null)
                 throw new ArgumentException("You must specify content, an embed, or at least one file.");
@@ -1668,8 +1661,8 @@ namespace DSharpPlus.Net
             var pld = new RestWebhookExecutePayload
             {
                 Content = content,
-                Username = username,
-                AvatarUrl = avatar_url,
+                Username = username.HasValue ? username.Value : null,
+                AvatarUrl = avatar_url.HasValue ? avatar_url.Value : null,
                 IsTTS = tts,
                 Embeds = embeds
             };
@@ -1683,8 +1676,11 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
-            await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, values: values, files: files).ConfigureAwait(false);
+            var url = Utilities.GetApiUriFor(path, "?wait=true");
+            var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, values: values, files: files).ConfigureAwait(false);
+            var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
+            ret.Discord = this.Discord;
+            return ret;
         }
 
         internal Task ExecuteWebhookSlackAsync(ulong webhook_id, string webhook_token, string json_payload)

--- a/DSharpPlus/Net/MultipartWebRequest.cs
+++ b/DSharpPlus/Net/MultipartWebRequest.cs
@@ -8,7 +8,7 @@ namespace DSharpPlus.Net
     /// <summary>
     /// Represents a multipart HTTP request.
     /// </summary>
-    public sealed class MultipartWebRequest : BaseRestRequest
+    internal sealed class MultipartWebRequest : BaseRestRequest
     {
         /// <summary>
         /// Gets the dictionary of values attached to this request.
@@ -20,12 +20,12 @@ namespace DSharpPlus.Net
         /// </summary>
         public IReadOnlyDictionary<string, Stream> Files { get; }
 
-        internal MultipartWebRequest(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, IDictionary<string, string> headers = null, IDictionary<string, string> values = null, 
-            IDictionary<string, Stream> files = null, double? ratelimit_wait_override = null)
+        internal MultipartWebRequest(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, IReadOnlyDictionary<string, string> headers = null, IReadOnlyDictionary<string, string> values = null, 
+            IReadOnlyDictionary<string, Stream> files = null, double? ratelimit_wait_override = null)
             : base(client, bucket, url, method, headers, ratelimit_wait_override)
         {
-            this.Values = values != null ? new ReadOnlyDictionary<string, string>(values) : null;
-            this.Files = files != null ? new ReadOnlyDictionary<string, Stream>(files) : null;
+            this.Values = values;
+            this.Files = files;
         }
     }
 }

--- a/DSharpPlus/Net/RestRequest.cs
+++ b/DSharpPlus/Net/RestRequest.cs
@@ -6,7 +6,7 @@ namespace DSharpPlus.Net
     /// <summary>
     /// Represents a non-multipart HTTP request.
     /// </summary>
-    public sealed class RestRequest : BaseRestRequest
+    internal sealed class RestRequest : BaseRestRequest
     {
         /// <summary>
         /// Gets the payload sent with this request.

--- a/DSharpPlus/Net/RestRequest.cs
+++ b/DSharpPlus/Net/RestRequest.cs
@@ -13,7 +13,7 @@ namespace DSharpPlus.Net
         /// </summary>
         public string Payload { get; }
 
-        internal RestRequest(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, IDictionary<string, string> headers = null, string payload = null, double? ratelimitWaitOverride = null)
+        internal RestRequest(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, IReadOnlyDictionary<string, string> headers = null, string payload = null, double? ratelimitWaitOverride = null)
             : base(client, bucket, url, method, headers, ratelimitWaitOverride)
         {
             this.Payload = payload;

--- a/DSharpPlus/QueryUriBuilder.cs
+++ b/DSharpPlus/QueryUriBuilder.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DSharpPlus
+{
+    internal class QueryUriBuilder
+    {
+        public Uri SourceUri { get; }
+
+        public IReadOnlyList<KeyValuePair<string, string>> QueryParameters => this._queryParams;
+        private readonly List<KeyValuePair<string, string>> _queryParams = new List<KeyValuePair<string, string>>();
+
+        public QueryUriBuilder(string uri)
+        {
+            if (uri == null)
+                throw new ArgumentNullException(nameof(uri));
+            
+            this.SourceUri = new Uri(uri);
+        }
+
+        public QueryUriBuilder(Uri uri)
+        {
+            if (uri == null)
+                throw new ArgumentNullException(nameof(uri));
+            
+            this.SourceUri = uri;
+        }
+
+        public QueryUriBuilder AddParameter(string key, string value)
+        {
+            this._queryParams.Add(new KeyValuePair<string, string>(key, value));
+            return this;
+        }
+
+        public Uri Build()
+        {
+            return new UriBuilder(this.SourceUri)
+            {
+                Query = string.Join("&",
+                    _queryParams.Select(e => Uri.EscapeDataString(e.Key) + '=' + Uri.EscapeDataString(e.Value)))
+            }.Uri;
+        }
+
+        public override string ToString()
+        {
+            return Build().ToString();
+        }
+    }
+}

--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -69,6 +69,9 @@ namespace DSharpPlus
         internal static Uri GetApiUriFor(string path, string queryString)
             => new Uri($"{GetApiBaseUri()}{path}{queryString}");
 
+        internal static QueryUriBuilder GetApiUriBuilderFor(string path)
+            => new QueryUriBuilder($"{GetApiBaseUri()}{path}");
+
         internal static string GetFormattedToken(BaseDiscordClient client)
         {
             return GetFormattedToken(client.Configuration);


### PR DESCRIPTION
# Summary

- Gets rid of methods with thousands of parameters in order to have a builder instead.
- Removes useless overloads.
- Now awaits and returns DiscordMessage objects.

- Replaces IDictionary with IReadOnlyDictionary in MultipartWebRequest / RestRequest / BaseRestRequest

- Fixes https://github.com/DSharpPlus/DSharpPlus/pull/460 which was on-hold.

Tested and worked properly!