### PR TITLE
Added New Events and Endpoint

### DIFF
--- a/DSharpPlus.Lavalink/EventArgs/StatisticsReceivedEventArgs.cs
+++ b/DSharpPlus.Lavalink/EventArgs/StatisticsReceivedEventArgs.cs
@@ -1,16 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DSharpPlus.Lavalink.Entities;
+﻿using DSharpPlus.Lavalink.Entities;
 
 namespace DSharpPlus.Lavalink.EventArgs
 {
     /// <summary>
     /// Represents arguments for Lavalink statistics received.
     /// </summary>
-    public sealed class StatsReceivedEventArgs : AsyncEventArgs
+    public sealed class StatisticsReceivedEventArgs : AsyncEventArgs
     {
         /// <summary>
         /// Gets the Lavalink statistics received.
@@ -18,7 +13,7 @@ namespace DSharpPlus.Lavalink.EventArgs
         public LavalinkStatistics Statistics { get; }
 
 
-        internal StatsReceivedEventArgs(LavalinkStatistics stats)
+        internal StatisticsReceivedEventArgs(LavalinkStatistics stats)
         {
             this.Statistics = stats;
         }

--- a/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
@@ -112,21 +112,21 @@ namespace DSharpPlus.Lavalink
         /// <summary>
         /// Disconnect from this voice channel.
         /// </summary>
-        public void Disconnect()
+        public async Task DisconnectAsync()
         {
             if (!this.IsConnected)
                 throw new InvalidOperationException("This connection is not valid.");
 
             Volatile.Write(ref this._isDisposed, true);
 
-            this.Node.SendPayload(new LavalinkDestroy(this));
-            this.SendVoiceUpdate();
+            await this.Node.SendPayloadAsync(new LavalinkDestroy(this)).ConfigureAwait(false);
+            await this.SendVoiceUpdateAsync().ConfigureAwait(false);
 
             if (this.ChannelDisconnected != null)
                 this.ChannelDisconnected(this);
         }
 
-        internal void SendVoiceUpdate()
+        internal async Task SendVoiceUpdateAsync()
         {
             var vsd = new VoiceDispatch
             {
@@ -140,20 +140,20 @@ namespace DSharpPlus.Lavalink
                 }
             };
             var vsj = JsonConvert.SerializeObject(vsd, Formatting.None);
-            (this.Channel.Discord as DiscordClient)._webSocketClient.SendMessage(vsj);
+            await (this.Channel.Discord as DiscordClient)._webSocketClient.SendMessageAsync(vsj).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Queues the specified track for playback.
         /// </summary>
         /// <param name="track">Track to play.</param>
-        public void Play(LavalinkTrack track)
+        public async Task PlayAsync(LavalinkTrack track)
         {
             if (!this.IsConnected)
                 throw new InvalidOperationException("This connection is not valid.");
 
             this.CurrentState.CurrentTrack = track;
-            this.Node.SendPayload(new LavalinkPlay(this, track));
+            await this.Node.SendPayloadAsync(new LavalinkPlay(this, track)).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace DSharpPlus.Lavalink
         /// <param name="track">Track to play.</param>
         /// <param name="start">Timestamp to start playback at.</param>
         /// <param name="end">Timestamp to stop playback at.</param>
-        public void PlayPartial(LavalinkTrack track, TimeSpan start, TimeSpan end)
+        public async Task PlayPartialAsync(LavalinkTrack track, TimeSpan start, TimeSpan end)
         {
             if (!this.IsConnected)
                 throw new InvalidOperationException("This connection is not valid.");
@@ -171,59 +171,59 @@ namespace DSharpPlus.Lavalink
                 throw new ArgumentException("Both start and end timestamps need to be greater or equal to zero, and the end timestamp needs to be greater than start timestamp.");
 
             this.CurrentState.CurrentTrack = track;
-            this.Node.SendPayload(new LavalinkPlayPartial(this, track, start, end));
+            await this.Node.SendPayloadAsync(new LavalinkPlayPartial(this, track, start, end)).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Stops the player completely.
         /// </summary>
-        public void Stop()
+        public async Task StopAsync()
         {
             if (!this.IsConnected)
                 throw new InvalidOperationException("This connection is not valid.");
 
-            this.Node.SendPayload(new LavalinkStop(this));
+            await this.Node.SendPayloadAsync(new LavalinkStop(this)).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Pauses the player.
         /// </summary>
-        public void Pause()
+        public async Task PauseAsync()
         {
             if (!this.IsConnected)
                 throw new InvalidOperationException("This connection is not valid.");
 
-            this.Node.SendPayload(new LavalinkPause(this, true));
+            await this.Node.SendPayloadAsync(new LavalinkPause(this, true)).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Resumes playback.
         /// </summary>
-        public void Resume()
+        public async Task ResumeAsync()
         {
             if (!this.IsConnected)
                 throw new InvalidOperationException("This connection is not valid.");
 
-            this.Node.SendPayload(new LavalinkPause(this, false));
+            await this.Node.SendPayloadAsync(new LavalinkPause(this, false)).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Seeks the current track to specified position.
         /// </summary>
         /// <param name="position">Position to seek to.</param>
-        public void Seek(TimeSpan position)
+        public async Task SeekAsync(TimeSpan position)
         {
             if (!this.IsConnected)
                 throw new InvalidOperationException("This connection is not valid.");
 
-            this.Node.SendPayload(new LavalinkSeek(this, position));
+            await this.Node.SendPayloadAsync(new LavalinkSeek(this, position)).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Sets the playback volume. This might incur a lot of CPU usage.
         /// </summary>
         /// <param name="volume">Volume to set. Needs to be greater or equal to 0, and less than or equal to 100. 100 means 100% and is the default value.</param>
-        public void SetVolume(int volume)
+        public async Task SetVolumeAsync(int volume)
         {
             if (!this.IsConnected)
                 throw new InvalidOperationException("This connection is not valid.");
@@ -231,14 +231,14 @@ namespace DSharpPlus.Lavalink
             if (volume < 0 || volume > 1000)
                 throw new ArgumentOutOfRangeException(nameof(volume), "Volume needs to range from 0 to 1000.");
 
-            this.Node.SendPayload(new LavalinkVolume(this, volume));
+            await this.Node.SendPayloadAsync(new LavalinkVolume(this, volume)).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Adjusts the specified bands in the audio equalizer. This will alter the sound output, and might incur a lot of CPU usage.
         /// </summary>
         /// <param name="bands">Bands adjustments to make. You must specify one adjustment per band at most.</param>
-        public void AdjustEqualizer(params LavalinkBandAdjustment[] bands)
+        public async Task AdjustEqualizerAsync(params LavalinkBandAdjustment[] bands)
         {
             if (!this.IsConnected)
                 throw new InvalidOperationException("This connection is not valid.");
@@ -249,18 +249,18 @@ namespace DSharpPlus.Lavalink
             if (bands.Distinct(new LavalinkBandAdjustmentComparer()).Count() != bands.Count())
                 throw new InvalidOperationException("You cannot specify multiple modifiers for the same band.");
 
-            this.Node.SendPayload(new LavalinkEqualizer(this, bands));
+            await this.Node.SendPayloadAsync(new LavalinkEqualizer(this, bands)).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Resets the audio equalizer to default values.
         /// </summary>
-        public void ResetEqualizer()
+        public async Task ResetEqualizerAsync()
         {
             if (!this.IsConnected)
                 throw new InvalidOperationException("This connection is not valid.");
 
-            this.Node.SendPayload(new LavalinkEqualizer(this, Enumerable.Range(0, 15).Select(x => new LavalinkBandAdjustment(x, 0))));
+            await this.Node.SendPayloadAsync(new LavalinkEqualizer(this, Enumerable.Range(0, 15).Select(x => new LavalinkBandAdjustment(x, 0)))).ConfigureAwait(false);
         }
 
         internal Task InternalUpdatePlayerStateAsync(LavalinkState newState)

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -46,12 +46,12 @@ namespace DSharpPlus.Lavalink
         /// <summary>
         /// Triggered when this node receives a statistics update.
         /// </summary>
-        public event AsyncEventHandler<StatsReceivedEventArgs> StatisticsReceived
+        public event AsyncEventHandler<StatisticsReceivedEventArgs> StatisticsReceived
         {
             add { this._statsReceived.Register(value); }
             remove { this._statsReceived.Unregister(value); }
         }
-        private AsyncEvent<StatsReceivedEventArgs> _statsReceived;
+        private AsyncEvent<StatisticsReceivedEventArgs> _statsReceived;
 
         /// <summary>
         /// Triggered whenever any of the players on this node is updated.
@@ -132,7 +132,7 @@ namespace DSharpPlus.Lavalink
 
             this._lavalinkSocketError = new AsyncEvent<SocketErrorEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_SOCKET_ERROR");
             this._disconnected = new AsyncEvent<NodeDisconnectedEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_NODE_DISCONNECTED");
-            this._statsReceived = new AsyncEvent<StatsReceivedEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_STATS_RECEIVED");
+            this._statsReceived = new AsyncEvent<StatisticsReceivedEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_STATS_RECEIVED");
             this._playerUpdated = new AsyncEvent<PlayerUpdateEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_PLAYER_UPDATED");
             this._playbackFinished = new AsyncEvent<TrackFinishEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_PLAYBACK_FINISHED");
             this._trackStuck = new AsyncEvent<TrackStuckEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_TRACK_STUCK");
@@ -276,7 +276,7 @@ namespace DSharpPlus.Lavalink
                 case "stats":
                     var statsRaw = jsonData.ToObject<LavalinkStats>();
                     this.Statistics.Update(statsRaw);
-                    await this._statsReceived.InvokeAsync(new StatsReceivedEventArgs(this.Statistics)).ConfigureAwait(false);
+                    await this._statsReceived.InvokeAsync(new StatisticsReceivedEventArgs(this.Statistics)).ConfigureAwait(false);
                     break;
 
                 case "event":

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -1,13 +1,8 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
@@ -123,12 +118,10 @@ namespace DSharpPlus.Lavalink
         private LavalinkConfiguration Configuration { get; }
         private ConcurrentDictionary<ulong, LavalinkGuildConnection> ConnectedGuilds { get; }
 
-        private BaseWebSocketClient WebSocket { get; set; }
+        private IWebSocketClient WebSocket { get; set; }
 
         private ConcurrentDictionary<ulong, TaskCompletionSource<VoiceStateUpdateEventArgs>> VoiceStateUpdates { get; }
         private ConcurrentDictionary<ulong, TaskCompletionSource<VoiceServerUpdateEventArgs>> VoiceServerUpdates { get; }
-
-        private static UTF8Encoding UTF8 { get; } = new UTF8Encoding(false);
 
         internal LavalinkNodeConnection(DiscordClient client, LavalinkConfiguration config)
         {
@@ -164,7 +157,7 @@ namespace DSharpPlus.Lavalink
             this.WebSocket = client.Configuration.WebSocketClientFactory(client.Configuration.Proxy);
             this.WebSocket.Connected += this.WebSocket_OnConnect;
             this.WebSocket.Disconnected += this.WebSocket_OnDisconnect;
-            this.WebSocket.Errored += this.WebSocket_OnError;
+            this.WebSocket.ExceptionThrown += this.WebSocket_OnException;
             this.WebSocket.MessageReceived += this.WebSocket_OnMessage;
 
             Volatile.Write(ref this._isDisposed, false);
@@ -179,17 +172,13 @@ namespace DSharpPlus.Lavalink
             if (this.Discord?.CurrentUser?.Id == null || this.Discord?.ShardCount == null)
                 throw new InvalidOperationException("This operation requires the Discord client to be fully initialized.");
 
-            var headers = new Dictionary<string, string>()
-            {
-                ["Authorization"] = this.Configuration.Password,
-                ["Num-Shards"] = this.Discord.ShardCount.ToString(CultureInfo.InvariantCulture),
-                ["User-Id"] = this.Discord.CurrentUser.Id.ToString(CultureInfo.InvariantCulture)
-            };
-
+            this.WebSocket.AddDefaultHeader("Authorization", this.Configuration.Password);
+            this.WebSocket.AddDefaultHeader("Num-Shards", this.Discord.ShardCount.ToString(CultureInfo.InvariantCulture));
+            this.WebSocket.AddDefaultHeader("User-Id", this.Discord.CurrentUser.Id.ToString(CultureInfo.InvariantCulture));
             if (this.Configuration.ResumeKey != null)
-                headers.Add("Resume-Key", this.Configuration.ResumeKey);
+                this.WebSocket.AddDefaultHeader("Resume-Key", this.Configuration.ResumeKey);
 
-            return this.WebSocket.ConnectAsync(new Uri($"ws://{this.Configuration.SocketEndpoint}/"), headers);
+            return this.WebSocket.ConnectAsync(new Uri($"ws://{this.Configuration.SocketEndpoint}/"));
         }
 
         /// <summary>
@@ -199,12 +188,12 @@ namespace DSharpPlus.Lavalink
         public async Task StopAsync()
         {
             foreach (var kvp in this.ConnectedGuilds)
-                kvp.Value.Disconnect();
+                await kvp.Value.DisconnectAsync().ConfigureAwait(false);
 
             this.NodeDisconnected?.Invoke(this);
 
             Volatile.Write(ref this._isDisposed, true);
-            await this.WebSocket.DisconnectAsync(null).ConfigureAwait(false);
+            await this.WebSocket.DisconnectAsync().ConfigureAwait(false);
             await this._disconnected.InvokeAsync(new NodeDisconnectedEventArgs(this)).ConfigureAwait(false);
         }
 
@@ -238,10 +227,10 @@ namespace DSharpPlus.Lavalink
                 }
             };
             var vsj = JsonConvert.SerializeObject(vsd, Formatting.None);
-            (channel.Discord as DiscordClient)._webSocketClient.SendMessage(vsj);
+            await (channel.Discord as DiscordClient)._webSocketClient.SendMessageAsync(vsj).ConfigureAwait(false);
             var vstu = await vstut.Task.ConfigureAwait(false);
             var vsru = await vsrut.Task.ConfigureAwait(false);
-            this.SendPayload(new LavalinkVoiceUpdate(vstu, vsru));
+            await this.SendPayloadAsync(new LavalinkVoiceUpdate(vstu, vsru)).ConfigureAwait(false);
 
             var con = new LavalinkGuildConnection(this, channel, vstu);
             con.ChannelDisconnected += this.Con_ChannelDisconnected;
@@ -261,17 +250,18 @@ namespace DSharpPlus.Lavalink
         public LavalinkGuildConnection GetConnection(DiscordGuild guild)
             => this.ConnectedGuilds.TryGetValue(guild.Id, out LavalinkGuildConnection lgc) && lgc.IsConnected ? lgc : null;
 
-
-        
-
-        internal void SendPayload(LavalinkPayload payload)
-            => this.WebSocket.SendMessage(JsonConvert.SerializeObject(payload, Formatting.None));
+        internal async Task SendPayloadAsync(LavalinkPayload payload)
+            => await this.WebSocket.SendMessageAsync(JsonConvert.SerializeObject(payload, Formatting.None)).ConfigureAwait(false);
 
         private async Task WebSocket_OnMessage(SocketMessageEventArgs e)
         {
-            //this.Discord.DebugLogger.LogMessage(LogLevel.Debug, "Lavalink", e.Message, DateTime.Now);
+            if (!(e is SocketTextMessageEventArgs et))
+            {
+                this.Discord.DebugLogger.LogMessage(LogLevel.Critical, "Lavalink", "Lavalink spewed out binary gibberish!", DateTime.Now);
+                return;
+            }
 
-            var json = e.Message;
+            var json = et.Message;
             var jsonData = JObject.Parse(json);
             ulong guildId = 0;
             switch (jsonData["op"].ToString())
@@ -337,10 +327,10 @@ namespace DSharpPlus.Lavalink
             }
         }
 
-        private Task WebSocket_OnError(SocketErrorEventArgs e)
+        private Task WebSocket_OnException(SocketErrorEventArgs e)
             => this._lavalinkSocketError.InvokeAsync(new SocketErrorEventArgs(this.Discord) { Exception = e.Exception });
 
-        private Task WebSocket_OnDisconnect(SocketCloseEventArgs e)
+        private async Task WebSocket_OnDisconnect(SocketCloseEventArgs e)
         {
             if (this.IsConnected && e.CloseCode != 1001 && e.CloseCode != -1)
             {
@@ -348,41 +338,39 @@ namespace DSharpPlus.Lavalink
                 this.WebSocket = this.Discord.Configuration.WebSocketClientFactory(this.Discord.Configuration.Proxy);
                 this.WebSocket.Connected += this.WebSocket_OnConnect;
                 this.WebSocket.Disconnected += this.WebSocket_OnDisconnect;
-                this.WebSocket.Errored += this.WebSocket_OnError;
+                this.WebSocket.ExceptionThrown += this.WebSocket_OnException;
                 this.WebSocket.MessageReceived += this.WebSocket_OnMessage;
-                return this.WebSocket.ConnectAsync(new Uri($"ws://{this.Configuration.SocketEndpoint}/"), new Dictionary<string, string>()
-                {
-                    ["Authorization"] = this.Configuration.Password,
-                    ["Num-Shards"] = this.Discord.ShardCount.ToString(CultureInfo.InvariantCulture),
-                    ["User-Id"] = this.Discord.CurrentUser.Id.ToString(CultureInfo.InvariantCulture)
-                });
+
+                this.WebSocket.AddDefaultHeader("Authorization", this.Configuration.Password);
+                this.WebSocket.AddDefaultHeader("Num-Shards", this.Discord.ShardCount.ToString(CultureInfo.InvariantCulture));
+                this.WebSocket.AddDefaultHeader("User-Id", this.Discord.CurrentUser.Id.ToString(CultureInfo.InvariantCulture));
+
+                await this.WebSocket.ConnectAsync(new Uri($"ws://{this.Configuration.SocketEndpoint}/"));
             }
             else if (e.CloseCode != 1001 && e.CloseCode != -1)
             {
                 this.Discord.DebugLogger.LogMessage(LogLevel.Info, "Lavalink", "Connection closed", DateTime.Now);
                 if (this.NodeDisconnected != null)
                     this.NodeDisconnected(this);
-                return this._disconnected.InvokeAsync(new NodeDisconnectedEventArgs(this));
+                await this._disconnected.InvokeAsync(new NodeDisconnectedEventArgs(this)).ConfigureAwait(false);
             }
             else
             {
                 this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "Lavalink", "Lavalink died", DateTime.Now);
                 foreach (var kvp in this.ConnectedGuilds)
-                    kvp.Value.SendVoiceUpdate();
+                    await kvp.Value.SendVoiceUpdateAsync().ConfigureAwait(false);
                 if (this.NodeDisconnected != null)
                     this.NodeDisconnected(this);
-                return this._disconnected.InvokeAsync(new NodeDisconnectedEventArgs(this));
+                await this._disconnected.InvokeAsync(new NodeDisconnectedEventArgs(this)).ConfigureAwait(false);
             }
         }
 
-        private Task WebSocket_OnConnect()
+        private async Task WebSocket_OnConnect()
         {
             this.Discord.DebugLogger.LogMessage(LogLevel.Info, "Lavalink", "Connection established", DateTime.Now);
 
             if (this.Configuration.ResumeKey != null)
-                this.SendPayload(new LavalinkConfigureResume(this.Configuration.ResumeKey, this.Configuration.ResumeTimeout));
-
-            return Task.Delay(0);
+                await this.SendPayloadAsync(new LavalinkConfigureResume(this.Configuration.ResumeKey, this.Configuration.ResumeTimeout)).ConfigureAwait(false);
         }
 
         private void Con_ChannelDisconnected(LavalinkGuildConnection con)
@@ -392,10 +380,10 @@ namespace DSharpPlus.Lavalink
         {
             var gld = e.Guild;
             if (gld == null)
-                return Task.Delay(0);
+                return Task.CompletedTask;
 
             if (e.User == null)
-                return Task.Delay(0);
+                return Task.CompletedTask;
 
             if (e.User.Id == this.Discord.CurrentUser.Id && this.ConnectedGuilds.TryGetValue(e.Guild.Id, out var lvlgc))
                 lvlgc.VoiceStateUpdate = e;
@@ -406,19 +394,19 @@ namespace DSharpPlus.Lavalink
                 xe.SetResult(e);
             }
 
-            return Task.Delay(0);
+            return Task.CompletedTask;
         }
 
-        private Task Discord_VoiceServerUpdated(VoiceServerUpdateEventArgs e)
+        private async Task Discord_VoiceServerUpdated(VoiceServerUpdateEventArgs e)
         {
             var gld = e.Guild;
             if (gld == null)
-                return Task.Delay(0);
+                return;
 
             if (this.ConnectedGuilds.TryGetValue(e.Guild.Id, out var lvlgc))
             {
                 var lvlp = new LavalinkVoiceUpdate(lvlgc.VoiceStateUpdate, e);
-                this.WebSocket.SendMessage(JsonConvert.SerializeObject(lvlp));
+                await this.WebSocket.SendMessageAsync(JsonConvert.SerializeObject(lvlp)).ConfigureAwait(false);
             }
 
             if (this.VoiceServerUpdates.ContainsKey(gld.Id))
@@ -426,8 +414,6 @@ namespace DSharpPlus.Lavalink
                 this.VoiceServerUpdates.TryRemove(gld.Id, out var xe);
                 xe.SetResult(e);
             }
-
-            return Task.Delay(0);
         }
 
         internal event NodeDisconnectedEventHandler NodeDisconnected;

--- a/DSharpPlus.Lavalink/LavalinkRest.cs
+++ b/DSharpPlus.Lavalink/LavalinkRest.cs
@@ -1,14 +1,13 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
-using System.Text;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
+using DSharpPlus.Lavalink.Entities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using DSharpPlus.Lavalink.Entities;
 
 namespace DSharpPlus.Lavalink
 {
@@ -19,8 +18,6 @@ namespace DSharpPlus.Lavalink
         private LavalinkConfiguration Configuration;
 
         private DebugLogger Logger;
-
-        private static UTF8Encoding UTF8 { get; } = new UTF8Encoding(false);
 
         internal LavalinkRest(LavalinkConfiguration config, DiscordClient client)
         {
@@ -173,7 +170,7 @@ namespace DSharpPlus.Lavalink
         {
             using (var req = await this.HttpClient.GetAsync(uri).ConfigureAwait(false))
             using (var res = await req.Content.ReadAsStreamAsync().ConfigureAwait(false))
-            using (var sr = new StreamReader(res, UTF8))
+            using (var sr = new StreamReader(res, Utilities.UTF8))
             {
                 var json = await sr.ReadToEndAsync().ConfigureAwait(false);
                 return json;
@@ -189,7 +186,7 @@ namespace DSharpPlus.Lavalink
             var json = "[]";
             using (var req = await this.HttpClient.GetAsync(uri).ConfigureAwait(false))
             using (var res = await req.Content.ReadAsStreamAsync().ConfigureAwait(false))
-            using (var sr = new StreamReader(res, UTF8))
+            using (var sr = new StreamReader(res, Utilities.UTF8))
                 json = await sr.ReadToEndAsync().ConfigureAwait(false);
 
             var jdata = JToken.Parse(json);
@@ -240,7 +237,7 @@ namespace DSharpPlus.Lavalink
         {
             using (var req = await this.HttpClient.GetAsync(uri).ConfigureAwait(false))
             using (var res = await req.Content.ReadAsStreamAsync().ConfigureAwait(false))
-            using (var sr = new StreamReader(res, UTF8))
+            using (var sr = new StreamReader(res, Utilities.UTF8))
             {
                 var json = await sr.ReadToEndAsync().ConfigureAwait(false);
                 if (!req.IsSuccessStatusCode)
@@ -257,10 +254,10 @@ namespace DSharpPlus.Lavalink
         internal async Task<IEnumerable<LavalinkTrack>> InternalDecodeTracksAsync(Uri uri, string[] ids)
         {
             var jsonOut = JsonConvert.SerializeObject(ids);
-            var content = new StringContent(jsonOut, UTF8, "application/json");
+            var content = new StringContent(jsonOut, Utilities.UTF8, "application/json");
             using (var req = await this.HttpClient.PostAsync(uri, content).ConfigureAwait(false))
             using (var res = await req.Content.ReadAsStreamAsync().ConfigureAwait(false))
-            using (var sr = new StreamReader(res, UTF8))
+            using (var sr = new StreamReader(res, Utilities.UTF8))
             {
                 var jsonIn = await sr.ReadToEndAsync().ConfigureAwait(false);
                 if (!req.IsSuccessStatusCode)
@@ -293,7 +290,7 @@ namespace DSharpPlus.Lavalink
         {
             using (var req = await this.HttpClient.GetAsync(uri).ConfigureAwait(false))
             using (var res = await req.Content.ReadAsStreamAsync().ConfigureAwait(false))
-            using (var sr = new StreamReader(res, UTF8))
+            using (var sr = new StreamReader(res, Utilities.UTF8))
             {
                 var json = await sr.ReadToEndAsync().ConfigureAwait(false);
                 var status = JsonConvert.DeserializeObject<LavalinkRouteStatus>(json);
@@ -303,7 +300,7 @@ namespace DSharpPlus.Lavalink
 
         internal async Task InternalFreeAddressAsync(Uri uri, string address)
         {
-            var payload = new StringContent(address, UTF8, "application/json");
+            var payload = new StringContent(address, Utilities.UTF8, "application/json");
             using (var req = await this.HttpClient.PostAsync(uri, payload).ConfigureAwait(false))
                 if (req.StatusCode == HttpStatusCode.InternalServerError)
                     this.Logger.LogMessage(LogLevel.Warning, "Lavalink", $"Request to {uri.ToString()} returned an internal server error. This likely indicates that the server route planner configuration is incorrect.", DateTime.Now);

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1137,6 +1137,8 @@ namespace DSharpPlus
         /// <param name="channel_id">Channel id</param>
         /// <param name="message_id">Message id</param>
         /// <param name="emoji">Emoji to check for</param>
+        /// <param name="after_id">Whether to search for reactions after this message id.</param>
+        /// <param name="limit">The maximum amount of reactions to fetch.</param>
         /// <returns></returns>
         public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, string emoji, ulong? after_id = null, int limit = 25)
             => ApiClient.GetReactionsAsync(channel_id, message_id, emoji, after_id, limit);
@@ -1147,6 +1149,8 @@ namespace DSharpPlus
         /// <param name="channel_id">Channel id</param>
         /// <param name="message_id">Message id</param>
         /// <param name="emoji">Emoji to check for</param>
+        /// <param name="after_id">Whether to search for reactions after this message id.</param>
+        /// <param name="limit">The maximum amount of reactions to fetch.</param>
         /// <returns></returns>
         public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, DiscordEmoji emoji, ulong? after_id = null, int limit = 25)
             => ApiClient.GetReactionsAsync(channel_id, message_id, emoji.ToReactionString(), after_id, limit);

--- a/DSharpPlus.Test/TestBotLavaCommands.cs
+++ b/DSharpPlus.Test/TestBotLavaCommands.cs
@@ -103,7 +103,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            this.LavalinkVoice.Disconnect();
+            await this.LavalinkVoice.DisconnectAsync().ConfigureAwait(false);
             this.LavalinkVoice = null;
             await ctx.RespondAsync("Disconnected.").ConfigureAwait(false);
         }
@@ -118,7 +118,7 @@ namespace DSharpPlus.Test
 
             var trackLoad = await this.Lavalink.Rest.GetTracksAsync(uri);
             var track = trackLoad.Tracks.First();
-            this.LavalinkVoice.Play(track);
+            await this.LavalinkVoice.PlayAsync(track);
 
             await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.").ConfigureAwait(false);
         }
@@ -131,7 +131,7 @@ namespace DSharpPlus.Test
 
             var trackLoad = await this.Lavalink.Rest.GetTracksAsync(new FileInfo(path));
             var track = trackLoad.Tracks.First();
-            this.LavalinkVoice.Play(track);
+            await this.LavalinkVoice.PlayAsync(track);
 
             await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.").ConfigureAwait(false);
         }
@@ -144,7 +144,7 @@ namespace DSharpPlus.Test
 
             var result = await this.Lavalink.Rest.GetTracksAsync(search, LavalinkSearchType.SoundCloud);
             var track = result.Tracks.First();
-            this.LavalinkVoice.Play(track);
+            await this.LavalinkVoice.PlayAsync(track);
 
             await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.");
         }
@@ -157,7 +157,7 @@ namespace DSharpPlus.Test
 
             var trackLoad = await this.Lavalink.Rest.GetTracksAsync(uri);
             var track = trackLoad.Tracks.First();
-            this.LavalinkVoice.PlayPartial(track, start, stop);
+            await this.LavalinkVoice.PlayPartialAsync(track, start, stop);
 
             await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.").ConfigureAwait(false);
         }
@@ -168,7 +168,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            this.LavalinkVoice.Pause();
+            await this.LavalinkVoice.PauseAsync();
             await ctx.RespondAsync("Paused.").ConfigureAwait(false);
         }
 
@@ -178,7 +178,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            this.LavalinkVoice.Resume();
+            await this.LavalinkVoice.ResumeAsync();
             await ctx.RespondAsync("Resumed.").ConfigureAwait(false);
         }
 
@@ -188,7 +188,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            this.LavalinkVoice.Stop();
+            await this.LavalinkVoice.StopAsync();
             await ctx.RespondAsync("Stopped.").ConfigureAwait(false);
         }
 
@@ -198,7 +198,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            this.LavalinkVoice.Seek(position);
+            await this.LavalinkVoice.SeekAsync(position);
             await ctx.RespondAsync($"Seeking to {position}.").ConfigureAwait(false);
         }
 
@@ -208,7 +208,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            this.LavalinkVoice.SetVolume(volume);
+            await this.LavalinkVoice.SetVolumeAsync(volume);
             await ctx.RespondAsync($"Volume set to {volume}%.").ConfigureAwait(false);
         }
 
@@ -229,7 +229,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            this.LavalinkVoice.ResetEqualizer();
+            await this.LavalinkVoice.ResetEqualizerAsync();
             await ctx.RespondAsync("All equalizer bands were reset.").ConfigureAwait(false);
         }
 
@@ -239,7 +239,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            this.LavalinkVoice.AdjustEqualizer(new LavalinkBandAdjustment(band, gain));
+            await this.LavalinkVoice.AdjustEqualizerAsync(new LavalinkBandAdjustment(band, gain));
             await ctx.RespondAsync($"Band {band} adjusted by {gain}").ConfigureAwait(false);
         }
 

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
@@ -23,7 +22,7 @@ using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.VoiceNext
 {
-    internal delegate void VoiceDisconnectedEventHandler(DiscordGuild guild);
+    internal delegate Task VoiceDisconnectedEventHandler(DiscordGuild guild);
 
     /// <summary>
     /// VoiceNext connection to a voice channel.
@@ -89,7 +88,7 @@ namespace DSharpPlus.VoiceNext
         private ConcurrentDictionary<uint, AudioSender> TransmittingSSRCs { get; }
 
         private BaseUdpClient UdpClient { get; }
-        private BaseWebSocketClient VoiceWs { get; set; }
+        private IWebSocketClient VoiceWs { get; set; }
         private Task HeartbeatTask { get; set; }
         private int HeartbeatInterval { get; set; }
         private DateTimeOffset LastHeartbeat { get; set; }
@@ -225,7 +224,7 @@ namespace DSharpPlus.VoiceNext
             this.VoiceWs.Disconnected += this.VoiceWS_SocketClosed;
             this.VoiceWs.MessageReceived += this.VoiceWS_SocketMessage;
             this.VoiceWs.Connected += this.VoiceWS_SocketOpened;
-            this.VoiceWs.Errored += this.VoiceWs_SocketErrored;
+            this.VoiceWs.ExceptionThrown += this.VoiceWs_SocketException;
         }
 
         ~VoiceNextConnection()
@@ -250,9 +249,9 @@ namespace DSharpPlus.VoiceNext
         }
 
         internal Task ReconnectAsync()
-            => this.VoiceWs.DisconnectAsync(new SocketCloseEventArgs(this.Discord));
+            => this.VoiceWs.DisconnectAsync();
 
-        internal Task StartAsync()
+        internal async Task StartAsync()
         {
             // Let's announce our intentions to the server
             var vdp = new VoiceDispatch();
@@ -280,9 +279,7 @@ namespace DSharpPlus.VoiceNext
                 };
             }
             var vdj = JsonConvert.SerializeObject(vdp, Formatting.None);
-            this.VoiceWs.SendMessage(vdj);
-
-            return Task.Delay(0);
+            await this.VoiceWs.SendMessageAsync(vdj).ConfigureAwait(false);
         }
 
         internal Task WaitForReadyAsync()
@@ -385,7 +382,7 @@ namespace DSharpPlus.VoiceNext
                 if (!hasPacket)
                     continue;
 
-                this.SendSpeaking(true);
+                await this.SendSpeakingAsync(true).ConfigureAwait(false);
                 await client.SendAsync(packetArray, packetArray.Length).ConfigureAwait(false);
 
                 if (!packet.IsSilence && queue.Count == 0)
@@ -402,7 +399,7 @@ namespace DSharpPlus.VoiceNext
                 }
                 else if (queue.Count == 0)
                 {
-                    this.SendSpeaking(false);
+                    await this.SendSpeakingAsync(false).ConfigureAwait(false);
                     this.PlayingWait?.SetResult(true);
                 }
             }
@@ -580,7 +577,7 @@ namespace DSharpPlus.VoiceNext
         /// </summary>
         /// <param name="speaking">Whether the current user is speaking or not.</param>
         /// <returns>A task representing the sending operation.</returns>
-        public void SendSpeaking(bool speaking = true)
+        public async Task SendSpeakingAsync(bool speaking = true)
         {
             if (!this.IsInitialized)
                 throw new InvalidOperationException("The connection is not initialized");
@@ -596,7 +593,7 @@ namespace DSharpPlus.VoiceNext
             };
 
             var plj = JsonConvert.SerializeObject(pld, Formatting.None);
-            this.VoiceWs.SendMessage(plj);
+            await this.VoiceWs.SendMessageAsync(plj).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -661,7 +658,7 @@ namespace DSharpPlus.VoiceNext
 
             try
             {
-                this.VoiceWs.DisconnectAsync(null).ConfigureAwait(false).GetAwaiter().GetResult();
+                this.VoiceWs.DisconnectAsync().ConfigureAwait(false).GetAwaiter().GetResult();
                 this.UdpClient.Close();
             }
             catch (Exception)
@@ -698,7 +695,7 @@ namespace DSharpPlus.VoiceNext
                         Payload = UnixTimestamp(dt)
                     };
                     var hbj = JsonConvert.SerializeObject(hbd);
-                    this.VoiceWs.SendMessage(hbj);
+                    await this.VoiceWs.SendMessageAsync(hbj).ConfigureAwait(false);
 
                     this.LastHeartbeat = dt;
                     await Task.Delay(this.HeartbeatInterval).ConfigureAwait(false);
@@ -763,7 +760,7 @@ namespace DSharpPlus.VoiceNext
             {
                 var packetSpan = packet.AsSpan();
 
-                var ipString = new UTF8Encoding(false).GetString(packet, 4, 64 /* 70 - 6 */).TrimEnd('\0');
+                var ipString = Utilities.UTF8.GetString(packet, 4, 64 /* 70 - 6 */).TrimEnd('\0');
                 decodedIp = System.Net.IPAddress.Parse(ipString);
 
                 decodedPort = BinaryPrimitives.ReadUInt16LittleEndian(packetSpan.Slice(68 /* 70 - 2 */));
@@ -790,7 +787,7 @@ namespace DSharpPlus.VoiceNext
                 }
             };
             var vsj = JsonConvert.SerializeObject(vsp, Formatting.None);
-            this.VoiceWs.SendMessage(vsj);
+            await this.VoiceWs.SendMessageAsync(vsj).ConfigureAwait(false);
 
             this.SenderTokenSource = new CancellationTokenSource();
             this.SenderTask = Task.Run(this.VoiceSenderTask, this.SenderToken);
@@ -821,7 +818,7 @@ namespace DSharpPlus.VoiceNext
             this.IsInitialized = true;
             this.ReadyWait.SetResult(true);
 
-            return Task.Delay(0);
+            return Task.CompletedTask;
         }
 
         private async Task HandleDispatch(JObject jo)
@@ -966,12 +963,20 @@ namespace DSharpPlus.VoiceNext
         }
 
         private Task VoiceWS_SocketMessage(SocketMessageEventArgs e)
-            => this.HandleDispatch(JObject.Parse(e.Message));
+        {
+            if (!(e is SocketTextMessageEventArgs et))
+            {
+                this.Discord.DebugLogger.LogMessage(LogLevel.Critical, "VoiceNext", "Discord Voice Gateway spewed out binary gibberish!", DateTime.Now);
+                return Task.CompletedTask;
+            }
+
+            return this.HandleDispatch(JObject.Parse(et.Message));
+        }
 
         private Task VoiceWS_SocketOpened()
             => this.StartAsync();
 
-        private Task VoiceWs_SocketErrored(SocketErrorEventArgs e)
+        private Task VoiceWs_SocketException(SocketErrorEventArgs e)
             => this._voiceSocketError.InvokeAsync(new SocketErrorEventArgs(this.Discord) { Exception = e.Exception });
 
         private static uint UnixTimestamp(DateTime dt)

--- a/DSharpPlus.VoiceNext/VoiceNextExtension.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextExtension.cs
@@ -88,7 +88,7 @@ namespace DSharpPlus.VoiceNext
                 }
             };
             var vsj = JsonConvert.SerializeObject(vsd, Formatting.None);
-            (channel.Discord as DiscordClient)._webSocketClient.SendMessage(vsj);
+            await (channel.Discord as DiscordClient)._webSocketClient.SendMessageAsync(vsj).ConfigureAwait(false);
             
             var vstu = await vstut.Task.ConfigureAwait(false);
             var vstup = new VoiceStateUpdatePayload
@@ -125,7 +125,7 @@ namespace DSharpPlus.VoiceNext
             return null;
         }
 
-        private void Vnc_VoiceDisconnected(DiscordGuild guild)
+        private async Task Vnc_VoiceDisconnected(DiscordGuild guild)
         {
             VoiceNextConnection vnc = null;
             if (this.ActiveConnections.ContainsKey(guild.Id))
@@ -141,17 +141,17 @@ namespace DSharpPlus.VoiceNext
                 }
             };
             var vsj = JsonConvert.SerializeObject(vsd, Formatting.None);
-            (guild.Discord as DiscordClient)._webSocketClient.SendMessage(vsj);
+            await (guild.Discord as DiscordClient)._webSocketClient.SendMessageAsync(vsj).ConfigureAwait(false);
         }
 
         private Task Client_VoiceStateUpdate(VoiceStateUpdateEventArgs e)
         {
             var gld = e.Guild;
             if (gld == null)
-                return Task.Delay(0);
+                return Task.CompletedTask;
 
             if (e.User == null)
-                return Task.Delay(0);
+                return Task.CompletedTask;
 
             if (e.User.Id == this.Client.CurrentUser.Id && this.ActiveConnections.TryGetValue(e.Guild.Id, out var vnc))
             {
@@ -164,7 +164,7 @@ namespace DSharpPlus.VoiceNext
                 xe.SetResult(e);
             }
 
-            return Task.Delay(0);
+            return Task.CompletedTask;
         }
 
         private async Task Client_VoiceServerUpdate(VoiceServerUpdateEventArgs e)

--- a/DSharpPlus/AsyncEvent.cs
+++ b/DSharpPlus/AsyncEvent.cs
@@ -86,11 +86,9 @@ namespace DSharpPlus
                 catch (Exception ex)
                 {
                     exs.Add(ex);
+                    this.ErrorHandler(this.EventName, ex);
                 }
             }
-
-            if (exs.Any())
-                this.ErrorHandler(this.EventName, new AggregateException("Exceptions occured within one or more event handlers. Check InnerExceptions for details.", exs));
         }
     }
 

--- a/DSharpPlus/BaseDiscordClient.cs
+++ b/DSharpPlus/BaseDiscordClient.cs
@@ -175,7 +175,7 @@ namespace DSharpPlus
         }
 
         internal DiscordUser InternalGetCachedUser(ulong user_id) 
-            => this.UserCache.TryGetValue(user_id, out var user) ? user : null;
+            => this.UserCache.TryGetValue(user_id, out var user) ? user : new DiscordUser { Id = user_id, Discord = this };
 
         /// <summary>
         /// Disposes this client.

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -131,8 +131,8 @@ namespace DSharpPlus
 
             InternalSetup();
 
-            this.Guilds = new ReadOnlyConcurrentDictionary<ulong, DiscordGuild>(_guilds);
-            this.PrivateChannels = new ReadOnlyConcurrentDictionary<ulong, DiscordDmChannel>(_privateChannels);
+            this.Guilds = new ReadOnlyConcurrentDictionary<ulong, DiscordGuild>(this._guilds);
+            this.PrivateChannels = new ReadOnlyConcurrentDictionary<ulong, DiscordDmChannel>(this._privateChannels);
         }
 
         internal void InternalSetup()
@@ -188,8 +188,8 @@ namespace DSharpPlus
 
             this._presencesLazy = new Lazy<IReadOnlyDictionary<ulong, DiscordPresence>>(() => new ReadOnlyDictionary<ulong, DiscordPresence>(this._presences));
 
-            if (Configuration.UseInternalLogHandler)
-                DebugLogger.LogMessageReceived += (sender, e) => DebugLogger.LogHandler(sender, e);
+            if (this.Configuration.UseInternalLogHandler)
+                this.DebugLogger.LogMessageReceived += (sender, e) => this.DebugLogger.LogHandler(sender, e);
         }
 
         /// <summary>
@@ -200,7 +200,7 @@ namespace DSharpPlus
         public void AddExtension(BaseExtension ext)
         {
             ext.Setup(this);
-            _extensions.Add(ext);
+            this._extensions.Add(ext);
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace DSharpPlus
         /// <typeparam name="T">Type of extension to retrieve.</typeparam>
         /// <returns>The requested extension.</returns>
         public T GetExtension<T>() where T : BaseExtension
-            => _extensions.FirstOrDefault(x => x.GetType() == typeof(T)) as T;
+            => this._extensions.FirstOrDefault(x => x.GetType() == typeof(T)) as T;
 
         /// <summary>
         /// Connects to the gateway
@@ -302,13 +302,13 @@ namespace DSharpPlus
         public Task ReconnectAsync(bool startNewSession = false)
         {
             if (startNewSession)
-                _sessionId = "";
+                this._sessionId = "";
 
-            return _webSocketClient.DisconnectAsync();
+            return this._webSocketClient.DisconnectAsync();
         }
 
         internal Task InternalReconnectAsync()
-            => ConnectAsync();
+            => this.ConnectAsync();
 
         internal async Task InternalConnectAsync()
         {
@@ -360,7 +360,7 @@ namespace DSharpPlus
                 : null;
 
             this._cancelTokenSource = new CancellationTokenSource();
-            this._cancelToken = _cancelTokenSource.Token;
+            this._cancelToken = this._cancelTokenSource.Token;
 
             this._webSocketClient.Connected += SocketOnConnect;
             this._webSocketClient.Disconnected += SocketOnDisconnect;
@@ -424,9 +424,9 @@ namespace DSharpPlus
                 this.DebugLogger.LogMessage(LogLevel.Debug, "Websocket", $"Connection closed. ({e.CloseCode.ToString(CultureInfo.InvariantCulture)}, '{e.CloseMessage}')", DateTime.Now);
                 await this._socketClosed.InvokeAsync(new SocketCloseEventArgs(this) { CloseCode = e.CloseCode, CloseMessage = e.CloseMessage }).ConfigureAwait(false);
 
-                if (Configuration.AutoReconnect)
+                if (this.Configuration.AutoReconnect)
                 {
-                    DebugLogger.LogMessage(LogLevel.Critical, "Websocket", $"Socket connection terminated ({e.CloseCode.ToString(CultureInfo.InvariantCulture)}, '{e.CloseMessage}'). Reconnecting.", DateTime.Now);
+                    this.DebugLogger.LogMessage(LogLevel.Critical, "Websocket", $"Socket connection terminated ({e.CloseCode.ToString(CultureInfo.InvariantCulture)}, '{e.CloseMessage}'). Reconnecting.", DateTime.Now);
 
                     if (this._status == null)
                         await this.ConnectAsync().ConfigureAwait(false);
@@ -445,9 +445,9 @@ namespace DSharpPlus
         /// <returns></returns>
         public async Task DisconnectAsync()
         {
-            Configuration.AutoReconnect = false;
+            this.Configuration.AutoReconnect = false;
             if (this._webSocketClient != null)
-                await _webSocketClient.DisconnectAsync().ConfigureAwait(false);
+                await this._webSocketClient.DisconnectAsync().ConfigureAwait(false);
         }
 
         #region Public Functions
@@ -524,7 +524,7 @@ namespace DSharpPlus
         {
             if (this._guilds.TryGetValue(id, out var guild))
                 return guild;
-
+            
             guild = await this.ApiClient.GetGuildAsync(id).ConfigureAwait(false);
             var channels = await this.ApiClient.GetGuildChannelsAsync(guild.Id).ConfigureAwait(false);
             foreach (var channel in channels) guild._channels[channel.Id] = channel;
@@ -630,7 +630,7 @@ namespace DSharpPlus
                     break;
 
                 default:
-                    DebugLogger.LogMessage(LogLevel.Warning, "Websocket", $"Unknown OP-Code: {((int)payload.OpCode).ToString(CultureInfo.InvariantCulture)}\n{payload.Data}", DateTime.Now);
+                    this.DebugLogger.LogMessage(LogLevel.Warning, "Websocket", $"Unknown OP-Code: {((int)payload.OpCode).ToString(CultureInfo.InvariantCulture)}\n{payload.Data}", DateTime.Now);
                     break;
             }
         }
@@ -832,7 +832,7 @@ namespace DSharpPlus
 
                 default:
                     await OnUnknownEventAsync(payload).ConfigureAwait(false);
-                    DebugLogger.LogMessage(LogLevel.Warning, "Websocket:Dispatch", $"Unknown event: {payload.EventName}\n{payload.Data}", DateTime.Now);
+                    this.DebugLogger.LogMessage(LogLevel.Warning, "Websocket:Dispatch", $"Unknown event: {payload.EventName}\n{payload.Data}", DateTime.Now);
                     break;
             }
         }
@@ -975,7 +975,7 @@ namespace DSharpPlus
                     .Select(xtu => this.InternalGetCachedUser(xtu.Id) ?? new DiscordUser(xtu) { Discord = this });
                 dmChannel._recipients = recips.ToList();
 
-                _privateChannels[dmChannel.Id] = dmChannel;
+                this._privateChannels[dmChannel.Id] = dmChannel;
 
                 await this._dmChannelCreated.InvokeAsync(new DmChannelCreateEventArgs(this) { Channel = dmChannel }).ConfigureAwait(false);
             }
@@ -988,7 +988,7 @@ namespace DSharpPlus
                     xo._channel_id = channel.Id;
                 }
 
-                _guilds[channel.GuildId]._channels[channel.Id] = channel;
+                this._guilds[channel.GuildId]._channels[channel.Id] = channel;
 
                 await this._channelCreated.InvokeAsync(new ChannelCreateEventArgs(this) { Channel = channel, Guild = channel.Guild }).ConfigureAwait(false);
             }
@@ -1212,12 +1212,21 @@ namespace DSharpPlus
                     IsUnavailable = gld.IsUnavailable,
                     JoinedAt = gld.JoinedAt,
                     MemberCount = gld.MemberCount,
+                    MaxMembers = gld.MaxMembers,
+                    MaxPresences = gld.MaxPresences,
+                    DiscoverySplashHash = gld.DiscoverySplashHash,
+                    PreferredLocale = gld.PreferredLocale,
                     MfaLevel = gld.MfaLevel,
                     OwnerId = gld.OwnerId,
                     SplashHash = gld.SplashHash,
                     SystemChannelId = gld.SystemChannelId,
+                    SystemChannelFlags = gld.SystemChannelFlags,
+                    WidgetEnabled = gld.WidgetEnabled,
+                    WidgetChannelId = gld.WidgetChannelId,
                     VerificationLevel = gld.VerificationLevel,
-                    VoiceRegionId = gld.VoiceRegionId,
+                    RulesChannelId = gld.RulesChannelId,
+                    PublicUpdatesChannelId = gld.PublicUpdatesChannelId,
+                    VoiceRegionId = gld.VoiceRegionId,   
                     _channels = new ConcurrentDictionary<ulong, DiscordChannel>(),
                     _emojis = new ConcurrentDictionary<ulong, DiscordEmoji>(),
                     _members = new ConcurrentDictionary<ulong, DiscordMember>(),
@@ -1613,7 +1622,7 @@ namespace DSharpPlus
             message.Discord = this;
 
             if (message.Channel == null)
-                DebugLogger.LogMessage(LogLevel.Warning, "Event", "Could not find channel last message belonged to.", DateTime.Now);
+                this.DebugLogger.LogMessage(LogLevel.Warning, "Event", "Could not find channel last message belonged to.", DateTime.Now);
             else
                 message.Channel.LastMessageId = message.Id;
 
@@ -2435,12 +2444,23 @@ namespace DSharpPlus
             guild.VoiceRegionId = newGuild.VoiceRegionId;
             guild.SplashHash = newGuild.SplashHash;
             guild.VerificationLevel = newGuild.VerificationLevel;
+            guild.WidgetEnabled = newGuild.WidgetEnabled;
+            guild.WidgetChannelId = newGuild.WidgetChannelId;
             guild.ExplicitContentFilter = newGuild.ExplicitContentFilter;
             guild.PremiumTier = newGuild.PremiumTier;
             guild.PremiumSubscriptionCount = newGuild.PremiumSubscriptionCount;
             guild.Banner = newGuild.Banner;
             guild.Description = newGuild.Description;
             guild.VanityUrlCode = newGuild.VanityUrlCode;
+            guild.Banner = newGuild.Banner;
+            guild.SystemChannelId = newGuild.SystemChannelId;
+            guild.SystemChannelFlags = newGuild.SystemChannelFlags;
+            guild.DiscoverySplashHash = newGuild.DiscoverySplashHash;
+            guild.MaxMembers = newGuild.MaxMembers;
+            guild.MaxPresences = newGuild.MaxPresences;
+            guild.PreferredLocale = newGuild.PreferredLocale;
+            guild.RulesChannelId = newGuild.RulesChannelId;
+            guild.PublicUpdatesChannelId = newGuild.PublicUpdatesChannelId;
 
             // fields not sent for update:
             // - guild.Channels
@@ -2467,7 +2487,7 @@ namespace DSharpPlus
             var jo = JObject.Parse(response.Response);
             this._gatewayUri = new Uri(jo.Value<string>("url"));
             if (jo["shards"] != null)
-                _shardCount = jo.Value<int>("shards");
+                this._shardCount = jo.Value<int>("shards");
         }
 
         private SocketLock GetSocketLock()
@@ -2475,7 +2495,7 @@ namespace DSharpPlus
 
         ~DiscordClient()
         {
-            Dispose();
+            this.Dispose();
         }
 
         private bool _disposed;

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -1656,7 +1656,7 @@ namespace DSharpPlus
             {
                 if (guild != null)
                 {
-                    mentionedUsers = Utilities.GetUserMentions(message).Select(xid => guild._members.TryGetValue(xid, out var member) ? member : null).Cast<DiscordUser>().ToList();
+                    mentionedUsers = Utilities.GetUserMentions(message).Select(xid => guild._members.TryGetValue(xid, out var member) ? member : new DiscordUser { Id = xid, Discord = this }).Cast<DiscordUser>().ToList();
                     mentionedRoles = Utilities.GetRoleMentions(message).Select(xid => guild.GetRole(xid)).ToList();
                     mentionedChannels = Utilities.GetChannelMentions(message).Select(xid => guild.GetChannel(xid)).ToList();
                 }

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -1593,7 +1593,7 @@ namespace DSharpPlus
         internal async Task OnGuildRoleDeleteEventAsync(ulong roleId, DiscordGuild guild)
         {
             if (!guild._roles.TryRemove(roleId, out var role))
-                throw new InvalidOperationException("Attempted to delete a nonexistent role");
+                throw new InvalidOperationException("Attempted to delete a nonexistent role.");
 
             var ea = new GuildRoleDeleteEventArgs(this)
             {

--- a/DSharpPlus/DiscordShardedClient.cs
+++ b/DSharpPlus/DiscordShardedClient.cs
@@ -200,6 +200,26 @@ namespace DSharpPlus
         private AsyncEvent<GuildDownloadCompletedEventArgs> _guildDownloadCompleted;
 
         /// <summary>
+        /// Fired when an invite is created.
+        /// </summary>
+        public event AsyncEventHandler<InviteCreateEventArgs> InviteCreated
+        {
+            add => this._inviteCreated.Register(value);
+            remove => this._inviteCreated.Unregister(value);
+        }
+        private AsyncEvent<InviteCreateEventArgs> _inviteCreated;
+
+        /// <summary>
+        /// Fired when an invite is deleted.
+        /// </summary>
+        public event AsyncEventHandler<InviteDeleteEventArgs> InviteDeleted
+        {
+            add => this._inviteDeleted.Register(value);
+            remove => this._inviteDeleted.Unregister(value);
+        }
+        private AsyncEvent<InviteDeleteEventArgs> _inviteDeleted;
+
+        /// <summary>
         /// Fired when a message is created.
         /// </summary>
         public event AsyncEventHandler<MessageCreateEventArgs> MessageCreated
@@ -450,6 +470,16 @@ namespace DSharpPlus
         private AsyncEvent<MessageReactionsClearEventArgs> _messageReactionsCleared;
 
         /// <summary>
+        /// Fired when all reactions of a specific reaction are removed from a message.
+        /// </summary>
+        public event AsyncEventHandler<MessageReactionRemoveEmojiEventArgs> MessageReactionRemovedEmoji
+        {
+            add => this._messageReactionRemovedEmoji.Register(value);
+            remove => this._messageReactionRemovedEmoji.Unregister(value);
+        }
+        private AsyncEvent<MessageReactionRemoveEmojiEventArgs> _messageReactionRemovedEmoji;
+
+        /// <summary>
         /// Fired whenever webhooks update.
         /// </summary>
         public event AsyncEventHandler<WebhooksUpdateEventArgs> WebhooksUpdated
@@ -547,6 +577,8 @@ namespace DSharpPlus
             this._guildDeleted = new AsyncEvent<GuildDeleteEventArgs>(this.EventErrorHandler, "GUILD_DELETED");
             this._guildUnavailable = new AsyncEvent<GuildDeleteEventArgs>(this.EventErrorHandler, "GUILD_UNAVAILABLE");
             this._guildDownloadCompleted = new AsyncEvent<GuildDownloadCompletedEventArgs>(this.EventErrorHandler, "GUILD_DOWNLOAD_COMPLETED");
+            this._inviteCreated = new AsyncEvent<InviteCreateEventArgs>(this.EventErrorHandler, "INVITE_CREATED");
+            this._inviteDeleted = new AsyncEvent<InviteDeleteEventArgs>(this.EventErrorHandler, "INVITE_DELETED");
             this._messageCreated = new AsyncEvent<MessageCreateEventArgs>(this.EventErrorHandler, "MESSAGE_CREATED");
             this._presenceUpdated = new AsyncEvent<PresenceUpdateEventArgs>(this.EventErrorHandler, "PRESENCE_UPDATED");
             this._guildBanAdded = new AsyncEvent<GuildBanAddEventArgs>(this.EventErrorHandler, "GUILD_BAN_ADDED");
@@ -572,6 +604,7 @@ namespace DSharpPlus
             this._messageReactionAdded = new AsyncEvent<MessageReactionAddEventArgs>(this.EventErrorHandler, "MESSAGE_REACTION_ADDED");
             this._messageReactionRemoved = new AsyncEvent<MessageReactionRemoveEventArgs>(this.EventErrorHandler, "MESSAGE_REACTION_REMOVED");
             this._messageReactionsCleared = new AsyncEvent<MessageReactionsClearEventArgs>(this.EventErrorHandler, "MESSAGE_REACTIONS_CLEARED");
+            this._messageReactionRemovedEmoji = new AsyncEvent<MessageReactionRemoveEmojiEventArgs>(this.EventErrorHandler, "MESSAGE_REACTION_REMOVED_EMOJI");
             this._webhooksUpdated = new AsyncEvent<WebhooksUpdateEventArgs>(this.EventErrorHandler, "WEBHOOKS_UPDATED");
             this._heartbeated = new AsyncEvent<HeartbeatEventArgs>(this.EventErrorHandler, "HEARTBEATED");
 
@@ -650,6 +683,8 @@ namespace DSharpPlus
                 client.GuildDeleted += this.Client_GuildDeleted;
                 client.GuildUnavailable += this.Client_GuildUnavailable;
                 client.GuildDownloadCompleted += this.Client_GuildDownloadCompleted;
+                client.InviteCreated += this.Client_InviteCreated;
+                client.InviteDeleted += this.Client_InviteDeleted;
                 client.MessageCreated += this.Client_MessageCreated;
                 client.PresenceUpdated += this.Client_PresenceUpdate;
                 client.GuildBanAdded += this.Client_GuildBanAdd;
@@ -675,6 +710,7 @@ namespace DSharpPlus
                 client.MessageReactionAdded += this.Client_MessageReactionAdd;
                 client.MessageReactionRemoved += this.Client_MessageReactionRemove;
                 client.MessageReactionsCleared += this.Client_MessageReactionRemoveAll;
+                client.MessageReactionRemovedEmoji += this.Client_MessageReactionRemovedEmoji;
                 client.WebhooksUpdated += this.Client_WebhooksUpdate;
                 client.Heartbeated += this.Client_HeartBeated;
                 client.DebugLogger.LogMessageReceived += this.DebugLogger_LogMessageReceived;
@@ -787,6 +823,12 @@ namespace DSharpPlus
         private Task Client_MessageCreated(MessageCreateEventArgs e) 
             => this._messageCreated.InvokeAsync(e);
 
+        private Task Client_InviteCreated(InviteCreateEventArgs e)
+            => this._inviteCreated.InvokeAsync(e);
+
+        private Task Client_InviteDeleted(InviteDeleteEventArgs e)
+            => this._inviteDeleted.InvokeAsync(e);
+
         private Task Client_PresenceUpdate(PresenceUpdateEventArgs e) 
             => this._presenceUpdated.InvokeAsync(e);
 
@@ -858,6 +900,9 @@ namespace DSharpPlus
 
         private Task Client_MessageReactionRemoveAll(MessageReactionsClearEventArgs e) 
             => this._messageReactionsCleared.InvokeAsync(e);
+
+        private Task Client_MessageReactionRemovedEmoji(MessageReactionRemoveEmojiEventArgs e)
+            => this._messageReactionRemovedEmoji.InvokeAsync(e);
 
         private Task Client_WebhooksUpdate(WebhooksUpdateEventArgs e) 
             => this._webhooksUpdated.InvokeAsync(e);

--- a/DSharpPlus/Entities/DiscordAuditLogObjects.cs
+++ b/DSharpPlus/Entities/DiscordAuditLogObjects.cs
@@ -103,9 +103,14 @@ namespace DSharpPlus.Entities
         public PropertyChange<MfaLevel> MfaLevelChange { get; internal set; }
 
         /// <summary>
-        /// Gets the the description of invite splash's change.
+        /// Gets the description of invite splash's change.
         /// </summary>
         public PropertyChange<string> SplashChange { get; internal set; }
+
+        /// <summary>
+        /// Gets the description of the guild's region change.
+        /// </summary>
+        public PropertyChange<string> RegionChange { get; internal set; }
 
         internal DiscordAuditLogGuildEntry() { }
     }

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -132,7 +132,7 @@ namespace DSharpPlus.Entities
             get
             {
                 if (!IsCategory)
-                    throw new ArgumentException("Only channel categories contain children");
+                    throw new ArgumentException("Only channel categories contain children.");
 
                 return Guild._channels.Values.Where(e => e.ParentId == Id);
             }
@@ -178,13 +178,9 @@ namespace DSharpPlus.Entities
         public Task<DiscordMessage> SendMessageAsync(string content = null, bool tts = false, DiscordEmbed embed = null)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a text message to a non-text channel");
-            if (string.IsNullOrWhiteSpace(content) && embed == null)
-                throw new ArgumentNullException("Must provide either content, embed or both, and content may not consist only of whitespace");
-            if (content != null && content.Length > 2000)
-                throw new ArgumentException("Message must be less than or exactly 2000 characters", nameof(content));
-
-            return this.Discord.ApiClient.CreateMessageAsync(Id, content, tts, embed);
+                throw new ArgumentException("Cannot send a text message to a non-text channel.");
+            
+            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, tts, embed);
         }
 
         /// <summary>
@@ -199,7 +195,7 @@ namespace DSharpPlus.Entities
         public Task<DiscordMessage> SendFileAsync(string fileName, Stream fileData, string content = null, bool tts = false, DiscordEmbed embed = null)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a file to a non-text channel");
+                throw new ArgumentException("Cannot send a file to a non-text channel.");
 
             return this.Discord.ApiClient.UploadFileAsync(this.Id, fileData, fileName, content, tts, embed);
         }
@@ -215,8 +211,8 @@ namespace DSharpPlus.Entities
         public Task<DiscordMessage> SendFileAsync(FileStream fileData, string content = null, bool tts = false, DiscordEmbed embed = null)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a file to a non-text channel");
-
+                throw new ArgumentException("Cannot send a file to a non-text channel.");
+            
             return this.Discord.ApiClient.UploadFileAsync(this.Id, fileData, Path.GetFileName(fileData.Name), content,
                 tts, embed);
         }
@@ -232,7 +228,7 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMessage> SendFileAsync(string filePath, string content = null, bool tts = false, DiscordEmbed embed = null)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a file to a non-text channel");
+                throw new ArgumentException("Cannot send a file to a non-text channel.");
 
             using (var fs = File.OpenRead(filePath))
                 return await this.Discord.ApiClient.UploadFileAsync(this.Id, fs, Path.GetFileName(fs.Name), content, tts, embed).ConfigureAwait(false);
@@ -249,9 +245,12 @@ namespace DSharpPlus.Entities
         public Task<DiscordMessage> SendMultipleFilesAsync(Dictionary<string, Stream> files, string content = "", bool tts = false, DiscordEmbed embed = null)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a file to a non-text channel");
+                throw new ArgumentException("Cannot send a file to a non-text channel.");
 
-            return this.Discord.ApiClient.UploadFilesAsync(Id, files, content, tts, embed);
+            if (files.Count > 10)
+                throw new ArgumentException("Cannot send more than 10 files with a single message.");
+
+            return this.Discord.ApiClient.UploadFilesAsync(this.Id, files, content, tts, embed);
         }
 
         // Please send memes to Naamloos#2887 at discord <3 thank you
@@ -385,7 +384,7 @@ namespace DSharpPlus.Entities
         private async Task<IReadOnlyList<DiscordMessage>> GetMessagesInternalAsync(int limit = 100, ulong? before = null, ulong? after = null, ulong? around = null)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot get the messages of a non-text channel");
+                throw new ArgumentException("Cannot get the messages of a non-text channel.");
 
             if (limit < 0)
                 throw new ArgumentException("Cannot get a negative number of messages.");
@@ -395,7 +394,7 @@ namespace DSharpPlus.Entities
 
             //return this.Discord.ApiClient.GetChannelMessagesAsync(this.Id, limit, before, after, around);
             if (limit > 100 && around != null)
-                throw new InvalidOperationException("Cannot get more than 100 messages around specified ID.");
+                throw new InvalidOperationException("Cannot get more than 100 messages around the specified ID.");
 
             var msgs = new List<DiscordMessage>(limit);
             var remaining = limit;
@@ -466,7 +465,7 @@ namespace DSharpPlus.Entities
         public Task<IReadOnlyList<DiscordInvite>> GetInvitesAsync()
         {
             if (this.Guild == null)
-                throw new ArgumentException("Cannot get the invites of a channel that does not belong to a Guild");
+                throw new ArgumentException("Cannot get the invites of a channel that does not belong to a guild.");
 
             return this.Discord.ApiClient.GetChannelInvitesAsync(Id);
         }
@@ -512,7 +511,7 @@ namespace DSharpPlus.Entities
         public Task TriggerTypingAsync()
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot start typing in a non-text channel");
+                throw new ArgumentException("Cannot start typing in a non-text channel.");
 
             return this.Discord.ApiClient.TriggerTypingAsync(Id);
         }
@@ -524,7 +523,7 @@ namespace DSharpPlus.Entities
         public Task<IReadOnlyList<DiscordMessage>> GetPinnedMessagesAsync()
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("A non-text channel does not have pinned messages");
+                throw new ArgumentException("A non-text channel does not have pinned messages.");
 
             return this.Discord.ApiClient.GetPinnedMessagesAsync(this.Id);
         }
@@ -563,7 +562,7 @@ namespace DSharpPlus.Entities
         public async Task PlaceMemberAsync(DiscordMember member)
         {
             if (this.Type != ChannelType.Voice)
-                throw new ArgumentException("Cannot place member in a non-voice channel!"); // be a little more angery, let em learn!!1
+                throw new ArgumentException("Cannot place a member in a non-voice channel!"); // be a little more angery, let em learn!!1
             
             await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, member.Id, default, default, default,
                 default, this.Id, null).ConfigureAwait(false);

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -7,11 +7,12 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using DSharpPlus.Net.Abstractions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using DSharpPlus.Enums;
 using DSharpPlus.Net.Models;
 using DSharpPlus.Net.Serialization;
+using DSharpPlus.Net.Abstractions;
 
 namespace DSharpPlus.Entities
 {
@@ -51,6 +52,26 @@ namespace DSharpPlus.Entities
         [JsonIgnore]
         public string SplashUrl
             => !string.IsNullOrWhiteSpace(this.SplashHash) ? $"https://cdn.discordapp.com/splashes/{this.Id.ToString(CultureInfo.InvariantCulture)}/{SplashHash}.jpg" : null;
+
+        /// <summary>
+        /// Gets the guild discovery splash's hash.
+        /// </summary>
+        [JsonProperty("discovery_splash", NullValueHandling = NullValueHandling.Ignore)]
+        public string DiscoverySplashHash { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild discovery splash's url.
+        /// </summary>
+        [JsonIgnore]
+        public string DiscoverySplashUrl
+            => !string.IsNullOrWhiteSpace(this.DiscoverySplashHash) ? $"https://cdn.discordapp.com/discovery-splashes/{this.Id.ToString(CultureInfo.InvariantCulture)}/{DiscoverySplashHash}.jpg" : null;
+
+        /// <summary>
+        /// Gets the preferred locale of this guild.
+        /// <para>This is used for server discovery and notices from Discord. Defaults to en-US.</para>
+        /// </summary>
+        [JsonProperty("preferred_locale", NullValueHandling = NullValueHandling.Ignore)]
+        public string PreferredLocale { get; internal set; }
 
         /// <summary>
         /// Gets the ID of the guild's owner.
@@ -146,12 +167,65 @@ namespace DSharpPlus.Entities
         internal ulong? SystemChannelId { get; set; }
 
         /// <summary>
-        /// Gets the channel to which system messages (such as join notifications) are sent.
+        /// Gets the channel where system messages (such as boost and welcome messages) are sent.
         /// </summary>
         [JsonIgnore]
-        public DiscordChannel SystemChannel => SystemChannelId.HasValue
-            ? this.GetChannel(SystemChannelId.Value)
+        public DiscordChannel SystemChannel => this.SystemChannelId.HasValue
+            ? this.GetChannel(this.SystemChannelId.Value)
             : null;
+
+        /// <summary>
+        /// Gets the settings for this guild's system channel.
+        /// </summary>
+        [JsonProperty("system_channel_flags")]
+        public SystemChannelFlags SystemChannelFlags { get; internal set; }
+
+        /// <summary>
+        /// Gets whether this guild's widget is enabled.
+        /// </summary>
+        [JsonProperty("widget_enabled", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? WidgetEnabled { get; internal set; }
+
+        [JsonProperty("widget_channel_id", NullValueHandling = NullValueHandling.Ignore)]
+        internal ulong? WidgetChannelId { get; set; }
+
+        /// <summary>
+        /// Gets the widget channel for this guild.
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel WidgetChannel => this.WidgetChannelId.HasValue
+            ? this.GetChannel(this.WidgetChannelId.Value)
+            : null;
+
+        [JsonProperty("rules_channel_id")]
+        internal ulong? RulesChannelId { get; set; }
+
+        /// <summary>
+        /// Gets the rules channel for this guild.
+        /// <para>This is only available if the guild is considered "discoverable".</para>
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel RulesChannel => this.RulesChannelId.HasValue
+            ? this.GetChannel(this.RulesChannelId.Value)
+            : null;
+
+        [JsonProperty("public_updates_channel_id")]
+        internal ulong? PublicUpdatesChannelId { get; set; }
+
+        /// <summary>
+        /// Gets the public updates channel (where admins and moderators receive messages from Discord) for this guild.
+        /// <para>This is only available if the guild is considered "discoverable".</para>
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel PublicUpdatesChannel => this.PublicUpdatesChannelId.HasValue
+            ? this.GetChannel(this.PublicUpdatesChannelId.Value)
+            : null;
+
+        /// <summary>
+        /// Gets the application id of this guild if it is bot created.
+        /// </summary>
+        [JsonProperty("application_id")]
+        public ulong? ApplicationId { get; internal set; }
 
         /// <summary>
         /// Gets a collection of this guild's roles.
@@ -208,6 +282,18 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("member_count", NullValueHandling = NullValueHandling.Ignore)]
         public int MemberCount { get; internal set; }
+
+        /// <summary>
+        /// Gets the maximum amount of members allowed for this guild.
+        /// </summary>
+        [JsonProperty("max_members")]
+        public int? MaxMembers { get; internal set; }
+
+        /// <summary>
+        /// Gets the maximum amount of presences allowed for this guild.
+        /// </summary>
+        [JsonProperty("max_presences")]
+        public int? MaxPresences { get; internal set; }
 
         /// <summary>
         /// Gets a dictionary of all the voice states for this guilds. The key for this dictionary is the ID of the user
@@ -271,16 +357,23 @@ namespace DSharpPlus.Entities
         public string VanityUrlCode { get; internal set; }
 
         /// <summary>
-        /// Gets guild description, when applicable.
+        /// Gets the guild description, when applicable.
         /// </summary>
         [JsonProperty("description")]
         public string Description { get; internal set; }
 
         /// <summary>
-        /// Gets guild banner hash, when applicable.
+        /// Gets this guild's banner hash, when applicable.
         /// </summary>
         [JsonProperty("banner")]
         public string Banner { get; internal set; }
+
+        /// <summary>
+        /// Gets this guild's banner in url form.
+        /// </summary>
+        [JsonIgnore]
+        public string BannerUrl
+            => !string.IsNullOrWhiteSpace(this.Banner) ? $"https://cdn.discordapp.com/banners/{this.Id}/{this.Banner}" : null;
 
         /// <summary>
         /// Gets this guild's premium tier (Nitro boosting).
@@ -293,6 +386,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("premium_subscription_count", NullValueHandling = NullValueHandling.Ignore)]
         public int? PremiumSubscriptionCount { get; internal set; }
+
         // Seriously discord?
 
         // I need to work on this
@@ -308,9 +402,7 @@ namespace DSharpPlus.Entities
         internal bool IsSynced { get; set; }
 
         internal DiscordGuild()
-        {
-            this._current_member_lazy = new Lazy<DiscordMember>(() => this._members.TryGetValue(this.Discord.CurrentUser.Id, out var member) ? member : null);
-        }
+            => this._current_member_lazy = new Lazy<DiscordMember>(() => this._members.TryGetValue(this.Discord.CurrentUser.Id, out var member) ? member : null);
 
         #region Guild Methods
         /// <summary>
@@ -580,11 +672,54 @@ namespace DSharpPlus.Entities
             => this.Discord.ApiClient.GetGuildInvitesAsync(this.Id);
 
         /// <summary>
+        /// Gets the vanity invite for this guild.
+        /// </summary>
+        /// <returns>A partial vanity invite.</returns>
+        public Task<DiscordInvite> GetVanityInviteAsync()
+            => this.Discord.ApiClient.GetGuildVanityUrlAsync(this.Id);
+        
+
+        /// <summary>
         /// Gets all the webhooks created for all the channels in this guild.
         /// </summary>
         /// <returns>A collection of webhooks this guild has.</returns>
         public Task<IReadOnlyList<DiscordWebhook>> GetWebhooksAsync()
             => this.Discord.ApiClient.GetGuildWebhooksAsync(this.Id);
+
+        /// <summary>
+        /// Gets this guild's widget image.
+        /// </summary>
+        /// <param name="bannerType">The format of the widget.</param>
+        /// <returns>The URL of the widget image.</returns>
+        public string GetWidgetImage(WidgetType bannerType = WidgetType.Shield)
+        {
+            string param;
+
+            switch(bannerType)
+            {
+                case WidgetType.Banner1:
+                    param = "banner1";
+                    break;
+
+                case WidgetType.Banner2:
+                    param = "banner2";
+                    break;
+
+                case WidgetType.Banner3:
+                    param = "banner3";
+                    break;
+
+                case WidgetType.Banner4:
+                    param = "banner4";
+                    break;
+
+                default:
+                    param = "shield";
+                    break;
+            }
+
+            return $"{Net.Endpoints.BASE_URI}{Net.Endpoints.GUILDS}/{this.Id}{Net.Endpoints.WIDGET_PNG}?style={param}";
+        }
 
         /// <summary>
         /// Gets a member of this guild by his user ID.
@@ -879,6 +1014,14 @@ namespace DSharpPlus.Entities
                                     };
                                     break;
 
+                                case "region":
+                                    entrygld.RegionChange = new PropertyChange<string>
+                                    {
+                                        Before = xc.OldValueString,
+                                        After = xc.NewValueString
+                                    };
+                                    break;
+                             
                                 default:
                                     this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in guild update: {xc.Key}; this should be reported to devs", DateTime.Now);
                                     break;
@@ -1822,5 +1965,37 @@ namespace DSharpPlus.Entities
         /// Messages from all members are scanned.
         /// </summary>
         AllMembers = 2
+    }
+
+    /// <summary>
+    /// Represents the formats for a guild widget.
+    /// </summary>
+    public enum WidgetType : int
+    {
+        /// <summary>
+        /// The widget is represented in shield format.
+        /// <para>This is the default widget type.</para>
+        /// </summary>
+        Shield = 0,
+
+        /// <summary>
+        /// The widget is represented as the first banner type.
+        /// </summary>
+        Banner1 = 1,
+
+        /// <summary>
+        /// The widget is represented as the second banner type.
+        /// </summary>
+        Banner2 = 2,
+
+        /// <summary>
+        /// The widget is represented as the third banner type.
+        /// </summary>
+        Banner3 = 3,
+
+        /// <summary>
+        /// The widget is represented in the fourth banner type.
+        /// </summary>
+        Banner4 = 4
     }
 }

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -641,7 +641,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Requests that Discord send a complete list of guild members. This method will return immediately.
         /// </summary>
-        public void RequestAllMembers()
+        public async Task RequestAllMembersAsync()
         {
             if (!(this.Discord is DiscordClient client))
                 throw new InvalidOperationException("This operation is only valid for regular Discord clients.");
@@ -652,7 +652,7 @@ namespace DSharpPlus.Entities
                 Data = new GatewayRequestGuildMembers(this)
             };
             var payloadStr = JsonConvert.SerializeObject(payload, Formatting.None);
-            client._webSocketClient.SendMessage(payloadStr);
+            await client._webSocketClient.SendMessageAsync(payloadStr).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -7,12 +7,11 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using DSharpPlus.Net.Abstractions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using DSharpPlus.Enums;
 using DSharpPlus.Net.Models;
 using DSharpPlus.Net.Serialization;
-using DSharpPlus.Net.Abstractions;
 
 namespace DSharpPlus.Entities
 {
@@ -52,26 +51,6 @@ namespace DSharpPlus.Entities
         [JsonIgnore]
         public string SplashUrl
             => !string.IsNullOrWhiteSpace(this.SplashHash) ? $"https://cdn.discordapp.com/splashes/{this.Id.ToString(CultureInfo.InvariantCulture)}/{SplashHash}.jpg" : null;
-
-        /// <summary>
-        /// Gets the guild discovery splash's hash.
-        /// </summary>
-        [JsonProperty("discovery_splash", NullValueHandling = NullValueHandling.Ignore)]
-        public string DiscoverySplashHash { get; internal set; }
-
-        /// <summary>
-        /// Gets the guild discovery splash's url.
-        /// </summary>
-        [JsonIgnore]
-        public string DiscoverySplashUrl
-            => !string.IsNullOrWhiteSpace(this.DiscoverySplashHash) ? $"https://cdn.discordapp.com/discovery-splashes/{this.Id.ToString(CultureInfo.InvariantCulture)}/{DiscoverySplashHash}.jpg" : null;
-
-        /// <summary>
-        /// Gets the preferred locale of this guild.
-        /// <para>This is used for server discovery and notices from Discord. Defaults to en-US.</para>
-        /// </summary>
-        [JsonProperty("preferred_locale", NullValueHandling = NullValueHandling.Ignore)]
-        public string PreferredLocale { get; internal set; }
 
         /// <summary>
         /// Gets the ID of the guild's owner.
@@ -167,65 +146,12 @@ namespace DSharpPlus.Entities
         internal ulong? SystemChannelId { get; set; }
 
         /// <summary>
-        /// Gets the channel where system messages (such as boost and welcome messages) are sent.
+        /// Gets the channel to which system messages (such as join notifications) are sent.
         /// </summary>
         [JsonIgnore]
-        public DiscordChannel SystemChannel => this.SystemChannelId.HasValue
-            ? this.GetChannel(this.SystemChannelId.Value)
+        public DiscordChannel SystemChannel => SystemChannelId.HasValue
+            ? this.GetChannel(SystemChannelId.Value)
             : null;
-
-        /// <summary>
-        /// Gets the settings for this guild's system channel.
-        /// </summary>
-        [JsonProperty("system_channel_flags")]
-        public SystemChannelFlags SystemChannelFlags { get; internal set; }
-
-        /// <summary>
-        /// Gets whether this guild's widget is enabled.
-        /// </summary>
-        [JsonProperty("widget_enabled", NullValueHandling = NullValueHandling.Ignore)]
-        public bool? WidgetEnabled { get; internal set; }
-
-        [JsonProperty("widget_channel_id", NullValueHandling = NullValueHandling.Ignore)]
-        internal ulong? WidgetChannelId { get; set; }
-
-        /// <summary>
-        /// Gets the widget channel for this guild.
-        /// </summary>
-        [JsonIgnore]
-        public DiscordChannel WidgetChannel => this.WidgetChannelId.HasValue
-            ? this.GetChannel(this.WidgetChannelId.Value)
-            : null;
-
-        [JsonProperty("rules_channel_id")]
-        internal ulong? RulesChannelId { get; set; }
-
-        /// <summary>
-        /// Gets the rules channel for this guild.
-        /// <para>This is only available if the guild is considered "discoverable".</para>
-        /// </summary>
-        [JsonIgnore]
-        public DiscordChannel RulesChannel => this.RulesChannelId.HasValue
-            ? this.GetChannel(this.RulesChannelId.Value)
-            : null;
-
-        [JsonProperty("public_updates_channel_id")]
-        internal ulong? PublicUpdatesChannelId { get; set; }
-
-        /// <summary>
-        /// Gets the public updates channel (where admins and moderators receive messages from Discord) for this guild.
-        /// <para>This is only available if the guild is considered "discoverable".</para>
-        /// </summary>
-        [JsonIgnore]
-        public DiscordChannel PublicUpdatesChannel => this.PublicUpdatesChannelId.HasValue
-            ? this.GetChannel(this.PublicUpdatesChannelId.Value)
-            : null;
-
-        /// <summary>
-        /// Gets the application id of this guild if it is bot created.
-        /// </summary>
-        [JsonProperty("application_id")]
-        public ulong? ApplicationId { get; internal set; }
 
         /// <summary>
         /// Gets a collection of this guild's roles.
@@ -284,18 +210,6 @@ namespace DSharpPlus.Entities
         public int MemberCount { get; internal set; }
 
         /// <summary>
-        /// Gets the maximum amount of members allowed for this guild.
-        /// </summary>
-        [JsonProperty("max_members")]
-        public int? MaxMembers { get; internal set; }
-
-        /// <summary>
-        /// Gets the maximum amount of presences allowed for this guild.
-        /// </summary>
-        [JsonProperty("max_presences")]
-        public int? MaxPresences { get; internal set; }
-
-        /// <summary>
         /// Gets a dictionary of all the voice states for this guilds. The key for this dictionary is the ID of the user
         /// the voice state corresponds to.
         /// </summary>
@@ -325,6 +239,8 @@ namespace DSharpPlus.Entities
         [JsonProperty("channels", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(SnowflakeArrayAsDictionaryJsonConverter))]
         internal ConcurrentDictionary<ulong, DiscordChannel> _channels;
+
+        internal ConcurrentDictionary<string, DiscordInvite> _invites;
 
         /// <summary>
         /// Gets the guild member for current user.
@@ -357,23 +273,16 @@ namespace DSharpPlus.Entities
         public string VanityUrlCode { get; internal set; }
 
         /// <summary>
-        /// Gets the guild description, when applicable.
+        /// Gets guild description, when applicable.
         /// </summary>
         [JsonProperty("description")]
         public string Description { get; internal set; }
 
         /// <summary>
-        /// Gets this guild's banner hash, when applicable.
+        /// Gets guild banner hash, when applicable.
         /// </summary>
         [JsonProperty("banner")]
         public string Banner { get; internal set; }
-
-        /// <summary>
-        /// Gets this guild's banner in url form.
-        /// </summary>
-        [JsonIgnore]
-        public string BannerUrl
-            => !string.IsNullOrWhiteSpace(this.Banner) ? $"https://cdn.discordapp.com/banners/{this.Id}/{this.Banner}" : null;
 
         /// <summary>
         /// Gets this guild's premium tier (Nitro boosting).
@@ -386,7 +295,6 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("premium_subscription_count", NullValueHandling = NullValueHandling.Ignore)]
         public int? PremiumSubscriptionCount { get; internal set; }
-
         // Seriously discord?
 
         // I need to work on this
@@ -402,7 +310,10 @@ namespace DSharpPlus.Entities
         internal bool IsSynced { get; set; }
 
         internal DiscordGuild()
-            => this._current_member_lazy = new Lazy<DiscordMember>(() => this._members.TryGetValue(this.Discord.CurrentUser.Id, out var member) ? member : null);
+        {
+            this._current_member_lazy = new Lazy<DiscordMember>(() => this._members.TryGetValue(this.Discord.CurrentUser.Id, out var member) ? member : null);
+            this._invites = new ConcurrentDictionary<string, DiscordInvite>();
+        }
 
         #region Guild Methods
         /// <summary>
@@ -665,19 +576,26 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// Gets an invite from this guild from an invite code.
+        /// </summary>
+        /// <param name="code">The invite code</param>
+        /// <returns>An invite.</returns>
+        public DiscordInvite GetInvite(string code)
+            => this._invites.TryGetValue(code, out var invite) ? invite : null;
+
+        /// <summary>
         /// Gets all the invites created for all the channels in this guild.
         /// </summary>
         /// <returns>A collection of invites.</returns>
-        public Task<IReadOnlyList<DiscordInvite>> GetInvitesAsync()
-            => this.Discord.ApiClient.GetGuildInvitesAsync(this.Id);
+        public async Task<IReadOnlyList<DiscordInvite>> GetInvitesAsync()
+        { 
+            var res = await this.Discord.ApiClient.GetGuildInvitesAsync(this.Id).ConfigureAwait(false);
 
-        /// <summary>
-        /// Gets the vanity invite for this guild.
-        /// </summary>
-        /// <returns>A partial vanity invite.</returns>
-        public Task<DiscordInvite> GetVanityInviteAsync()
-            => this.Discord.ApiClient.GetGuildVanityUrlAsync(this.Id);
-        
+            for (var i = 0; i < res.Count; i++)
+                this._invites[res[i].Code] = res[i];
+
+            return res;
+        }
 
         /// <summary>
         /// Gets all the webhooks created for all the channels in this guild.
@@ -685,41 +603,6 @@ namespace DSharpPlus.Entities
         /// <returns>A collection of webhooks this guild has.</returns>
         public Task<IReadOnlyList<DiscordWebhook>> GetWebhooksAsync()
             => this.Discord.ApiClient.GetGuildWebhooksAsync(this.Id);
-
-        /// <summary>
-        /// Gets this guild's widget image.
-        /// </summary>
-        /// <param name="bannerType">The format of the widget.</param>
-        /// <returns>The URL of the widget image.</returns>
-        public string GetWidgetImage(WidgetType bannerType = WidgetType.Shield)
-        {
-            string param;
-
-            switch(bannerType)
-            {
-                case WidgetType.Banner1:
-                    param = "banner1";
-                    break;
-
-                case WidgetType.Banner2:
-                    param = "banner2";
-                    break;
-
-                case WidgetType.Banner3:
-                    param = "banner3";
-                    break;
-
-                case WidgetType.Banner4:
-                    param = "banner4";
-                    break;
-
-                default:
-                    param = "shield";
-                    break;
-            }
-
-            return $"{Net.Endpoints.BASE_URI}{Net.Endpoints.GUILDS}/{this.Id}{Net.Endpoints.WIDGET_PNG}?style={param}";
-        }
 
         /// <summary>
         /// Gets a member of this guild by his user ID.
@@ -955,8 +838,8 @@ namespace DSharpPlus.Entities
 
                                     entrygld.AfkChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id },
-                                        After = this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id }
+                                        Before = this.GetChannel(t1),
+                                        After = this.GetChannel(t2)
                                     };
                                     break;
 
@@ -966,8 +849,8 @@ namespace DSharpPlus.Entities
 
                                     entrygld.EmbedChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id },
-                                        After = this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id }
+                                        Before = this.GetChannel(t1),
+                                        After = this.GetChannel(t2)
                                     };
                                     break;
 
@@ -993,8 +876,8 @@ namespace DSharpPlus.Entities
 
                                     entrygld.SystemChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id },
-                                        After = this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id }
+                                        Before = this.GetChannel(t1),
+                                        After = this.GetChannel(t2)
                                     };
                                     break;
 
@@ -1014,14 +897,6 @@ namespace DSharpPlus.Entities
                                     };
                                     break;
 
-                                case "region":
-                                    entrygld.RegionChange = new PropertyChange<string>
-                                    {
-                                        Before = xc.OldValueString,
-                                        After = xc.NewValueString
-                                    };
-                                    break;
-                             
                                 default:
                                     this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in guild update: {xc.Key}; this should be reported to devs", DateTime.Now);
                                     break;
@@ -1034,7 +909,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.ChannelUpdate:
                         entry = new DiscordAuditLogChannelEntry
                         {
-                            Target = this.GetChannel(xac.TargetId.Value) ?? new DiscordChannel { Id = xac.TargetId.Value, Discord = this.Discord, GuildId = this.Id }
+                            Target = this.GetChannel(xac.TargetId.Value) ?? new DiscordChannel { Id = xac.TargetId.Value }
                         };
 
                         var entrychn = entry as DiscordAuditLogChannelEntry;
@@ -1181,7 +1056,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.Kick:
                         entry = new DiscordAuditLogKickEntry
                         {
-                            Target = amd.TryGetValue(xac.TargetId.Value, out var kickMember) ? kickMember : new DiscordMember { Id = xac.TargetId.Value, Discord = this.Discord, _guild_id = this.Id }
+                            Target = amd.TryGetValue(xac.TargetId.Value, out var kickMember) ? kickMember : new DiscordMember { Id = xac.TargetId.Value }
                         };
                         break;
 
@@ -1197,7 +1072,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.Unban:
                         entry = new DiscordAuditLogBanEntry
                         {
-                            Target = amd.TryGetValue(xac.TargetId.Value, out var unbanMember) ? unbanMember : new DiscordMember { Id = xac.TargetId.Value, Discord = this.Discord, _guild_id = this.Id }
+                            Target = amd.TryGetValue(xac.TargetId.Value, out var unbanMember) ? unbanMember : new DiscordMember { Id = xac.TargetId.Value }
                         };
                         break;
 
@@ -1205,7 +1080,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.MemberRoleUpdate:
                         entry = new DiscordAuditLogMemberUpdateEntry
                         {
-                            Target = amd.TryGetValue(xac.TargetId.Value, out var roleUpdMember) ? roleUpdMember : new DiscordMember { Id = xac.TargetId.Value, Discord = this.Discord, _guild_id = this.Id }
+                            Target = amd.TryGetValue(xac.TargetId.Value, out var roleUpdMember) ? roleUpdMember : new DiscordMember { Id = xac.TargetId.Value }
                         };
 
                         var entrymbu = entry as DiscordAuditLogMemberUpdateEntry;
@@ -1257,7 +1132,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.RoleUpdate:
                         entry = new DiscordAuditLogRoleUpdateEntry
                         {
-                            Target = this.GetRole(xac.TargetId.Value) ?? new DiscordRole { Id = xac.TargetId.Value, Discord = this.Discord }
+                            Target = this.GetRole(xac.TargetId.Value) ?? new DiscordRole { Id = xac.TargetId.Value }
                         };
 
                         var entryrol = entry as DiscordAuditLogRoleUpdateEntry;
@@ -1380,8 +1255,8 @@ namespace DSharpPlus.Entities
 
                                     entryinv.InviterChange = new PropertyChange<DiscordMember>
                                     {
-                                        Before = amd.TryGetValue(t1, out var propBeforeMember) ? propBeforeMember : new DiscordMember { Id = t1, Discord = this.Discord, _guild_id = this.Id },
-                                        After = amd.TryGetValue(t2, out var propAfterMember) ? propAfterMember : new DiscordMember { Id = t1, Discord = this.Discord, _guild_id = this.Id },
+                                        Before = amd.TryGetValue(t1, out var propBeforeMember) ? propBeforeMember : null,
+                                        After = amd.TryGetValue(t2, out var propAfterMember) ? propAfterMember : null,
                                     };
                                     break;
 
@@ -1391,8 +1266,8 @@ namespace DSharpPlus.Entities
 
                                     entryinv.ChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = p1 ? this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null,
-                                        After = p2 ? this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null
+                                        Before = p1 ? this.GetChannel(t1) : null,
+                                        After = p2 ? this.GetChannel(t2) : null
                                     };
 
                                     var ch = entryinv.ChannelChange.Before ?? entryinv.ChannelChange.After;
@@ -1442,7 +1317,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.WebhookUpdate:
                         entry = new DiscordAuditLogWebhookEntry
                         {
-                            Target = ahd.TryGetValue(xac.TargetId.Value, out var webhook) ? webhook : new DiscordWebhook { Id = xac.TargetId.Value, Discord = this.Discord }
+                            Target = ahd.TryGetValue(xac.TargetId.Value, out var webhook) ? webhook : new DiscordWebhook { Id = xac.TargetId.Value }
                         };
 
                         var entrywhk = entry as DiscordAuditLogWebhookEntry;
@@ -1464,8 +1339,8 @@ namespace DSharpPlus.Entities
 
                                     entrywhk.ChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = p1 ? this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null,
-                                        After = p2 ? this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null
+                                        Before = p1 ? this.GetChannel(t1) : null,
+                                        After = p2 ? this.GetChannel(t2) : null
                                     };
                                     break;
 
@@ -1500,7 +1375,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.EmojiUpdate:
                         entry = new DiscordAuditLogEmojiEntry
                         {
-                            Target = this._emojis.TryGetValue(xac.TargetId.Value, out var target) ? target : new DiscordEmoji { Id = xac.TargetId.Value, Discord = this.Discord }
+                            Target = this._emojis.TryGetValue(xac.TargetId.Value, out var target) ? target : new DiscordEmoji { Id = xac.TargetId.Value }
                         };
 
                         var entryemo = entry as DiscordAuditLogEmojiEntry;
@@ -1532,7 +1407,7 @@ namespace DSharpPlus.Entities
 
                             if (xac.Options != null)
                             {
-                                entrymsg.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
+                                entrymsg.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId };
                                 entrymsg.MessageCount = xac.Options.Count;
                             }
 
@@ -1563,14 +1438,14 @@ namespace DSharpPlus.Entities
                             {
                                 dc.MessageCache.TryGet(x => x.Id == xac.Options.MessageId && x.ChannelId == xac.Options.ChannelId, out var message);
 
-                                entrypin.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
-                                entrypin.Message = message ?? new DiscordMessage { Id = xac.Options.MessageId, Discord = this.Discord };
+                                entrypin.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId };
+                                entrypin.Message = message ?? new DiscordMessage { Id = xac.Options.MessageId };
                             }
 
                             if (xac.TargetId.HasValue)
                             {
                                 dc.UserCache.TryGetValue(xac.TargetId.Value, out var user);
-                                entrypin.Target = user ?? new DiscordUser { Id = user.Id, Discord = this.Discord };
+                                entrypin.Target = user ?? new DiscordUser { Id = user.Id };
                             }
 
                             break;
@@ -1586,7 +1461,7 @@ namespace DSharpPlus.Entities
                             }
 
                             dc.UserCache.TryGetValue(xac.TargetId.Value, out var bot);
-                            (entry as DiscordAuditLogBotAddEntry).TargetBot = bot ?? new DiscordUser { Id = xac.TargetId.Value, Discord = this.Discord };
+                            (entry as DiscordAuditLogBotAddEntry).TargetBot = bot ?? new DiscordUser { Id = xac.TargetId.Value };
 
                             break;
                         }
@@ -1602,7 +1477,7 @@ namespace DSharpPlus.Entities
                         var moveentry = entry as DiscordAuditLogMemberMoveEntry;
 
                         moveentry.UserCount = xac.Options.Count;
-                        moveentry.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
+                        moveentry.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId };
                         break;
 
                     case AuditLogActionType.MemberDisconnect:
@@ -1965,37 +1840,5 @@ namespace DSharpPlus.Entities
         /// Messages from all members are scanned.
         /// </summary>
         AllMembers = 2
-    }
-
-    /// <summary>
-    /// Represents the formats for a guild widget.
-    /// </summary>
-    public enum WidgetType : int
-    {
-        /// <summary>
-        /// The widget is represented in shield format.
-        /// <para>This is the default widget type.</para>
-        /// </summary>
-        Shield = 0,
-
-        /// <summary>
-        /// The widget is represented as the first banner type.
-        /// </summary>
-        Banner1 = 1,
-
-        /// <summary>
-        /// The widget is represented as the second banner type.
-        /// </summary>
-        Banner2 = 2,
-
-        /// <summary>
-        /// The widget is represented as the third banner type.
-        /// </summary>
-        Banner3 = 3,
-
-        /// <summary>
-        /// The widget is represented in the fourth banner type.
-        /// </summary>
-        Banner4 = 4
     }
 }

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -955,8 +955,8 @@ namespace DSharpPlus.Entities
 
                                     entrygld.AfkChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = this.GetChannel(t1),
-                                        After = this.GetChannel(t2)
+                                        Before = this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id },
+                                        After = this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id }
                                     };
                                     break;
 
@@ -966,8 +966,8 @@ namespace DSharpPlus.Entities
 
                                     entrygld.EmbedChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = this.GetChannel(t1),
-                                        After = this.GetChannel(t2)
+                                        Before = this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id },
+                                        After = this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id }
                                     };
                                     break;
 
@@ -993,8 +993,8 @@ namespace DSharpPlus.Entities
 
                                     entrygld.SystemChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = this.GetChannel(t1),
-                                        After = this.GetChannel(t2)
+                                        Before = this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id },
+                                        After = this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id }
                                     };
                                     break;
 
@@ -1034,7 +1034,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.ChannelUpdate:
                         entry = new DiscordAuditLogChannelEntry
                         {
-                            Target = this.GetChannel(xac.TargetId.Value) ?? new DiscordChannel { Id = xac.TargetId.Value }
+                            Target = this.GetChannel(xac.TargetId.Value) ?? new DiscordChannel { Id = xac.TargetId.Value, Discord = this.Discord, GuildId = this.Id }
                         };
 
                         var entrychn = entry as DiscordAuditLogChannelEntry;
@@ -1181,7 +1181,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.Kick:
                         entry = new DiscordAuditLogKickEntry
                         {
-                            Target = amd.TryGetValue(xac.TargetId.Value, out var kickMember) ? kickMember : new DiscordMember { Id = xac.TargetId.Value }
+                            Target = amd.TryGetValue(xac.TargetId.Value, out var kickMember) ? kickMember : new DiscordMember { Id = xac.TargetId.Value, Discord = this.Discord, _guild_id = this.Id }
                         };
                         break;
 
@@ -1197,7 +1197,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.Unban:
                         entry = new DiscordAuditLogBanEntry
                         {
-                            Target = amd.TryGetValue(xac.TargetId.Value, out var unbanMember) ? unbanMember : new DiscordMember { Id = xac.TargetId.Value }
+                            Target = amd.TryGetValue(xac.TargetId.Value, out var unbanMember) ? unbanMember : new DiscordMember { Id = xac.TargetId.Value, Discord = this.Discord, _guild_id = this.Id }
                         };
                         break;
 
@@ -1205,7 +1205,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.MemberRoleUpdate:
                         entry = new DiscordAuditLogMemberUpdateEntry
                         {
-                            Target = amd.TryGetValue(xac.TargetId.Value, out var roleUpdMember) ? roleUpdMember : new DiscordMember { Id = xac.TargetId.Value }
+                            Target = amd.TryGetValue(xac.TargetId.Value, out var roleUpdMember) ? roleUpdMember : new DiscordMember { Id = xac.TargetId.Value, Discord = this.Discord, _guild_id = this.Id }
                         };
 
                         var entrymbu = entry as DiscordAuditLogMemberUpdateEntry;
@@ -1257,7 +1257,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.RoleUpdate:
                         entry = new DiscordAuditLogRoleUpdateEntry
                         {
-                            Target = this.GetRole(xac.TargetId.Value) ?? new DiscordRole { Id = xac.TargetId.Value }
+                            Target = this.GetRole(xac.TargetId.Value) ?? new DiscordRole { Id = xac.TargetId.Value, Discord = this.Discord }
                         };
 
                         var entryrol = entry as DiscordAuditLogRoleUpdateEntry;
@@ -1380,8 +1380,8 @@ namespace DSharpPlus.Entities
 
                                     entryinv.InviterChange = new PropertyChange<DiscordMember>
                                     {
-                                        Before = amd.TryGetValue(t1, out var propBeforeMember) ? propBeforeMember : null,
-                                        After = amd.TryGetValue(t2, out var propAfterMember) ? propAfterMember : null,
+                                        Before = amd.TryGetValue(t1, out var propBeforeMember) ? propBeforeMember : new DiscordMember { Id = t1, Discord = this.Discord, _guild_id = this.Id },
+                                        After = amd.TryGetValue(t2, out var propAfterMember) ? propAfterMember : new DiscordMember { Id = t1, Discord = this.Discord, _guild_id = this.Id },
                                     };
                                     break;
 
@@ -1391,8 +1391,8 @@ namespace DSharpPlus.Entities
 
                                     entryinv.ChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = p1 ? this.GetChannel(t1) : null,
-                                        After = p2 ? this.GetChannel(t2) : null
+                                        Before = p1 ? this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null,
+                                        After = p2 ? this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null
                                     };
 
                                     var ch = entryinv.ChannelChange.Before ?? entryinv.ChannelChange.After;
@@ -1442,7 +1442,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.WebhookUpdate:
                         entry = new DiscordAuditLogWebhookEntry
                         {
-                            Target = ahd.TryGetValue(xac.TargetId.Value, out var webhook) ? webhook : new DiscordWebhook { Id = xac.TargetId.Value }
+                            Target = ahd.TryGetValue(xac.TargetId.Value, out var webhook) ? webhook : new DiscordWebhook { Id = xac.TargetId.Value, Discord = this.Discord }
                         };
 
                         var entrywhk = entry as DiscordAuditLogWebhookEntry;
@@ -1464,8 +1464,8 @@ namespace DSharpPlus.Entities
 
                                     entrywhk.ChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = p1 ? this.GetChannel(t1) : null,
-                                        After = p2 ? this.GetChannel(t2) : null
+                                        Before = p1 ? this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null,
+                                        After = p2 ? this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null
                                     };
                                     break;
 
@@ -1500,7 +1500,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.EmojiUpdate:
                         entry = new DiscordAuditLogEmojiEntry
                         {
-                            Target = this._emojis.TryGetValue(xac.TargetId.Value, out var target) ? target : new DiscordEmoji { Id = xac.TargetId.Value }
+                            Target = this._emojis.TryGetValue(xac.TargetId.Value, out var target) ? target : new DiscordEmoji { Id = xac.TargetId.Value, Discord = this.Discord }
                         };
 
                         var entryemo = entry as DiscordAuditLogEmojiEntry;
@@ -1532,7 +1532,7 @@ namespace DSharpPlus.Entities
 
                             if (xac.Options != null)
                             {
-                                entrymsg.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId };
+                                entrymsg.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
                                 entrymsg.MessageCount = xac.Options.Count;
                             }
 
@@ -1563,14 +1563,14 @@ namespace DSharpPlus.Entities
                             {
                                 dc.MessageCache.TryGet(x => x.Id == xac.Options.MessageId && x.ChannelId == xac.Options.ChannelId, out var message);
 
-                                entrypin.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId };
-                                entrypin.Message = message ?? new DiscordMessage { Id = xac.Options.MessageId };
+                                entrypin.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
+                                entrypin.Message = message ?? new DiscordMessage { Id = xac.Options.MessageId, Discord = this.Discord };
                             }
 
                             if (xac.TargetId.HasValue)
                             {
                                 dc.UserCache.TryGetValue(xac.TargetId.Value, out var user);
-                                entrypin.Target = user ?? new DiscordUser { Id = user.Id };
+                                entrypin.Target = user ?? new DiscordUser { Id = user.Id, Discord = this.Discord };
                             }
 
                             break;
@@ -1586,7 +1586,7 @@ namespace DSharpPlus.Entities
                             }
 
                             dc.UserCache.TryGetValue(xac.TargetId.Value, out var bot);
-                            (entry as DiscordAuditLogBotAddEntry).TargetBot = bot ?? new DiscordUser { Id = xac.TargetId.Value };
+                            (entry as DiscordAuditLogBotAddEntry).TargetBot = bot ?? new DiscordUser { Id = xac.TargetId.Value, Discord = this.Discord };
 
                             break;
                         }
@@ -1602,7 +1602,7 @@ namespace DSharpPlus.Entities
                         var moveentry = entry as DiscordAuditLogMemberMoveEntry;
 
                         moveentry.UserCount = xac.Options.Count;
-                        moveentry.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId };
+                        moveentry.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
                         break;
 
                     case AuditLogActionType.MemberDisconnect:

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -240,7 +240,7 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMessage> SendMessageAsync(string content = null, bool is_tts = false, DiscordEmbed embed = null)
         {
             if (this.IsBot && this.Discord.CurrentUser.IsBot)
-                throw new ArgumentException("Bots cannot DM each other");
+                throw new ArgumentException("Bots cannot DM each other.");
             
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
             return await chn.SendMessageAsync(content, is_tts, embed).ConfigureAwait(false);
@@ -258,7 +258,7 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMessage> SendFileAsync(string fileName, Stream fileData, string content = null, bool is_tts = false, DiscordEmbed embed = null)
         {
             if (this.IsBot && this.Discord.CurrentUser.IsBot)
-                throw new ArgumentException("Bots cannot DM each other");
+                throw new ArgumentException("Bots cannot DM each other.");
             
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
             return await chn.SendFileAsync(fileName, fileData, content, is_tts, embed).ConfigureAwait(false);
@@ -275,7 +275,7 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMessage> SendFileAsync(FileStream fileData, string content = null, bool is_tts = false, DiscordEmbed embed = null)
         {
             if (this.IsBot && this.Discord.CurrentUser.IsBot)
-                throw new ArgumentException("Bots cannot DM each other");
+                throw new ArgumentException("Bots cannot DM each other.");
 
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
             return await chn.SendFileAsync(fileData, content, is_tts, embed).ConfigureAwait(false);
@@ -292,7 +292,7 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMessage> SendFileAsync(string filePath, string content = null, bool is_tts = false, DiscordEmbed embed = null)
         {
             if (this.IsBot && this.Discord.CurrentUser.IsBot)
-                throw new ArgumentException("Bots cannot DM each other");
+                throw new ArgumentException("Bots cannot DM each other.");
 
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
             return await chn.SendFileAsync(filePath, content, is_tts, embed).ConfigureAwait(false);
@@ -309,7 +309,7 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMessage> SendMultipleFilesAsync(Dictionary<string, Stream> files, string content = null, bool is_tts = false, DiscordEmbed embed = null)
         {
             if (this.IsBot && this.Discord.CurrentUser.IsBot)
-                throw new ArgumentException("Bots cannot DM each other");
+                throw new ArgumentException("Bots cannot DM each other.");
 
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
             return await chn.SendMultipleFilesAsync(files, content, is_tts, embed).ConfigureAwait(false);

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -359,14 +359,14 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <returns></returns>
         public Task PinAsync() 
-            => this.Discord.ApiClient.PinMessageAsync(this.ChannelId, Id);
+            => this.Discord.ApiClient.PinMessageAsync(this.ChannelId, this.Id);
 
         /// <summary>
         /// Unpins the message in its channel.
         /// </summary>
         /// <returns></returns>
         public Task UnpinAsync() 
-            => this.Discord.ApiClient.UnpinMessageAsync(this.ChannelId, Id);
+            => this.Discord.ApiClient.UnpinMessageAsync(this.ChannelId, this.Id);
 
         /// <summary>
         /// Responds to the message.
@@ -387,7 +387,7 @@ namespace DSharpPlus.Entities
         /// <param name="tts">Whether the message is to be read using TTS.</param>
         /// <param name="embed">Embed to attach to the message.</param>
         /// <returns>The sent message.</returns>
-        public Task<DiscordMessage> RespondWithFileAsync(string fileName, Stream fileData, string content = null, bool tts = false, DiscordEmbed embed = null) 
+        public Task<DiscordMessage> RespondWithFileAsync(string fileName, Stream fileData, string content = null, bool tts = false, DiscordEmbed embed = null)
             => this.Discord.ApiClient.UploadFileAsync(this.ChannelId, fileData, fileName, content, tts, embed);
 
         /// <summary>
@@ -398,7 +398,7 @@ namespace DSharpPlus.Entities
         /// <param name="tts">Whether the message is to be read using TTS.</param>
         /// <param name="embed">Embed to attach to the message.</param>
         /// <returns>The sent message.</returns>
-        public Task<DiscordMessage> RespondWithFileAsync(FileStream fileData, string content = null, bool tts = false, DiscordEmbed embed = null) 
+        public Task<DiscordMessage> RespondWithFileAsync(FileStream fileData, string content = null, bool tts = false, DiscordEmbed embed = null)
             => this.Discord.ApiClient.UploadFileAsync(this.ChannelId, fileData, Path.GetFileName(fileData.Name), content, tts, embed);
 
         /// <summary>
@@ -423,8 +423,13 @@ namespace DSharpPlus.Entities
         /// <param name="tts">Whether the message is to be read using TTS.</param>
         /// <param name="embed">Embed to attach to the message.</param>
         /// <returns>The sent message.</returns>
-        public Task<DiscordMessage> RespondWithFilesAsync(Dictionary<string, Stream> files, string content = null, bool tts = false, DiscordEmbed embed = null) 
-            => this.Discord.ApiClient.UploadFilesAsync(ChannelId, files, content, tts, embed);
+        public Task<DiscordMessage> RespondWithFilesAsync(Dictionary<string, Stream> files, string content = null, bool tts = false, DiscordEmbed embed = null)
+        {
+            if (files.Count > 10)
+                throw new ArgumentException("Cannot send more than 10 files with a single message.");
+
+            return this.Discord.ApiClient.UploadFilesAsync(this.ChannelId, files, content, tts, embed);
+        }
 
         /// <summary>
         /// Creates a reaction to this message
@@ -468,7 +473,7 @@ namespace DSharpPlus.Entities
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
         public Task DeleteAllReactionsAsync(string reason = null) 
-            => this.Discord.ApiClient.DeleteAllReactionsAsync(this.Channel.Id, this.Id, reason);
+            => this.Discord.ApiClient.DeleteAllReactionsAsync(this.ChannelId, this.Id, reason);
         
         private async Task<IReadOnlyList<DiscordUser>> GetReactionsInternalAsync(DiscordEmoji emoji, int limit = 25, ulong? after = null)
         {

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -457,7 +457,6 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="emoji">Emoji to react with.</param>
         /// <param name="limit">Limit of users to fetch.</param>
-        /// <param name="before">Fetch users before this user's id.</param>
         /// <param name="after">Fetch users after this user's id.</param>
         /// <returns></returns>
         public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(DiscordEmoji emoji, int limit = 25, ulong? after = null) 

--- a/DSharpPlus/Enums/MessageFlags.cs
+++ b/DSharpPlus/Enums/MessageFlags.cs
@@ -7,10 +7,10 @@ namespace DSharpPlus.Enums
         /// <summary>
         /// Calculates whether these message flags contain a specific flag.
         /// </summary>
-        /// <param name="f">The existing bitwise flags.</param>
+        /// <param name="baseFlags">The existing flags.</param>
         /// <param name="flag">The flags to search for.</param>
         /// <returns></returns>
-        public static bool HasMessageFlag(this MessageFlags f, MessageFlags flag) => (f & flag) == flag;
+        public static bool HasMessageFlag(this MessageFlags baseFlags, MessageFlags flag) => (baseFlags & flag) == flag;
     }
 
     /// <summary>

--- a/DSharpPlus/Enums/PremiumTier.cs
+++ b/DSharpPlus/Enums/PremiumTier.cs
@@ -16,12 +16,12 @@
         Tier_1 = 1,
 
         /// <summary>
-        /// Indicates that this server was boosted ten times.
+        /// Indicates that this server was boosted fifteen times.
         /// </summary>
         Tier_2 = 2,
 
         /// <summary>
-        /// Indicates that this server was boosted fifty times.
+        /// Indicates that this server was boosted thirty times.
         /// </summary>
         Tier_3 = 3,
 

--- a/DSharpPlus/Enums/SystemChannelFlags.cs
+++ b/DSharpPlus/Enums/SystemChannelFlags.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace DSharpPlus.Enums
+{
+    public static class SystemChannelFlagsExtension
+    {
+        /// <summary>
+        /// Calculates whether these system channel flags contain a specific flag.
+        /// </summary>
+        /// <param name="baseFlags">The existing flags.</param>
+        /// <param name="flag">The flag to search for.</param>
+        /// <returns></returns>
+        public static bool HasSystemChannelFlag(this SystemChannelFlags baseFlags, SystemChannelFlags flag) => (baseFlags & flag) == flag;
+    }
+
+    /// <summary>
+    /// Represents settings for a guild's system channel.
+    /// </summary>
+    [Flags]
+    public enum SystemChannelFlags
+    {
+        /// <summary>
+        /// Member join messages are disabled.
+        /// </summary>
+        SuppressJoinNotifications = 1 << 0,
+
+        /// <summary>
+        /// Server boost messages are disabled.
+        /// </summary>
+        SuppressPremiumSubscriptions = 1 << 1
+    }
+}

--- a/DSharpPlus/EventArgs/InviteCreateEventArgs.cs
+++ b/DSharpPlus/EventArgs/InviteCreateEventArgs.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs
+{
+    /// <summary>
+    /// Represents arguments for <see cref="DiscordClient.InviteCreated"/>
+    /// </summary>
+    public class InviteCreateEventArgs : DiscordEventArgs
+    {
+        /// <summary>
+        /// Gets the guild that created the invite.
+        /// </summary>
+        public DiscordGuild Guild { get; internal set; }
+
+        /// <summary>
+        /// Gets the channel that the invite is for.
+        /// </summary>
+        public DiscordChannel Channel { get; internal set; }
+
+        /// <summary>
+        /// Gets the created invite.
+        /// </summary>
+        public DiscordInvite Invite { get; internal set; }
+
+        internal InviteCreateEventArgs(DiscordClient client) : base(client) { }
+    }
+}

--- a/DSharpPlus/EventArgs/InviteCreateEventArgs.cs
+++ b/DSharpPlus/EventArgs/InviteCreateEventArgs.cs
@@ -1,12 +1,11 @@
-﻿using Newtonsoft.Json;
-using DSharpPlus.Entities;
+﻿using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {
     /// <summary>
     /// Represents arguments for <see cref="DiscordClient.InviteCreated"/>
     /// </summary>
-    public class InviteCreateEventArgs : DiscordEventArgs
+    public sealed class InviteCreateEventArgs : DiscordEventArgs
     {
         /// <summary>
         /// Gets the guild that created the invite.

--- a/DSharpPlus/EventArgs/InviteDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/InviteDeleteEventArgs.cs
@@ -1,12 +1,11 @@
-﻿using Newtonsoft.Json;
-using DSharpPlus.Entities;
+﻿using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {
     /// <summary>
     /// Represents arguments for <see cref="DiscordClient.InviteDeleted"/>
     /// </summary>
-    public class InviteDeleteEventArgs : DiscordEventArgs
+    public sealed class InviteDeleteEventArgs : DiscordEventArgs
     {
         /// <summary>
         /// Gets the guild that deleted the invite.

--- a/DSharpPlus/EventArgs/InviteDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/InviteDeleteEventArgs.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs
+{
+    /// <summary>
+    /// Represents arguments for <see cref="DiscordClient.InviteDeleted"/>
+    /// </summary>
+    public class InviteDeleteEventArgs : DiscordEventArgs
+    {
+        /// <summary>
+        /// Gets the guild that deleted the invite.
+        /// </summary>
+        public DiscordGuild Guild { get; internal set; }
+
+        /// <summary>
+        /// Gets the channel that the invite was for.
+        /// </summary>
+        public DiscordChannel Channel { get; internal set; }
+
+        /// <summary>
+        /// Gets the invite that was deleted.
+        /// </summary>
+        public DiscordInvite Invite { get; internal set; }
+
+        internal InviteDeleteEventArgs(DiscordClient client) : base(client) { }
+    }
+}

--- a/DSharpPlus/EventArgs/MessageReactionRemoveEmojiEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageReactionRemoveEmojiEventArgs.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs
+{
+    /// <summary>
+    /// Represents arguments for <see cref="DiscordClient.MessageReactionRemovedEmoji"/>
+    /// </summary>
+    public class MessageReactionRemoveEmojiEventArgs : DiscordEventArgs
+    {
+        /// <summary>
+        /// Gets the channel the removed reactions were in.
+        /// </summary>
+        public DiscordChannel Channel { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild the removed reactions were in.
+        /// </summary>
+        public DiscordGuild Guild { get; internal set; }
+
+        /// <summary>
+        /// Gets the message that had the removed reactions.
+        /// </summary>
+        public DiscordMessage Message { get; internal set; }
+
+        /// <summary>
+        /// Gets the emoji of the reaction that was removed.
+        /// </summary>
+        public DiscordEmoji Emoji { get; internal set; }
+
+        internal MessageReactionRemoveEmojiEventArgs(DiscordClient client) : base(client) { }
+    }
+}

--- a/DSharpPlus/EventArgs/MessageReactionRemoveEmojiEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageReactionRemoveEmojiEventArgs.cs
@@ -1,12 +1,11 @@
-﻿using Newtonsoft.Json;
-using DSharpPlus.Entities;
+﻿using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {
     /// <summary>
     /// Represents arguments for <see cref="DiscordClient.MessageReactionRemovedEmoji"/>
     /// </summary>
-    public class MessageReactionRemoveEmojiEventArgs : DiscordEventArgs
+    public sealed class MessageReactionRemoveEmojiEventArgs : DiscordEventArgs
     {
         /// <summary>
         /// Gets the channel the removed reactions were in.

--- a/DSharpPlus/EventArgs/WebSocketMessageEventArgs.cs
+++ b/DSharpPlus/EventArgs/WebSocketMessageEventArgs.cs
@@ -1,15 +1,48 @@
 ﻿namespace DSharpPlus.EventArgs
 {
     /// <summary>
-    /// Represents arguments for raw socket message events.
+    /// Represents base class for raw socket message event arguments.
     /// </summary>
-    public class SocketMessageEventArgs : AsyncEventArgs
+    public abstract class SocketMessageEventArgs : AsyncEventArgs
+    { }
+
+    /// <summary>
+    /// Represents arguments for text message websocket event.
+    /// </summary>
+    public sealed class SocketTextMessageEventArgs : SocketMessageEventArgs
     {
         /// <summary>
-        /// Gets the received message.
+        /// Gets the received message string.
         /// </summary>
-        public string Message { get; internal set; }
+        public string Message { get; }
 
-        public SocketMessageEventArgs() { }
+        /// <summary>
+        /// Creates a new instance of text message event arguments.
+        /// </summary>
+        /// <param name="message">Received message string.</param>
+        public SocketTextMessageEventArgs(string message)
+        {
+            this.Message = message;
+        }
+    }
+
+    /// <summary>
+    /// Represents arguments for binary message websocket event.
+    /// </summary>
+    public sealed class SocketBinaryMessageEventArgs : SocketMessageEventArgs
+    {
+        /// <summary>
+        /// Gets the received message bytes.
+        /// </summary>
+        public byte[] Message { get; }
+
+        /// <summary>
+        /// Creates a new instance of binary message event arguments.
+        /// </summary>
+        /// <param name="message">Received message bytes.</param>
+        public SocketBinaryMessageEventArgs(byte[] message)
+        {
+            this.Message = message;
+        }
     }
 }

--- a/DSharpPlus/Exceptions/RequestSizeException.cs
+++ b/DSharpPlus/Exceptions/RequestSizeException.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Newtonsoft.Json.Linq;
+using DSharpPlus.Net;
+
+namespace DSharpPlus.Exceptions
+{
+    /// <summary>
+    /// Represents an exception thrown when the request sent to Discord is too large.
+    /// </summary>
+    public class RequestSizeException : Exception
+    {
+        /// <summary>
+        /// Gets the request that caused the exception.
+        /// </summary>
+        public BaseRestRequest WebRequest { get; internal set; }
+
+        /// <summary>
+        /// Gets the response to the request.
+        /// </summary>
+        public RestResponse WebResponse { get; internal set; }
+
+        /// <summary>
+        /// Gets the JSON received.
+        /// </summary>
+        public string JsonMessage { get; internal set; }
+
+        internal RequestSizeException(BaseRestRequest request, RestResponse response) : base($"Request entity too large: {response.ResponseCode}. Make sure the data sent is within Discord's upload limit.")
+        {
+            this.WebRequest = request;
+            this.WebResponse = response;
+
+            try
+            {
+                JObject j = JObject.Parse(response.Response);
+
+                if (j["message"] != null)
+                    JsonMessage = j["message"].ToString();
+            }
+            catch (Exception) { }
+        }
+    }
+}

--- a/DSharpPlus/ImageTool.cs
+++ b/DSharpPlus/ImageTool.cs
@@ -57,7 +57,7 @@ namespace DSharpPlus
             if (this._ifcache != ImageFormat.Unknown)
                 return this._ifcache;
 
-            using (var br = new BinaryReader(this.SourceStream, new UTF8Encoding(false), true))
+            using (var br = new BinaryReader(this.SourceStream, Utilities.UTF8, true))
             {
                 var bgn64 = br.ReadUInt64();
                 if (bgn64 == PNG_MAGIC)

--- a/DSharpPlus/Net/Abstractions/TransportActivity.cs
+++ b/DSharpPlus/Net/Abstractions/TransportActivity.cs
@@ -119,14 +119,10 @@ namespace DSharpPlus.Net.Abstractions
         }
 
         public bool IsRichPresence()
-        {
-            return this.Details != null || this.State != null || this.ApplicationId != null || this.Instance != null || this.Party != null || this.Assets != null || this.Secrets != null || this.Timestamps != null;
-        }
+            => this.Details != null || this.State != null || this.ApplicationId != null || this.Instance != null || this.Party != null || this.Assets != null || this.Secrets != null || this.Timestamps != null;
 
         public bool IsCustomStatus()
-        {
-            return this.Name == "Custom Status";
-        }
+            => this.Name == "Custom Status";
 
         /// <summary>
         /// Represents information about assets attached to a rich presence.

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1756,6 +1756,15 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers, ratelimitWaitOverride: 0.26);
         }
+
+        internal Task DeleteReactionsEmojiAsync(ulong channel_id, ulong message_id, string emoji)
+        {
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}/:emoji";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id, emoji }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, ratelimitWaitOverride: 0.26);
+        }
         #endregion
 
         #region Emoji

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -536,7 +536,7 @@ namespace DSharpPlus.Net
             if (embed == null)
             {
                 if (content == null)
-                    throw new ArgumentException("You must specify content or an embed.");
+                    throw new ArgumentException("You must specify message content or an embed.");
 
                 if (content == "")
                     throw new ArgumentException("Message content must not be empty.");

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -401,6 +401,19 @@ namespace DSharpPlus.Net
 
             return audit_log_data_raw;
         }
+
+        internal async Task<DiscordInvite> GetGuildVanityUrlAsync(ulong guild_id)
+        {
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.VANITY_URL}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
+
+            var invite = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
+
+            return invite;
+        }
         #endregion
 
         #region Channel

--- a/DSharpPlus/Net/Endpoints.cs
+++ b/DSharpPlus/Net/Endpoints.cs
@@ -44,5 +44,7 @@
         public const string ASSETS = "/assets";
         public const string EMOJIS = "/emojis";
         public const string SUPPRESS_EMBEDS = "/suppress-embeds";
+        public const string VANITY_URL = "/vanity-url";
+        public const string WIDGET_PNG = "/widget.png";
     }
 }

--- a/DSharpPlus/Net/Models/GuildEditModel.cs
+++ b/DSharpPlus/Net/Models/GuildEditModel.cs
@@ -6,54 +6,80 @@ namespace DSharpPlus.Net.Models
     public class GuildEditModel : BaseEditModel
     {
         /// <summary>
-        /// New guild name
+        /// The new guild name.
         /// </summary>
         public Optional<string> Name { internal get; set; }
+
         /// <summary>
-        /// New guild voice region
+        /// The new guild voice region.
         /// </summary>
         public Optional<DiscordVoiceRegion> Region { internal get; set; }
+
         /// <summary>
-        /// New guild icon
+        /// The new guild icon.
         /// </summary>
         public Optional<Stream> Icon { internal get; set; }
+
         /// <summary>
-        /// New guild verification level
+        /// The new guild verification level.
         /// </summary>
         public Optional<VerificationLevel> VerificationLevel { internal get; set; }
+
         /// <summary>
-        /// New guild default message notification level
+        /// The new guild default message notification level.
         /// </summary>
         public Optional<DefaultMessageNotifications> DefaultMessageNotifications { internal get; set; }
+
         /// <summary>
-        /// New guild MFA level
+        /// The new guild MFA level.
         /// </summary>
         public Optional<MfaLevel> MfaLevel { internal get; set; }
+
         /// <summary>
-        /// New guild explicit content filter level
+        /// The new guild explicit content filter level.
         /// </summary>
         public Optional<ExplicitContentFilter> ExplicitContentFilter { internal get; set; }
+
         /// <summary>
-        /// New AFK voice channel
+        /// The new AFK voice channel.
         /// </summary>
         public Optional<DiscordChannel> AfkChannel { internal get; set; }
+
         /// <summary>
-        /// New AFK timeout time in seconds
+        /// The new AFK timeout time in seconds.
         /// </summary>
         public Optional<int> AfkTimeout { internal get; set; }
+
         /// <summary>
-        /// New guild owner
+        /// The new guild owner.
         /// </summary>
         public Optional<DiscordMember> Owner { internal get; set; }
+
         /// <summary>
-        /// New guild splash
+        /// The new guild splash.
         /// </summary>
         public Optional<Stream> Splash { internal get; set; }
+
         /// <summary>
-        /// New guild system channel
+        /// The new guild system channel.
         /// </summary>
         public Optional<DiscordChannel> SystemChannel { internal get; set; }
+
+        /// <summary>
+        /// The new guild rules channel.
+        /// </summary>
+        public Optional<DiscordChannel> RulesChannel { internal get; set; }
         
+        /// <summary>
+        /// The new guild public updates channel.
+        /// </summary>
+        public Optional<DiscordChannel> PublicUpdatesChannel { internal get; set; }
+
+        /// <summary>
+        /// The new guild preferred locale.
+        /// </summary>
+        public Optional<string> PreferredLocale { internal get; set; }
+
         internal GuildEditModel()
         {
 

--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -20,7 +20,6 @@ namespace DSharpPlus.Net
     /// </summary>
     internal sealed class RestClient
     {
-        private static UTF8Encoding UTF8 { get; } = new UTF8Encoding(false);
         private static Regex RouteArgumentRegex { get; } = new Regex(@":([a-z_]+)");
 
         private BaseDiscordClient Discord { get; }
@@ -147,7 +146,7 @@ namespace DSharpPlus.Net
                     var res = await HttpClient.SendAsync(req, CancellationToken.None).ConfigureAwait(false);
 
                     var bts = await res.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
-                    var txt = UTF8.GetString(bts, 0, bts.Length);
+                    var txt = Utilities.UTF8.GetString(bts, 0, bts.Length);
 
                     response.Headers = res.Headers.ToDictionary(xh => xh.Key, xh => string.Join("\n", xh.Value));
                     response.Response = txt;

--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -179,6 +179,10 @@ namespace DSharpPlus.Net
                         ex = new NotFoundException(request, response);
                         break;
 
+                    case 413:
+                        ex = new RequestSizeException(request, response);
+                        break;
+
                     case 429:
                         ex = new RateLimitException(request, response);
 

--- a/DSharpPlus/Net/WebSocket/BaseWebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/BaseWebSocketClient.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.IO.Compression;
 using System.Net;
 using System.Threading.Tasks;
 using DSharpPlus.EventArgs;
@@ -13,107 +11,75 @@ namespace DSharpPlus.Net.WebSocket
     /// </summary>
     /// <param name="proxy">Proxy settings to use for the new WebSocket client instance.</param>
     /// <returns>Constructed WebSocket client implementation.</returns>
-    public delegate BaseWebSocketClient WebSocketClientFactoryDelegate(IWebProxy proxy);
+    public delegate IWebSocketClient WebSocketClientFactoryDelegate(IWebProxy proxy);
 
     /// <summary>
     /// Represents a base abstraction for all WebSocket client implementations.
     /// </summary>
-    public abstract class BaseWebSocketClient : IDisposable
+    public interface IWebSocketClient : IDisposable
     {
-        /// <summary>
-        /// Gets the ZLib stream suffix (0xFFFF) to detect stream-compressed messages.
-        /// </summary>
-        protected const ushort ZLIB_STREAM_SUFFIX = 0xFFFF;
-
         /// <summary>
         /// Gets the proxy settings for this client.
         /// </summary>
-        public IWebProxy Proxy { get; }
+        IWebProxy Proxy { get; }
 
         /// <summary>
-        /// Gets the stream decompressor for stream compression.
+        /// Gets the collection of default headers to send when connecting to the remote endpoint.
         /// </summary>
-        protected DeflateStream StreamDecompressor { get; set; }
+        IReadOnlyDictionary<string, string> DefaultHeaders { get; }
 
         /// <summary>
-        /// Gets the target stream for the stream decompressor.
+        /// Connects to a specified remote WebSocket endpoint.
         /// </summary>
-        protected MemoryStream DecompressedStream { get; set; }
-
-        /// <summary>
-        /// Gets the source stream for the stream decompressor.
-        /// </summary>
-        protected MemoryStream CompressedStream { get; set; }
-
-        /// <summary>
-        /// Creates a new WebSocket client.
-        /// </summary>
-        public BaseWebSocketClient(IWebProxy proxy)
-        {
-            this.Proxy = proxy;
-        }
-
-        /// <summary>
-        /// Connects to the WebSocket server.
-        /// </summary>
-        /// <param name="uri">The URI of the WebSocket server.</param>
-        /// <param name="customHeaders">Custom headers to send with the request.</param>
+        /// <param name="uri">The URI of the WebSocket endpoint.</param>
         /// <returns></returns>
-        public abstract Task ConnectAsync(Uri uri, IReadOnlyDictionary<string, string> customHeaders = null);
+        Task ConnectAsync(Uri uri);
 
         /// <summary>
         /// Disconnects the WebSocket connection.
         /// </summary>
-        /// <param name="e">Disconect event arguments.</param>
         /// <returns></returns>
-        public abstract Task DisconnectAsync(SocketCloseEventArgs e);
+        Task DisconnectAsync();
 
         /// <summary>
         /// Send a message to the WebSocket server.
         /// </summary>
         /// <param name="message">The message to send.</param>
-        public abstract void SendMessage(string message);
+        Task SendMessageAsync(string message);
 
         /// <summary>
-        /// Set the Action to call when the connection has been established.
+        /// Adds a header to the default header collection.
         /// </summary>
-        /// <returns></returns>
-        protected abstract Task OnConnectedAsync();
+        /// <param name="name">Name of the header to add.</param>
+        /// <param name="value">Value of the header to add.</param>
+        /// <returns>Whether the operation succeeded.</returns>
+        bool AddDefaultHeader(string name, string value);
 
         /// <summary>
-        /// Set the Action to call when the connection has been terminated.
+        /// Removes a header from the default header collection.
         /// </summary>
-        /// <returns></returns>
-        protected abstract Task OnDisconnectedAsync(SocketCloseEventArgs e);
-
-        /// <summary>
-        /// Disposes this socket client.
-        /// </summary>
-        public virtual void Dispose()
-        {
-            this.StreamDecompressor?.Dispose();
-            this.CompressedStream?.Dispose();
-            this.DecompressedStream?.Dispose();
-        }
+        /// <param name="name">Name of the header to remove.</param>
+        /// <returns>Whether the operation succeeded.</returns>
+        bool RemoveDefaultHeader(string name);
 
         /// <summary>
         /// Triggered when the client connects successfully.
         /// </summary>
-        public abstract event AsyncEventHandler Connected;
+        event AsyncEventHandler Connected;
 
         /// <summary>
         /// Triggered when the client is disconnected.
         /// </summary>
-        public abstract event AsyncEventHandler<SocketCloseEventArgs> Disconnected;
+        event AsyncEventHandler<SocketCloseEventArgs> Disconnected;
 
         /// <summary>
         /// Triggered when the client receives a message from the remote party.
         /// </summary>
-        public abstract event AsyncEventHandler<SocketMessageEventArgs> MessageReceived;
+        event AsyncEventHandler<SocketMessageEventArgs> MessageReceived;
 
         /// <summary>
         /// Triggered when an error occurs in the client.
         /// </summary>
-        public abstract event AsyncEventHandler<SocketErrorEventArgs> Errored;
+        event AsyncEventHandler<SocketErrorEventArgs> ExceptionThrown;
     }
 }

--- a/DSharpPlus/Net/WebSocket/PayloadDecompressor.cs
+++ b/DSharpPlus/Net/WebSocket/PayloadDecompressor.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.IO.Compression;
+
+namespace DSharpPlus.Net.WebSocket
+{
+    internal sealed class PayloadDecompressor : IDisposable
+    {
+        private const uint ZlibFlush = 0x0000FFFF;
+        private const byte ZlibPrefix = 0x78;
+
+        public GatewayCompressionLevel CompressionLevel { get; }
+
+        private MemoryStream CompressedStream { get; }
+        private DeflateStream DecompressorStream { get; }
+
+        public PayloadDecompressor(GatewayCompressionLevel compressionLevel)
+        {
+            if (compressionLevel == GatewayCompressionLevel.None)
+                throw new InvalidOperationException("Decompressor requires a valid compression mode.");
+
+            this.CompressionLevel = compressionLevel;
+            this.CompressedStream = new MemoryStream();
+            if (this.CompressionLevel == GatewayCompressionLevel.Stream)
+                this.DecompressorStream = new DeflateStream(this.CompressedStream, CompressionMode.Decompress);
+        }
+
+        public bool TryDecompress(ArraySegment<byte> compressed, MemoryStream decompressed)
+        {
+            var zlib = this.CompressionLevel == GatewayCompressionLevel.Stream
+                ? this.DecompressorStream
+                : new DeflateStream(this.CompressedStream, CompressionMode.Decompress, true);
+
+            if (compressed.Array[0] == ZlibPrefix)
+                this.CompressedStream.Write(compressed.Array, compressed.Offset + 2, compressed.Count - 2);
+            else
+                this.CompressedStream.Write(compressed.Array, compressed.Offset, compressed.Count);
+
+            this.CompressedStream.Flush();
+            this.CompressedStream.Position = 0;
+
+            var cspan = compressed.AsSpan();
+            var suffix = BinaryPrimitives.ReadUInt32BigEndian(cspan.Slice(cspan.Length - 4));
+            if (this.CompressionLevel == GatewayCompressionLevel.Stream && suffix != ZlibFlush)
+            {
+                if (this.CompressionLevel == GatewayCompressionLevel.Payload)
+                    zlib.Dispose();
+
+                return false;
+            }
+
+            try
+            {
+                zlib.CopyTo(decompressed);
+                return true;
+            }
+            catch { return false; }
+            finally
+            {
+                this.CompressedStream.Position = 0;
+                this.CompressedStream.SetLength(0);
+
+                if (this.CompressionLevel == GatewayCompressionLevel.Payload)
+                    zlib.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            this.DecompressorStream?.Dispose();
+            this.CompressedStream.Dispose();
+        }
+    }
+}

--- a/DSharpPlus/Net/WebSocket/WebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient.cs
@@ -114,16 +114,28 @@ namespace DSharpPlus.Net.WebSocket
             try
             {
                 // Cancel all running tasks
-                this._socketTokenSource.Cancel();
-                this._receiverTokenSource.Cancel();
-                this._socketTokenSource.Dispose();
-                this._receiverTokenSource.Dispose();
+                if (this._socketTokenSource != null)
+                {
+                    this._socketTokenSource.Cancel();
+                    this._socketTokenSource.Dispose();
+                }
+
+                if (this._receiverTokenSource != null)
+                {
+                    this._receiverTokenSource.Cancel();
+                    this._receiverTokenSource.Dispose();
+                }
 
                 this._isClientClose = true;
-                await this._ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None).ConfigureAwait(false);
-                await this._receiverTask.ConfigureAwait(false); // Ensure that receving completed
+
+                if (this._ws != null)
+                    await this._ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None).ConfigureAwait(false);
+
+                if (this._receiverTask != null)
+                    await this._receiverTask.ConfigureAwait(false); // Ensure that receving completed
             }
             catch { }
+
             finally
             {
                 this._senderLock.Release();

--- a/DSharpPlus/Net/WebSocket/WebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
-using System.IO.Compression;
 using System.Net;
 using System.Net.WebSockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using DSharpPlus.EventArgs;
@@ -17,283 +15,253 @@ namespace DSharpPlus.Net.WebSocket
     /// <summary>
     /// The default, native-based WebSocket client implementation.
     /// </summary>
-    public class WebSocketClient : BaseWebSocketClient
+    public class WebSocketClient : IWebSocketClient
     {
-        private const int BUFFER_SIZE = 32768;
+        private const int OutgoingChunkSize = 8192; // 8 KiB
+        private const int IncomingChunkSize = 32768; // 32 KiB
 
-        private static UTF8Encoding UTF8 { get; } = new UTF8Encoding(false);
+        /// <inheritdoc />
+        public IWebProxy Proxy { get; }
 
-        private ConcurrentQueue<string> SocketMessageQueue { get; set; }
-        private CancellationTokenSource TokenSource { get; set; }
-        private CancellationToken Token 
-            => this.TokenSource.Token;
+        /// <inheritdoc />
+        public IReadOnlyDictionary<string, string> DefaultHeaders { get; }
+        private Dictionary<string, string> _defaultHeaders;
 
-        private ClientWebSocket Socket { get; set; }
-        private Task WsListener { get; set; }
+        private Task _receiverTask;
+        private CancellationTokenSource _receiverTokenSource;
+        private CancellationToken _receiverToken;
+        private readonly SemaphoreSlim _senderLock;
+
+        private CancellationTokenSource _socketTokenSource;
+        private CancellationToken _socketToken;
+        private ClientWebSocket _ws;
+
+        private volatile bool _isClientClose = false;
+        private volatile bool _isDisposed = false;
+
         private Task SocketQueueManager { get; set; }
-
-        private volatile bool _closeRequested = false;
 
         /// <summary>
         /// Instantiates a new WebSocket client with specified proxy settings.
         /// </summary>
         /// <param name="proxy">Proxy settings for the client.</param>
-        public WebSocketClient(IWebProxy proxy)
-            : base(proxy)
+        private WebSocketClient(IWebProxy proxy)
         {
             this._connected = new AsyncEvent(this.EventErrorHandler, "WS_CONNECT");
             this._disconnected = new AsyncEvent<SocketCloseEventArgs>(this.EventErrorHandler, "WS_DISCONNECT");
             this._messageReceived = new AsyncEvent<SocketMessageEventArgs>(this.EventErrorHandler, "WS_MESSAGE");
-            this._errored = new AsyncEvent<SocketErrorEventArgs>(null, "WS_ERROR");
+            this._exceptionThrown = new AsyncEvent<SocketErrorEventArgs>(null, "WS_ERROR");
+
+            this.Proxy = proxy;
+            this._defaultHeaders = new Dictionary<string, string>();
+            this.DefaultHeaders = new ReadOnlyDictionary<string, string>(this._defaultHeaders);
+
+            this._receiverTokenSource = null;
+            this._receiverToken = CancellationToken.None;
+            this._senderLock = new SemaphoreSlim(1);
+
+            this._socketTokenSource = null;
+            this._socketToken = CancellationToken.None;
+
         }
 
-        /// <summary>
-        /// Connects to the WebSocket server.
-        /// </summary>
-        /// <param name="uri">The URI of the WebSocket server.</param>
-        /// <param name="customHeaders">Custom headers to send with the request.</param>
-        /// <returns></returns>
-        public override async Task ConnectAsync(Uri uri, IReadOnlyDictionary<string, string> customHeaders = null)
+        /// <inheritdoc />
+        public async Task ConnectAsync(Uri uri)
         {
-            this._closeRequested = false;
+            // Disconnect first
+            try { await this.DisconnectAsync().ConfigureAwait(false); } catch { }
 
-            this.SocketMessageQueue = new ConcurrentQueue<string>();
-            this.TokenSource = new CancellationTokenSource();
-
-            this.StreamDecompressor?.Dispose();
-            this.CompressedStream?.Dispose();
-            this.DecompressedStream?.Dispose();
-
-            this.DecompressedStream = new MemoryStream();
-            this.CompressedStream = new MemoryStream();
-            this.StreamDecompressor = new DeflateStream(this.CompressedStream, CompressionMode.Decompress);
-            
-            this.Socket = new ClientWebSocket();
-            this.Socket.Options.KeepAliveInterval = TimeSpan.FromSeconds(20);
-            if (this.Proxy != null) // because mono doesn't implement this properly
-                this.Socket.Options.Proxy = this.Proxy;
-
-            if (customHeaders != null)
-                foreach (var kvp in customHeaders)
-                    this.Socket.Options.SetRequestHeader(kvp.Key, kvp.Value);
-        
-            await this.Socket.ConnectAsync(uri, this.Token).ConfigureAwait(false);
-            await this.OnConnectedAsync().ConfigureAwait(false);
-            this.WsListener = Task.Run(this.ListenAsync, this.Token);
-        }
-
-        /// <summary>
-        /// Disconnects the WebSocket connection.
-        /// </summary>
-        /// <param name="e">Disconect event arguments.</param>
-        /// <returns></returns>
-        public override async Task DisconnectAsync(SocketCloseEventArgs e)
-        {
-            try
-            {
-                this.TokenSource.Cancel();
-                this.TokenSource.Dispose();
-            }
-            catch
-            { }
-
-            if (this._closeRequested)
-                return;
-            this._closeRequested = true;
+            // Disallow sending messages
+            await this._senderLock.WaitAsync().ConfigureAwait(false);
 
             try
             {
-                // Wait for all items to be processed post-cancellation
-                await this.SocketQueueManager.ConfigureAwait(false);
-            }
-            catch
-            { } // if anything throws here we have a stuck close cycle without this
+                // This can be null at this point
+                this._receiverTokenSource?.Dispose();
+                this._socketTokenSource?.Dispose();
 
-            try
-            {
-                var code = e != null ? (WebSocketCloseStatus)e.CloseCode : WebSocketCloseStatus.NormalClosure;
-                var msg = e?.CloseMessage ?? "";
+                this._ws?.Dispose();
+                this._ws = new ClientWebSocket();
+                this._ws.Options.Proxy = this.Proxy;
+                this._ws.Options.KeepAliveInterval = TimeSpan.Zero;
+                if (this._defaultHeaders != null)
+                    foreach (var (k, v) in this._defaultHeaders)
+                        this._ws.Options.SetRequestHeader(k, v);
 
-                await this.Socket.CloseAsync(code, msg, CancellationToken.None).ConfigureAwait(false);
-                await this.WsListener.ConfigureAwait(false);
+                this._receiverTokenSource = new CancellationTokenSource();
+                this._receiverToken = this._receiverTokenSource.Token;
+
+                this._socketTokenSource = new CancellationTokenSource();
+                this._socketToken = this._socketTokenSource.Token;
+
+                this._isClientClose = false;
+                await this._ws.ConnectAsync(uri, this._socketToken).ConfigureAwait(false);
+                this._receiverTask = Task.Run(this.ReceiverLoopAsync, this._receiverToken);
             }
-            catch (Exception ex)
+            finally
             {
-                await this.OnDisconnectedAsync(new SocketCloseEventArgs(null) { CloseCode = -1, CloseMessage = $"{ex.GetType()}: {ex.Message}" }).ConfigureAwait(false);
+                this._senderLock.Release();
+                await this._connected.InvokeAsync().ConfigureAwait(false);
             }
         }
 
-        /// <summary>
-        /// Send a message to the WebSocket server.
-        /// </summary>
-        /// <param name="message">The message to send</param>
-        public override void SendMessage(string message)
+        /// <inheritdoc />
+        public async Task DisconnectAsync()
         {
-            if (this.Socket.State != WebSocketState.Open)
+            // Ensure that messages cannot be sent
+            await this._senderLock.WaitAsync().ConfigureAwait(false);
+
+            try
+            {
+                // Cancel all running tasks
+                this._socketTokenSource.Cancel();
+                this._receiverTokenSource.Cancel();
+                this._socketTokenSource.Dispose();
+                this._receiverTokenSource.Dispose();
+
+                this._isClientClose = true;
+                await this._ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None).ConfigureAwait(false);
+                await this._receiverTask.ConfigureAwait(false); // Ensure that receving completed
+            }
+            catch { }
+            finally
+            {
+                this._senderLock.Release();
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task SendMessageAsync(string message)
+        {
+            if (this._ws == null)
                 return;
 
-            this.SocketMessageQueue.Enqueue(message);
+            var bytes = Utilities.UTF8.GetBytes(message);
+            await this._senderLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                var len = bytes.Length;
+                var segCount = len / OutgoingChunkSize;
+                if (len % OutgoingChunkSize != 0)
+                    segCount++;
 
-            if (this.SocketQueueManager == null || this.SocketQueueManager.IsCompleted)
-                this.SocketQueueManager = Task.Run(this.ProcessSmqAsync, this.Token);
+                for (var i = 0; i < segCount; i++)
+                {
+                    var segStart = OutgoingChunkSize * i;
+                    var segLen = Math.Min(OutgoingChunkSize, len - segStart);
+
+                    await this._ws.SendAsync(new ArraySegment<byte>(bytes, segStart, segLen), WebSocketMessageType.Text, i == segCount - 1, CancellationToken.None).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                this._senderLock.Release();
+            }
+
         }
+
+        /// <inheritdoc />
+        public bool AddDefaultHeader(string name, string value)
+        {
+            this._defaultHeaders[name] = value;
+            return true;
+        }
+
+        /// <inheritdoc />
+        public bool RemoveDefaultHeader(string name)
+            => this._defaultHeaders.Remove(name);
 
         /// <summary>
-        /// Set the Action to call when the connection has been established.
+        /// Disposes of resources used by this WebSocket client instance.
         /// </summary>
-        /// <returns></returns>
-        protected override Task OnConnectedAsync()
+        public void Dispose()
         {
-            return this._connected.InvokeAsync();
+            if (this._isDisposed)
+                return;
+
+            this._isDisposed = true;
+            this.DisconnectAsync().GetAwaiter().GetResult();
+
+            this._receiverTokenSource.Dispose();
+            this._socketTokenSource.Dispose();
+
         }
 
-        /// <summary>
-        /// Set the Action to call when the connection has been terminated.
-        /// </summary>
-        /// <returns></returns>
-        protected override Task OnDisconnectedAsync(SocketCloseEventArgs e)
-        {
-            this.Socket.Abort();
-            this.Socket.Dispose();
-
-            _ = this._disconnected.InvokeAsync(e).ConfigureAwait(false);
-            return Task.Delay(0);
-        }
-
-        internal async Task ListenAsync()
+        internal async Task ReceiverLoopAsync()
         {
             await Task.Yield();
 
-            var buff = new byte[BUFFER_SIZE];
-            var buffseg = new ArraySegment<byte>(buff);
+            var token = this._receiverToken;
+            var buffer = new ArraySegment<byte>(new byte[IncomingChunkSize]);
 
-            byte[] resultbuff = null;
-            WebSocketReceiveResult result = null;
-            SocketCloseEventArgs close = null;
-            
             try
             {
-                while (this.Socket.State != WebSocketState.Aborted && this.Socket.State != WebSocketState.Closed)
+                while (!token.IsCancellationRequested)
                 {
-                    using (var ms = new MemoryStream())
+                    // See https://github.com/RogueException/Discord.Net/commit/ac389f5f6823e3a720aedd81b7805adbdd78b66d 
+                    // for explanation on the cancellation token
+
+                    WebSocketReceiveResult result;
+                    byte[] resultBytes;
+                    using (var bs = new MemoryStream())
                     {
                         do
                         {
-                            result = await this.Socket.ReceiveAsync(buffseg, CancellationToken.None).ConfigureAwait(false);
-
+                            result = await this._ws.ReceiveAsync(buffer, CancellationToken.None).ConfigureAwait(false);
                             if (result.MessageType == WebSocketMessageType.Close)
-                            {
-                                var cc = result.CloseStatus != null ? (int)result.CloseStatus.Value : -1;
-                                close = new SocketCloseEventArgs(null) { CloseCode = cc, CloseMessage = result.CloseStatusDescription };
-                            }
-                            else
-                                ms.Write(buff, 0, result.Count);
+                                break;
+
+                            bs.Write(buffer.Array, 0, result.Count);
                         }
                         while (!result.EndOfMessage);
 
-                        resultbuff = ms.ToArray();
+                        resultBytes = new byte[bs.Length];
+                        bs.Position = 0;
+                        bs.Read(resultBytes, 0, (int)bs.Length);
                     }
 
-                    if (close != null)
-                        break;
-
-                    var resultstr = "";
                     if (result.MessageType == WebSocketMessageType.Binary)
                     {
-                        if (resultbuff[0] == 0x78)
-                            await this.CompressedStream.WriteAsync(resultbuff, 2, resultbuff.Length - 2).ConfigureAwait(false);
-                        else
-                            await this.CompressedStream.WriteAsync(resultbuff, 0, resultbuff.Length).ConfigureAwait(false);
-                        await this.CompressedStream.FlushAsync().ConfigureAwait(false);
-                        this.CompressedStream.Position = 0;
-
-                        // partial credit to FiniteReality
-                        // overall idea is his
-                        // I tuned the finer details
-                        // -Emzi
-                        //
-                        // This is actually wrong. While it will work for 99.999999999999999999999% cases,
-                        // the ZLib suffix is actually 0x00 0x00 0xFF 0xFF, and we only test for the last 2 
-                        // bytes, which could cause some problems later down the line (e.g. if we ever introduce
-                        // ETF support, since it's a purely binary format). While the magic check should eliminate
-                        // *most* issues, it might still be a good idea to look into doing this properly.
-                        // -Emzi
-                        var sfix = BitConverter.ToUInt16(resultbuff, resultbuff.Length - 2);
-                        if (sfix != ZLIB_STREAM_SUFFIX)
-                        {
-                            using (var zlib = new DeflateStream(this.CompressedStream, CompressionMode.Decompress, true))
-                                await zlib.CopyToAsync(this.DecompressedStream).ConfigureAwait(false);
-                        }
-                        else
-                        {
-                            await this.StreamDecompressor.CopyToAsync(this.DecompressedStream).ConfigureAwait(false);
-                        }
-
-                        resultbuff = this.DecompressedStream.ToArray();
-                        this.DecompressedStream.Position = 0;
-                        this.DecompressedStream.SetLength(0);
-                        this.CompressedStream.Position = 0;
-                        this.CompressedStream.SetLength(0);
+                        await this._messageReceived.InvokeAsync(new SocketBinaryMessageEventArgs(resultBytes)).ConfigureAwait(false);
                     }
-                    
-                    resultstr = UTF8.GetString(resultbuff, 0, resultbuff.Length);
-                    await this.CallOnMessageAsync(resultstr).ConfigureAwait(false);
+                    else if (result.MessageType == WebSocketMessageType.Text)
+                    {
+                        await this._messageReceived.InvokeAsync(new SocketTextMessageEventArgs(Utilities.UTF8.GetString(resultBytes))).ConfigureAwait(false);
+                    }
+                    else // close
+                    {
+                        if (!this._isClientClose)
+                            await this._ws.CloseOutputAsync(result.CloseStatus.Value, result.CloseStatusDescription, CancellationToken.None).ConfigureAwait(false);
+
+                        await this._disconnected.InvokeAsync(new SocketCloseEventArgs(null) { CloseCode = (int)result.CloseStatus, CloseMessage = result.CloseStatusDescription }).ConfigureAwait(false);
+                        break;
+                    }
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                close = new SocketCloseEventArgs(null) { CloseCode = -1, CloseMessage = e.Message };
+                await this._exceptionThrown.InvokeAsync(new SocketErrorEventArgs(null) { Exception = ex }).ConfigureAwait(false);
+                await this._disconnected.InvokeAsync(new SocketCloseEventArgs(null) { CloseCode = -1, CloseMessage = "" }).ConfigureAwait(false);
             }
 
-            _ = this.DisconnectAsync(close).ConfigureAwait(false);
-            await this.OnDisconnectedAsync(close).ConfigureAwait(false);
+            // Don't await or you deadlock
+            // DisconnectAsync waits for this method
+            _ = this.DisconnectAsync().ConfigureAwait(false);
         }
-
-        internal async Task ProcessSmqAsync()
-        {
-            await Task.Yield();
-
-            var token = this.Token;
-            while (!token.IsCancellationRequested && this.Socket.State == WebSocketState.Open)
-            {
-                if (this.SocketMessageQueue.IsEmpty)
-                    break;
-
-                if (!this.SocketMessageQueue.TryDequeue(out var message))
-                    break;
-
-                var buff = UTF8.GetBytes(message);
-                var msgc = buff.Length / BUFFER_SIZE;
-                if (buff.Length % BUFFER_SIZE != 0)
-                    msgc++;
-
-                for (var i = 0; i < msgc; i++)
-                {
-                    var off = BUFFER_SIZE * i;
-                    var cnt = Math.Min(BUFFER_SIZE, buff.Length - off);
-
-                    var lm = i == msgc - 1;
-                    await this.Socket.SendAsync(new ArraySegment<byte>(buff, off, cnt), WebSocketMessageType.Text, lm, this.Token).ConfigureAwait(false);
-                }
-            }
-        }
-
-        internal Task CallOnMessageAsync(string result)
-            => _messageReceived.InvokeAsync(new SocketMessageEventArgs() { Message = result });
 
         /// <summary>
         /// Creates a new instance of <see cref="WebSocketClient"/>.
         /// </summary>
         /// <param name="proxy">Proxy to use for this client instance.</param>
         /// <returns>An instance of <see cref="WebSocketClient"/>.</returns>
-        public static BaseWebSocketClient CreateNew(IWebProxy proxy)
+        public static IWebSocketClient CreateNew(IWebProxy proxy)
             => new WebSocketClient(proxy);
 
         #region Events
         /// <summary>
         /// Triggered when the client connects successfully.
         /// </summary>
-        public override event AsyncEventHandler Connected
+        public event AsyncEventHandler Connected
         {
             add => this._connected.Register(value);
             remove => this._connected.Unregister(value);
@@ -303,7 +271,7 @@ namespace DSharpPlus.Net.WebSocket
         /// <summary>
         /// Triggered when the client is disconnected.
         /// </summary>
-        public override event AsyncEventHandler<SocketCloseEventArgs> Disconnected
+        public event AsyncEventHandler<SocketCloseEventArgs> Disconnected
         {
             add => this._disconnected.Register(value);
             remove => this._disconnected.Unregister(value);
@@ -313,7 +281,7 @@ namespace DSharpPlus.Net.WebSocket
         /// <summary>
         /// Triggered when the client receives a message from the remote party.
         /// </summary>
-        public override event AsyncEventHandler<SocketMessageEventArgs> MessageReceived
+        public event AsyncEventHandler<SocketMessageEventArgs> MessageReceived
         {
             add => this._messageReceived.Register(value);
             remove => this._messageReceived.Unregister(value);
@@ -323,19 +291,19 @@ namespace DSharpPlus.Net.WebSocket
         /// <summary>
         /// Triggered when an error occurs in the client.
         /// </summary>
-        public override event AsyncEventHandler<SocketErrorEventArgs> Errored
+        public event AsyncEventHandler<SocketErrorEventArgs> ExceptionThrown
         {
-            add => this._errored.Register(value);
-            remove => this._errored.Unregister(value);
+            add => this._exceptionThrown.Register(value);
+            remove => this._exceptionThrown.Unregister(value);
         }
-        private AsyncEvent<SocketErrorEventArgs> _errored;
+        private AsyncEvent<SocketErrorEventArgs> _exceptionThrown;
 
         private void EventErrorHandler(string evname, Exception ex)
         {
             if (evname.ToLowerInvariant() == "ws_error")
                 Console.WriteLine($"WSERROR: {ex.GetType()} in {evname}!");
             else
-                this._errored.InvokeAsync(new SocketErrorEventArgs(null) { Exception = ex }).ConfigureAwait(false).GetAwaiter().GetResult();
+                this._exceptionThrown.InvokeAsync(new SocketErrorEventArgs(null) { Exception = ex }).ConfigureAwait(false).GetAwaiter().GetResult();
         }
         #endregion
     }

--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 using DSharpPlus.Entities;
 using DSharpPlus.Net;
@@ -19,6 +20,8 @@ namespace DSharpPlus
         /// </summary>
         private static string VersionHeader { get; set; }
         private static Dictionary<Permissions, string> PermissionStrings { get; set; }
+
+        internal static UTF8Encoding UTF8 { get; } = new UTF8Encoding(false);
 
         static Utilities()
         {
@@ -247,6 +250,12 @@ namespace DSharpPlus
                     return true;
 
             return false;
+        }
+
+        internal static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> kvp, out TKey key, out TValue value)
+        {
+            key = kvp.Key;
+            value = kvp.Value;
         }
     }
 }


### PR DESCRIPTION
# Summary
Fixes #522 by implementing support for these events and endpoint.

# Details
As documented [here](https://github.com/discordapp/discord-api-docs/pull/1309), this PR adds 3 new events:

`InviteCreated` - Fired when an invite is created.

`InviteDeleted` - Fired when an invite is deleted.

`MessageReactionRemovedEmoji` - Fired when all of a specific reaction are deleted.

Additionally, added support for a new endpoint that directly causes the `MessageReactionRemovedEmoji` event, which is `DiscordMessage.DeleteReactionsEmojiAsync(DiscordEmoji)`.

Because invite objects can now be sent via dispatch, I also created an invite cache to more reliably retrieve invites, this does a couple of things: 

1. Allows the InviteDeleted event to possibly return a more detailed object rather than the partial one.
2. Could allow a user to get an invite from the cache, which is modeled by `DiscordGuild.GetInvite(string)`.

Currently, the cache has invites added and removed from their respective events, and added automatically through `DiscordGuild.GetInvitesAsync()`. This change and `DiscordGuild.GetInvite()` may not be necessary, but I figured they may be nice to include.

# Changes proposed
* Added support for the 3 new events.
* Added support for the new endpoint.
* Added a method to delete all reactions from a specific emoji.
* Added a cache for invites.
* Added/modified a couple methods to interact with the invite cache.