### PR TITLE
Fixes #524 and removes support for before_id.

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1138,8 +1138,8 @@ namespace DSharpPlus
         /// <param name="message_id">Message id</param>
         /// <param name="emoji">Emoji to check for</param>
         /// <returns></returns>
-        public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, string emoji)
-            => ApiClient.GetReactionsAsync(channel_id, message_id, emoji);
+        public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, string emoji, ulong? after_id = null, int limit = 25)
+            => ApiClient.GetReactionsAsync(channel_id, message_id, emoji, after_id, limit);
 
         /// <summary>
         /// Gets all users that reacted with a specific emoji to a message
@@ -1148,8 +1148,8 @@ namespace DSharpPlus
         /// <param name="message_id">Message id</param>
         /// <param name="emoji">Emoji to check for</param>
         /// <returns></returns>
-        public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, DiscordEmoji emoji)
-            => ApiClient.GetReactionsAsync(channel_id, message_id, emoji.ToReactionString());
+        public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, DiscordEmoji emoji, ulong? after_id = null, int limit = 25)
+            => ApiClient.GetReactionsAsync(channel_id, message_id, emoji.ToReactionString(), after_id, limit);
 
         /// <summary>
         /// Deletes all reactions from a message

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1698,11 +1698,9 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers, ratelimitWaitOverride: 0.26);
         }
 
-        internal async Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, string emoji, ulong? before_id = null, ulong? after_id = null, int limit = 25)
+        internal async Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, string emoji, ulong? after_id = null, int limit = 25)
         {
             var urlparams = new Dictionary<string, string>();
-            if (before_id.HasValue)
-                urlparams["before"] = before_id.Value.ToString(CultureInfo.InvariantCulture);
             if (after_id.HasValue)
                 urlparams["after"] = after_id.Value.ToString(CultureInfo.InvariantCulture);
 


### PR DESCRIPTION
# Summary
Fixes #524 and removes the support for before_id parameter because it's not supported by the API. cf: https://github.com/discordapp/discord-api-docs/issues/1324#issuecomment-579019973

# Details
I also added support for limit and after_id parameters in the Rest client, because they were missing.