### PR TITLE
Cumulative API updates.

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1137,6 +1137,8 @@ namespace DSharpPlus
         /// <param name="channel_id">Channel id</param>
         /// <param name="message_id">Message id</param>
         /// <param name="emoji">Emoji to check for</param>
+        /// <param name="after_id">Whether to search for reactions after this message id.</param>
+        /// <param name="limit">The maximum amount of reactions to fetch.</param>
         /// <returns></returns>
         public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, string emoji, ulong? after_id = null, int limit = 25)
             => ApiClient.GetReactionsAsync(channel_id, message_id, emoji, after_id, limit);
@@ -1147,6 +1149,8 @@ namespace DSharpPlus
         /// <param name="channel_id">Channel id</param>
         /// <param name="message_id">Message id</param>
         /// <param name="emoji">Emoji to check for</param>
+        /// <param name="after_id">Whether to search for reactions after this message id.</param>
+        /// <param name="limit">The maximum amount of reactions to fetch.</param>
         /// <returns></returns>
         public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, DiscordEmoji emoji, ulong? after_id = null, int limit = 25)
             => ApiClient.GetReactionsAsync(channel_id, message_id, emoji.ToReactionString(), after_id, limit);

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2487,7 +2487,7 @@ namespace DSharpPlus
             var jo = JObject.Parse(response.Response);
             this._gatewayUri = new Uri(jo.Value<string>("url"));
             if (jo["shards"] != null)
-                _shardCount = jo.Value<int>("shards");
+                this._shardCount = jo.Value<int>("shards");
         }
 
         private SocketLock GetSocketLock()
@@ -2495,7 +2495,7 @@ namespace DSharpPlus
 
         ~DiscordClient()
         {
-            Dispose();
+            this.Dispose();
         }
 
         private bool _disposed;

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -131,8 +131,8 @@ namespace DSharpPlus
 
             InternalSetup();
 
-            this.Guilds = new ReadOnlyConcurrentDictionary<ulong, DiscordGuild>(_guilds);
-            this.PrivateChannels = new ReadOnlyConcurrentDictionary<ulong, DiscordDmChannel>(_privateChannels);
+            this.Guilds = new ReadOnlyConcurrentDictionary<ulong, DiscordGuild>(this._guilds);
+            this.PrivateChannels = new ReadOnlyConcurrentDictionary<ulong, DiscordDmChannel>(this._privateChannels);
         }
 
         internal void InternalSetup()
@@ -188,8 +188,8 @@ namespace DSharpPlus
 
             this._presencesLazy = new Lazy<IReadOnlyDictionary<ulong, DiscordPresence>>(() => new ReadOnlyDictionary<ulong, DiscordPresence>(this._presences));
 
-            if (Configuration.UseInternalLogHandler)
-                DebugLogger.LogMessageReceived += (sender, e) => DebugLogger.LogHandler(sender, e);
+            if (this.Configuration.UseInternalLogHandler)
+                this.DebugLogger.LogMessageReceived += (sender, e) => this.DebugLogger.LogHandler(sender, e);
         }
 
         /// <summary>
@@ -200,7 +200,7 @@ namespace DSharpPlus
         public void AddExtension(BaseExtension ext)
         {
             ext.Setup(this);
-            _extensions.Add(ext);
+            this._extensions.Add(ext);
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace DSharpPlus
         /// <typeparam name="T">Type of extension to retrieve.</typeparam>
         /// <returns>The requested extension.</returns>
         public T GetExtension<T>() where T : BaseExtension
-            => _extensions.FirstOrDefault(x => x.GetType() == typeof(T)) as T;
+            => this._extensions.FirstOrDefault(x => x.GetType() == typeof(T)) as T;
 
         /// <summary>
         /// Connects to the gateway
@@ -302,13 +302,13 @@ namespace DSharpPlus
         public Task ReconnectAsync(bool startNewSession = false)
         {
             if (startNewSession)
-                _sessionId = "";
+                this._sessionId = "";
 
-            return _webSocketClient.DisconnectAsync();
+            return this._webSocketClient.DisconnectAsync();
         }
 
         internal Task InternalReconnectAsync()
-            => ConnectAsync();
+            => this.ConnectAsync();
 
         internal async Task InternalConnectAsync()
         {
@@ -360,7 +360,7 @@ namespace DSharpPlus
                 : null;
 
             this._cancelTokenSource = new CancellationTokenSource();
-            this._cancelToken = _cancelTokenSource.Token;
+            this._cancelToken = this._cancelTokenSource.Token;
 
             this._webSocketClient.Connected += SocketOnConnect;
             this._webSocketClient.Disconnected += SocketOnDisconnect;
@@ -424,9 +424,9 @@ namespace DSharpPlus
                 this.DebugLogger.LogMessage(LogLevel.Debug, "Websocket", $"Connection closed. ({e.CloseCode.ToString(CultureInfo.InvariantCulture)}, '{e.CloseMessage}')", DateTime.Now);
                 await this._socketClosed.InvokeAsync(new SocketCloseEventArgs(this) { CloseCode = e.CloseCode, CloseMessage = e.CloseMessage }).ConfigureAwait(false);
 
-                if (Configuration.AutoReconnect)
+                if (this.Configuration.AutoReconnect)
                 {
-                    DebugLogger.LogMessage(LogLevel.Critical, "Websocket", $"Socket connection terminated ({e.CloseCode.ToString(CultureInfo.InvariantCulture)}, '{e.CloseMessage}'). Reconnecting.", DateTime.Now);
+                    this.DebugLogger.LogMessage(LogLevel.Critical, "Websocket", $"Socket connection terminated ({e.CloseCode.ToString(CultureInfo.InvariantCulture)}, '{e.CloseMessage}'). Reconnecting.", DateTime.Now);
 
                     if (this._status == null)
                         await this.ConnectAsync().ConfigureAwait(false);
@@ -445,9 +445,9 @@ namespace DSharpPlus
         /// <returns></returns>
         public async Task DisconnectAsync()
         {
-            Configuration.AutoReconnect = false;
+            this.Configuration.AutoReconnect = false;
             if (this._webSocketClient != null)
-                await _webSocketClient.DisconnectAsync().ConfigureAwait(false);
+                await this._webSocketClient.DisconnectAsync().ConfigureAwait(false);
         }
 
         #region Public Functions
@@ -524,7 +524,7 @@ namespace DSharpPlus
         {
             if (this._guilds.TryGetValue(id, out var guild))
                 return guild;
-
+            
             guild = await this.ApiClient.GetGuildAsync(id).ConfigureAwait(false);
             var channels = await this.ApiClient.GetGuildChannelsAsync(guild.Id).ConfigureAwait(false);
             foreach (var channel in channels) guild._channels[channel.Id] = channel;
@@ -630,7 +630,7 @@ namespace DSharpPlus
                     break;
 
                 default:
-                    DebugLogger.LogMessage(LogLevel.Warning, "Websocket", $"Unknown OP-Code: {((int)payload.OpCode).ToString(CultureInfo.InvariantCulture)}\n{payload.Data}", DateTime.Now);
+                    this.DebugLogger.LogMessage(LogLevel.Warning, "Websocket", $"Unknown OP-Code: {((int)payload.OpCode).ToString(CultureInfo.InvariantCulture)}\n{payload.Data}", DateTime.Now);
                     break;
             }
         }
@@ -832,7 +832,7 @@ namespace DSharpPlus
 
                 default:
                     await OnUnknownEventAsync(payload).ConfigureAwait(false);
-                    DebugLogger.LogMessage(LogLevel.Warning, "Websocket:Dispatch", $"Unknown event: {payload.EventName}\n{payload.Data}", DateTime.Now);
+                    this.DebugLogger.LogMessage(LogLevel.Warning, "Websocket:Dispatch", $"Unknown event: {payload.EventName}\n{payload.Data}", DateTime.Now);
                     break;
             }
         }
@@ -975,7 +975,7 @@ namespace DSharpPlus
                     .Select(xtu => this.InternalGetCachedUser(xtu.Id) ?? new DiscordUser(xtu) { Discord = this });
                 dmChannel._recipients = recips.ToList();
 
-                _privateChannels[dmChannel.Id] = dmChannel;
+                this._privateChannels[dmChannel.Id] = dmChannel;
 
                 await this._dmChannelCreated.InvokeAsync(new DmChannelCreateEventArgs(this) { Channel = dmChannel }).ConfigureAwait(false);
             }
@@ -988,7 +988,7 @@ namespace DSharpPlus
                     xo._channel_id = channel.Id;
                 }
 
-                _guilds[channel.GuildId]._channels[channel.Id] = channel;
+                this._guilds[channel.GuildId]._channels[channel.Id] = channel;
 
                 await this._channelCreated.InvokeAsync(new ChannelCreateEventArgs(this) { Channel = channel, Guild = channel.Guild }).ConfigureAwait(false);
             }
@@ -1212,12 +1212,21 @@ namespace DSharpPlus
                     IsUnavailable = gld.IsUnavailable,
                     JoinedAt = gld.JoinedAt,
                     MemberCount = gld.MemberCount,
+                    MaxMembers = gld.MaxMembers,
+                    MaxPresences = gld.MaxPresences,
+                    DiscoverySplashHash = gld.DiscoverySplashHash,
+                    PreferredLocale = gld.PreferredLocale,
                     MfaLevel = gld.MfaLevel,
                     OwnerId = gld.OwnerId,
                     SplashHash = gld.SplashHash,
                     SystemChannelId = gld.SystemChannelId,
+                    SystemChannelFlags = gld.SystemChannelFlags,
+                    WidgetEnabled = gld.WidgetEnabled,
+                    WidgetChannelId = gld.WidgetChannelId,
                     VerificationLevel = gld.VerificationLevel,
-                    VoiceRegionId = gld.VoiceRegionId,
+                    RulesChannelId = gld.RulesChannelId,
+                    PublicUpdatesChannelId = gld.PublicUpdatesChannelId,
+                    VoiceRegionId = gld.VoiceRegionId,   
                     _channels = new ConcurrentDictionary<ulong, DiscordChannel>(),
                     _emojis = new ConcurrentDictionary<ulong, DiscordEmoji>(),
                     _members = new ConcurrentDictionary<ulong, DiscordMember>(),
@@ -1613,7 +1622,7 @@ namespace DSharpPlus
             message.Discord = this;
 
             if (message.Channel == null)
-                DebugLogger.LogMessage(LogLevel.Warning, "Event", "Could not find channel last message belonged to.", DateTime.Now);
+                this.DebugLogger.LogMessage(LogLevel.Warning, "Event", "Could not find channel last message belonged to.", DateTime.Now);
             else
                 message.Channel.LastMessageId = message.Id;
 
@@ -2435,12 +2444,23 @@ namespace DSharpPlus
             guild.VoiceRegionId = newGuild.VoiceRegionId;
             guild.SplashHash = newGuild.SplashHash;
             guild.VerificationLevel = newGuild.VerificationLevel;
+            guild.WidgetEnabled = newGuild.WidgetEnabled;
+            guild.WidgetChannelId = newGuild.WidgetChannelId;
             guild.ExplicitContentFilter = newGuild.ExplicitContentFilter;
             guild.PremiumTier = newGuild.PremiumTier;
             guild.PremiumSubscriptionCount = newGuild.PremiumSubscriptionCount;
             guild.Banner = newGuild.Banner;
             guild.Description = newGuild.Description;
             guild.VanityUrlCode = newGuild.VanityUrlCode;
+            guild.Banner = newGuild.Banner;
+            guild.SystemChannelId = newGuild.SystemChannelId;
+            guild.SystemChannelFlags = newGuild.SystemChannelFlags;
+            guild.DiscoverySplashHash = newGuild.DiscoverySplashHash;
+            guild.MaxMembers = newGuild.MaxMembers;
+            guild.MaxPresences = newGuild.MaxPresences;
+            guild.PreferredLocale = newGuild.PreferredLocale;
+            guild.RulesChannelId = newGuild.RulesChannelId;
+            guild.PublicUpdatesChannelId = newGuild.PublicUpdatesChannelId;
 
             // fields not sent for update:
             // - guild.Channels

--- a/DSharpPlus/Entities/DiscordAuditLogObjects.cs
+++ b/DSharpPlus/Entities/DiscordAuditLogObjects.cs
@@ -103,9 +103,14 @@ namespace DSharpPlus.Entities
         public PropertyChange<MfaLevel> MfaLevelChange { get; internal set; }
 
         /// <summary>
-        /// Gets the the description of invite splash's change.
+        /// Gets the description of invite splash's change.
         /// </summary>
         public PropertyChange<string> SplashChange { get; internal set; }
+
+        /// <summary>
+        /// Gets the description of the guild's region change.
+        /// </summary>
+        public PropertyChange<string> RegionChange { get; internal set; }
 
         internal DiscordAuditLogGuildEntry() { }
     }

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -7,11 +7,12 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using DSharpPlus.Net.Abstractions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using DSharpPlus.Enums;
 using DSharpPlus.Net.Models;
 using DSharpPlus.Net.Serialization;
+using DSharpPlus.Net.Abstractions;
 
 namespace DSharpPlus.Entities
 {
@@ -51,6 +52,26 @@ namespace DSharpPlus.Entities
         [JsonIgnore]
         public string SplashUrl
             => !string.IsNullOrWhiteSpace(this.SplashHash) ? $"https://cdn.discordapp.com/splashes/{this.Id.ToString(CultureInfo.InvariantCulture)}/{SplashHash}.jpg" : null;
+
+        /// <summary>
+        /// Gets the guild discovery splash's hash.
+        /// </summary>
+        [JsonProperty("discovery_splash", NullValueHandling = NullValueHandling.Ignore)]
+        public string DiscoverySplashHash { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild discovery splash's url.
+        /// </summary>
+        [JsonIgnore]
+        public string DiscoverySplashUrl
+            => !string.IsNullOrWhiteSpace(this.DiscoverySplashHash) ? $"https://cdn.discordapp.com/discovery-splashes/{this.Id.ToString(CultureInfo.InvariantCulture)}/{DiscoverySplashHash}.jpg" : null;
+
+        /// <summary>
+        /// Gets the preferred locale of this guild.
+        /// <para>This is used for server discovery and notices from Discord. Defaults to en-US.</para>
+        /// </summary>
+        [JsonProperty("preferred_locale", NullValueHandling = NullValueHandling.Ignore)]
+        public string PreferredLocale { get; internal set; }
 
         /// <summary>
         /// Gets the ID of the guild's owner.
@@ -146,12 +167,65 @@ namespace DSharpPlus.Entities
         internal ulong? SystemChannelId { get; set; }
 
         /// <summary>
-        /// Gets the channel to which system messages (such as join notifications) are sent.
+        /// Gets the channel where system messages (such as boost and welcome messages) are sent.
         /// </summary>
         [JsonIgnore]
-        public DiscordChannel SystemChannel => SystemChannelId.HasValue
-            ? this.GetChannel(SystemChannelId.Value)
+        public DiscordChannel SystemChannel => this.SystemChannelId.HasValue
+            ? this.GetChannel(this.SystemChannelId.Value)
             : null;
+
+        /// <summary>
+        /// Gets the settings for this guild's system channel.
+        /// </summary>
+        [JsonProperty("system_channel_flags")]
+        public SystemChannelFlags SystemChannelFlags { get; internal set; }
+
+        /// <summary>
+        /// Gets whether this guild's widget is enabled.
+        /// </summary>
+        [JsonProperty("widget_enabled", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? WidgetEnabled { get; internal set; }
+
+        [JsonProperty("widget_channel_id", NullValueHandling = NullValueHandling.Ignore)]
+        internal ulong? WidgetChannelId { get; set; }
+
+        /// <summary>
+        /// Gets the widget channel for this guild.
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel WidgetChannel => this.WidgetChannelId.HasValue
+            ? this.GetChannel(this.WidgetChannelId.Value)
+            : null;
+
+        [JsonProperty("rules_channel_id")]
+        internal ulong? RulesChannelId { get; set; }
+
+        /// <summary>
+        /// Gets the rules channel for this guild.
+        /// <para>This is only available if the guild is considered "discoverable".</para>
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel RulesChannel => this.RulesChannelId.HasValue
+            ? this.GetChannel(this.RulesChannelId.Value)
+            : null;
+
+        [JsonProperty("public_updates_channel_id")]
+        internal ulong? PublicUpdatesChannelId { get; set; }
+
+        /// <summary>
+        /// Gets the public updates channel (where admins and moderators receive messages from Discord) for this guild.
+        /// <para>This is only available if the guild is considered "discoverable".</para>
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel PublicUpdatesChannel => this.PublicUpdatesChannelId.HasValue
+            ? this.GetChannel(this.PublicUpdatesChannelId.Value)
+            : null;
+
+        /// <summary>
+        /// Gets the application id of this guild if it is bot created.
+        /// </summary>
+        [JsonProperty("application_id")]
+        public ulong? ApplicationId { get; internal set; }
 
         /// <summary>
         /// Gets a collection of this guild's roles.
@@ -208,6 +282,18 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("member_count", NullValueHandling = NullValueHandling.Ignore)]
         public int MemberCount { get; internal set; }
+
+        /// <summary>
+        /// Gets the maximum amount of members allowed for this guild.
+        /// </summary>
+        [JsonProperty("max_members")]
+        public int? MaxMembers { get; internal set; }
+
+        /// <summary>
+        /// Gets the maximum amount of presences allowed for this guild.
+        /// </summary>
+        [JsonProperty("max_presences")]
+        public int? MaxPresences { get; internal set; }
 
         /// <summary>
         /// Gets a dictionary of all the voice states for this guilds. The key for this dictionary is the ID of the user
@@ -271,16 +357,23 @@ namespace DSharpPlus.Entities
         public string VanityUrlCode { get; internal set; }
 
         /// <summary>
-        /// Gets guild description, when applicable.
+        /// Gets the guild description, when applicable.
         /// </summary>
         [JsonProperty("description")]
         public string Description { get; internal set; }
 
         /// <summary>
-        /// Gets guild banner hash, when applicable.
+        /// Gets this guild's banner hash, when applicable.
         /// </summary>
         [JsonProperty("banner")]
         public string Banner { get; internal set; }
+
+        /// <summary>
+        /// Gets this guild's banner in url form.
+        /// </summary>
+        [JsonIgnore]
+        public string BannerUrl
+            => !string.IsNullOrWhiteSpace(this.Banner) ? $"https://cdn.discordapp.com/banners/{this.Id}/{this.Banner}" : null;
 
         /// <summary>
         /// Gets this guild's premium tier (Nitro boosting).
@@ -293,6 +386,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("premium_subscription_count", NullValueHandling = NullValueHandling.Ignore)]
         public int? PremiumSubscriptionCount { get; internal set; }
+
         // Seriously discord?
 
         // I need to work on this
@@ -308,9 +402,7 @@ namespace DSharpPlus.Entities
         internal bool IsSynced { get; set; }
 
         internal DiscordGuild()
-        {
-            this._current_member_lazy = new Lazy<DiscordMember>(() => this._members.TryGetValue(this.Discord.CurrentUser.Id, out var member) ? member : null);
-        }
+            => this._current_member_lazy = new Lazy<DiscordMember>(() => this._members.TryGetValue(this.Discord.CurrentUser.Id, out var member) ? member : null);
 
         #region Guild Methods
         /// <summary>
@@ -580,11 +672,54 @@ namespace DSharpPlus.Entities
             => this.Discord.ApiClient.GetGuildInvitesAsync(this.Id);
 
         /// <summary>
+        /// Gets the vanity invite for this guild.
+        /// </summary>
+        /// <returns>A partial vanity invite.</returns>
+        public Task<DiscordInvite> GetVanityInviteAsync()
+            => this.Discord.ApiClient.GetGuildVanityUrlAsync(this.Id);
+        
+
+        /// <summary>
         /// Gets all the webhooks created for all the channels in this guild.
         /// </summary>
         /// <returns>A collection of webhooks this guild has.</returns>
         public Task<IReadOnlyList<DiscordWebhook>> GetWebhooksAsync()
             => this.Discord.ApiClient.GetGuildWebhooksAsync(this.Id);
+
+        /// <summary>
+        /// Gets this guild's widget image.
+        /// </summary>
+        /// <param name="bannerType">The format of the widget.</param>
+        /// <returns>The URL of the widget image.</returns>
+        public string GetWidgetImage(WidgetType bannerType = WidgetType.Shield)
+        {
+            string param;
+
+            switch(bannerType)
+            {
+                case WidgetType.Banner1:
+                    param = "banner1";
+                    break;
+
+                case WidgetType.Banner2:
+                    param = "banner2";
+                    break;
+
+                case WidgetType.Banner3:
+                    param = "banner3";
+                    break;
+
+                case WidgetType.Banner4:
+                    param = "banner4";
+                    break;
+
+                default:
+                    param = "shield";
+                    break;
+            }
+
+            return $"{Net.Endpoints.BASE_URI}{Net.Endpoints.GUILDS}/{this.Id}{Net.Endpoints.WIDGET_PNG}?style={param}";
+        }
 
         /// <summary>
         /// Gets a member of this guild by his user ID.
@@ -879,6 +1014,14 @@ namespace DSharpPlus.Entities
                                     };
                                     break;
 
+                                case "region":
+                                    entrygld.RegionChange = new PropertyChange<string>
+                                    {
+                                        Before = xc.OldValueString,
+                                        After = xc.NewValueString
+                                    };
+                                    break;
+                             
                                 default:
                                     this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in guild update: {xc.Key}; this should be reported to devs", DateTime.Now);
                                     break;
@@ -1822,5 +1965,37 @@ namespace DSharpPlus.Entities
         /// Messages from all members are scanned.
         /// </summary>
         AllMembers = 2
+    }
+
+    /// <summary>
+    /// Represents the formats for a guild widget.
+    /// </summary>
+    public enum WidgetType : int
+    {
+        /// <summary>
+        /// The widget is represented in shield format.
+        /// <para>This is the default widget type.</para>
+        /// </summary>
+        Shield = 0,
+
+        /// <summary>
+        /// The widget is represented as the first banner type.
+        /// </summary>
+        Banner1 = 1,
+
+        /// <summary>
+        /// The widget is represented as the second banner type.
+        /// </summary>
+        Banner2 = 2,
+
+        /// <summary>
+        /// The widget is represented as the third banner type.
+        /// </summary>
+        Banner3 = 3,
+
+        /// <summary>
+        /// The widget is represented in the fourth banner type.
+        /// </summary>
+        Banner4 = 4
     }
 }

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -457,7 +457,6 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="emoji">Emoji to react with.</param>
         /// <param name="limit">Limit of users to fetch.</param>
-        /// <param name="before">Fetch users before this user's id.</param>
         /// <param name="after">Fetch users after this user's id.</param>
         /// <returns></returns>
         public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(DiscordEmoji emoji, int limit = 25, ulong? after = null) 

--- a/DSharpPlus/Enums/MessageFlags.cs
+++ b/DSharpPlus/Enums/MessageFlags.cs
@@ -7,10 +7,10 @@ namespace DSharpPlus.Enums
         /// <summary>
         /// Calculates whether these message flags contain a specific flag.
         /// </summary>
-        /// <param name="f">The existing bitwise flags.</param>
+        /// <param name="baseFlags">The existing flags.</param>
         /// <param name="flag">The flags to search for.</param>
         /// <returns></returns>
-        public static bool HasMessageFlag(this MessageFlags f, MessageFlags flag) => (f & flag) == flag;
+        public static bool HasMessageFlag(this MessageFlags baseFlags, MessageFlags flag) => (baseFlags & flag) == flag;
     }
 
     /// <summary>

--- a/DSharpPlus/Enums/SystemChannelFlags.cs
+++ b/DSharpPlus/Enums/SystemChannelFlags.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace DSharpPlus.Enums
+{
+    public static class SystemChannelFlagsExtension
+    {
+        /// <summary>
+        /// Calculates whether these system channel flags contain a specific flag.
+        /// </summary>
+        /// <param name="baseFlags">The existing flags.</param>
+        /// <param name="flag">The flag to search for.</param>
+        /// <returns></returns>
+        public static bool HasSystemChannelFlag(this SystemChannelFlags baseFlags, SystemChannelFlags flag) => (baseFlags & flag) == flag;
+    }
+
+    /// <summary>
+    /// Represents settings for a guild's system channel.
+    /// </summary>
+    [Flags]
+    public enum SystemChannelFlags
+    {
+        /// <summary>
+        /// Member join messages are disabled.
+        /// </summary>
+        SuppressJoinNotifications = 1 << 0,
+
+        /// <summary>
+        /// Server boost messages are disabled.
+        /// </summary>
+        SuppressPremiumSubscriptions = 1 << 1
+    }
+}

--- a/DSharpPlus/Net/Abstractions/TransportActivity.cs
+++ b/DSharpPlus/Net/Abstractions/TransportActivity.cs
@@ -119,14 +119,10 @@ namespace DSharpPlus.Net.Abstractions
         }
 
         public bool IsRichPresence()
-        {
-            return this.Details != null || this.State != null || this.ApplicationId != null || this.Instance != null || this.Party != null || this.Assets != null || this.Secrets != null || this.Timestamps != null;
-        }
+            => this.Details != null || this.State != null || this.ApplicationId != null || this.Instance != null || this.Party != null || this.Assets != null || this.Secrets != null || this.Timestamps != null;
 
         public bool IsCustomStatus()
-        {
-            return this.Name == "Custom Status";
-        }
+            => this.Name == "Custom Status";
 
         /// <summary>
         /// Represents information about assets attached to a rich presence.

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -401,6 +401,19 @@ namespace DSharpPlus.Net
 
             return audit_log_data_raw;
         }
+
+        internal async Task<DiscordInvite> GetGuildVanityUrlAsync(ulong guild_id)
+        {
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.VANITY_URL}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET).ConfigureAwait(false);
+
+            var invite = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
+
+            return invite;
+        }
         #endregion
 
         #region Channel

--- a/DSharpPlus/Net/Endpoints.cs
+++ b/DSharpPlus/Net/Endpoints.cs
@@ -44,5 +44,7 @@
         public const string ASSETS = "/assets";
         public const string EMOJIS = "/emojis";
         public const string SUPPRESS_EMBEDS = "/suppress-embeds";
+        public const string VANITY_URL = "/vanity-url";
+        public const string WIDGET_PNG = "/widget.png";
     }
 }

--- a/DSharpPlus/Net/Models/GuildEditModel.cs
+++ b/DSharpPlus/Net/Models/GuildEditModel.cs
@@ -6,54 +6,80 @@ namespace DSharpPlus.Net.Models
     public class GuildEditModel : BaseEditModel
     {
         /// <summary>
-        /// New guild name
+        /// The new guild name.
         /// </summary>
         public Optional<string> Name { internal get; set; }
+
         /// <summary>
-        /// New guild voice region
+        /// The new guild voice region.
         /// </summary>
         public Optional<DiscordVoiceRegion> Region { internal get; set; }
+
         /// <summary>
-        /// New guild icon
+        /// The new guild icon.
         /// </summary>
         public Optional<Stream> Icon { internal get; set; }
+
         /// <summary>
-        /// New guild verification level
+        /// The new guild verification level.
         /// </summary>
         public Optional<VerificationLevel> VerificationLevel { internal get; set; }
+
         /// <summary>
-        /// New guild default message notification level
+        /// The new guild default message notification level.
         /// </summary>
         public Optional<DefaultMessageNotifications> DefaultMessageNotifications { internal get; set; }
+
         /// <summary>
-        /// New guild MFA level
+        /// The new guild MFA level.
         /// </summary>
         public Optional<MfaLevel> MfaLevel { internal get; set; }
+
         /// <summary>
-        /// New guild explicit content filter level
+        /// The new guild explicit content filter level.
         /// </summary>
         public Optional<ExplicitContentFilter> ExplicitContentFilter { internal get; set; }
+
         /// <summary>
-        /// New AFK voice channel
+        /// The new AFK voice channel.
         /// </summary>
         public Optional<DiscordChannel> AfkChannel { internal get; set; }
+
         /// <summary>
-        /// New AFK timeout time in seconds
+        /// The new AFK timeout time in seconds.
         /// </summary>
         public Optional<int> AfkTimeout { internal get; set; }
+
         /// <summary>
-        /// New guild owner
+        /// The new guild owner.
         /// </summary>
         public Optional<DiscordMember> Owner { internal get; set; }
+
         /// <summary>
-        /// New guild splash
+        /// The new guild splash.
         /// </summary>
         public Optional<Stream> Splash { internal get; set; }
+
         /// <summary>
-        /// New guild system channel
+        /// The new guild system channel.
         /// </summary>
         public Optional<DiscordChannel> SystemChannel { internal get; set; }
+
+        /// <summary>
+        /// The new guild rules channel.
+        /// </summary>
+        public Optional<DiscordChannel> RulesChannel { internal get; set; }
         
+        /// <summary>
+        /// The new guild public updates channel.
+        /// </summary>
+        public Optional<DiscordChannel> PublicUpdatesChannel { internal get; set; }
+
+        /// <summary>
+        /// The new guild preferred locale.
+        /// </summary>
+        public Optional<string> PreferredLocale { internal get; set; }
+
         internal GuildEditModel()
         {
 

--- a/DSharpPlus/Net/WebSocket/WebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient.cs
@@ -114,16 +114,28 @@ namespace DSharpPlus.Net.WebSocket
             try
             {
                 // Cancel all running tasks
-                this._socketTokenSource.Cancel();
-                this._receiverTokenSource.Cancel();
-                this._socketTokenSource.Dispose();
-                this._receiverTokenSource.Dispose();
+                if (this._socketTokenSource != null)
+                {
+                    this._socketTokenSource.Cancel();
+                    this._socketTokenSource.Dispose();
+                }
+
+                if (this._socketTokenSource != null)
+                {
+                    this._receiverTokenSource.Cancel();
+                    this._receiverTokenSource.Dispose();
+                }
 
                 this._isClientClose = true;
-                await this._ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None).ConfigureAwait(false);
-                await this._receiverTask.ConfigureAwait(false); // Ensure that receving completed
+
+                if (this._ws != null)
+                    await this._ws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None).ConfigureAwait(false);
+
+                if (this._receiverTask != null)
+                    await this._receiverTask.ConfigureAwait(false); // Ensure that receving completed
             }
             catch { }
+
             finally
             {
                 this._senderLock.Release();

--- a/DSharpPlus/Net/WebSocket/WebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient.cs
@@ -120,7 +120,7 @@ namespace DSharpPlus.Net.WebSocket
                     this._socketTokenSource.Dispose();
                 }
 
-                if (this._socketTokenSource != null)
+                if (this._receiverTokenSource != null)
                 {
                     this._receiverTokenSource.Cancel();
                     this._receiverTokenSource.Dispose();


### PR DESCRIPTION
# Summary
Fixes #432, and adds a variety of updates from the API.

# Details
The bulk of the changes were made to the `DiscordGuild` class, with the addition of the properties/endpoints mentioned there, as well as the addition of properties added in the server "Discovery" update, which were the `PreferredLocale`, `PublicUpdatesChannel`, and the `RulesChannel`. 

The minor changes included adding support for an guild region change in the audit logs, adding `this` to a variety of properties in `DiscordClient`, XML documentation updates, as well as fixing a null ref exception being thrown on startup.

# Changes proposed
* Added all properties from issue #432
* Added guild discovery properties.
* Added support for the region change in getting audit logs.
* Fixed a variety of style preferences, such as adding more `this` and fixing XML documentation
* Fixed a minor null ref being caught on startup.