### PR TITLE
Fixes MentionedUsers containing null users instead of skeletons

### DIFF
--- a/DSharpPlus/BaseDiscordClient.cs
+++ b/DSharpPlus/BaseDiscordClient.cs
@@ -175,7 +175,7 @@ namespace DSharpPlus
         }
 
         internal DiscordUser InternalGetCachedUser(ulong user_id) 
-            => this.UserCache.TryGetValue(user_id, out var user) ? user : null;
+            => this.UserCache.TryGetValue(user_id, out var user) ? user : new DiscordUser { Id = user_id, Discord = this };
 
         /// <summary>
         /// Disposes this client.

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -1647,7 +1647,7 @@ namespace DSharpPlus
             {
                 if (guild != null)
                 {
-                    mentionedUsers = Utilities.GetUserMentions(message).Select(xid => guild._members.TryGetValue(xid, out var member) ? member : null).Cast<DiscordUser>().ToList();
+                    mentionedUsers = Utilities.GetUserMentions(message).Select(xid => guild._members.TryGetValue(xid, out var member) ? member : new DiscordUser { Id = xid }).Cast<DiscordUser>().ToList();
                     mentionedRoles = Utilities.GetRoleMentions(message).Select(xid => guild.GetRole(xid)).ToList();
                     mentionedChannels = Utilities.GetChannelMentions(message).Select(xid => guild.GetChannel(xid)).ToList();
                 }

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -1647,7 +1647,7 @@ namespace DSharpPlus
             {
                 if (guild != null)
                 {
-                    mentionedUsers = Utilities.GetUserMentions(message).Select(xid => guild._members.TryGetValue(xid, out var member) ? member : new DiscordUser { Id = xid }).Cast<DiscordUser>().ToList();
+                    mentionedUsers = Utilities.GetUserMentions(message).Select(xid => guild._members.TryGetValue(xid, out var member) ? member : new DiscordUser { Id = xid, Discord = this }).Cast<DiscordUser>().ToList();
                     mentionedRoles = Utilities.GetRoleMentions(message).Select(xid => guild.GetRole(xid)).ToList();
                     mentionedChannels = Utilities.GetChannelMentions(message).Select(xid => guild.GetChannel(xid)).ToList();
                 }


### PR DESCRIPTION
# Summary
Fixes MentionedUsers containing null users instead of skeletons

# Details
Create a skeleton object of DiscordUser instead of filling the list with null values and losing the user ids.

# Notes
Baguette