### PR TITLE
Added New Events and Endpoint

### DIFF
--- a/DSharpPlus.Lavalink/EventArgs/StatisticsReceivedEventArgs.cs
+++ b/DSharpPlus.Lavalink/EventArgs/StatisticsReceivedEventArgs.cs
@@ -1,16 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using DSharpPlus.Lavalink.Entities;
+﻿using DSharpPlus.Lavalink.Entities;
 
 namespace DSharpPlus.Lavalink.EventArgs
 {
     /// <summary>
     /// Represents arguments for Lavalink statistics received.
     /// </summary>
-    public sealed class StatsReceivedEventArgs : AsyncEventArgs
+    public sealed class StatisticsReceivedEventArgs : AsyncEventArgs
     {
         /// <summary>
         /// Gets the Lavalink statistics received.
@@ -18,7 +13,7 @@ namespace DSharpPlus.Lavalink.EventArgs
         public LavalinkStatistics Statistics { get; }
 
 
-        internal StatsReceivedEventArgs(LavalinkStatistics stats)
+        internal StatisticsReceivedEventArgs(LavalinkStatistics stats)
         {
             this.Statistics = stats;
         }

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -46,12 +46,12 @@ namespace DSharpPlus.Lavalink
         /// <summary>
         /// Triggered when this node receives a statistics update.
         /// </summary>
-        public event AsyncEventHandler<StatsReceivedEventArgs> StatisticsReceived
+        public event AsyncEventHandler<StatisticsReceivedEventArgs> StatisticsReceived
         {
             add { this._statsReceived.Register(value); }
             remove { this._statsReceived.Unregister(value); }
         }
-        private AsyncEvent<StatsReceivedEventArgs> _statsReceived;
+        private AsyncEvent<StatisticsReceivedEventArgs> _statsReceived;
 
         /// <summary>
         /// Triggered whenever any of the players on this node is updated.
@@ -132,7 +132,7 @@ namespace DSharpPlus.Lavalink
 
             this._lavalinkSocketError = new AsyncEvent<SocketErrorEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_SOCKET_ERROR");
             this._disconnected = new AsyncEvent<NodeDisconnectedEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_NODE_DISCONNECTED");
-            this._statsReceived = new AsyncEvent<StatsReceivedEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_STATS_RECEIVED");
+            this._statsReceived = new AsyncEvent<StatisticsReceivedEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_STATS_RECEIVED");
             this._playerUpdated = new AsyncEvent<PlayerUpdateEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_PLAYER_UPDATED");
             this._playbackFinished = new AsyncEvent<TrackFinishEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_PLAYBACK_FINISHED");
             this._trackStuck = new AsyncEvent<TrackStuckEventArgs>(this.Discord.EventErrorHandler, "LAVALINK_TRACK_STUCK");
@@ -276,7 +276,7 @@ namespace DSharpPlus.Lavalink
                 case "stats":
                     var statsRaw = jsonData.ToObject<LavalinkStats>();
                     this.Statistics.Update(statsRaw);
-                    await this._statsReceived.InvokeAsync(new StatsReceivedEventArgs(this.Statistics)).ConfigureAwait(false);
+                    await this._statsReceived.InvokeAsync(new StatisticsReceivedEventArgs(this.Statistics)).ConfigureAwait(false);
                     break;
 
                 case "event":

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -155,6 +155,8 @@ namespace DSharpPlus
             this._guildDeleted = new AsyncEvent<GuildDeleteEventArgs>(this.EventErrorHandler, "GUILD_DELETED");
             this._guildUnavailable = new AsyncEvent<GuildDeleteEventArgs>(this.EventErrorHandler, "GUILD_UNAVAILABLE");
             this._guildDownloadCompletedEv = new AsyncEvent<GuildDownloadCompletedEventArgs>(this.EventErrorHandler, "GUILD_DOWNLOAD_COMPLETED");
+            this._inviteCreated = new AsyncEvent<InviteCreateEventArgs>(this.EventErrorHandler, "INVITE_CREATED");
+            this._inviteDeleted = new AsyncEvent<InviteDeleteEventArgs>(this.EventErrorHandler, "INVITE_DELETED");
             this._messageCreated = new AsyncEvent<MessageCreateEventArgs>(this.EventErrorHandler, "MESSAGE_CREATED");
             this._presenceUpdated = new AsyncEvent<PresenceUpdateEventArgs>(this.EventErrorHandler, "PRESENCE_UPDATED");
             this._guildBanAdded = new AsyncEvent<GuildBanAddEventArgs>(this.EventErrorHandler, "GUILD_BAN_ADD");
@@ -181,6 +183,7 @@ namespace DSharpPlus
             this._messageReactionAdded = new AsyncEvent<MessageReactionAddEventArgs>(this.EventErrorHandler, "MESSAGE_REACTION_ADDED");
             this._messageReactionRemoved = new AsyncEvent<MessageReactionRemoveEventArgs>(this.EventErrorHandler, "MESSAGE_REACTION_REMOVED");
             this._messageReactionsCleared = new AsyncEvent<MessageReactionsClearEventArgs>(this.EventErrorHandler, "MESSAGE_REACTIONS_CLEARED");
+            this._messageReactionRemovedEmoji = new AsyncEvent<MessageReactionRemoveEmojiEventArgs>(this.EventErrorHandler, "MESSAGE_REACTION_REMOVED_EMOJI");
             this._webhooksUpdated = new AsyncEvent<WebhooksUpdateEventArgs>(this.EventErrorHandler, "WEBHOOKS_UPDATED");
             this._heartbeated = new AsyncEvent<HeartbeatEventArgs>(this.EventErrorHandler, "HEARTBEATED");
 
@@ -763,6 +766,18 @@ namespace DSharpPlus
                     await OnGuildRoleDeleteEventAsync((ulong)dat["role_id"], this._guilds[gid]).ConfigureAwait(false);
                     break;
 
+                case "invite_create":
+                    gid = (ulong)dat["guild_id"];
+                    cid = (ulong)dat["channel_id"];
+                    await OnInviteCreateEventAsync(cid, gid, dat.ToObject<DiscordInvite>()).ConfigureAwait(false);
+                    break;
+
+                case "invite_delete":
+                    gid = (ulong)dat["guild_id"];
+                    cid = (ulong)dat["channel_id"];
+                    await OnInviteDeleteEventAsync(cid, gid, dat).ConfigureAwait(false);
+                    break;
+
                 case "message_ack":
                     cid = (ulong)dat["channel_id"];
                     var mid = (ulong)dat["message_id"];
@@ -822,6 +837,10 @@ namespace DSharpPlus
 
                 case "message_reaction_remove_all":
                     await OnMessageReactionRemoveAllAsync((ulong)dat["message_id"], (ulong)dat["channel_id"], (ulong?)dat["guild_id"]).ConfigureAwait(false);
+                    break;
+
+                case "message_reaction_remove_emoji":
+                    await OnMessageReactionRemoveEmojiAsync((ulong)dat["message_id"], (ulong)dat["channel_id"], (ulong)dat["guild_id"], dat["emoji"]).ConfigureAwait(false);
                     break;
 
                 case "webhooks_update":
@@ -1603,6 +1622,47 @@ namespace DSharpPlus
             await this._guildRoleDeleted.InvokeAsync(ea).ConfigureAwait(false);
         }
 
+        internal async Task OnInviteCreateEventAsync(ulong channelId, ulong guildId, DiscordInvite invite)
+        {
+            var guild = this.InternalGetCachedGuild(guildId);
+            var channel = this.InternalGetCachedChannel(channelId);
+
+            invite.Discord = this;            
+
+            guild._invites[invite.Code] = invite;
+
+            var ea = new InviteCreateEventArgs(this)
+            {
+                Client = this,
+                Channel = channel,
+                Guild = guild,
+                Invite = invite
+            };
+            await this._inviteCreated.InvokeAsync(ea).ConfigureAwait(false);
+        }
+
+        internal async Task OnInviteDeleteEventAsync(ulong channelId, ulong guildId, JToken dat)
+        {
+            var guild = this.InternalGetCachedGuild(guildId);
+            var channel = this.InternalGetCachedChannel(channelId);
+
+            if (!guild._invites.TryRemove(dat["code"].ToString(), out var invite))
+            {
+                invite = dat.ToObject<DiscordInvite>();
+                invite.IsRevoked = true;
+                invite.Discord = this;
+            }
+
+            var ea = new InviteDeleteEventArgs(this)
+            {
+                Client = this,
+                Channel = channel,
+                Guild = guild,
+                Invite = invite
+            };
+            await this._inviteDeleted.InvokeAsync(ea).ConfigureAwait(false);
+        }
+
         internal async Task OnMessageAckEventAsync(DiscordChannel chn, ulong messageId)
         {
             DiscordMessage msg = null;
@@ -2115,6 +2175,43 @@ namespace DSharpPlus
             };
 
             await this._messageReactionsCleared.InvokeAsync(ea).ConfigureAwait(false);
+        }
+
+        internal async Task OnMessageReactionRemoveEmojiAsync(ulong messageId, ulong channelId, ulong guildId, JToken dat)
+        {
+            var guild = this.InternalGetCachedGuild(guildId);
+            var channel = this.InternalGetCachedChannel(channelId);
+
+            if (channel == null || this.Configuration.MessageCacheSize == 0 ||
+                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
+            {
+                msg = new DiscordMessage
+                {
+                    Id = messageId,
+                    ChannelId = channelId,
+                    Discord = this
+                };
+            }
+
+            var partialEmoji = dat.ToObject<DiscordEmoji>();
+
+            if (!guild._emojis.TryGetValue(partialEmoji.Id, out var emoji))
+            {
+                emoji = partialEmoji;
+                emoji.Discord = this;
+            }
+
+            msg._reactions?.RemoveAll(r => r.Emoji.Equals(emoji));
+
+            var ea = new MessageReactionRemoveEmojiEventArgs(this)
+            {
+                Channel = channel,
+                Guild = guild,
+                Message = msg,
+                Emoji = emoji
+            };
+
+            await this._messageReactionRemovedEmoji.InvokeAsync(ea).ConfigureAwait(false);
         }
 
         internal async Task OnWebhooksUpdateAsync(DiscordChannel channel, DiscordGuild guild)
@@ -2716,6 +2813,25 @@ namespace DSharpPlus
         private AsyncEvent<GuildDownloadCompletedEventArgs> _guildDownloadCompletedEv;
 
         /// <summary>
+        /// Fired when an invite is created.
+        /// </summary>
+        public event AsyncEventHandler<InviteCreateEventArgs> InviteCreated
+        {
+            add => this._inviteCreated.Register(value);
+            remove => this._inviteCreated.Unregister(value);
+        }
+        private AsyncEvent<InviteCreateEventArgs> _inviteCreated;
+
+        /// <summary>
+        /// Fired when an invite is deleted.
+        /// </summary>
+        public event AsyncEventHandler<InviteDeleteEventArgs> InviteDeleted
+        {
+            add => this._inviteDeleted.Register(value);
+            remove => this._inviteDeleted.Unregister(value);
+        }
+        private AsyncEvent<InviteDeleteEventArgs> _inviteDeleted;
+        /// <summary>
         /// Fired when a message is created.
         /// </summary>
         public event AsyncEventHandler<MessageCreateEventArgs> MessageCreated
@@ -2977,6 +3093,16 @@ namespace DSharpPlus
             remove => this._messageReactionsCleared.Unregister(value);
         }
         private AsyncEvent<MessageReactionsClearEventArgs> _messageReactionsCleared;
+
+        /// <summary>
+        /// Fired when all reactions of a specific reaction are removed from a message.
+        /// </summary>
+        public event AsyncEventHandler<MessageReactionRemoveEmojiEventArgs> MessageReactionRemovedEmoji
+        {
+            add => this._messageReactionRemovedEmoji.Register(value);
+            remove => this._messageReactionRemovedEmoji.Unregister(value);
+        }
+        private AsyncEvent<MessageReactionRemoveEmojiEventArgs> _messageReactionRemovedEmoji;
 
         /// <summary>
         /// Fired whenever webhooks update.

--- a/DSharpPlus/DiscordShardedClient.cs
+++ b/DSharpPlus/DiscordShardedClient.cs
@@ -200,6 +200,26 @@ namespace DSharpPlus
         private AsyncEvent<GuildDownloadCompletedEventArgs> _guildDownloadCompleted;
 
         /// <summary>
+        /// Fired when an invite is created.
+        /// </summary>
+        public event AsyncEventHandler<InviteCreateEventArgs> InviteCreated
+        {
+            add => this._inviteCreated.Register(value);
+            remove => this._inviteCreated.Unregister(value);
+        }
+        private AsyncEvent<InviteCreateEventArgs> _inviteCreated;
+
+        /// <summary>
+        /// Fired when an invite is deleted.
+        /// </summary>
+        public event AsyncEventHandler<InviteDeleteEventArgs> InviteDeleted
+        {
+            add => this._inviteDeleted.Register(value);
+            remove => this._inviteDeleted.Unregister(value);
+        }
+        private AsyncEvent<InviteDeleteEventArgs> _inviteDeleted;
+
+        /// <summary>
         /// Fired when a message is created.
         /// </summary>
         public event AsyncEventHandler<MessageCreateEventArgs> MessageCreated
@@ -450,6 +470,16 @@ namespace DSharpPlus
         private AsyncEvent<MessageReactionsClearEventArgs> _messageReactionsCleared;
 
         /// <summary>
+        /// Fired when all reactions of a specific reaction are removed from a message.
+        /// </summary>
+        public event AsyncEventHandler<MessageReactionRemoveEmojiEventArgs> MessageReactionRemovedEmoji
+        {
+            add => this._messageReactionRemovedEmoji.Register(value);
+            remove => this._messageReactionRemovedEmoji.Unregister(value);
+        }
+        private AsyncEvent<MessageReactionRemoveEmojiEventArgs> _messageReactionRemovedEmoji;
+
+        /// <summary>
         /// Fired whenever webhooks update.
         /// </summary>
         public event AsyncEventHandler<WebhooksUpdateEventArgs> WebhooksUpdated
@@ -547,6 +577,8 @@ namespace DSharpPlus
             this._guildDeleted = new AsyncEvent<GuildDeleteEventArgs>(this.EventErrorHandler, "GUILD_DELETED");
             this._guildUnavailable = new AsyncEvent<GuildDeleteEventArgs>(this.EventErrorHandler, "GUILD_UNAVAILABLE");
             this._guildDownloadCompleted = new AsyncEvent<GuildDownloadCompletedEventArgs>(this.EventErrorHandler, "GUILD_DOWNLOAD_COMPLETED");
+            this._inviteCreated = new AsyncEvent<InviteCreateEventArgs>(this.EventErrorHandler, "INVITE_CREATED");
+            this._inviteDeleted = new AsyncEvent<InviteDeleteEventArgs>(this.EventErrorHandler, "INVITE_DELETED");
             this._messageCreated = new AsyncEvent<MessageCreateEventArgs>(this.EventErrorHandler, "MESSAGE_CREATED");
             this._presenceUpdated = new AsyncEvent<PresenceUpdateEventArgs>(this.EventErrorHandler, "PRESENCE_UPDATED");
             this._guildBanAdded = new AsyncEvent<GuildBanAddEventArgs>(this.EventErrorHandler, "GUILD_BAN_ADDED");
@@ -572,6 +604,7 @@ namespace DSharpPlus
             this._messageReactionAdded = new AsyncEvent<MessageReactionAddEventArgs>(this.EventErrorHandler, "MESSAGE_REACTION_ADDED");
             this._messageReactionRemoved = new AsyncEvent<MessageReactionRemoveEventArgs>(this.EventErrorHandler, "MESSAGE_REACTION_REMOVED");
             this._messageReactionsCleared = new AsyncEvent<MessageReactionsClearEventArgs>(this.EventErrorHandler, "MESSAGE_REACTIONS_CLEARED");
+            this._messageReactionRemovedEmoji = new AsyncEvent<MessageReactionRemoveEmojiEventArgs>(this.EventErrorHandler, "MESSAGE_REACTION_REMOVED_EMOJI");
             this._webhooksUpdated = new AsyncEvent<WebhooksUpdateEventArgs>(this.EventErrorHandler, "WEBHOOKS_UPDATED");
             this._heartbeated = new AsyncEvent<HeartbeatEventArgs>(this.EventErrorHandler, "HEARTBEATED");
 
@@ -650,6 +683,8 @@ namespace DSharpPlus
                 client.GuildDeleted += this.Client_GuildDeleted;
                 client.GuildUnavailable += this.Client_GuildUnavailable;
                 client.GuildDownloadCompleted += this.Client_GuildDownloadCompleted;
+                client.InviteCreated += this.Client_InviteCreated;
+                client.InviteDeleted += this.Client_InviteDeleted;
                 client.MessageCreated += this.Client_MessageCreated;
                 client.PresenceUpdated += this.Client_PresenceUpdate;
                 client.GuildBanAdded += this.Client_GuildBanAdd;
@@ -675,6 +710,7 @@ namespace DSharpPlus
                 client.MessageReactionAdded += this.Client_MessageReactionAdd;
                 client.MessageReactionRemoved += this.Client_MessageReactionRemove;
                 client.MessageReactionsCleared += this.Client_MessageReactionRemoveAll;
+                client.MessageReactionRemovedEmoji += this.Client_MessageReactionRemovedEmoji;
                 client.WebhooksUpdated += this.Client_WebhooksUpdate;
                 client.Heartbeated += this.Client_HeartBeated;
                 client.DebugLogger.LogMessageReceived += this.DebugLogger_LogMessageReceived;
@@ -787,6 +823,12 @@ namespace DSharpPlus
         private Task Client_MessageCreated(MessageCreateEventArgs e) 
             => this._messageCreated.InvokeAsync(e);
 
+        private Task Client_InviteCreated(InviteCreateEventArgs e)
+            => this._inviteCreated.InvokeAsync(e);
+
+        private Task Client_InviteDeleted(InviteDeleteEventArgs e)
+            => this._inviteDeleted.InvokeAsync(e);
+
         private Task Client_PresenceUpdate(PresenceUpdateEventArgs e) 
             => this._presenceUpdated.InvokeAsync(e);
 
@@ -858,6 +900,9 @@ namespace DSharpPlus
 
         private Task Client_MessageReactionRemoveAll(MessageReactionsClearEventArgs e) 
             => this._messageReactionsCleared.InvokeAsync(e);
+
+        private Task Client_MessageReactionRemovedEmoji(MessageReactionRemoveEmojiEventArgs e)
+            => this._messageReactionRemovedEmoji.InvokeAsync(e);
 
         private Task Client_WebhooksUpdate(WebhooksUpdateEventArgs e) 
             => this._webhooksUpdated.InvokeAsync(e);

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -7,11 +7,12 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using DSharpPlus.Net.Abstractions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using DSharpPlus.Enums;
 using DSharpPlus.Net.Models;
 using DSharpPlus.Net.Serialization;
+using DSharpPlus.Net.Abstractions;
 
 namespace DSharpPlus.Entities
 {
@@ -53,6 +54,26 @@ namespace DSharpPlus.Entities
             => !string.IsNullOrWhiteSpace(this.SplashHash) ? $"https://cdn.discordapp.com/splashes/{this.Id.ToString(CultureInfo.InvariantCulture)}/{SplashHash}.jpg" : null;
 
         /// <summary>
+        /// Gets the guild discovery splash's hash.
+        /// </summary>
+        [JsonProperty("discovery_splash", NullValueHandling = NullValueHandling.Ignore)]
+        public string DiscoverySplashHash { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild discovery splash's url.
+        /// </summary>
+        [JsonIgnore]
+        public string DiscoverySplashUrl
+            => !string.IsNullOrWhiteSpace(this.DiscoverySplashHash) ? $"https://cdn.discordapp.com/discovery-splashes/{this.Id.ToString(CultureInfo.InvariantCulture)}/{DiscoverySplashHash}.jpg" : null;
+
+        /// <summary>
+        /// Gets the preferred locale of this guild.
+        /// <para>This is used for server discovery and notices from Discord. Defaults to en-US.</para>
+        /// </summary>
+        [JsonProperty("preferred_locale", NullValueHandling = NullValueHandling.Ignore)]
+        public string PreferredLocale { get; internal set; }
+
+        /// <summary>
         /// Gets the ID of the guild's owner.
         /// </summary>
         [JsonProperty("owner_id", NullValueHandling = NullValueHandling.Ignore)]
@@ -69,8 +90,8 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public DiscordMember Owner
-            => this.Members.TryGetValue(this.OwnerId, out var owner) 
-                ? owner 
+            => this.Members.TryGetValue(this.OwnerId, out var owner)
+                ? owner
                 : this.Discord.ApiClient.GetGuildMemberAsync(this.Id, this.OwnerId).ConfigureAwait(false).GetAwaiter().GetResult();
 
         /// <summary>
@@ -146,12 +167,65 @@ namespace DSharpPlus.Entities
         internal ulong? SystemChannelId { get; set; }
 
         /// <summary>
-        /// Gets the channel to which system messages (such as join notifications) are sent.
+        /// Gets the channel where system messages (such as boost and welcome messages) are sent.
         /// </summary>
         [JsonIgnore]
-        public DiscordChannel SystemChannel => SystemChannelId.HasValue
-            ? this.GetChannel(SystemChannelId.Value)
+        public DiscordChannel SystemChannel => this.SystemChannelId.HasValue
+            ? this.GetChannel(this.SystemChannelId.Value)
             : null;
+
+        /// <summary>
+        /// Gets the settings for this guild's system channel.
+        /// </summary>
+        [JsonProperty("system_channel_flags")]
+        public SystemChannelFlags SystemChannelFlags { get; internal set; }
+
+        /// <summary>
+        /// Gets whether this guild's widget is enabled.
+        /// </summary>
+        [JsonProperty("widget_enabled", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? WidgetEnabled { get; internal set; }
+
+        [JsonProperty("widget_channel_id", NullValueHandling = NullValueHandling.Ignore)]
+        internal ulong? WidgetChannelId { get; set; }
+
+        /// <summary>
+        /// Gets the widget channel for this guild.
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel WidgetChannel => this.WidgetChannelId.HasValue
+            ? this.GetChannel(this.WidgetChannelId.Value)
+            : null;
+
+        [JsonProperty("rules_channel_id")]
+        internal ulong? RulesChannelId { get; set; }
+
+        /// <summary>
+        /// Gets the rules channel for this guild.
+        /// <para>This is only available if the guild is considered "discoverable".</para>
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel RulesChannel => this.RulesChannelId.HasValue
+            ? this.GetChannel(this.RulesChannelId.Value)
+            : null;
+
+        [JsonProperty("public_updates_channel_id")]
+        internal ulong? PublicUpdatesChannelId { get; set; }
+
+        /// <summary>
+        /// Gets the public updates channel (where admins and moderators receive messages from Discord) for this guild.
+        /// <para>This is only available if the guild is considered "discoverable".</para>
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel PublicUpdatesChannel => this.PublicUpdatesChannelId.HasValue
+            ? this.GetChannel(this.PublicUpdatesChannelId.Value)
+            : null;
+
+        /// <summary>
+        /// Gets the application id of this guild if it is bot created.
+        /// </summary>
+        [JsonProperty("application_id")]
+        public ulong? ApplicationId { get; internal set; }
 
         /// <summary>
         /// Gets a collection of this guild's roles.
@@ -208,6 +282,18 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("member_count", NullValueHandling = NullValueHandling.Ignore)]
         public int MemberCount { get; internal set; }
+
+        /// <summary>
+        /// Gets the maximum amount of members allowed for this guild.
+        /// </summary>
+        [JsonProperty("max_members")]
+        public int? MaxMembers { get; internal set; }
+
+        /// <summary>
+        /// Gets the maximum amount of presences allowed for this guild.
+        /// </summary>
+        [JsonProperty("max_presences")]
+        public int? MaxPresences { get; internal set; }
 
         /// <summary>
         /// Gets a dictionary of all the voice states for this guilds. The key for this dictionary is the ID of the user
@@ -273,16 +359,23 @@ namespace DSharpPlus.Entities
         public string VanityUrlCode { get; internal set; }
 
         /// <summary>
-        /// Gets guild description, when applicable.
+        /// Gets the guild description, when applicable.
         /// </summary>
         [JsonProperty("description")]
         public string Description { get; internal set; }
 
         /// <summary>
-        /// Gets guild banner hash, when applicable.
+        /// Gets this guild's banner hash, when applicable.
         /// </summary>
         [JsonProperty("banner")]
         public string Banner { get; internal set; }
+
+        /// <summary>
+        /// Gets this guild's banner in url form.
+        /// </summary>
+        [JsonIgnore]
+        public string BannerUrl
+            => !string.IsNullOrWhiteSpace(this.Banner) ? $"https://cdn.discordapp.com/banners/{this.Id}/{this.Banner}" : null;
 
         /// <summary>
         /// Gets this guild's premium tier (Nitro boosting).
@@ -295,6 +388,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("premium_subscription_count", NullValueHandling = NullValueHandling.Ignore)]
         public int? PremiumSubscriptionCount { get; internal set; }
+
         // Seriously discord?
 
         // I need to work on this
@@ -310,7 +404,7 @@ namespace DSharpPlus.Entities
         internal bool IsSynced { get; set; }
 
         internal DiscordGuild()
-        {
+        { 
             this._current_member_lazy = new Lazy<DiscordMember>(() => this._members.TryGetValue(this.Discord.CurrentUser.Id, out var member) ? member : null);
             this._invites = new ConcurrentDictionary<string, DiscordInvite>();
         }
@@ -475,7 +569,7 @@ namespace DSharpPlus.Entities
         public Task<DiscordChannel> CreateChannelAsync(string name, ChannelType type, DiscordChannel parent = null, Optional<string> topic = default, int? bitrate = null, int? userLimit = null, IEnumerable<DiscordOverwriteBuilder> overwrites = null, bool? nsfw = null, Optional<int?> perUserRateLimit = default, string reason = null)
         {
             // technically you can create news/store channels but not always
-            if (type != ChannelType.Text && type != ChannelType.Voice && type != ChannelType.Category && type != ChannelType.News && type != ChannelType.Store) 
+            if (type != ChannelType.Text && type != ChannelType.Voice && type != ChannelType.Category && type != ChannelType.News && type != ChannelType.Store)
                 throw new ArgumentException("Channel type must be text, voice, or category.", nameof(type));
 
             if (type == ChannelType.Category && parent != null)
@@ -576,7 +670,7 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Gets an invite from this guild from an invite code.
+        /// Gets an invite from this guild from an invite code. 
         /// </summary>
         /// <param name="code">The invite code</param>
         /// <returns>An invite.</returns>
@@ -588,7 +682,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <returns>A collection of invites.</returns>
         public async Task<IReadOnlyList<DiscordInvite>> GetInvitesAsync()
-        { 
+        {
             var res = await this.Discord.ApiClient.GetGuildInvitesAsync(this.Id).ConfigureAwait(false);
 
             for (var i = 0; i < res.Count; i++)
@@ -598,11 +692,54 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// Gets the vanity invite for this guild.
+        /// </summary>
+        /// <returns>A partial vanity invite.</returns>
+        public Task<DiscordInvite> GetVanityInviteAsync()
+            => this.Discord.ApiClient.GetGuildVanityUrlAsync(this.Id);
+
+
+        /// <summary>
         /// Gets all the webhooks created for all the channels in this guild.
         /// </summary>
         /// <returns>A collection of webhooks this guild has.</returns>
         public Task<IReadOnlyList<DiscordWebhook>> GetWebhooksAsync()
             => this.Discord.ApiClient.GetGuildWebhooksAsync(this.Id);
+
+        /// <summary>
+        /// Gets this guild's widget image.
+        /// </summary>
+        /// <param name="bannerType">The format of the widget.</param>
+        /// <returns>The URL of the widget image.</returns>
+        public string GetWidgetImage(WidgetType bannerType = WidgetType.Shield)
+        {
+            string param;
+
+            switch (bannerType)
+            {
+                case WidgetType.Banner1:
+                    param = "banner1";
+                    break;
+
+                case WidgetType.Banner2:
+                    param = "banner2";
+                    break;
+
+                case WidgetType.Banner3:
+                    param = "banner3";
+                    break;
+
+                case WidgetType.Banner4:
+                    param = "banner4";
+                    break;
+
+                default:
+                    param = "shield";
+                    break;
+            }
+
+            return $"{Net.Endpoints.BASE_URI}{Net.Endpoints.GUILDS}/{this.Id}{Net.Endpoints.WIDGET_PNG}?style={param}";
+        }
 
         /// <summary>
         /// Gets a member of this guild by his user ID.
@@ -838,8 +975,8 @@ namespace DSharpPlus.Entities
 
                                     entrygld.AfkChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = this.GetChannel(t1),
-                                        After = this.GetChannel(t2)
+                                        Before = this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id },
+                                        After = this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id }
                                     };
                                     break;
 
@@ -849,8 +986,8 @@ namespace DSharpPlus.Entities
 
                                     entrygld.EmbedChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = this.GetChannel(t1),
-                                        After = this.GetChannel(t2)
+                                        Before = this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id },
+                                        After = this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id }
                                     };
                                     break;
 
@@ -876,8 +1013,8 @@ namespace DSharpPlus.Entities
 
                                     entrygld.SystemChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = this.GetChannel(t1),
-                                        After = this.GetChannel(t2)
+                                        Before = this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id },
+                                        After = this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id }
                                     };
                                     break;
 
@@ -897,6 +1034,14 @@ namespace DSharpPlus.Entities
                                     };
                                     break;
 
+                                case "region":
+                                    entrygld.RegionChange = new PropertyChange<string>
+                                    {
+                                        Before = xc.OldValueString,
+                                        After = xc.NewValueString
+                                    };
+                                    break;
+
                                 default:
                                     this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in guild update: {xc.Key}; this should be reported to devs", DateTime.Now);
                                     break;
@@ -909,7 +1054,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.ChannelUpdate:
                         entry = new DiscordAuditLogChannelEntry
                         {
-                            Target = this.GetChannel(xac.TargetId.Value) ?? new DiscordChannel { Id = xac.TargetId.Value }
+                            Target = this.GetChannel(xac.TargetId.Value) ?? new DiscordChannel { Id = xac.TargetId.Value, Discord = this.Discord, GuildId = this.Id }
                         };
 
                         var entrychn = entry as DiscordAuditLogChannelEntry;
@@ -1056,7 +1201,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.Kick:
                         entry = new DiscordAuditLogKickEntry
                         {
-                            Target = amd.TryGetValue(xac.TargetId.Value, out var kickMember) ? kickMember : new DiscordMember { Id = xac.TargetId.Value }
+                            Target = amd.TryGetValue(xac.TargetId.Value, out var kickMember) ? kickMember : new DiscordMember { Id = xac.TargetId.Value, Discord = this.Discord, _guild_id = this.Id }
                         };
                         break;
 
@@ -1072,7 +1217,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.Unban:
                         entry = new DiscordAuditLogBanEntry
                         {
-                            Target = amd.TryGetValue(xac.TargetId.Value, out var unbanMember) ? unbanMember : new DiscordMember { Id = xac.TargetId.Value }
+                            Target = amd.TryGetValue(xac.TargetId.Value, out var unbanMember) ? unbanMember : new DiscordMember { Id = xac.TargetId.Value, Discord = this.Discord, _guild_id = this.Id }
                         };
                         break;
 
@@ -1080,7 +1225,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.MemberRoleUpdate:
                         entry = new DiscordAuditLogMemberUpdateEntry
                         {
-                            Target = amd.TryGetValue(xac.TargetId.Value, out var roleUpdMember) ? roleUpdMember : new DiscordMember { Id = xac.TargetId.Value }
+                            Target = amd.TryGetValue(xac.TargetId.Value, out var roleUpdMember) ? roleUpdMember : new DiscordMember { Id = xac.TargetId.Value, Discord = this.Discord, _guild_id = this.Id }
                         };
 
                         var entrymbu = entry as DiscordAuditLogMemberUpdateEntry;
@@ -1099,16 +1244,16 @@ namespace DSharpPlus.Entities
                                 case "deaf":
                                     entrymbu.DeafenChange = new PropertyChange<bool?>
                                     {
-                                        Before = (bool?) xc.OldValue,
-                                        After = (bool?) xc.NewValue
+                                        Before = (bool?)xc.OldValue,
+                                        After = (bool?)xc.NewValue
                                     };
                                     break;
 
                                 case "mute":
                                     entrymbu.MuteChange = new PropertyChange<bool?>
                                     {
-                                        Before = (bool?) xc.OldValue,
-                                        After = (bool?) xc.NewValue
+                                        Before = (bool?)xc.OldValue,
+                                        After = (bool?)xc.NewValue
                                     };
                                     break;
 
@@ -1132,7 +1277,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.RoleUpdate:
                         entry = new DiscordAuditLogRoleUpdateEntry
                         {
-                            Target = this.GetRole(xac.TargetId.Value) ?? new DiscordRole { Id = xac.TargetId.Value }
+                            Target = this.GetRole(xac.TargetId.Value) ?? new DiscordRole { Id = xac.TargetId.Value, Discord = this.Discord }
                         };
 
                         var entryrol = entry as DiscordAuditLogRoleUpdateEntry;
@@ -1255,8 +1400,8 @@ namespace DSharpPlus.Entities
 
                                     entryinv.InviterChange = new PropertyChange<DiscordMember>
                                     {
-                                        Before = amd.TryGetValue(t1, out var propBeforeMember) ? propBeforeMember : null,
-                                        After = amd.TryGetValue(t2, out var propAfterMember) ? propAfterMember : null,
+                                        Before = amd.TryGetValue(t1, out var propBeforeMember) ? propBeforeMember : new DiscordMember { Id = t1, Discord = this.Discord, _guild_id = this.Id },
+                                        After = amd.TryGetValue(t2, out var propAfterMember) ? propAfterMember : new DiscordMember { Id = t1, Discord = this.Discord, _guild_id = this.Id },
                                     };
                                     break;
 
@@ -1266,8 +1411,8 @@ namespace DSharpPlus.Entities
 
                                     entryinv.ChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = p1 ? this.GetChannel(t1) : null,
-                                        After = p2 ? this.GetChannel(t2) : null
+                                        Before = p1 ? this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null,
+                                        After = p2 ? this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null
                                     };
 
                                     var ch = entryinv.ChannelChange.Before ?? entryinv.ChannelChange.After;
@@ -1317,7 +1462,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.WebhookUpdate:
                         entry = new DiscordAuditLogWebhookEntry
                         {
-                            Target = ahd.TryGetValue(xac.TargetId.Value, out var webhook) ? webhook : new DiscordWebhook { Id = xac.TargetId.Value }
+                            Target = ahd.TryGetValue(xac.TargetId.Value, out var webhook) ? webhook : new DiscordWebhook { Id = xac.TargetId.Value, Discord = this.Discord }
                         };
 
                         var entrywhk = entry as DiscordAuditLogWebhookEntry;
@@ -1339,8 +1484,8 @@ namespace DSharpPlus.Entities
 
                                     entrywhk.ChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = p1 ? this.GetChannel(t1) : null,
-                                        After = p2 ? this.GetChannel(t2) : null
+                                        Before = p1 ? this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null,
+                                        After = p2 ? this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null
                                     };
                                     break;
 
@@ -1375,7 +1520,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.EmojiUpdate:
                         entry = new DiscordAuditLogEmojiEntry
                         {
-                            Target = this._emojis.TryGetValue(xac.TargetId.Value, out var target) ? target : new DiscordEmoji { Id = xac.TargetId.Value }
+                            Target = this._emojis.TryGetValue(xac.TargetId.Value, out var target) ? target : new DiscordEmoji { Id = xac.TargetId.Value, Discord = this.Discord }
                         };
 
                         var entryemo = entry as DiscordAuditLogEmojiEntry;
@@ -1407,7 +1552,7 @@ namespace DSharpPlus.Entities
 
                             if (xac.Options != null)
                             {
-                                entrymsg.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId };
+                                entrymsg.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
                                 entrymsg.MessageCount = xac.Options.Count;
                             }
 
@@ -1438,14 +1583,14 @@ namespace DSharpPlus.Entities
                             {
                                 dc.MessageCache.TryGet(x => x.Id == xac.Options.MessageId && x.ChannelId == xac.Options.ChannelId, out var message);
 
-                                entrypin.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId };
-                                entrypin.Message = message ?? new DiscordMessage { Id = xac.Options.MessageId };
+                                entrypin.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
+                                entrypin.Message = message ?? new DiscordMessage { Id = xac.Options.MessageId, Discord = this.Discord };
                             }
 
                             if (xac.TargetId.HasValue)
                             {
                                 dc.UserCache.TryGetValue(xac.TargetId.Value, out var user);
-                                entrypin.Target = user ?? new DiscordUser { Id = user.Id };
+                                entrypin.Target = user ?? new DiscordUser { Id = user.Id, Discord = this.Discord };
                             }
 
                             break;
@@ -1461,7 +1606,7 @@ namespace DSharpPlus.Entities
                             }
 
                             dc.UserCache.TryGetValue(xac.TargetId.Value, out var bot);
-                            (entry as DiscordAuditLogBotAddEntry).TargetBot = bot ?? new DiscordUser { Id = xac.TargetId.Value };
+                            (entry as DiscordAuditLogBotAddEntry).TargetBot = bot ?? new DiscordUser { Id = xac.TargetId.Value, Discord = this.Discord };
 
                             break;
                         }
@@ -1477,7 +1622,7 @@ namespace DSharpPlus.Entities
                         var moveentry = entry as DiscordAuditLogMemberMoveEntry;
 
                         moveentry.UserCount = xac.Options.Count;
-                        moveentry.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId };
+                        moveentry.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
                         break;
 
                     case AuditLogActionType.MemberDisconnect:
@@ -1840,5 +1985,37 @@ namespace DSharpPlus.Entities
         /// Messages from all members are scanned.
         /// </summary>
         AllMembers = 2
+    }
+
+    /// <summary>
+    /// Represents the formats for a guild widget.
+    /// </summary>
+    public enum WidgetType : int
+    {
+        /// <summary>
+        /// The widget is represented in shield format.
+        /// <para>This is the default widget type.</para>
+        /// </summary>
+        Shield = 0,
+
+        /// <summary>
+        /// The widget is represented as the first banner type.
+        /// </summary>
+        Banner1 = 1,
+
+        /// <summary>
+        /// The widget is represented as the second banner type.
+        /// </summary>
+        Banner2 = 2,
+
+        /// <summary>
+        /// The widget is represented as the third banner type.
+        /// </summary>
+        Banner3 = 3,
+
+        /// <summary>
+        /// The widget is represented in the fourth banner type.
+        /// </summary>
+        Banner4 = 4
     }
 }

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -7,12 +7,11 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using DSharpPlus.Net.Abstractions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using DSharpPlus.Enums;
 using DSharpPlus.Net.Models;
 using DSharpPlus.Net.Serialization;
-using DSharpPlus.Net.Abstractions;
 
 namespace DSharpPlus.Entities
 {
@@ -52,26 +51,6 @@ namespace DSharpPlus.Entities
         [JsonIgnore]
         public string SplashUrl
             => !string.IsNullOrWhiteSpace(this.SplashHash) ? $"https://cdn.discordapp.com/splashes/{this.Id.ToString(CultureInfo.InvariantCulture)}/{SplashHash}.jpg" : null;
-
-        /// <summary>
-        /// Gets the guild discovery splash's hash.
-        /// </summary>
-        [JsonProperty("discovery_splash", NullValueHandling = NullValueHandling.Ignore)]
-        public string DiscoverySplashHash { get; internal set; }
-
-        /// <summary>
-        /// Gets the guild discovery splash's url.
-        /// </summary>
-        [JsonIgnore]
-        public string DiscoverySplashUrl
-            => !string.IsNullOrWhiteSpace(this.DiscoverySplashHash) ? $"https://cdn.discordapp.com/discovery-splashes/{this.Id.ToString(CultureInfo.InvariantCulture)}/{DiscoverySplashHash}.jpg" : null;
-
-        /// <summary>
-        /// Gets the preferred locale of this guild.
-        /// <para>This is used for server discovery and notices from Discord. Defaults to en-US.</para>
-        /// </summary>
-        [JsonProperty("preferred_locale", NullValueHandling = NullValueHandling.Ignore)]
-        public string PreferredLocale { get; internal set; }
 
         /// <summary>
         /// Gets the ID of the guild's owner.
@@ -167,65 +146,12 @@ namespace DSharpPlus.Entities
         internal ulong? SystemChannelId { get; set; }
 
         /// <summary>
-        /// Gets the channel where system messages (such as boost and welcome messages) are sent.
+        /// Gets the channel to which system messages (such as join notifications) are sent.
         /// </summary>
         [JsonIgnore]
-        public DiscordChannel SystemChannel => this.SystemChannelId.HasValue
-            ? this.GetChannel(this.SystemChannelId.Value)
+        public DiscordChannel SystemChannel => SystemChannelId.HasValue
+            ? this.GetChannel(SystemChannelId.Value)
             : null;
-
-        /// <summary>
-        /// Gets the settings for this guild's system channel.
-        /// </summary>
-        [JsonProperty("system_channel_flags")]
-        public SystemChannelFlags SystemChannelFlags { get; internal set; }
-
-        /// <summary>
-        /// Gets whether this guild's widget is enabled.
-        /// </summary>
-        [JsonProperty("widget_enabled", NullValueHandling = NullValueHandling.Ignore)]
-        public bool? WidgetEnabled { get; internal set; }
-
-        [JsonProperty("widget_channel_id", NullValueHandling = NullValueHandling.Ignore)]
-        internal ulong? WidgetChannelId { get; set; }
-
-        /// <summary>
-        /// Gets the widget channel for this guild.
-        /// </summary>
-        [JsonIgnore]
-        public DiscordChannel WidgetChannel => this.WidgetChannelId.HasValue
-            ? this.GetChannel(this.WidgetChannelId.Value)
-            : null;
-
-        [JsonProperty("rules_channel_id")]
-        internal ulong? RulesChannelId { get; set; }
-
-        /// <summary>
-        /// Gets the rules channel for this guild.
-        /// <para>This is only available if the guild is considered "discoverable".</para>
-        /// </summary>
-        [JsonIgnore]
-        public DiscordChannel RulesChannel => this.RulesChannelId.HasValue
-            ? this.GetChannel(this.RulesChannelId.Value)
-            : null;
-
-        [JsonProperty("public_updates_channel_id")]
-        internal ulong? PublicUpdatesChannelId { get; set; }
-
-        /// <summary>
-        /// Gets the public updates channel (where admins and moderators receive messages from Discord) for this guild.
-        /// <para>This is only available if the guild is considered "discoverable".</para>
-        /// </summary>
-        [JsonIgnore]
-        public DiscordChannel PublicUpdatesChannel => this.PublicUpdatesChannelId.HasValue
-            ? this.GetChannel(this.PublicUpdatesChannelId.Value)
-            : null;
-
-        /// <summary>
-        /// Gets the application id of this guild if it is bot created.
-        /// </summary>
-        [JsonProperty("application_id")]
-        public ulong? ApplicationId { get; internal set; }
 
         /// <summary>
         /// Gets a collection of this guild's roles.
@@ -284,18 +210,6 @@ namespace DSharpPlus.Entities
         public int MemberCount { get; internal set; }
 
         /// <summary>
-        /// Gets the maximum amount of members allowed for this guild.
-        /// </summary>
-        [JsonProperty("max_members")]
-        public int? MaxMembers { get; internal set; }
-
-        /// <summary>
-        /// Gets the maximum amount of presences allowed for this guild.
-        /// </summary>
-        [JsonProperty("max_presences")]
-        public int? MaxPresences { get; internal set; }
-
-        /// <summary>
         /// Gets a dictionary of all the voice states for this guilds. The key for this dictionary is the ID of the user
         /// the voice state corresponds to.
         /// </summary>
@@ -325,6 +239,8 @@ namespace DSharpPlus.Entities
         [JsonProperty("channels", NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(SnowflakeArrayAsDictionaryJsonConverter))]
         internal ConcurrentDictionary<ulong, DiscordChannel> _channels;
+
+        internal ConcurrentDictionary<string, DiscordInvite> _invites;
 
         /// <summary>
         /// Gets the guild member for current user.
@@ -357,23 +273,16 @@ namespace DSharpPlus.Entities
         public string VanityUrlCode { get; internal set; }
 
         /// <summary>
-        /// Gets the guild description, when applicable.
+        /// Gets guild description, when applicable.
         /// </summary>
         [JsonProperty("description")]
         public string Description { get; internal set; }
 
         /// <summary>
-        /// Gets this guild's banner hash, when applicable.
+        /// Gets guild banner hash, when applicable.
         /// </summary>
         [JsonProperty("banner")]
         public string Banner { get; internal set; }
-
-        /// <summary>
-        /// Gets this guild's banner in url form.
-        /// </summary>
-        [JsonIgnore]
-        public string BannerUrl
-            => !string.IsNullOrWhiteSpace(this.Banner) ? $"https://cdn.discordapp.com/banners/{this.Id}/{this.Banner}" : null;
 
         /// <summary>
         /// Gets this guild's premium tier (Nitro boosting).
@@ -386,7 +295,6 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("premium_subscription_count", NullValueHandling = NullValueHandling.Ignore)]
         public int? PremiumSubscriptionCount { get; internal set; }
-
         // Seriously discord?
 
         // I need to work on this
@@ -402,7 +310,10 @@ namespace DSharpPlus.Entities
         internal bool IsSynced { get; set; }
 
         internal DiscordGuild()
-            => this._current_member_lazy = new Lazy<DiscordMember>(() => this._members.TryGetValue(this.Discord.CurrentUser.Id, out var member) ? member : null);
+        {
+            this._current_member_lazy = new Lazy<DiscordMember>(() => this._members.TryGetValue(this.Discord.CurrentUser.Id, out var member) ? member : null);
+            this._invites = new ConcurrentDictionary<string, DiscordInvite>();
+        }
 
         #region Guild Methods
         /// <summary>
@@ -665,19 +576,26 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// Gets an invite from this guild from an invite code.
+        /// </summary>
+        /// <param name="code">The invite code</param>
+        /// <returns>An invite.</returns>
+        public DiscordInvite GetInvite(string code)
+            => this._invites.TryGetValue(code, out var invite) ? invite : null;
+
+        /// <summary>
         /// Gets all the invites created for all the channels in this guild.
         /// </summary>
         /// <returns>A collection of invites.</returns>
-        public Task<IReadOnlyList<DiscordInvite>> GetInvitesAsync()
-            => this.Discord.ApiClient.GetGuildInvitesAsync(this.Id);
+        public async Task<IReadOnlyList<DiscordInvite>> GetInvitesAsync()
+        { 
+            var res = await this.Discord.ApiClient.GetGuildInvitesAsync(this.Id).ConfigureAwait(false);
 
-        /// <summary>
-        /// Gets the vanity invite for this guild.
-        /// </summary>
-        /// <returns>A partial vanity invite.</returns>
-        public Task<DiscordInvite> GetVanityInviteAsync()
-            => this.Discord.ApiClient.GetGuildVanityUrlAsync(this.Id);
-        
+            for (var i = 0; i < res.Count; i++)
+                this._invites[res[i].Code] = res[i];
+
+            return res;
+        }
 
         /// <summary>
         /// Gets all the webhooks created for all the channels in this guild.
@@ -685,41 +603,6 @@ namespace DSharpPlus.Entities
         /// <returns>A collection of webhooks this guild has.</returns>
         public Task<IReadOnlyList<DiscordWebhook>> GetWebhooksAsync()
             => this.Discord.ApiClient.GetGuildWebhooksAsync(this.Id);
-
-        /// <summary>
-        /// Gets this guild's widget image.
-        /// </summary>
-        /// <param name="bannerType">The format of the widget.</param>
-        /// <returns>The URL of the widget image.</returns>
-        public string GetWidgetImage(WidgetType bannerType = WidgetType.Shield)
-        {
-            string param;
-
-            switch(bannerType)
-            {
-                case WidgetType.Banner1:
-                    param = "banner1";
-                    break;
-
-                case WidgetType.Banner2:
-                    param = "banner2";
-                    break;
-
-                case WidgetType.Banner3:
-                    param = "banner3";
-                    break;
-
-                case WidgetType.Banner4:
-                    param = "banner4";
-                    break;
-
-                default:
-                    param = "shield";
-                    break;
-            }
-
-            return $"{Net.Endpoints.BASE_URI}{Net.Endpoints.GUILDS}/{this.Id}{Net.Endpoints.WIDGET_PNG}?style={param}";
-        }
 
         /// <summary>
         /// Gets a member of this guild by his user ID.
@@ -955,8 +838,8 @@ namespace DSharpPlus.Entities
 
                                     entrygld.AfkChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id },
-                                        After = this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id }
+                                        Before = this.GetChannel(t1),
+                                        After = this.GetChannel(t2)
                                     };
                                     break;
 
@@ -966,8 +849,8 @@ namespace DSharpPlus.Entities
 
                                     entrygld.EmbedChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id },
-                                        After = this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id }
+                                        Before = this.GetChannel(t1),
+                                        After = this.GetChannel(t2)
                                     };
                                     break;
 
@@ -993,8 +876,8 @@ namespace DSharpPlus.Entities
 
                                     entrygld.SystemChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id },
-                                        After = this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id }
+                                        Before = this.GetChannel(t1),
+                                        After = this.GetChannel(t2)
                                     };
                                     break;
 
@@ -1014,14 +897,6 @@ namespace DSharpPlus.Entities
                                     };
                                     break;
 
-                                case "region":
-                                    entrygld.RegionChange = new PropertyChange<string>
-                                    {
-                                        Before = xc.OldValueString,
-                                        After = xc.NewValueString
-                                    };
-                                    break;
-                             
                                 default:
                                     this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in guild update: {xc.Key}; this should be reported to devs", DateTime.Now);
                                     break;
@@ -1034,7 +909,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.ChannelUpdate:
                         entry = new DiscordAuditLogChannelEntry
                         {
-                            Target = this.GetChannel(xac.TargetId.Value) ?? new DiscordChannel { Id = xac.TargetId.Value, Discord = this.Discord, GuildId = this.Id }
+                            Target = this.GetChannel(xac.TargetId.Value) ?? new DiscordChannel { Id = xac.TargetId.Value }
                         };
 
                         var entrychn = entry as DiscordAuditLogChannelEntry;
@@ -1181,7 +1056,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.Kick:
                         entry = new DiscordAuditLogKickEntry
                         {
-                            Target = amd.TryGetValue(xac.TargetId.Value, out var kickMember) ? kickMember : new DiscordMember { Id = xac.TargetId.Value, Discord = this.Discord, _guild_id = this.Id }
+                            Target = amd.TryGetValue(xac.TargetId.Value, out var kickMember) ? kickMember : new DiscordMember { Id = xac.TargetId.Value }
                         };
                         break;
 
@@ -1197,7 +1072,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.Unban:
                         entry = new DiscordAuditLogBanEntry
                         {
-                            Target = amd.TryGetValue(xac.TargetId.Value, out var unbanMember) ? unbanMember : new DiscordMember { Id = xac.TargetId.Value, Discord = this.Discord, _guild_id = this.Id }
+                            Target = amd.TryGetValue(xac.TargetId.Value, out var unbanMember) ? unbanMember : new DiscordMember { Id = xac.TargetId.Value }
                         };
                         break;
 
@@ -1205,7 +1080,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.MemberRoleUpdate:
                         entry = new DiscordAuditLogMemberUpdateEntry
                         {
-                            Target = amd.TryGetValue(xac.TargetId.Value, out var roleUpdMember) ? roleUpdMember : new DiscordMember { Id = xac.TargetId.Value, Discord = this.Discord, _guild_id = this.Id }
+                            Target = amd.TryGetValue(xac.TargetId.Value, out var roleUpdMember) ? roleUpdMember : new DiscordMember { Id = xac.TargetId.Value }
                         };
 
                         var entrymbu = entry as DiscordAuditLogMemberUpdateEntry;
@@ -1257,7 +1132,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.RoleUpdate:
                         entry = new DiscordAuditLogRoleUpdateEntry
                         {
-                            Target = this.GetRole(xac.TargetId.Value) ?? new DiscordRole { Id = xac.TargetId.Value, Discord = this.Discord }
+                            Target = this.GetRole(xac.TargetId.Value) ?? new DiscordRole { Id = xac.TargetId.Value }
                         };
 
                         var entryrol = entry as DiscordAuditLogRoleUpdateEntry;
@@ -1380,8 +1255,8 @@ namespace DSharpPlus.Entities
 
                                     entryinv.InviterChange = new PropertyChange<DiscordMember>
                                     {
-                                        Before = amd.TryGetValue(t1, out var propBeforeMember) ? propBeforeMember : new DiscordMember { Id = t1, Discord = this.Discord, _guild_id = this.Id },
-                                        After = amd.TryGetValue(t2, out var propAfterMember) ? propAfterMember : new DiscordMember { Id = t1, Discord = this.Discord, _guild_id = this.Id },
+                                        Before = amd.TryGetValue(t1, out var propBeforeMember) ? propBeforeMember : null,
+                                        After = amd.TryGetValue(t2, out var propAfterMember) ? propAfterMember : null,
                                     };
                                     break;
 
@@ -1391,8 +1266,8 @@ namespace DSharpPlus.Entities
 
                                     entryinv.ChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = p1 ? this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null,
-                                        After = p2 ? this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null
+                                        Before = p1 ? this.GetChannel(t1) : null,
+                                        After = p2 ? this.GetChannel(t2) : null
                                     };
 
                                     var ch = entryinv.ChannelChange.Before ?? entryinv.ChannelChange.After;
@@ -1442,7 +1317,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.WebhookUpdate:
                         entry = new DiscordAuditLogWebhookEntry
                         {
-                            Target = ahd.TryGetValue(xac.TargetId.Value, out var webhook) ? webhook : new DiscordWebhook { Id = xac.TargetId.Value, Discord = this.Discord }
+                            Target = ahd.TryGetValue(xac.TargetId.Value, out var webhook) ? webhook : new DiscordWebhook { Id = xac.TargetId.Value }
                         };
 
                         var entrywhk = entry as DiscordAuditLogWebhookEntry;
@@ -1464,8 +1339,8 @@ namespace DSharpPlus.Entities
 
                                     entrywhk.ChannelChange = new PropertyChange<DiscordChannel>
                                     {
-                                        Before = p1 ? this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null,
-                                        After = p2 ? this.GetChannel(t2) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id } : null
+                                        Before = p1 ? this.GetChannel(t1) : null,
+                                        After = p2 ? this.GetChannel(t2) : null
                                     };
                                     break;
 
@@ -1500,7 +1375,7 @@ namespace DSharpPlus.Entities
                     case AuditLogActionType.EmojiUpdate:
                         entry = new DiscordAuditLogEmojiEntry
                         {
-                            Target = this._emojis.TryGetValue(xac.TargetId.Value, out var target) ? target : new DiscordEmoji { Id = xac.TargetId.Value, Discord = this.Discord }
+                            Target = this._emojis.TryGetValue(xac.TargetId.Value, out var target) ? target : new DiscordEmoji { Id = xac.TargetId.Value }
                         };
 
                         var entryemo = entry as DiscordAuditLogEmojiEntry;
@@ -1532,7 +1407,7 @@ namespace DSharpPlus.Entities
 
                             if (xac.Options != null)
                             {
-                                entrymsg.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
+                                entrymsg.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId };
                                 entrymsg.MessageCount = xac.Options.Count;
                             }
 
@@ -1563,14 +1438,14 @@ namespace DSharpPlus.Entities
                             {
                                 dc.MessageCache.TryGet(x => x.Id == xac.Options.MessageId && x.ChannelId == xac.Options.ChannelId, out var message);
 
-                                entrypin.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
-                                entrypin.Message = message ?? new DiscordMessage { Id = xac.Options.MessageId, Discord = this.Discord };
+                                entrypin.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId };
+                                entrypin.Message = message ?? new DiscordMessage { Id = xac.Options.MessageId };
                             }
 
                             if (xac.TargetId.HasValue)
                             {
                                 dc.UserCache.TryGetValue(xac.TargetId.Value, out var user);
-                                entrypin.Target = user ?? new DiscordUser { Id = user.Id, Discord = this.Discord };
+                                entrypin.Target = user ?? new DiscordUser { Id = user.Id };
                             }
 
                             break;
@@ -1586,7 +1461,7 @@ namespace DSharpPlus.Entities
                             }
 
                             dc.UserCache.TryGetValue(xac.TargetId.Value, out var bot);
-                            (entry as DiscordAuditLogBotAddEntry).TargetBot = bot ?? new DiscordUser { Id = xac.TargetId.Value, Discord = this.Discord };
+                            (entry as DiscordAuditLogBotAddEntry).TargetBot = bot ?? new DiscordUser { Id = xac.TargetId.Value };
 
                             break;
                         }
@@ -1602,7 +1477,7 @@ namespace DSharpPlus.Entities
                         var moveentry = entry as DiscordAuditLogMemberMoveEntry;
 
                         moveentry.UserCount = xac.Options.Count;
-                        moveentry.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
+                        moveentry.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId };
                         break;
 
                     case AuditLogActionType.MemberDisconnect:
@@ -1965,37 +1840,5 @@ namespace DSharpPlus.Entities
         /// Messages from all members are scanned.
         /// </summary>
         AllMembers = 2
-    }
-
-    /// <summary>
-    /// Represents the formats for a guild widget.
-    /// </summary>
-    public enum WidgetType : int
-    {
-        /// <summary>
-        /// The widget is represented in shield format.
-        /// <para>This is the default widget type.</para>
-        /// </summary>
-        Shield = 0,
-
-        /// <summary>
-        /// The widget is represented as the first banner type.
-        /// </summary>
-        Banner1 = 1,
-
-        /// <summary>
-        /// The widget is represented as the second banner type.
-        /// </summary>
-        Banner2 = 2,
-
-        /// <summary>
-        /// The widget is represented as the third banner type.
-        /// </summary>
-        Banner3 = 3,
-
-        /// <summary>
-        /// The widget is represented in the fourth banner type.
-        /// </summary>
-        Banner4 = 4
     }
 }

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -450,7 +450,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Deletes another user's reaction.
         /// </summary>
-        /// <param name="emoji">Emoji for the reaction you want to remove, either an emoji or name:id</param>
+        /// <param name="emoji">Emoji for the reaction you want to remove, either an emoji or name:id.</param>
         /// <param name="user">Member you want to remove the reaction for</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
@@ -458,7 +458,7 @@ namespace DSharpPlus.Entities
             => this.Discord.ApiClient.DeleteUserReactionAsync(this.ChannelId, this.Id, user.Id, emoji.ToReactionString(), reason);
 
         /// <summary>
-        /// Gets users that reacted with this emoji
+        /// Gets users that reacted with this emoji.
         /// </summary>
         /// <param name="emoji">Emoji to react with.</param>
         /// <param name="limit">Limit of users to fetch.</param>
@@ -468,13 +468,21 @@ namespace DSharpPlus.Entities
             => this.GetReactionsInternalAsync(emoji, limit, after);
 
         /// <summary>
-        /// Deletes all reactions for this message
+        /// Deletes all reactions for this message.
         /// </summary>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
         public Task DeleteAllReactionsAsync(string reason = null) 
             => this.Discord.ApiClient.DeleteAllReactionsAsync(this.ChannelId, this.Id, reason);
-        
+
+        /// <summary>
+        /// Deletes all reactions of a specific reaction for this message.
+        /// </summary>
+        /// <param name="emoji">The emoji to clear, either an emoji or name:id.</param>
+        /// <returns></returns>
+        public Task DeleteReactionsEmojiAsync(DiscordEmoji emoji)
+            => this.Discord.ApiClient.DeleteReactionsEmojiAsync(this.ChannelId, this.Id, emoji.ToReactionString());
+
         private async Task<IReadOnlyList<DiscordUser>> GetReactionsInternalAsync(DiscordEmoji emoji, int limit = 25, ulong? after = null)
         {
             if (limit < 0)

--- a/DSharpPlus/EventArgs/InviteCreateEventArgs.cs
+++ b/DSharpPlus/EventArgs/InviteCreateEventArgs.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs
+{
+    /// <summary>
+    /// Represents arguments for <see cref="DiscordClient.InviteCreated"/>
+    /// </summary>
+    public class InviteCreateEventArgs : DiscordEventArgs
+    {
+        /// <summary>
+        /// Gets the guild that created the invite.
+        /// </summary>
+        public DiscordGuild Guild { get; internal set; }
+
+        /// <summary>
+        /// Gets the channel that the invite is for.
+        /// </summary>
+        public DiscordChannel Channel { get; internal set; }
+
+        /// <summary>
+        /// Gets the created invite.
+        /// </summary>
+        public DiscordInvite Invite { get; internal set; }
+
+        internal InviteCreateEventArgs(DiscordClient client) : base(client) { }
+    }
+}

--- a/DSharpPlus/EventArgs/InviteCreateEventArgs.cs
+++ b/DSharpPlus/EventArgs/InviteCreateEventArgs.cs
@@ -1,12 +1,11 @@
-﻿using Newtonsoft.Json;
-using DSharpPlus.Entities;
+﻿using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {
     /// <summary>
     /// Represents arguments for <see cref="DiscordClient.InviteCreated"/>
     /// </summary>
-    public class InviteCreateEventArgs : DiscordEventArgs
+    public sealed class InviteCreateEventArgs : DiscordEventArgs
     {
         /// <summary>
         /// Gets the guild that created the invite.

--- a/DSharpPlus/EventArgs/InviteDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/InviteDeleteEventArgs.cs
@@ -1,12 +1,11 @@
-﻿using Newtonsoft.Json;
-using DSharpPlus.Entities;
+﻿using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {
     /// <summary>
     /// Represents arguments for <see cref="DiscordClient.InviteDeleted"/>
     /// </summary>
-    public class InviteDeleteEventArgs : DiscordEventArgs
+    public sealed class InviteDeleteEventArgs : DiscordEventArgs
     {
         /// <summary>
         /// Gets the guild that deleted the invite.

--- a/DSharpPlus/EventArgs/InviteDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/InviteDeleteEventArgs.cs
@@ -18,7 +18,7 @@ namespace DSharpPlus.EventArgs
         public DiscordChannel Channel { get; internal set; }
 
         /// <summary>
-        /// Gets the invite that was deleted.
+        /// Gets the deleted invite.
         /// </summary>
         public DiscordInvite Invite { get; internal set; }
 

--- a/DSharpPlus/EventArgs/InviteDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/InviteDeleteEventArgs.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs
+{
+    /// <summary>
+    /// Represents arguments for <see cref="DiscordClient.InviteDeleted"/>
+    /// </summary>
+    public class InviteDeleteEventArgs : DiscordEventArgs
+    {
+        /// <summary>
+        /// Gets the guild that deleted the invite.
+        /// </summary>
+        public DiscordGuild Guild { get; internal set; }
+
+        /// <summary>
+        /// Gets the channel that the invite was for.
+        /// </summary>
+        public DiscordChannel Channel { get; internal set; }
+
+        /// <summary>
+        /// Gets the invite that was deleted.
+        /// </summary>
+        public DiscordInvite Invite { get; internal set; }
+
+        internal InviteDeleteEventArgs(DiscordClient client) : base(client) { }
+    }
+}

--- a/DSharpPlus/EventArgs/MessageReactionRemoveEmojiEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageReactionRemoveEmojiEventArgs.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs
+{
+    /// <summary>
+    /// Represents arguments for <see cref="DiscordClient.MessageReactionRemovedEmoji"/>
+    /// </summary>
+    public class MessageReactionRemoveEmojiEventArgs : DiscordEventArgs
+    {
+        /// <summary>
+        /// Gets the channel the removed reactions were in.
+        /// </summary>
+        public DiscordChannel Channel { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild the removed reactions were in.
+        /// </summary>
+        public DiscordGuild Guild { get; internal set; }
+
+        /// <summary>
+        /// Gets the message that had the removed reactions.
+        /// </summary>
+        public DiscordMessage Message { get; internal set; }
+
+        /// <summary>
+        /// Gets the emoji of the reaction that was removed.
+        /// </summary>
+        public DiscordEmoji Emoji { get; internal set; }
+
+        internal MessageReactionRemoveEmojiEventArgs(DiscordClient client) : base(client) { }
+    }
+}

--- a/DSharpPlus/EventArgs/MessageReactionRemoveEmojiEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageReactionRemoveEmojiEventArgs.cs
@@ -1,12 +1,11 @@
-﻿using Newtonsoft.Json;
-using DSharpPlus.Entities;
+﻿using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {
     /// <summary>
     /// Represents arguments for <see cref="DiscordClient.MessageReactionRemovedEmoji"/>
     /// </summary>
-    public class MessageReactionRemoveEmojiEventArgs : DiscordEventArgs
+    public sealed class MessageReactionRemoveEmojiEventArgs : DiscordEventArgs
     {
         /// <summary>
         /// Gets the channel the removed reactions were in.

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1756,6 +1756,15 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers, ratelimitWaitOverride: 0.26);
         }
+
+        internal Task DeleteReactionsEmojiAsync(ulong channel_id, ulong message_id, string emoji)
+        {
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}/:emoji";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id, emoji }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, ratelimitWaitOverride: 0.26);
+        }
         #endregion
 
         #region Emoji


### PR DESCRIPTION
# Summary
Fixes #522 by implementing support for these events and endpoint.
# Details
As documented [here](https://github.com/discordapp/discord-api-docs/pull/1309), this PR adds 3 new events:

`InviteCreated` - Fired when an invite is created.

`InviteDeleted` - Fired when an invite is deleted.

`MessageReactionRemovedEmoji` - Fired when all of a specific reaction are deleted.

Additionally, added support for a new endpoint that directly causes the MessageReactionRemovedEmoji event, which is `DiscordMessage.DeleteReactionsEmojiAsync(DiscordEmoji)`.

Because invite objects can now be sent via dispatch, I also created an invite cache to more reliably retrieve invites, this does a couple of things:

1. Allows the InviteDeleted event to possibly return a more detailed object rather than the partial one.

2. Could allow a user to get an invite from the cache, which is modeled by DiscordGuild.GetInvite(string).

Currently, the cache has invites added and removed from their respective events, and added automatically through DiscordGuild.GetInvitesAsync(). This change and DiscordGuild.GetInvite() may not be necessary, but I figured they may be nice to include.

# Changes proposed
* Added support for the 3 new events.
* Added support for the new endpoint.
* Added a method to delete all reactions from a specific emoji.
* Added a cache for invites.
* Added/modified a couple methods to interact with the invite cache.