### PR TITLE
Using nullable enums as interactivity params overload instead "Default" enum field.

### DIFF
--- a/DSharpPlus.Interactivity/Enums/PaginationBehaviour.cs
+++ b/DSharpPlus.Interactivity/Enums/PaginationBehaviour.cs
@@ -9,36 +9,28 @@ namespace DSharpPlus.Interactivity.Enums
     public enum PaginationDeletion
     {
         /// <summary>
-        /// Defaults to DeleteEmojis
-        /// </summary>
-        Default = 0,
-        /// <summary>
         /// Deletes emojis
         /// </summary>
-        DeleteEmojis = 1,
+        DeleteEmojis = 0,
         /// <summary>
         /// Keeps emojis
         /// </summary>
-        KeepEmojis = 2,
+        KeepEmojis = 1,
         /// <summary>
         /// Deletes message
         /// </summary>
-        DeleteMessage = 3
+        DeleteMessage = 2
     }
 
     public enum PaginationBehaviour
     {
         /// <summary>
-        /// Defaults to WrapAround
-        /// </summary>
-        Default = 0,
-        /// <summary>
         /// Wraps around indices (e.g. when the index in over the max, loop back to 0)
         /// </summary>
-        WrapAround = 1,
+        WrapAround = 0,
         /// <summary>
         /// Disallows moving pas 0 and max indices
         /// </summary>
-        Ignore = 2
+        Ignore = 1
     }
 }

--- a/DSharpPlus.Interactivity/Enums/PollBehaviour.cs
+++ b/DSharpPlus.Interactivity/Enums/PollBehaviour.cs
@@ -10,16 +10,12 @@ namespace DSharpPlus.Interactivity.Enums
     public enum PollBehaviour
     {
         /// <summary>
-        /// Defaults to DeleteEmojis
-        /// </summary>
-        Default = 0,
-        /// <summary>
         /// Keeps emojis
         /// </summary>
-        KeepEmojis = 1,
+        KeepEmojis = 0,
         /// <summary>
         /// Deletes Emojis
         /// </summary>
-        DeleteEmojis = 2
+        DeleteEmojis = 1
     }
 }

--- a/DSharpPlus.Interactivity/EventHandling/Requests/PaginationRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/PaginationRequest.cs
@@ -82,7 +82,6 @@ namespace DSharpPlus.Interactivity.EventHandling
 
             switch (_behaviour)
             {
-                case PaginationBehaviour.Default:
                 case PaginationBehaviour.Ignore:
                     if (index == _pages.Count - 1)
                         break;
@@ -107,7 +106,6 @@ namespace DSharpPlus.Interactivity.EventHandling
 
             switch (_behaviour)
             {
-                case PaginationBehaviour.Default:
                 case PaginationBehaviour.Ignore:
                     if (index == 0)
                         break;
@@ -151,7 +149,6 @@ namespace DSharpPlus.Interactivity.EventHandling
         {
             switch (_deletion)
             {
-                case PaginationDeletion.Default:
                 case PaginationDeletion.DeleteEmojis:
                     await _message.DeleteAllReactionsAsync();
                     break;

--- a/DSharpPlus.Interactivity/Extensions.cs
+++ b/DSharpPlus.Interactivity/Extensions.cs
@@ -142,7 +142,7 @@ namespace DSharpPlus.Interactivity
         /// <param name="timeoutoverride">Override timeout period.</param>
         /// <returns></returns>
         public static async Task SendPaginatedMessageAsync(this DiscordChannel c, DiscordUser user, Page[] pages, PaginationEmojis emojis,
-            PaginationBehaviour behaviour = PaginationBehaviour.Default, PaginationDeletion deletion = PaginationDeletion.Default,
+            PaginationBehaviour? behaviour = default, PaginationDeletion? deletion = default,
             TimeSpan? timeoutoverride = null)
             => await ((DiscordClient)c.Discord).GetInteractivity().SendPaginatedMessageAsync(c, user, pages, emojis, behaviour, deletion, timeoutoverride);
     }

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -288,13 +288,13 @@ namespace DSharpPlus.Interactivity
         /// <param name="timeoutoverride">Override timeout period.</param>
         /// <returns></returns>
         public async Task SendPaginatedMessageAsync(DiscordChannel c, DiscordUser u, IEnumerable<Page> pages, PaginationEmojis emojis = null,
-            PaginationBehaviour behaviour = PaginationBehaviour.Default, PaginationDeletion deletion = PaginationDeletion.Default, TimeSpan? timeoutoverride = null)
+            PaginationBehaviour? behaviour = default, PaginationDeletion? deletion = default, TimeSpan? timeoutoverride = null)
         {
             var m = await c.SendMessageAsync(pages.First().Content, false, pages.First().Embed);
             var timeout = timeoutoverride ?? Config.Timeout;
 
-            var bhv = behaviour == PaginationBehaviour.Default ? this.Config.PaginationBehaviour : behaviour;
-            var del = deletion == PaginationDeletion.Default ? this.Config.PaginationDeletion : deletion;
+            var bhv = behaviour ?? this.Config.PaginationBehaviour;
+            var del = deletion ?? this.Config.PaginationDeletion;
             var ems = emojis ?? this.Config.PaginationEmojis;
 
             var prequest = new PaginationRequest(m, u, bhv, del, ems, timeout, pages.ToArray());

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -103,7 +103,7 @@ namespace DSharpPlus.Interactivity
         /// <param name="behaviour">What to do when the poll ends.</param>
         /// <param name="timeout">override timeout period.</param>
         /// <returns></returns>
-        public async Task<ReadOnlyCollection<PollEmoji>> DoPollAsync(DiscordMessage m, DiscordEmoji[] emojis, PollBehaviour behaviour = PollBehaviour.Default, TimeSpan? timeout = null)
+        public async Task<ReadOnlyCollection<PollEmoji>> DoPollAsync(DiscordMessage m, DiscordEmoji[] emojis, PollBehaviour? behaviour = default, TimeSpan? timeout = null)
         {
             if (emojis.Count() < 1)
                 throw new ArgumentException("You need to provide at least one emoji for a poll!");
@@ -114,7 +114,7 @@ namespace DSharpPlus.Interactivity
             }
             var res = await Poller.DoPollAsync(new PollRequest(m, timeout ?? this.Config.Timeout, emojis));
 
-            var pollbehaviour = behaviour == PollBehaviour.Default ? this.Config.PollBehaviour : behaviour;
+            var pollbehaviour = behaviour ?? this.Config.PollBehaviour;
             var thismember = await m.Channel.Guild.GetMemberAsync(Client.CurrentUser.Id);
 
             if (pollbehaviour == PollBehaviour.DeleteEmojis && m.Channel.PermissionsFor(thismember).HasPermission(Permissions.ManageMessages))


### PR DESCRIPTION
# Summary 
Using nullable enums as interactivity params overload instead "Default" enum field .

# Details
Sometimes when pass one of optional arguments and other is not fetched from interactivity configuration.
