### PR TITLE
Fixed Description Key

### DIFF
--- a/DSharpPlus/Entities/DiscordGuildPreview.cs
+++ b/DSharpPlus/Entities/DiscordGuildPreview.cs
@@ -72,7 +72,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the integration type.
         /// </summary>
-        [JsonProperty("description ", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get; internal set; }
 
         internal DiscordGuildPreview() { }


### PR DESCRIPTION
# Summary
There was a whitespace after the description key. This caused the description to not be sent. 
Other than that, everything else works fine.


# Changes proposed
* Updated the JSON key

# Notes
Woops. 

Might want to hold of as it seems that this endpoint is in question for its accessibility anyways.
https://github.com/discordapp/discord-api-docs/pull/1405#issuecomment-595485313