### PR TITLE
Implemented X-RateLimit-Precision

### DIFF
--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -108,13 +108,6 @@ namespace DSharpPlus
         public bool ReconnectIndefinitely { internal get; set; } = false;
 
         /// <summary>
-        /// Defines whether this client should use more precise rate limit headers.
-        /// <para>This will have rate limit times rounded to the nearest milisecond, rather than second, allowing for faster response times.</para>
-        /// <para>Defaults to true.</para>
-        /// </summary>
-        public bool UsePrecisionHeaders { internal get; set; } = true;
-
-        /// <summary>
         /// <para>Sets the factory method used to create instances of WebSocket clients.</para>
         /// <para>Use <see cref="WebSocketClient.CreateNew(IWebProxy)"/> and equivalents on other implementations to switch out client implementations.</para>
         /// <para>Defaults to <see cref="WebSocketClient.CreateNew(IWebProxy)"/>.</para>
@@ -174,7 +167,6 @@ namespace DSharpPlus
             this.Proxy = other.Proxy;
             this.HttpTimeout = other.HttpTimeout;
             this.ReconnectIndefinitely = other.ReconnectIndefinitely;
-            this.UsePrecisionHeaders = other.UsePrecisionHeaders;
         }
     }
 }

--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -108,6 +108,13 @@ namespace DSharpPlus
         public bool ReconnectIndefinitely { internal get; set; } = false;
 
         /// <summary>
+        /// Defines whether this client should use more precise rate limit headers.
+        /// <para>This will have rate limit times rounded to the nearest milisecond, rather than second, allowing for faster response times.</para>
+        /// <para>Defaults to true.</para>
+        /// </summary>
+        public bool UsePrecisionHeaders { internal get; set; } = true;
+
+        /// <summary>
         /// <para>Sets the factory method used to create instances of WebSocket clients.</para>
         /// <para>Use <see cref="WebSocketClient.CreateNew(IWebProxy)"/> and equivalents on other implementations to switch out client implementations.</para>
         /// <para>Defaults to <see cref="WebSocketClient.CreateNew(IWebProxy)"/>.</para>
@@ -167,6 +174,7 @@ namespace DSharpPlus
             this.Proxy = other.Proxy;
             this.HttpTimeout = other.HttpTimeout;
             this.ReconnectIndefinitely = other.ReconnectIndefinitely;
+            this.UsePrecisionHeaders = other.UsePrecisionHeaders;
         }
     }
 }

--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -32,6 +32,7 @@ namespace DSharpPlus.Net
         {
             this.Discord = client;
             this.HttpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", Utilities.GetFormattedToken(client));
+            this.HttpClient.DefaultRequestHeaders.Add("X-RateLimit-Precision", "millisecond");
         }
 
         internal RestClient(IWebProxy proxy, TimeSpan timeout) // This is for meta-clients, such as the webhook client
@@ -287,9 +288,6 @@ namespace DSharpPlus.Net
                 foreach (var kvp in request.Headers)
                     req.Headers.Add(kvp.Key, kvp.Value);
 
-            if (this.Discord.Configuration.UsePrecisionHeaders)
-                req.Headers.Add("X-RateLimit-Precision", "millisecond");
-
             if (request is RestRequest nmprequest && !string.IsNullOrWhiteSpace(nmprequest.Payload))
             {
                 req.Content = new StringContent(nmprequest.Payload);
@@ -377,9 +375,7 @@ namespace DSharpPlus.Net
             }
 
             var clienttime = DateTimeOffset.UtcNow;
-            var resettime = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddSeconds(this.Discord.Configuration.UsePrecisionHeaders 
-                ? double.Parse(reset, CultureInfo.InvariantCulture) 
-                : long.Parse(reset, CultureInfo.InvariantCulture));
+            var resettime = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddSeconds(double.Parse(reset, CultureInfo.InvariantCulture));
             var servertime = clienttime;
             if (hs.TryGetValue("Date", out var raw_date))
                 servertime = DateTimeOffset.Parse(raw_date, CultureInfo.InvariantCulture).ToUniversalTime();

--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -287,6 +287,9 @@ namespace DSharpPlus.Net
                 foreach (var kvp in request.Headers)
                     req.Headers.Add(kvp.Key, kvp.Value);
 
+            if (this.Discord.Configuration.UsePrecisionHeaders)
+                req.Headers.Add("X-RateLimit-Precision", "millisecond");
+
             if (request is RestRequest nmprequest && !string.IsNullOrWhiteSpace(nmprequest.Payload))
             {
                 req.Content = new StringContent(nmprequest.Payload);
@@ -374,7 +377,9 @@ namespace DSharpPlus.Net
             }
 
             var clienttime = DateTimeOffset.UtcNow;
-            var resettime = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddSeconds(long.Parse(reset, CultureInfo.InvariantCulture));
+            var resettime = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddSeconds(this.Discord.Configuration.UsePrecisionHeaders 
+                ? double.Parse(reset, CultureInfo.InvariantCulture) 
+                : long.Parse(reset, CultureInfo.InvariantCulture));
             var servertime = clienttime;
             if (hs.TryGetValue("Date", out var raw_date))
                 servertime = DateTimeOffset.Parse(raw_date, CultureInfo.InvariantCulture).ToUniversalTime();


### PR DESCRIPTION
# Summary
Implements support for specifying and handling more precise rate limit headers.

# Details
This can be specified in the `DiscordConfiguration`, and allows ratelimits to be rounded to the largest millisecond rather than second. This will also allow for slightly faster response times. More details on the headers can be found [here](https://discordapp.com/developers/docs/topics/rate-limits#more-precise-rate-limit-resets).

# Changes proposed
* Added the option as a property in the `DiscordConfiguration`.
* The `RestClient` now handles parsing a double or a long reset time, depending on the configuration.