### PR TITLE
Add BaseDiscordClient.TryGetCachedUserInternal()

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -762,7 +762,7 @@ namespace DSharpPlus.CommandsNext
                 }
                 else
                 {
-                    mentionedUsers = Utilities.GetUserMentions(msg).Select(this.Client.InternalGetCachedUser).ToList();
+                    mentionedUsers = Utilities.GetUserMentions(msg).Select(this.Client.GetCachedOrEmptyUserInternal).ToList();
                 }
             }
 

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -852,14 +852,15 @@ namespace DSharpPlus.VoiceNext
                     // Don't spam OP5
                     //this.Discord.DebugLogger.LogMessage(LogLevel.Debug, "VoiceNext", "OP5 received", DateTime.Now);
                     var spd = opp.ToObject<VoiceSpeakingPayload>();
+                    var foundUserInCache = this.Discord.TryGetCachedUserInternal(spd.UserId.Value, out var resolvedUser);
                     var spk = new UserSpeakingEventArgs(this.Discord)
                     {
                         Speaking = spd.Speaking,
                         SSRC = spd.SSRC.Value,
-                        User = this.Discord.InternalGetCachedUser(spd.UserId.Value)
+                        User = resolvedUser,
                     };
 
-                    if (spk.User != null && this.TransmittingSSRCs.TryGetValue(spk.SSRC, out var txssrc5) && txssrc5.Id == 0)
+                    if (foundUserInCache && this.TransmittingSSRCs.TryGetValue(spk.SSRC, out var txssrc5) && txssrc5.Id == 0)
                     {
                         txssrc5.User = spk.User;
                     }

--- a/DSharpPlus/BaseDiscordClient.cs
+++ b/DSharpPlus/BaseDiscordClient.cs
@@ -174,8 +174,20 @@ namespace DSharpPlus
             }
         }
 
-        internal DiscordUser InternalGetCachedUser(ulong user_id) 
-            => this.UserCache.TryGetValue(user_id, out var user) ? user : new DiscordUser { Id = user_id, Discord = this };
+        internal DiscordUser GetCachedOrEmptyUserInternal(ulong user_id)
+        {
+            TryGetCachedUserInternal(user_id, out var user);
+            return user;
+        }
+
+        internal bool TryGetCachedUserInternal(ulong user_id, out DiscordUser user)
+        {
+            if (this.UserCache.TryGetValue(user_id, out user))
+                return true;
+
+            user = new DiscordUser { Id = user_id, Discord = this };
+            return false;
+        }
 
         /// <summary>
         /// Disposes this client.

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -461,8 +461,7 @@ namespace DSharpPlus
         /// <returns></returns>
         public async Task<DiscordUser> GetUserAsync(ulong userId)
         {
-            var usr = this.InternalGetCachedUser(userId);
-            if (usr != null)
+            if (this.TryGetCachedUserInternal(userId, out var usr))
                 return usr;
 
             usr = await this.ApiClient.GetUserAsync(userId).ConfigureAwait(false);
@@ -999,7 +998,7 @@ namespace DSharpPlus
                 var dmChannel = channel as DiscordDmChannel;
 
                 var recips = rawRecipients.ToObject<IEnumerable<TransportUser>>()
-                    .Select(xtu => this.InternalGetCachedUser(xtu.Id) ?? new DiscordUser(xtu) { Discord = this });
+                    .Select(xtu => this.TryGetCachedUserInternal(xtu.Id, out var usr) ? usr : new DiscordUser(xtu) { Discord = this });
                 dmChannel._recipients = recips.ToList();
 
                 this._privateChannels[dmChannel.Id] = dmChannel;
@@ -1730,7 +1729,7 @@ namespace DSharpPlus
                 }
                 else
                 {
-                    mentionedUsers = Utilities.GetUserMentions(message).Select(this.InternalGetCachedUser).ToList();
+                    mentionedUsers = Utilities.GetUserMentions(message).Select(this.GetCachedOrEmptyUserInternal).ToList();
                 }
             }
 
@@ -1826,7 +1825,7 @@ namespace DSharpPlus
                 }
                 else
                 {
-                    mentioned_users = Utilities.GetUserMentions(message).Select(this.InternalGetCachedUser).ToList();
+                    mentioned_users = Utilities.GetUserMentions(message).Select(this.GetCachedOrEmptyUserInternal).ToList();
                 }
             }
 

--- a/DSharpPlus/Entities/DiscordPresence.cs
+++ b/DSharpPlus/Entities/DiscordPresence.cs
@@ -21,7 +21,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public DiscordUser User 
-            => this.Discord.InternalGetCachedUser(this.InternalUser.Id);
+            => this.Discord.GetCachedOrEmptyUserInternal(this.InternalUser.Id);
 
         /// <summary>
         /// Gets the user's current activity.

--- a/DSharpPlus/Entities/DiscordVoiceState.cs
+++ b/DSharpPlus/Entities/DiscordVoiceState.cs
@@ -57,7 +57,7 @@ namespace DSharpPlus.Entities
 					usr = this.Guild._members.TryGetValue(this.UserId, out var member) ? member : null;
 
 				if (usr == null)
-					usr = this.Discord.InternalGetCachedUser(this.UserId);
+					usr = this.Discord.GetCachedOrEmptyUserInternal(this.UserId);
 
 				return usr;
 			}

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -84,7 +84,7 @@ namespace DSharpPlus.Net
                 }
                 else
                 {
-                    mentioned_users = Utilities.GetUserMentions(ret).Select(this.Discord.InternalGetCachedUser).ToList();
+                    mentioned_users = Utilities.GetUserMentions(ret).Select(this.Discord.GetCachedOrEmptyUserInternal).ToList();
                 }
             }
 
@@ -222,8 +222,7 @@ namespace DSharpPlus.Net
 
             var bans_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordBan>>(res.Response).Select(xb =>
             {
-                var usr = this.Discord.InternalGetCachedUser(xb.RawUser.Id);
-                if (usr == null)
+                if (!this.Discord.TryGetCachedUserInternal(xb.RawUser.Id, out var usr))
                 {
                     usr = new DiscordUser(xb.RawUser) { Discord = this.Discord };
                     usr = this.Discord.UserCache.AddOrUpdate(usr.Id, usr, (id, old) =>


### PR DESCRIPTION

# Summary
Fixes #541

# Details
Old method was renamed to better reflect it's current implementation. All calls were updated to use `TryGet` pattern where it makes sense.


# Notes
Some usage patterns of this method are still questionable. I'd presume you'd want proper user resolution every time