### PR TITLE
Fixes Lavalink Manual Disconnection Bug

### DIFF
--- a/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
@@ -93,6 +93,7 @@ namespace DSharpPlus.Lavalink
         internal string GuildIdString => this.GuildId.ToString(CultureInfo.InvariantCulture);
         internal ulong GuildId => this.Channel.Guild.Id;
         internal VoiceStateUpdateEventArgs VoiceStateUpdate { get; set; }
+        internal bool ManuallyDisconnected { get; set; } = false;
 
         internal LavalinkGuildConnection(LavalinkNodeConnection node, DiscordChannel channel, VoiceStateUpdateEventArgs vstu)
         {
@@ -120,10 +121,11 @@ namespace DSharpPlus.Lavalink
             Volatile.Write(ref this._isDisposed, true);
 
             await this.Node.SendPayloadAsync(new LavalinkDestroy(this)).ConfigureAwait(false);
-            await this.SendVoiceUpdateAsync().ConfigureAwait(false);
 
-            if (this.ChannelDisconnected != null)
-                this.ChannelDisconnected(this);
+            if(!this.ManuallyDisconnected)
+                await this.SendVoiceUpdateAsync().ConfigureAwait(false);
+
+            this.ChannelDisconnected?.Invoke(this);
         }
 
         internal async Task SendVoiceUpdateAsync()

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -376,25 +376,29 @@ namespace DSharpPlus.Lavalink
         private void Con_ChannelDisconnected(LavalinkGuildConnection con)
             => this.ConnectedGuilds.TryRemove(con.GuildId, out _);
 
-        private Task Discord_VoiceStateUpdated(VoiceStateUpdateEventArgs e)
+        private async Task Discord_VoiceStateUpdated(VoiceStateUpdateEventArgs e)
         {
             var gld = e.Guild;
             if (gld == null)
-                return Task.CompletedTask;
+                return;
 
             if (e.User == null)
-                return Task.CompletedTask;
+                return;
 
-            if (e.User.Id == this.Discord.CurrentUser.Id && this.ConnectedGuilds.TryGetValue(e.Guild.Id, out var lvlgc))
-                lvlgc.VoiceStateUpdate = e;
-
-            if (!string.IsNullOrWhiteSpace(e.SessionId) && e.User.Id == this.Discord.CurrentUser.Id && e.Channel != null && this.VoiceStateUpdates.ContainsKey(gld.Id))
+            if(e.User.Id == this.Discord.CurrentUser.Id)
             {
-                this.VoiceStateUpdates.TryRemove(gld.Id, out var xe);
-                xe.SetResult(e);
-            }
+                if (e.After.Channel == null && this.ConnectedGuilds.TryRemove(gld.Id, out var gc))
+                {
+                    gc.ManuallyDisconnected = true;
+                    await gc.DisconnectAsync().ConfigureAwait(false);
+                }
 
-            return Task.CompletedTask;
+                if (this.ConnectedGuilds.TryGetValue(e.Guild.Id, out var lvlgc))
+                    lvlgc.VoiceStateUpdate = e;
+
+                if (!string.IsNullOrWhiteSpace(e.SessionId) && e.Channel != null && this.VoiceStateUpdates.TryRemove(gld.Id, out var xe))
+                    xe.SetResult(e);
+            }
         }
 
         private async Task Discord_VoiceServerUpdated(VoiceServerUpdateEventArgs e)


### PR DESCRIPTION
# Summary
This fixes an issue that was reported in the guild that would not allow the client to reconnect from the voice channel if it was manually disconnected. 

# Details
This bug is caused by the guild connection not being removed when the bot is manually disconnected. I fixed this by adding to the VoiceStateUpdate handler to check if the client has left the voice channel, and if so, remove it from the guild connections cache and disconnect it from Lavalink using the destroy payload. 

# Notes
I also simplified a few code segments in the handler and in the guild connection class.