### PR TITLE
Fixes bug with manual VoiceNext disconnection.

### DIFF
--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -201,7 +201,7 @@ namespace DSharpPlus.Test
             if (e.Exception is CommandNotFoundException && (e.Command == null || e.Command.QualifiedName != "help"))
                 return;
 
-            Discord.DebugLogger.LogMessage(LogLevel.Error, "DSP Test", $"An exception occured during {e.Context.User.Username}'s invocation of '{e.Context.Command.QualifiedName}': {e.Exception.GetType()}", DateTime.Now.Date, e.Exception);
+            Discord.DebugLogger.LogMessage(LogLevel.Error, "DSP Test", $"An exception occured during {e.Context.User.Username}'s invocation of '{e.Context.Command.QualifiedName}': {e.Exception}", DateTime.Now.Date, e.Exception);
 
             var exs = new List<Exception>();
             if (e.Exception is AggregateException ae)

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -201,7 +201,7 @@ namespace DSharpPlus.Test
             if (e.Exception is CommandNotFoundException && (e.Command == null || e.Command.QualifiedName != "help"))
                 return;
 
-            Discord.DebugLogger.LogMessage(LogLevel.Error, "DSP Test", $"An exception occured during {e.Context.User.Username}'s invocation of '{e.Context.Command.QualifiedName}': {e.Exception}", DateTime.Now.Date, e.Exception);
+            Discord.DebugLogger.LogMessage(LogLevel.Error, "DSP Test", $"An exception occured during {e.Context.User.Username}'s invocation of '{e.Context.Command.QualifiedName}': {e.Exception.GetType()}", DateTime.Now.Date, e.Exception);
 
             var exs = new List<Exception>();
             if (e.Exception is AggregateException ae)

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -287,6 +287,9 @@ namespace DSharpPlus.VoiceNext
 
         internal void PreparePacket(ReadOnlySpan<byte> pcm, ref Memory<byte> target)
         {
+            if (this.IsDisposed)
+                return;
+
             var audioFormat = this.AudioFormat;
 
             var packetArray = ArrayPool<byte>.Shared.Rent(this.Rtp.CalculatePacketSize(audioFormat.SampleCountToSampleSize(audioFormat.CalculateMaximumFrameSize()), this.SelectedEncryptionMode));
@@ -671,8 +674,7 @@ namespace DSharpPlus.VoiceNext
             this.Rtp?.Dispose();
             this.Rtp = null;
 
-            if (this.VoiceDisconnected != null)
-                this.VoiceDisconnected(this.Guild);
+            this.VoiceDisconnected?.Invoke(this.Guild);
         }
 
         private async Task HeartbeatAsync()

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -664,8 +664,7 @@ namespace DSharpPlus.VoiceNext
                 this.VoiceWs.DisconnectAsync().ConfigureAwait(false).GetAwaiter().GetResult();
                 this.UdpClient.Close();
             }
-            catch (Exception)
-            { }
+            catch { }
 
             this.Opus?.Dispose();
             this.Opus = null;

--- a/DSharpPlus.VoiceNext/VoiceNextExtension.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextExtension.cs
@@ -153,15 +153,16 @@ namespace DSharpPlus.VoiceNext
             if (e.User == null)
                 return Task.CompletedTask;
 
-            if (e.User.Id == this.Client.CurrentUser.Id && this.ActiveConnections.TryGetValue(e.Guild.Id, out var vnc))
+            if(e.User.Id == this.Client.CurrentUser.Id)
             {
-                vnc.Channel = e.Channel;
-            }
+                if (e.After.Channel == null && this.ActiveConnections.TryRemove(gld.Id, out var ac))
+                    ac.Disconnect();
 
-            if (!string.IsNullOrWhiteSpace(e.SessionId) && e.User.Id == this.Client.CurrentUser.Id && e.Channel != null && this.VoiceStateUpdates.ContainsKey(gld.Id))
-            {
-                this.VoiceStateUpdates.TryRemove(gld.Id, out var xe);
-                xe.SetResult(e);
+                if (this.ActiveConnections.TryGetValue(e.Guild.Id, out var vnc))
+                    vnc.Channel = e.Channel;
+
+                if (!string.IsNullOrWhiteSpace(e.SessionId) && e.Channel != null && this.VoiceStateUpdates.TryRemove(gld.Id, out var xe))
+                    xe.SetResult(e);
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
# Summary
Similar to #544, this fixes a bug with VoiceNext that does not allow it to reconnect after being manually disconnected.

# Details
The changes made are very similar to #544, but I additionally included a dispose check inside PreparePacket if there was still audio playing. This prevents a null ref from being thrown if both PreparePacket and Dispose are being performed concurrently.