### PR TITLE
Fix for client not reconnecting when idlesince is set.

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -242,7 +242,6 @@ namespace DSharpPlus
                     IdleSince = since_unix,
                     IsAFK = idlesince != null,
                     _activity = activity
-
                 };
             }
 
@@ -438,7 +437,7 @@ namespace DSharpPlus
                         await this.ConnectAsync().ConfigureAwait(false);
                     else
                         if (this._status.IdleSince.HasValue)
-                            await this.ConnectAsync(this._status._activity, this._status.Status, Utilities.GetDateTimeOffset(this._status.IdleSince.Value)).ConfigureAwait(false);
+                            await this.ConnectAsync(this._status._activity, this._status.Status, Utilities.GetDateTimeOffsetFromMilliseconds(this._status.IdleSince.Value)).ConfigureAwait(false);
                         else
                             await this.ConnectAsync(this._status._activity, this._status.Status).ConfigureAwait(false);
                 }
@@ -1660,9 +1659,10 @@ namespace DSharpPlus
             if (!guild._invites.TryRemove(dat["code"].ToString(), out var invite))
             {
                 invite = dat.ToObject<DiscordInvite>();
-                invite.IsRevoked = true;
                 invite.Discord = this;
             }
+
+            invite.IsRevoked = true;
 
             var ea = new InviteDeleteEventArgs(this)
             {

--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -217,9 +217,7 @@ namespace DSharpPlus
         /// <param name="dto"><see cref="DateTimeOffset"/> to calculate Unix time for.</param>
         /// <returns>Calculated Unix time.</returns>
         public static long GetUnixTime(DateTimeOffset dto)
-        {
-            return dto.ToUnixTimeMilliseconds();
-        }
+            => dto.ToUnixTimeMilliseconds();
         
         /// <summary>
         /// Converts this <see cref="Permissions"/> into human-readable format.


### PR DESCRIPTION
# Summary
This PR fixes a bug which causes an exception to be thrown when reconnecting with an idlesince DateTime. Resolves #547.

# Details
This was actually caused by a PR I did a while ago for a separate patch for reapplying statuses. Previously, I used the `Utilities.GetDateTimeOffset()` method, which calculated the offset from seconds, which is what threw an `ArgumentOutOfRangeException`. The reconnection now uses `Utilities.GetDateTimeOffsetFromMilliseconds()`.

There is also a fix for the InviteDeleted event which wouldn't set the returned invites revoked status to true, even though an invite fired from that event would always be revoked.

# Notes
The only weird thing about reconnecting will be that the new idlesince timestamp will be in Utc regardless if the original timestamp was based off the system clock, although I don't think this will be an issue. 