### PR TITLE
Added public flag support

### DIFF
--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -145,7 +145,7 @@ namespace DSharpPlus.Entities
         public int Hierarchy
             => this.IsOwner ? int.MaxValue : this.RoleIds.Count == 0 ? 0 : this.Roles.Max(x => x.Position);
 
-        #region Overriden user properties
+        #region Overridden user properties
         [JsonIgnore]
         internal DiscordUser User 
             => this.Discord.UserCache[this.Id];
@@ -188,6 +188,7 @@ namespace DSharpPlus.Entities
 
         /// <summary>
         /// Gets the member's email address.
+        /// <para>This is only present in OAuth.</para>
         /// </summary>
         public override string Email
         {
@@ -206,6 +207,7 @@ namespace DSharpPlus.Entities
 
         /// <summary>
         /// Gets whether the member is verified.
+        /// <para>This is only present in OAuth.</para>
         /// </summary>
         public override bool? Verified
         {
@@ -223,7 +225,16 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Gets the member's OAuth account flags.
+        /// Gets the user's flags.
+        /// </summary>
+        public override UserFlags? OAuthFlags 
+        { 
+            get => this.User.OAuthFlags; 
+            internal set => this.User.OAuthFlags = value; 
+        }
+
+        /// <summary>
+        /// Gets the member's flags for OAuth.
         /// </summary>
         public override UserFlags? Flags 
         { 

--- a/DSharpPlus/Entities/DiscordUser.cs
+++ b/DSharpPlus/Entities/DiscordUser.cs
@@ -25,6 +25,7 @@ namespace DSharpPlus.Entities
             this.PremiumType = transport.PremiumType;
             this.Locale = transport.Locale;
             this.Flags = transport.Flags;
+            this.OAuthFlags = transport.OAuthFlags;
         }
 
         /// <summary>
@@ -76,13 +77,21 @@ namespace DSharpPlus.Entities
         public virtual bool? MfaEnabled { get; internal set; }
 
         /// <summary>
+        /// Gets whether the user is an official Discord system user.
+        /// </summary>
+        [JsonProperty("system", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsSystem { get; internal set; }
+
+        /// <summary>
         /// Gets whether the user is verified.
+        /// <para>This is only present in OAuth.</para>
         /// </summary>
         [JsonProperty("verified", NullValueHandling = NullValueHandling.Ignore)]
         public virtual bool? Verified { get; internal set; }
 
         /// <summary>
         /// Gets the user's email address.
+        /// <para>This is only present in OAuth.</para>
         /// </summary>
         [JsonProperty("email", NullValueHandling = NullValueHandling.Ignore)]
         public virtual string Email { get; internal set; }
@@ -100,9 +109,15 @@ namespace DSharpPlus.Entities
         public virtual string Locale { get; internal set; }
         
         /// <summary>
-        /// Gets the user's OAuth account flags.
+        /// Gets the user's flags for OAuth.
         /// </summary>
         [JsonProperty("flags", NullValueHandling = NullValueHandling.Ignore)]
+        public virtual UserFlags? OAuthFlags { get; internal set; }
+
+        /// <summary>
+        /// Gets the user's flags.
+        /// </summary>
+        [JsonProperty("public_flags", NullValueHandling = NullValueHandling.Ignore)]
         public virtual UserFlags? Flags { get; internal set; }
 
         /// <summary>

--- a/DSharpPlus/Enums/UserFlags.cs
+++ b/DSharpPlus/Enums/UserFlags.cs
@@ -66,6 +66,16 @@ namespace DSharpPlus
         /// <summary>
         /// The user reached the second bug hunter tier.
         /// </summary>
-        BugHunterLevelTwo = 1 << 14
+        BugHunterLevelTwo = 1 << 14,
+
+        /// <summary>
+        /// The user is a verified bot.
+        /// </summary>
+        VerifiedBot = 1 << 16,
+
+        /// <summary>
+        /// The user is a verified bot developer.
+        /// </summary>
+        VerifiedBotDeveloper = 1 << 17
     }
 }

--- a/DSharpPlus/Net/Abstractions/TransportUser.cs
+++ b/DSharpPlus/Net/Abstractions/TransportUser.cs
@@ -35,6 +35,9 @@ namespace DSharpPlus.Net.Abstractions
         public string Locale { get; internal set; }
 
         [JsonProperty("flags", NullValueHandling = NullValueHandling.Ignore)]
+        public UserFlags? OAuthFlags { get; internal set; }
+
+        [JsonProperty("public_flags", NullValueHandling = NullValueHandling.Ignore)]
         public UserFlags? Flags { get; internal set; }
 
         internal TransportUser() { }
@@ -52,6 +55,7 @@ namespace DSharpPlus.Net.Abstractions
             this.PremiumType = other.PremiumType;
             this.Locale = other.Locale;
             this.Flags = other.Flags;
+            this.OAuthFlags = other.OAuthFlags;
         }
     }
 }


### PR DESCRIPTION
# Summary
This adds support for the public user flags Discord is implementing [here](https://github.com/discord/discord-api-docs/pull/1490).

# Details
Unlike the previous flags (which have been renamed to `OAuthFlags`), the new flags property can be accessed by bots without OAuth. I've also heard that both of these flags have different values, but I haven't been able to confirm that. 

There were also 2 new flags added: `VerifiedBot` and `VerifiedBotDeveloper`.

# Changes proposed
* Added the new public flags property as `Flags`, and changed the previous flags to `OAuthFlags`
* Added 2 new flags for `UserFlags`