### PR TITLE
Fix for NullReference if no connection was established #554

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2634,8 +2634,7 @@ namespace DSharpPlus
             this._guilds = null;
             this._heartbeatTask = null;
             this._privateChannels = null;
-            this._webSocketClient.DisconnectAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-            this._webSocketClient.Dispose();
+            this._webSocketClient?.Dispose();
         }
 
         #region Events


### PR DESCRIPTION
# Summary
Fixes #554 
Added a null check when disposing the WebsSocketClient and removed the Disconnect because this is done in a nullsafe way in DiscordClient::DisconnectAsync().

# Notes
I picked up this issue because i am relatively new to open source development and this issue looked relatively easy. I would love any feedback😄. 

