### PR TITLE
Pass computed timeout parameter to WaitForMessageAsync

### DIFF
--- a/DSharpPlus.Interactivity/Extensions.cs
+++ b/DSharpPlus.Interactivity/Extensions.cs
@@ -34,7 +34,7 @@ namespace DSharpPlus.Interactivity
                 throw new InvalidOperationException("Interactivity was not set up!");
 
             var timeout = timeoutoverride ?? interactivity.Config.Timeout;
-            return await interactivity.WaitForMessageAsync(x => x.ChannelId == c.Id && predicate(x),timeout);
+            return await interactivity.WaitForMessageAsync(x => x.ChannelId == c.Id && predicate(x), timeout);
         }
 
         /// <summary>

--- a/DSharpPlus.Interactivity/Extensions.cs
+++ b/DSharpPlus.Interactivity/Extensions.cs
@@ -34,7 +34,7 @@ namespace DSharpPlus.Interactivity
                 throw new InvalidOperationException("Interactivity was not set up!");
 
             var timeout = timeoutoverride ?? interactivity.Config.Timeout;
-            return await interactivity.WaitForMessageAsync(x => x.ChannelId == c.Id && predicate(x));
+            return await interactivity.WaitForMessageAsync(x => x.ChannelId == c.Id && predicate(x),timeout);
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary
Fixes #559.
It passes the computed timeout parameter and restores the lost functionality.

# Details
`var timeout` is correctly computed but its never used on the underlying `WaitForMessageAsync`