### PR TITLE
Prevent deadlock by checking if the client is closed before trying to acquire the senderlock.

### DIFF
--- a/DSharpPlus/Net/WebSocket/WebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient.cs
@@ -140,7 +140,9 @@ namespace DSharpPlus.Net.WebSocket
         /// <inheritdoc />
         public async Task SendMessageAsync(string message)
         {
-            if (this._ws == null)
+            // Check if the websocket is available.
+            // Also check if the client isn't closed because this could lead to a deadlock
+            if (this._ws == null || this._isClientClose)
                 return;
 
             var bytes = Utilities.UTF8.GetBytes(message);


### PR DESCRIPTION
# Summary
Fixes #561. 
Added a check to WebSocketClient::SendMessageAsync(), which checks if the client hasn't been closed, to prevent the issue raised in #561.
