### PR TITLE
Added workaround for #575

### DIFF
--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -73,7 +73,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public IEnumerable<DiscordRole> Roles 
-            => this.RoleIds.Select(id => this.Guild.GetRole(id));
+            => this.RoleIds.Select(id => this.Guild.GetRole(id)).Where(x => x != null);
 
         /// <summary>
         /// Gets the color associated with this user's top color-giving role, otherwise 0 (no color).


### PR DESCRIPTION
# Summary
Creates a workaround for the issue detailed in #575 by simply excluding any null entries in `DiscordMember.Roles`.