### PR TITLE
Forgot to change variable in loop.

### DIFF
--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -2084,7 +2084,7 @@ namespace DSharpPlus
                     {
                         xp.InternalActivities = new DiscordActivity[xp.RawActivities.Length];
                         for (int j = 0; j < xp.RawActivities.Length; j++)
-                            xp.InternalActivities[i] = new DiscordActivity(xp.RawActivities[i]);
+                            xp.InternalActivities[j] = new DiscordActivity(xp.RawActivities[j]);
                     }
                     
                     pres.Add(xp);


### PR DESCRIPTION
 # Summary
I forgot to change the activities' indexing variable in #573 from `i` to `j`. This fixes an `IndexOutOfRangeException` from being thrown.  