### PR TITLE
[ci-skip] Fix UseInteractivity() example in Interactivity Tutorial

### DIFF
--- a/docs/articles/interactivity/intro.md
+++ b/docs/articles/interactivity/intro.md
@@ -15,7 +15,12 @@ and the bot class.
 Before you connect, enable the module on your client: 
 
 ```cs
-interactivity = discord.UseInteractivity();
+interactivity = discord.UseInteractivity(new InteractivityConfiguration
+{
+    PaginationBehaviour = TimeoutBehaviour.Ignore,
+    PaginationTimeout = TimeSpan.FromMinutes(5),
+    Timeout = TimeSpan.FromMinutes(2),
+});
 ```
 
 This will enable the module.


### PR DESCRIPTION
The tutorial used ```cs
interactivity = discord.UseInteractivity();```
which is not defined.

So, I replaced it with the code seen in Example Bot 3 [here](https://github.com/DSharpPlus/Example-Bots/blob/a4b24b5bd2bbeb79d92d321b3b65afa7db2f4745/DSPlus.Examples.CSharp.Ex03/Program.cs#L105-L115). I'm not sure what each of those fields in the initializer do but I just put them there. If you have any preferences on what should go there instead tell me and I will update my PR. 

Also, apparently I did something wrong because the ci-skip doesn't seem like it skipped.