### PR TITLE
Added new parameters to prune methods.

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -797,23 +797,26 @@ namespace DSharpPlus
 
         #region Prune
         /// <summary>
-        /// Get a guild's prune count
+        /// Get a guild's prune count.
         /// </summary>
         /// <param name="guild_id">Guild id</param>
         /// <param name="days">Days to check for</param>
+        /// <param name="include_roles">The roles to be included in the prune.</param>
         /// <returns></returns>
-        public Task<int> GetGuildPruneCountAsync(ulong guild_id, int days)
-            => this.ApiClient.GetGuildPruneCountAsync(guild_id, days);
+        public Task<int> GetGuildPruneCountAsync(ulong guild_id, int days, IEnumerable<ulong> include_roles)
+            => this.ApiClient.GetGuildPruneCountAsync(guild_id, days, include_roles);
 
         /// <summary>
-        /// Begins a guild prune
+        /// Begins a guild prune.
         /// </summary>
         /// <param name="guild_id">Guild id</param>
         /// <param name="days">Days to prune for</param>
+        /// <param name="compute_prune_count">Whether to return the prune count after this method completes. This is discouraged for larger guilds.</param>
+        /// <param name="include_roles">The roles to be included in the prune.</param>
         /// <param name="reason">Reason why this guild was pruned</param>
         /// <returns></returns>
-        public Task<int> BeginGuildPruneAsync(ulong guild_id, int days, string reason)
-            => this.ApiClient.BeginGuildPruneAsync(guild_id, days, reason);
+        public Task<int?> BeginGuildPruneAsync(ulong guild_id, int days, bool compute_prune_count, IEnumerable<ulong> include_roles, string reason)
+            => this.ApiClient.BeginGuildPruneAsync(guild_id, days, compute_prune_count, include_roles, reason);
         #endregion
 
         #region GuildVarious

--- a/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
@@ -149,8 +149,8 @@ namespace DSharpPlus.Net.Abstractions
 
     internal sealed class RestGuildPruneResultPayload
     {
-        [JsonProperty("pruned")]
-        public int Pruned { get; set; }
+        [JsonProperty("pruned", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Pruned { get; set; }
     }
 
     internal sealed class RestGuildIntegrationAttachPayload


### PR DESCRIPTION
# Summary
Implements the new parameters for pruning as documented [here](https://github.com/discord/discord-api-docs/pull/1563).

# Details
Discord recently added the ability for members to be pruned, even when in roles. They also added an option to determine whether the prune count should be returned when pruning, which saves time when pruning larger guilds. These changes are now reflected in the library, where the user can pass this option and/or a collection of roles to check to prune.

# Changes proposed
* Added the `include_roles` parameter to both `GetPruneCountAsync()` and `PruneAsync()`
* Added the `compute_prune_count` parameter to `PruneAsync()`, and changed the return type of this method to a nullable integer.
* Changed these methods in both the guild and rest client.