### PR TITLE
Fix embed URIs not being encoded properly.

### DIFF
--- a/DSharpPlus/Entities/DiscordActivity.cs
+++ b/DSharpPlus/Entities/DiscordActivity.cs
@@ -152,7 +152,7 @@ namespace DSharpPlus.Entities
         public DiscordActivity(string name, ActivityType type)
         {
             if (type == ActivityType.Custom)
-                throw new InvalidOperationException("Bots cannot use a custom status");
+                throw new InvalidOperationException("Bots cannot use a custom status.");
 
             this.Name = name;
             this.ActivityType = type;

--- a/DSharpPlus/Entities/DiscordActivity.cs
+++ b/DSharpPlus/Entities/DiscordActivity.cs
@@ -151,6 +151,9 @@ namespace DSharpPlus.Entities
         /// <param name="type">Type of the activity.</param>
         public DiscordActivity(string name, ActivityType type)
         {
+            if (type == ActivityType.Custom)
+                throw new InvalidOperationException("Bots cannot use a custom status");
+
             this.Name = name;
             this.ActivityType = type;
         }

--- a/DSharpPlus/Entities/DiscordEmbedBuilder.cs
+++ b/DSharpPlus/Entities/DiscordEmbedBuilder.cs
@@ -70,26 +70,21 @@ namespace DSharpPlus.Entities
             set => this._imageUri = string.IsNullOrEmpty(value) ? null : new DiscordUri(value);
         }
         private DiscordUri _imageUri;
-
+        
         /// <summary>
-        /// Gets or sets the thumbnail's image url.
-        /// </summary>
-        public string ThumbnailUrl
-        {
-            get => this._thumbnailUri?.ToString();
-            set => this._thumbnailUri = string.IsNullOrEmpty(value) ? null : new DiscordUri(value);
-        }
-        private DiscordUri _thumbnailUri;
-
-        /// <summary>
-        /// Gets the embed's author.
+        /// Gets or sets the embed's author.
         /// </summary>
         public EmbedAuthor Author { get; set; }
 
         /// <summary>
-        /// Gets the embed's footer.
+        /// Gets or sets the embed's footer.
         /// </summary>
         public EmbedFooter Footer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the embed's thumbnail.
+        /// </summary>
+        public EmbedThumbnail Thumbnail { get; set; }
 
         /// <summary>
         /// Gets the embed's fields.
@@ -117,7 +112,14 @@ namespace DSharpPlus.Entities
             this.Url = original.Url?.ToString();
             this.Color = original.Color;
             this.Timestamp = original.Timestamp;
-            this.ThumbnailUrl = original.Thumbnail?.Url?.ToString();
+
+            if (original.Thumbnail != null)
+                this.Thumbnail = new EmbedThumbnail
+                {
+                    Url = original.Thumbnail.Url?.ToString(),
+                    Height = original.Thumbnail.Height,
+                    Width = original.Thumbnail.Width
+                };
 
             if (original.Author != null)
                 this.Author = new EmbedAuthor
@@ -258,10 +260,18 @@ namespace DSharpPlus.Entities
         /// Sets the embed's thumbnail url.
         /// </summary>
         /// <param name="url">Thumbnail url to set.</param>
+        /// <param name="height">The height of the thumbnail to set.</param>
+        /// <param name="width">The width of the thumbnail to set.</param>
         /// <returns>This embed builder.</returns>
-        public DiscordEmbedBuilder WithThumbnailUrl(string url)
+        public DiscordEmbedBuilder WithThumbnail(string url, int height = 0, int width = 0)
         {
-            this.ThumbnailUrl = url;
+            this.Thumbnail = new EmbedThumbnail
+            {
+                Url = url,
+                Height = height,
+                Width = width
+            };
+
             return this;
         }
 
@@ -269,10 +279,18 @@ namespace DSharpPlus.Entities
         /// Sets the embed's thumbnail url.
         /// </summary>
         /// <param name="url">Thumbnail url to set.</param>
+        /// <param name="height">The height of the thumbnail to set.</param>
+        /// <param name="width">The width of the thumbnail to set.</param>
         /// <returns>This embed builder.</returns>
-        public DiscordEmbedBuilder WithThumbnailUrl(Uri url)
+        public DiscordEmbedBuilder WithThumbnail(Uri url, int height = 0, int width = 0)
         {
-            this._thumbnailUri = new DiscordUri(url);
+            this.Thumbnail = new EmbedThumbnail
+            {
+                _uri = new DiscordUri(url),
+                Height = height,
+                Width = width
+            };
+
             return this;
         }
 
@@ -410,21 +428,26 @@ namespace DSharpPlus.Entities
                 embed.Footer = new DiscordEmbedFooter
                 {
                     Text = this.Footer.Text,
-                    IconUrl = this.Footer.IconUrl != null ? new DiscordUri(this.Footer.IconUrl) : null
+                    IconUrl = this.Footer._iconUri
                 };
 
             if (this.Author != null)
                 embed.Author = new DiscordEmbedAuthor
                 {
                     Name = this.Author.Name,
-                    Url = this.Author.Url != null ? new Uri(this.Author.Url) : null,
-                    IconUrl = this.Author.IconUrl != null ? new DiscordUri(this.Author.IconUrl) : null
+                    Url = this.Author._uri,
+                    IconUrl = this.Author._iconUri
                 };
 
             if (this._imageUri != null)
                 embed.Image = new DiscordEmbedImage { Url = this._imageUri };
-            if (this._thumbnailUri != null)
-                embed.Thumbnail = new DiscordEmbedThumbnail { Url = this._thumbnailUri };
+            if (this.Thumbnail != null)
+                embed.Thumbnail = new DiscordEmbedThumbnail
+                {
+                    Url = this.Thumbnail._uri,
+                    Height = this.Thumbnail.Height,
+                    Width =  this.Thumbnail.Width
+                };
 
             embed.Fields = new ReadOnlyCollection<DiscordEmbedField>(new List<DiscordEmbedField>(this._fields)); // copy the list, don't wrap it, prevents mutation
 
@@ -463,7 +486,7 @@ namespace DSharpPlus.Entities
                 get => this._uri?.ToString();
                 set => this._uri = string.IsNullOrEmpty(value) ? null : new Uri(value);
             }
-            private Uri _uri;
+            internal Uri _uri;
 
             /// <summary>
             /// Gets or sets the Author's icon url.
@@ -473,7 +496,7 @@ namespace DSharpPlus.Entities
                 get => this._iconUri?.ToString();
                 set => this._iconUri = string.IsNullOrEmpty(value) ? null : new DiscordUri(value);
             }
-            private DiscordUri _iconUri;
+            internal DiscordUri _iconUri;
         }
 
         public class EmbedFooter
@@ -501,7 +524,40 @@ namespace DSharpPlus.Entities
                 get => this._iconUri?.ToString();
                 set => this._iconUri = string.IsNullOrEmpty(value) ? null : new DiscordUri(value);
             }
-            private DiscordUri _iconUri;
+            internal DiscordUri _iconUri;
+        }
+
+        public class EmbedThumbnail
+        {
+            /// <summary>
+            /// Gets or sets the thumbnail's image url.
+            /// </summary>
+            public string Url
+            {
+                get => this._uri?.ToString();
+                set => this._uri = string.IsNullOrEmpty(value) ? null : new DiscordUri(value);
+            }
+            internal DiscordUri _uri;
+
+            /// <summary>
+            /// Gets or sets the thumbnail's height.
+            /// </summary>
+            public int Height
+            {
+                get => this._height;
+                set => this._height = value >= 0 ? value : 0;
+            }
+            private int _height;
+
+            /// <summary>
+            /// Gets or sets the thumbnail's width.
+            /// </summary>
+            public int Width
+            {
+                get => this._width;
+                set => this._width = value >= 0 ? value : 0;
+            }
+            private int _width;
         }
     }
 }

--- a/DSharpPlus/Entities/DiscordEmbedBuilder.cs
+++ b/DSharpPlus/Entities/DiscordEmbedBuilder.cs
@@ -461,6 +461,9 @@ namespace DSharpPlus.Entities
         public static implicit operator DiscordEmbed(DiscordEmbedBuilder builder)
             => builder?.Build();
 
+        /// <summary>
+        /// Represents an embed author.
+        /// </summary>
         public class EmbedAuthor
         {
             /// <summary>
@@ -499,6 +502,9 @@ namespace DSharpPlus.Entities
             internal DiscordUri _iconUri;
         }
 
+        /// <summary>
+        /// Represents an embed footer.
+        /// </summary>
         public class EmbedFooter
         {
             /// <summary>
@@ -527,6 +533,9 @@ namespace DSharpPlus.Entities
             internal DiscordUri _iconUri;
         }
 
+        /// <summary>
+        /// Represents an embed thumbnail.
+        /// </summary>
         public class EmbedThumbnail
         {
             /// <summary>


### PR DESCRIPTION
# Summary
Fixes #565.

# Details
This primarily resolves the encoding issue described in the linked issue. I also added the ability for users to change the width and height of the thumbnail and made the thumbnail its own class as an `EmbedThumbnail`. I also made it to where users cannot set a custom status for bots.

# Changes proposed
* Fix encoding issue.
* Make embed thumbnail a separate class to specify height and width.
* Fixed a few documentation issues
* Throws an exception if the user tries to set a custom activity type.