### PR TITLE
Gave BeforeExecutionAsync() a bool return type that decides whether or not to continue with Task execution.

### DIFF
--- a/DSharpPlus.CommandsNext/BaseCommandModule.cs
+++ b/DSharpPlus.CommandsNext/BaseCommandModule.cs
@@ -12,8 +12,8 @@ namespace DSharpPlus.CommandsNext
         /// </summary>
         /// <param name="ctx">Context in which the method is being executed.</param>
         /// <returns></returns>
-        public virtual Task BeforeExecutionAsync(CommandContext ctx)
-            => Task.Delay(0);
+        public virtual Task<bool> BeforeExecutionAsync(CommandContext ctx)
+            => Task.FromResult(true);
 
         /// <summary>
         /// Called after a command in the implementing module is successfully executed.

--- a/DSharpPlus.CommandsNext/BaseCommandModule.cs
+++ b/DSharpPlus.CommandsNext/BaseCommandModule.cs
@@ -11,7 +11,7 @@ namespace DSharpPlus.CommandsNext
         /// Called before a command in the implementing module is executed.
         /// </summary>
         /// <param name="ctx">Context in which the method is being executed.</param>
-        /// <returns></returns>
+        /// <returns>True if D#+ should handle execution of the command.</returns>
         public virtual Task<bool> BeforeExecutionAsync(CommandContext ctx)
             => Task.FromResult(true);
 

--- a/DSharpPlus.CommandsNext/Entities/Command.cs
+++ b/DSharpPlus.CommandsNext/Entities/Command.cs
@@ -85,10 +85,17 @@ namespace DSharpPlus.CommandsNext
                         continue;
 
                     ctx.RawArguments = args.Raw;
-                    
+
                     var mdl = ovl.InvocationTarget ?? this.Module?.GetInstance(ctx.Services);
                     if (mdl is BaseCommandModule bcmBefore)
-                        await bcmBefore.BeforeExecutionAsync(ctx).ConfigureAwait(false);
+                    {
+                        var shouldHandleExecution = await bcmBefore.BeforeExecutionAsync(ctx).ConfigureAwait(false);
+                        if (!shouldHandleExecution)
+                        {
+                            executed = true;
+                            break;
+                        }
+                    }
 
                     args.Converted[0] = mdl;
                     var ret = (Task)ovl.Callable.DynamicInvoke(args.Converted);


### PR DESCRIPTION
# Summary
Implements an ability for the developer to decide whether or not to let the library handle the command execution.

# Details
The virtual method `BeforeExecutionAsync` now has a return type of `bool`, which would be used to decide whether or not to continue with the command execution:
```cs
public virtual Task<bool> BeforeExecutionAsync(CommandContext ctx)
            => Task.FromResult(true);
```
The result is then handled in `Command.cs`:
```cs
var shouldHandleExecution = await bcmBefore.BeforeExecutionAsync(ctx).ConfigureAwait(false);
if (!shouldHandleExecution)
{
    executed = true;
    break;
}
```

A good use case would be the following example, where the bot first determines whether or not the user is allowed to use commands in the current channel:
```cs
public override Task<bool> BeforeExecutionAsync(CommandContext ctx)
{
    return MyDAL.Guilds[ctx.Guild].UserCanUseBotInChannel(ctx);
}
```

# Changes proposed
* Give `BeforeExecutionAsync` a return type that would decide if the library would handle the command.

# Notes
I wasn't sure whether or not I should set `executed = true` when `false` is returned, but I assumed so since not setting it would cause it to be handled as if no overload was found.