### PR TITLE
Added .Auto to ImageFormat to enhance GetAvatarUrl

### DIFF
--- a/DSharpPlus/Entities/DiscordApplication.cs
+++ b/DSharpPlus/Entities/DiscordApplication.cs
@@ -101,6 +101,7 @@ namespace DSharpPlus.Entities
                     sfmt = "jpg";
                     break;
 
+                case ImageFormat.Auto:
                 case ImageFormat.Png:
                     sfmt = "png";
                     break;

--- a/DSharpPlus/Entities/DiscordUser.cs
+++ b/DSharpPlus/Entities/DiscordUser.cs
@@ -194,6 +194,9 @@ namespace DSharpPlus.Entities
                     sfmt = "webp";
                     break;
 
+                case ImageFormat.Auto:
+                    sfmt = !string.IsNullOrWhiteSpace(this.AvatarHash) ? (AvatarHash.StartsWith("a_") ? "gif" : "png") : "png";
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(fmt));
             }

--- a/DSharpPlus/Entities/DiscordUser.cs
+++ b/DSharpPlus/Entities/DiscordUser.cs
@@ -55,7 +55,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public string AvatarUrl 
-            => !string.IsNullOrWhiteSpace(this.AvatarHash) ? (AvatarHash.StartsWith("a_") ? $"https://cdn.discordapp.com/avatars/{this.Id.ToString(CultureInfo.InvariantCulture)}/{AvatarHash}.gif?size=1024" : $"https://cdn.discordapp.com/avatars/{Id}/{AvatarHash}.png?size=1024") : this.DefaultAvatarUrl;
+            => !string.IsNullOrWhiteSpace(this.AvatarHash) ? (this.AvatarHash.StartsWith("a_") ? $"https://cdn.discordapp.com/avatars/{this.Id.ToString(CultureInfo.InvariantCulture)}/{AvatarHash}.gif?size=1024" : $"https://cdn.discordapp.com/avatars/{Id}/{AvatarHash}.png?size=1024") : this.DefaultAvatarUrl;
 
         /// <summary>
         /// Gets the URL of default avatar for this user.
@@ -195,8 +195,9 @@ namespace DSharpPlus.Entities
                     break;
 
                 case ImageFormat.Auto:
-                    sfmt = !string.IsNullOrWhiteSpace(this.AvatarHash) ? (AvatarHash.StartsWith("a_") ? "gif" : "png") : "png";
+                    sfmt = !string.IsNullOrWhiteSpace(this.AvatarHash) ? (this.AvatarHash.StartsWith("a_") ? "gif" : "png") : "png";
                     break;
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(fmt));
             }

--- a/DSharpPlus/ImageTool.cs
+++ b/DSharpPlus/ImageTool.cs
@@ -129,6 +129,7 @@ namespace DSharpPlus
         Jpeg = 1,
         Png = 2,
         Gif = 3,
-        WebP = 4
+        WebP = 4,
+        Auto = 5
     }
 }


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Adds .Auto to ImageFormat to enhance the use of GetAvatarUrl

# Details
There is no convenient way to get the avatar url of an user with a specific size without checking if it's animated or not. With this change you can use GetAvatarUrl for that.

# Changes proposed
See diff. No breaking changes.

# Notes
It's quite simple~