### PR TITLE
Feature: Implement X-Ratelimit-Reset-After

### DIFF
--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -45,6 +45,14 @@ namespace DSharpPlus
         public bool UseInternalLogHandler { internal get; set; } = false;
 
         /// <summary>
+        /// <para>Sets whether to rely on Discord for NTP (Network Time Protocol) synchronization with the "X-Ratelimit-Reset-After" header.</para>
+        /// <para>If the system clock is unsynced, setting this to true will ensure ratelimits are synced with Discord and reduce the risk of hitting one.</para>
+        /// <para>This should only be set to false if the system clock is synced with NTP.</para>
+        /// <para>Defaults to true.</para>
+        /// </summary>
+        public bool UseRelativeRatelimit { internal get; set; } = true;
+
+        /// <summary>
         /// <para>Allows you to overwrite the time format used by the internal debug logger.</para>
         /// <para>Only applicable when <see cref="UseInternalLogHandler"/> is set to true. Defaults to ISO 8601-like format.</para>
         /// </summary>
@@ -155,6 +163,7 @@ namespace DSharpPlus
             this.TokenType = other.TokenType;
             this.LogLevel = other.LogLevel;
             this.UseInternalLogHandler = other.UseInternalLogHandler;
+            this.UseRelativeRatelimit = other.UseRelativeRatelimit;
             this.DateTimeFormat = other.DateTimeFormat;
             this.LargeThreshold = other.LargeThreshold;
             this.AutoReconnect = other.AutoReconnect;

--- a/DSharpPlus/DiscordWebhookClient.cs
+++ b/DSharpPlus/DiscordWebhookClient.cs
@@ -59,9 +59,10 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="proxy">Proxy to use for HTTP connections.</param>
         /// <param name="timeout">Timeout to use for HTTP requests. Set to <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to disable timeouts.</param>
-        public DiscordWebhookClient(IWebProxy proxy, TimeSpan timeout)
+        /// <param name="useRelativeRateLimit">Whether to use the system clock for computing rate limit resets. See <see cref="DiscordConfiguration.UseRelativeRatelimit"/> for more details.</param>
+        public DiscordWebhookClient(IWebProxy proxy, TimeSpan timeout, bool useRelativeRateLimit = true)
         {
-            this._apiclient = new DiscordApiClient(proxy, timeout);
+            this._apiclient = new DiscordApiClient(proxy, timeout, useRelativeRateLimit);
             this._hooks = new List<DiscordWebhook>();
             this.Webhooks = new ReadOnlyCollection<DiscordWebhook>(this._hooks);
         }

--- a/DSharpPlus/Entities/DiscordEmbedBuilder.cs
+++ b/DSharpPlus/Entities/DiscordEmbedBuilder.cs
@@ -257,7 +257,7 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Sets the embed's thumbnail url.
+        /// Sets the embed's thumbnail.
         /// </summary>
         /// <param name="url">Thumbnail url to set.</param>
         /// <param name="height">The height of the thumbnail to set.</param>
@@ -276,7 +276,7 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Sets the embed's thumbnail url.
+        /// Sets the embed's thumbnail.
         /// </summary>
         /// <param name="url">Thumbnail url to set.</param>
         /// <param name="height">The height of the thumbnail to set.</param>

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -32,9 +32,9 @@ namespace DSharpPlus.Net
             this.Rest = new RestClient(client);
         }
 
-        internal DiscordApiClient(IWebProxy proxy, TimeSpan timeout) // This is for meta-clients, such as the webhook client
+        internal DiscordApiClient(IWebProxy proxy, TimeSpan timeout, bool useRelativeRateLimit) // This is for meta-clients, such as the webhook client
         {
-            this.Rest = new RestClient(proxy, timeout);
+            this.Rest = new RestClient(proxy, timeout, useRelativeRateLimit);
         }
 
         private static string BuildQueryString(IDictionary<string, string> values, bool post = false)
@@ -1741,7 +1741,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { channel_id, message_id, emoji }, out var path);
 
             var url = Utilities.GetApiUriFor(path);
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, ratelimitWaitOverride: 0.26);
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, ratelimitWaitOverride: this.Discord.Configuration.UseRelativeRatelimit ? null : (double?)0.26);
         }
 
         internal Task DeleteOwnReactionAsync(ulong channel_id, ulong message_id, string emoji)
@@ -1750,7 +1750,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id, emoji }, out var path);
 
             var url = Utilities.GetApiUriFor(path);
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, ratelimitWaitOverride: 0.26);
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, ratelimitWaitOverride: this.Discord.Configuration.UseRelativeRatelimit ? null : (double?)0.26);
         }
 
         internal Task DeleteUserReactionAsync(ulong channel_id, ulong message_id, ulong user_id, string emoji, string reason)
@@ -1763,7 +1763,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id, emoji, user_id }, out var path);
 
             var url = Utilities.GetApiUriFor(path);
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers, ratelimitWaitOverride: 0.26);
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers, ratelimitWaitOverride: this.Discord.Configuration.UseRelativeRatelimit ? null : (double?)0.26);
         }
 
         internal async Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(ulong channel_id, ulong message_id, string emoji, ulong? after_id = null, int limit = 25)
@@ -1809,7 +1809,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id }, out var path);
 
             var url = Utilities.GetApiUriFor(path);
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers, ratelimitWaitOverride: 0.26);
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, headers, ratelimitWaitOverride: this.Discord.Configuration.UseRelativeRatelimit ? null : (double?)0.26);
         }
 
         internal Task DeleteReactionsEmojiAsync(ulong channel_id, ulong message_id, string emoji)
@@ -1818,7 +1818,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id, emoji }, out var path);
 
             var url = Utilities.GetApiUriFor(path);
-            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, ratelimitWaitOverride: 0.26);
+            return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, ratelimitWaitOverride: this.Discord.Configuration.UseRelativeRatelimit ? null : (double?)0.26);
         }
         #endregion
 

--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -142,14 +142,14 @@ namespace DSharpPlus.Net
                         if (delay < TimeSpan.Zero)
                             delay = TimeSpan.FromMilliseconds(100);
 
-                        request.Discord?.DebugLogger?.LogMessage(LogLevel.Warning, "REST", $"Pre-emptive ratelimit triggered, waiting until {resetDate:yyyy-MM-dd HH:mm:ss zzz} ({delay:c})", DateTime.Now);
+                        request.Discord?.DebugLogger?.LogMessage(LogLevel.Warning, "REST", $"Pre-emptive ratelimit triggered. Waiting until {resetDate:yyyy-MM-dd HH:mm:ss zzz} ({delay:c}).", DateTime.Now);
                         request.Discord?.DebugLogger?.LogTaskFault(Task.Delay(delay).ContinueWith(_ => this.ExecuteRequestAsync(request, null, null)), LogLevel.Error, "RESET", "Error while executing request: ");
                         return;
                     }
                     request.Discord?.DebugLogger?.LogMessage(LogLevel.Debug, "REST", $"Request for {bucket}. Allowing.", DateTime.Now);
                 }
                 else
-                    request.Discord?.DebugLogger?.LogMessage(LogLevel.Debug, "REST", $"Initial Request for {bucket}. Allowing.", DateTime.Now);
+                    request.Discord?.DebugLogger?.LogMessage(LogLevel.Debug, "REST", $"Initial request for {bucket}. Allowing.", DateTime.Now);
 
                 var req = this.BuildRequest(request);
                 var response = new RestResponse();


### PR DESCRIPTION
# Summary
Fixes #580.

# Details
This will allow clients to decide whether to compute ratelimits using this header, which will have a slightly longer reset time to reduce the risk of hitting a ratelimit. This is true by default, but clients can use the old method by setting `UseRelativeRatelimit` to false.

This was tested by spamming the following endpoints:

`POST channels/channel_id/messages` (should work for the other endpoints as well)

`DELETE channels/channel_id/messages/message_id` (special endpoint)

`POST webhooks/webhook_id/webhook_token` (due to weirdness with webhooks)

# Changes proposed
* Add support for this header, enabled by default but can be toggled off.
* Made a few grammatical changes in the logger and with comments.

# Notes
The only thing which may throw an occasional 429 would be spamming delete message, but there is no practical reason to do this.