### PR TITLE
Fix error with trailing escape char

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
@@ -92,7 +92,7 @@ namespace DSharpPlus.CommandsNext
                 if (char.IsWhiteSpace(str[i]) && !inQuote && !inTripleBacktick && !inBacktick && !inEscape)
                     endPosition = i;
 
-                if (str[i] == '\\')
+                if (str[i] == '\\' && str.Length > i + 1)
                 {
                     if (!inEscape && !inBacktick && !inTripleBacktick)
                     {


### PR DESCRIPTION
# Summary
Fixes error with trailing escape char (`\`).

# Details
Currently when you try adding \ at the end of argument following exception will be thrown:
```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at DSharpPlus.CommandsNext.CommandsNextUtilities.ExtractNextArgument(String str, Int32& startPos)
   at DSharpPlus.CommandsNext.CommandsNextUtilities.BindArguments(CommandContext ctx, Boolean ignoreSurplus)
   at DSharpPlus.CommandsNext.Command.ExecuteAsync(CommandContext ctx)
```