### PR TITLE
Making the internal LogHandler threadsafe

### DIFF
--- a/DSharpPlus/DebugLogger.cs
+++ b/DSharpPlus/DebugLogger.cs
@@ -61,7 +61,7 @@ namespace DSharpPlus
 
         internal void LogHandler(object sender, DebugLogMessageEventArgs e)
         {
-            lock (this._lock)
+            lock (_lock)
             {
                 switch (e.Level) {
                     case LogLevel.Debug:

--- a/DSharpPlus/DebugLogger.cs
+++ b/DSharpPlus/DebugLogger.cs
@@ -6,7 +6,7 @@ namespace DSharpPlus
 {
     public class DebugLogger
     {
-        static readonly object _lock = new object();
+        private static readonly object _lock = new object();
 
         private LogLevel Level { get; }
         private string DateTimeFormat { get; }

--- a/DSharpPlus/DebugLogger.cs
+++ b/DSharpPlus/DebugLogger.cs
@@ -63,7 +63,8 @@ namespace DSharpPlus
         {
             lock (_lock)
             {
-                switch (e.Level) {
+                switch (e.Level)
+                {
                     case LogLevel.Debug:
                         Console.ForegroundColor = ConsoleColor.DarkGreen;
                         break;

--- a/DSharpPlus/DebugLogger.cs
+++ b/DSharpPlus/DebugLogger.cs
@@ -6,9 +6,10 @@ namespace DSharpPlus
 {
     public class DebugLogger
     {
+        static readonly object _lock = new object();
+
         private LogLevel Level { get; }
         private string DateTimeFormat { get; }
-        private object Lock { get; }
 
         internal DebugLogger(BaseDiscordClient client)
         {
@@ -60,7 +61,7 @@ namespace DSharpPlus
 
         internal void LogHandler(object sender, DebugLogMessageEventArgs e)
         {
-            lock (this.Lock)
+            lock (this._lock)
             {
                 switch (e.Level) {
                     case LogLevel.Debug:

--- a/DSharpPlus/DebugLogger.cs
+++ b/DSharpPlus/DebugLogger.cs
@@ -8,6 +8,7 @@ namespace DSharpPlus
     {
         private LogLevel Level { get; }
         private string DateTimeFormat { get; }
+        private object Lock { get; }
 
         internal DebugLogger(BaseDiscordClient client)
         {
@@ -59,33 +60,35 @@ namespace DSharpPlus
 
         internal void LogHandler(object sender, DebugLogMessageEventArgs e)
         {
-            switch (e.Level)
+            lock (this.Lock)
             {
-                case LogLevel.Debug:
-                    Console.ForegroundColor = ConsoleColor.DarkGreen;
-                    break;
+                switch (e.Level) {
+                    case LogLevel.Debug:
+                        Console.ForegroundColor = ConsoleColor.DarkGreen;
+                        break;
 
-                case LogLevel.Info:
-                    Console.ForegroundColor = ConsoleColor.White;
-                    break;
+                    case LogLevel.Info:
+                        Console.ForegroundColor = ConsoleColor.White;
+                        break;
 
-                case LogLevel.Warning:
-                    Console.ForegroundColor = ConsoleColor.DarkYellow;
-                    break;
+                    case LogLevel.Warning:
+                        Console.ForegroundColor = ConsoleColor.DarkYellow;
+                        break;
 
-                case LogLevel.Error:
-                    Console.ForegroundColor = ConsoleColor.DarkRed;
-                    break;
+                    case LogLevel.Error:
+                        Console.ForegroundColor = ConsoleColor.DarkRed;
+                        break;
 
-                case LogLevel.Critical:
-                    Console.BackgroundColor = ConsoleColor.DarkRed;
-                    Console.ForegroundColor = ConsoleColor.Black;
-                    break;
+                    case LogLevel.Critical:
+                        Console.BackgroundColor = ConsoleColor.DarkRed;
+                        Console.ForegroundColor = ConsoleColor.Black;
+                        break;
+                }
+
+                Console.Write($"[{e.Timestamp.ToString(this.DateTimeFormat)}] [{e.Application}] [{e.Level}]");
+                Console.ResetColor();
+                Console.WriteLine($" {e.Message}{(e.Exception != null ? $"\n{e.Exception}" : "")}");
             }
-
-            Console.Write($"[{e.Timestamp.ToString(this.DateTimeFormat)}] [{e.Application}] [{e.Level}]");
-            Console.ResetColor();
-            Console.WriteLine($" {e.Message}{(e.Exception != null ? $"\n{e.Exception}" : "")}");
         }
 
         public event EventHandler<DebugLogMessageEventArgs> LogMessageReceived;


### PR DESCRIPTION
# Summary
Using the internal log handler can cause log messages to overlap and create weird colors in console.

# Details
Using a lock ensures that only one thread can access the Console at a time.
No breaking changes.

# Changes proposed
Added a lock object to the internal log class.
Locking that object while Console is accessed.

# Notes
The diff is quite ugly on this, but there were only 4 lines added. Is there any way to avoid this?