### PR TITLE
Added new DefaultDateTime to DiscordConfiguration.

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -152,7 +152,7 @@ namespace DSharpPlus.CommandsNext
             if (this.Config.UseDefaultCommandHandler)
                 this.Client.MessageCreated += this.HandleCommandsAsync;
             else
-                this.Client.DebugLogger.LogMessage(LogLevel.Warning, "CommandsNext", "Default command handler is not attached. If this was intentional, you can ignore this message.", DateTime.Now);
+                this.Client.DebugLogger.LogMessage(LogLevel.Warning, "CommandsNext", "Default command handler is not attached. If this was intentional, you can ignore this message.", this.Client.Configuration.DefaultDateTime);
 
             if (this.Config.EnableDefaultHelp)
             {

--- a/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
@@ -58,7 +58,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             catch (Exception ex)
             {
                 this._client.DebugLogger.LogMessage(LogLevel.Error, "Interactivity", 
-                    $"Something went wrong waiting for {typeof(T).Name} with exception {ex.GetType().Name}.", DateTime.Now);
+                    $"Something went wrong waiting for {typeof(T).Name} with exception {ex.GetType().Name}.", this._client.Configuration.DefaultDateTime);
             }
             finally
             {
@@ -79,7 +79,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             catch (Exception ex)
             {
                 this._client.DebugLogger.LogMessage(LogLevel.Error, "Interactivity", 
-                    $"Something went wrong collecting from {typeof(T).Name} with exception {ex.GetType().Name}.", DateTime.Now);
+                    $"Something went wrong collecting from {typeof(T).Name} with exception {ex.GetType().Name}.", this._client.Configuration.DefaultDateTime);
             }
             finally
             {

--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -38,7 +38,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             catch (Exception ex)
             {
                 this._client.DebugLogger.LogMessage(LogLevel.Error, "Interactivity",
-                    $"Something went wrong with exception {ex.GetType().Name}.", DateTime.Now);
+                    $"Something went wrong with exception {ex.GetType().Name}.", this._client.Configuration.DefaultDateTime);
             }
             finally
             {

--- a/DSharpPlus.Interactivity/EventHandling/Poller.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Poller.cs
@@ -38,7 +38,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             catch (Exception ex)
             {
                 this._client.DebugLogger.LogMessage(LogLevel.Error, "Interactivity",
-                    $"Something went wrong with exception {ex.GetType().Name}.", DateTime.Now);
+                    $"Something went wrong with exception {ex.GetType().Name}.", this._client.Configuration.DefaultDateTime);
             }
             finally
             {

--- a/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
@@ -74,7 +74,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             catch (Exception ex)
             {
                 this._client.DebugLogger.LogMessage(LogLevel.Error, "Interactivity",
-                    $"Something went wrong collecting reactions with exception {ex.GetType().Name}.", DateTime.Now);
+                    $"Something went wrong collecting reactions with exception {ex.GetType().Name}.", this._client.Configuration.DefaultDateTime);
             }
             finally
             {

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -271,7 +271,7 @@ namespace DSharpPlus.Lavalink
         {
             if (!(e is SocketTextMessageEventArgs et))
             {
-                this.Discord.DebugLogger.LogMessage(LogLevel.Critical, "Lavalink", "Lavalink spewed out binary gibberish!", DateTime.Now);
+                this.Discord.DebugLogger.LogMessage(LogLevel.Critical, "Lavalink", "Lavalink spewed out binary gibberish!", this.Discord.Configuration.DefaultDateTime);
                 return;
             }
 
@@ -359,7 +359,7 @@ namespace DSharpPlus.Lavalink
         {
             if (this.IsConnected && e.CloseCode != 1001 && e.CloseCode != -1)
             {
-                this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "Lavalink", $"Connection broken ({e.CloseCode}, {e.CloseMessage}); re-establishing...", DateTime.Now);
+                this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "Lavalink", $"Connection broken ({e.CloseCode}, {e.CloseMessage}); re-establishing...", this.Discord.Configuration.DefaultDateTime);
                 this.WebSocket = this.Discord.Configuration.WebSocketClientFactory(this.Discord.Configuration.Proxy);
                 this.WebSocket.Connected += this.WebSocket_OnConnect;
                 this.WebSocket.Disconnected += this.WebSocket_OnDisconnect;
@@ -374,14 +374,14 @@ namespace DSharpPlus.Lavalink
             }
             else if (e.CloseCode != 1001 && e.CloseCode != -1)
             {
-                this.Discord.DebugLogger.LogMessage(LogLevel.Info, "Lavalink", $"Connection closed ({e.CloseCode}, {e.CloseMessage}).", DateTime.Now);
+                this.Discord.DebugLogger.LogMessage(LogLevel.Info, "Lavalink", $"Connection closed ({e.CloseCode}, {e.CloseMessage}).", this.Discord.Configuration.DefaultDateTime);
                 this.NodeDisconnected?.Invoke(this);
                 await this._disconnected.InvokeAsync(new NodeDisconnectedEventArgs(this)).ConfigureAwait(false);
             }
             else
             {
                 Volatile.Write(ref this._isDisposed, true);
-                this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "Lavalink", "Lavalink died.", DateTime.Now);
+                this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "Lavalink", "Lavalink died.", this.Discord.Configuration.DefaultDateTime);
                 foreach (var kvp in this.ConnectedGuilds)
                     await kvp.Value.SendVoiceUpdateAsync().ConfigureAwait(false);
                 this.NodeDisconnected?.Invoke(this);
@@ -391,7 +391,7 @@ namespace DSharpPlus.Lavalink
 
         private async Task WebSocket_OnConnect()
         {
-            this.Discord.DebugLogger.LogMessage(LogLevel.Info, "Lavalink", "Connection established", DateTime.Now);
+            this.Discord.DebugLogger.LogMessage(LogLevel.Info, "Lavalink", "Connection established", this.Discord.Configuration.DefaultDateTime);
 
             if (this.Configuration.ResumeKey != null)
                 await this.SendPayloadAsync(new LavalinkConfigureResume(this.Configuration.ResumeKey, this.Configuration.ResumeTimeout)).ConfigureAwait(false);

--- a/DSharpPlus.Lavalink/LavalinkRest.cs
+++ b/DSharpPlus.Lavalink/LavalinkRest.cs
@@ -17,12 +17,12 @@ namespace DSharpPlus.Lavalink
 
         private LavalinkConfiguration Configuration;
 
-        private DebugLogger Logger;
+        private DiscordClient Client;
 
         internal LavalinkRest(LavalinkConfiguration config, DiscordClient client)
         {
             this.Configuration = config;
-            this.Logger = client.DebugLogger;
+            this.Client = client;
 
             var httphandler = new HttpClientHandler
             {
@@ -243,7 +243,7 @@ namespace DSharpPlus.Lavalink
                 if (!req.IsSuccessStatusCode)
                 {
                     var jsonError = JToken.Parse(json) as JObject;
-                    this.Logger.LogMessage(LogLevel.Error, "Lavalink", $"Unable to decode the given track strings: {jsonError["message"]}", DateTime.Now);
+                    this.Client.DebugLogger.LogMessage(LogLevel.Error, "Lavalink", $"Unable to decode the given track strings: {jsonError["message"]}", this.Client.Configuration.DefaultDateTime);
                     return null;
                 }
                 var track = JsonConvert.DeserializeObject<LavalinkTrack>(json);
@@ -263,7 +263,7 @@ namespace DSharpPlus.Lavalink
                 if (!req.IsSuccessStatusCode)
                 {
                     var jsonError = JToken.Parse(jsonIn) as JObject;
-                    this.Logger.LogMessage(LogLevel.Error, "Lavalink", $"Unable to decode the given track strings: {jsonError["message"]}", DateTime.Now);
+                    this.Client.DebugLogger.LogMessage(LogLevel.Error, "Lavalink", $"Unable to decode the given track strings: {jsonError["message"]}", this.Client.Configuration.DefaultDateTime);
                     return null;
                 }
 
@@ -303,7 +303,7 @@ namespace DSharpPlus.Lavalink
             var payload = new StringContent(address, Utilities.UTF8, "application/json");
             using (var req = await this.HttpClient.PostAsync(uri, payload).ConfigureAwait(false))
                 if (req.StatusCode == HttpStatusCode.InternalServerError)
-                    this.Logger.LogMessage(LogLevel.Warning, "Lavalink", $"Request to {uri.ToString()} returned an internal server error. This likely indicates that the server route planner configuration is incorrect.", DateTime.Now);
+                    this.Client.DebugLogger.LogMessage(LogLevel.Warning, "Lavalink", $"Request to {uri.ToString()} returned an internal server error. This likely indicates that the server route planner configuration is incorrect.", this.Client.Configuration.DefaultDateTime);
 
         }
 
@@ -312,7 +312,7 @@ namespace DSharpPlus.Lavalink
             var httpReq = new HttpRequestMessage(HttpMethod.Post, uri);
             using (var req = await this.HttpClient.SendAsync(httpReq).ConfigureAwait(false))
                 if (req.StatusCode == HttpStatusCode.InternalServerError)
-                    this.Logger.LogMessage(LogLevel.Warning, "Lavalink", $"Request to {uri.ToString()} returned an internal server error. This likely indicates that the server route planner configuration is incorrect.", DateTime.Now);
+                    this.Client.DebugLogger.LogMessage(LogLevel.Warning, "Lavalink", $"Request to {uri.ToString()} returned an internal server error. This likely indicates that the server route planner configuration is incorrect.", this.Client.Configuration.DefaultDateTime);
         }
 
         #endregion

--- a/DSharpPlus/DebugLogger.cs
+++ b/DSharpPlus/DebugLogger.cs
@@ -8,11 +8,13 @@ namespace DSharpPlus
     {
         private LogLevel Level { get; }
         private string DateTimeFormat { get; }
+        private DateTime DateTime { get; }
 
         internal DebugLogger(BaseDiscordClient client)
         {
             this.Level = client.Configuration.LogLevel;
             this.DateTimeFormat = client.Configuration.DateTimeFormat;
+            this.DateTime = client.Configuration.DefaultDateTime;
         }
 
         internal DebugLogger(LogLevel level, string timeformatting)
@@ -54,7 +56,7 @@ namespace DSharpPlus
             if (task == null)
                 throw new ArgumentNullException(nameof(task));
 
-            task.ContinueWith(t => LogMessage(level, application, message, DateTime.Now, t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+            task.ContinueWith(t => LogMessage(level, application, message, this.DateTime, t.Exception), TaskContinuationOptions.OnlyOnFaulted);
         }
 
         internal void LogHandler(object sender, DebugLogMessageEventArgs e)

--- a/DSharpPlus/DiscordClient.cs
+++ b/DSharpPlus/DiscordClient.cs
@@ -246,8 +246,8 @@ namespace DSharpPlus
             }
 
             if (this.Configuration.TokenType != TokenType.Bot)
-                this.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", "You are logging in with a token that is not a bot token. This is not officially supported by Discord, and can result in your account being terminated if you aren't careful.", DateTime.Now);
-            this.DebugLogger.LogMessage(LogLevel.Info, "DSharpPlus", $"DSharpPlus, version {this.VersionString}", DateTime.Now);
+                this.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", "You are logging in with a token that is not a bot token. This is not officially supported by Discord, and can result in your account being terminated if you aren't careful.", this.Configuration.DefaultDateTime);
+            this.DebugLogger.LogMessage(LogLevel.Info, "DSharpPlus", $"DSharpPlus, version {this.VersionString}", this.Configuration.DefaultDateTime);
 
             while (i-- > 0 || this.Configuration.ReconnectIndefinitely)
             {
@@ -279,7 +279,7 @@ namespace DSharpPlus
                     cex = ex;
                     if (i <= 0 && !this.Configuration.ReconnectIndefinitely) break;
 
-                    this.DebugLogger.LogMessage(LogLevel.Error, "DSharpPlus", $"Connection attempt failed, retrying in {w / 1000}s", DateTime.Now, ex);
+                    this.DebugLogger.LogMessage(LogLevel.Error, "DSharpPlus", $"Connection attempt failed, retrying in {w / 1000}s", this.Configuration.DefaultDateTime, ex);
                     await Task.Delay(w).ConfigureAwait(false);
 
                     if (i > 0)
@@ -395,7 +395,7 @@ namespace DSharpPlus
                     {
                         if (!this._payloadDecompressor.TryDecompress(new ArraySegment<byte>(ebin.Message), ms))
                         {
-                            this.DebugLogger.LogMessage(LogLevel.Error, "WebSocket", "Payload decompression failed", DateTime.Now);
+                            this.DebugLogger.LogMessage(LogLevel.Error, "WebSocket", "Payload decompression failed", this.Configuration.DefaultDateTime);
                             return;
                         }
 
@@ -411,7 +411,7 @@ namespace DSharpPlus
                 }
                 catch (Exception ex)
                 {
-                    this.DebugLogger.LogMessage(LogLevel.Error, "WebSocket", "Socket swallowed an exception:", DateTime.Now, ex);
+                    this.DebugLogger.LogMessage(LogLevel.Error, "WebSocket", "Socket swallowed an exception:", this.Configuration.DefaultDateTime, ex);
                 }
             }
 
@@ -426,12 +426,12 @@ namespace DSharpPlus
 
                 this._cancelTokenSource.Cancel();
 
-                this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", $"Connection closed. ({e.CloseCode.ToString(CultureInfo.InvariantCulture)}, '{e.CloseMessage}')", DateTime.Now);
+                this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", $"Connection closed. ({e.CloseCode.ToString(CultureInfo.InvariantCulture)}, '{e.CloseMessage}')", this.Configuration.DefaultDateTime);
                 await this._socketClosed.InvokeAsync(new SocketCloseEventArgs(this) { CloseCode = e.CloseCode, CloseMessage = e.CloseMessage }).ConfigureAwait(false);
 
                 if (this.Configuration.AutoReconnect)
                 {
-                    this.DebugLogger.LogMessage(LogLevel.Critical, "WebSocket", $"Socket connection terminated ({e.CloseCode.ToString(CultureInfo.InvariantCulture)}, '{e.CloseMessage}'). Reconnecting.", DateTime.Now);
+                    this.DebugLogger.LogMessage(LogLevel.Critical, "WebSocket", $"Socket connection terminated ({e.CloseCode.ToString(CultureInfo.InvariantCulture)}, '{e.CloseMessage}'). Reconnecting.", this.Configuration.DefaultDateTime);
 
                     if (this._status == null)
                         await this.ConnectAsync().ConfigureAwait(false);
@@ -645,7 +645,7 @@ namespace DSharpPlus
                     break;
 
                 default:
-                    this.DebugLogger.LogMessage(LogLevel.Warning, "WebSocket", $"Unknown OP-Code: {((int)payload.OpCode).ToString(CultureInfo.InvariantCulture)}\n{payload.Data}", DateTime.Now);
+                    this.DebugLogger.LogMessage(LogLevel.Warning, "WebSocket", $"Unknown OP-Code: {((int)payload.OpCode).ToString(CultureInfo.InvariantCulture)}\n{payload.Data}", this.Configuration.DefaultDateTime);
                     break;
             }
         }
@@ -654,7 +654,7 @@ namespace DSharpPlus
         {
             if (!(payload.Data is JObject dat))
             {
-                DebugLogger.LogMessage(LogLevel.Warning, "WebSocket:Dispatch", $"Invalid payload body, you can probably ignore this message: {payload.OpCode}:{payload.EventName}\n{payload.Data}", DateTime.Now);
+                DebugLogger.LogMessage(LogLevel.Warning, "WebSocket:Dispatch", $"Invalid payload body, you can probably ignore this message: {payload.OpCode}:{payload.EventName}\n{payload.Data}", this.Configuration.DefaultDateTime);
                 return;
             }
 
@@ -747,7 +747,7 @@ namespace DSharpPlus
                     gid = (ulong)dat["guild_id"];
                     if (!this._guilds.ContainsKey(gid))
                     {
-                        this.DebugLogger.LogMessage(LogLevel.Error, "WebSocket:Dispatch", $"Could not find {gid.ToString(CultureInfo.InvariantCulture)} in guild cache.", DateTime.Now);
+                        this.DebugLogger.LogMessage(LogLevel.Error, "WebSocket:Dispatch", $"Could not find {gid.ToString(CultureInfo.InvariantCulture)} in guild cache.", this.Configuration.DefaultDateTime);
                         return;
                     }
                     await OnGuildMemberRemoveEventAsync(dat["user"].ToObject<TransportUser>(), this._guilds[gid]).ConfigureAwait(false);
@@ -862,7 +862,7 @@ namespace DSharpPlus
 
                 default:
                     await OnUnknownEventAsync(payload).ConfigureAwait(false);
-                    this.DebugLogger.LogMessage(LogLevel.Warning, "WebSocket:Dispatch", $"Unknown event: {payload.EventName}\n{payload.Data}", DateTime.Now);
+                    this.DebugLogger.LogMessage(LogLevel.Warning, "WebSocket:Dispatch", $"Unknown event: {payload.EventName}\n{payload.Data}", this.Configuration.DefaultDateTime);
                     break;
             }
         }
@@ -989,7 +989,7 @@ namespace DSharpPlus
 
         internal Task OnResumedAsync()
         {
-            this.DebugLogger.LogMessage(LogLevel.Info, "DSharpPlus", "Session resumed.", DateTime.Now);
+            this.DebugLogger.LogMessage(LogLevel.Info, "DSharpPlus", "Session resumed.", this.Configuration.DefaultDateTime);
             return this._resumed.InvokeAsync(new ReadyEventArgs(this));
         }
 
@@ -1697,7 +1697,7 @@ namespace DSharpPlus
             message.Discord = this;
 
             if (message.Channel == null)
-                this.DebugLogger.LogMessage(LogLevel.Warning, "Event", "Could not find channel last message belonged to.", DateTime.Now);
+                this.DebugLogger.LogMessage(LogLevel.Warning, "Event", "Could not find channel last message belonged to.", this.Configuration.DefaultDateTime);
             else
                 message.Channel.LastMessageId = message.Id;
 
@@ -2292,13 +2292,13 @@ namespace DSharpPlus
 
         internal async Task OnHeartbeatAsync(long seq)
         {
-            this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", "Received Heartbeat - Sending Ack.", DateTime.Now);
+            this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", "Received Heartbeat - Sending Ack.", this.Configuration.DefaultDateTime);
             await SendHeartbeatAsync(seq).ConfigureAwait(false);
         }
 
         internal async Task OnReconnectAsync()
         {
-            this.DebugLogger.LogMessage(LogLevel.Info, "WebSocket", "Received OP 7 - Reconnect.", DateTime.Now);
+            this.DebugLogger.LogMessage(LogLevel.Info, "WebSocket", "Received OP 7 - Reconnect.", this.Configuration.DefaultDateTime);
             await this.InternalReconnectAsync(code: 4000, message: "OP7 acknowledged").ConfigureAwait(false);
         }
 
@@ -2315,13 +2315,13 @@ namespace DSharpPlus
 
             if (data)
             {
-                this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", "Received true in OP 9 - Waiting a few seconds and sending resume again.", DateTime.Now);
+                this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", "Received true in OP 9 - Waiting a few seconds and sending resume again.", this.Configuration.DefaultDateTime);
                 await Task.Delay(6000).ConfigureAwait(false);
                 await SendResumeAsync().ConfigureAwait(false);
             }
             else
             {
-                this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", "Received false in OP 9 - Starting a new session.", DateTime.Now);
+                this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", "Received false in OP 9 - Starting a new session.", this.Configuration.DefaultDateTime);
                 this._sessionId = null;
                 await SendIdentifyAsync(this._status).ConfigureAwait(false);
             }
@@ -2329,7 +2329,7 @@ namespace DSharpPlus
 
         internal async Task OnHelloAsync(GatewayHello hello)
         {
-            this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", "Received OP 10 (HELLO) - Trying to either resume or identify.", DateTime.Now);
+            this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", "Received OP 10 (HELLO) - Trying to either resume or identify.", this.Configuration.DefaultDateTime);
 
             if (this.SessionLock.Wait(0))
             {
@@ -2338,7 +2338,7 @@ namespace DSharpPlus
             }
             else
             {
-                this.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", "Session start attempt was made while another session is active", DateTime.Now);
+                this.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", "Session start attempt was made while another session is active", this.Configuration.DefaultDateTime);
                 return;
             }
 
@@ -2356,16 +2356,15 @@ namespace DSharpPlus
         {
             Interlocked.Decrement(ref this._skippedHeartbeats);
 
-            var ping = (int)(DateTime.Now - this._lastHeartbeat).TotalMilliseconds;
+            var ping = (int)(DateTime.UtcNow - this._lastHeartbeat).TotalMilliseconds;
 
-            this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", $"Received WebSocket Heartbeat Ack. Ping: {ping.ToString(CultureInfo.InvariantCulture)}ms", DateTime.Now);
-
+            this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", $"Received WebSocket Heartbeat Ack. Ping: {ping.ToString(CultureInfo.InvariantCulture)}ms", this.Configuration.DefaultDateTime);
             Volatile.Write(ref this._ping, ping);
 
             var args = new HeartbeatEventArgs(this)
             {
                 Ping = this.Ping,
-                Timestamp = DateTimeOffset.Now
+                Timestamp = DateTimeOffset.UtcNow
             };
 
             await _heartbeated.InvokeAsync(args).ConfigureAwait(false);
@@ -2374,7 +2373,7 @@ namespace DSharpPlus
         //internal async Task StartHeartbeatingAsync()
         internal async Task HeartbeatLoopAsync()
         {
-            this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", "Starting Heartbeat.", DateTime.Now);
+            this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", "Starting Heartbeat.", this.Configuration.DefaultDateTime);
             var token = this._cancelToken;
             try
             {
@@ -2435,7 +2434,7 @@ namespace DSharpPlus
 
         internal Task SendHeartbeatAsync()
         {
-            var _last_heartbeat = DateTimeOffset.Now;
+            var _last_heartbeat = DateTimeOffset.UtcNow;
             var _sequence = (long)(_last_heartbeat - DiscordEpoch).TotalMilliseconds;
 
             return this.SendHeartbeatAsync(_sequence);
@@ -2447,17 +2446,17 @@ namespace DSharpPlus
             var guilds_comp = Volatile.Read(ref this._guildDownloadCompleted);
             if (guilds_comp && more_than_5)
             {
-                this.DebugLogger.LogMessage(LogLevel.Critical, "DSharpPlus", "More than 5 heartbeats were skipped. Issuing reconnect.", DateTime.Now);
+                this.DebugLogger.LogMessage(LogLevel.Critical, "DSharpPlus", "More than 5 heartbeats were skipped. Issuing reconnect.", this.Configuration.DefaultDateTime);
                 await this.InternalReconnectAsync(code: 4001, message: "Too many heartbeats missed").ConfigureAwait(false);
                 return;
             }
             else if (!guilds_comp && more_than_5)
             {
-                this.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", "More than 5 heartbeats were skipped while the guild download is running.", DateTime.Now);
+                this.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", "More than 5 heartbeats were skipped while the guild download is running.", this.Configuration.DefaultDateTime);
             }
 
             Volatile.Write(ref this._lastSequence, seq);
-            this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", "Sending Heartbeat.", DateTime.Now);
+            this.DebugLogger.LogMessage(LogLevel.Debug, "WebSocket", "Sending Heartbeat.", this.Configuration.DefaultDateTime);
             var heartbeat = new GatewayPayload
             {
                 OpCode = GatewayOpCode.Heartbeat,
@@ -2466,7 +2465,7 @@ namespace DSharpPlus
             var heartbeat_str = JsonConvert.SerializeObject(heartbeat);
             await this._webSocketClient.SendMessageAsync(heartbeat_str).ConfigureAwait(false);
 
-            this._lastHeartbeat = DateTimeOffset.Now;
+            this._lastHeartbeat = DateTimeOffset.UtcNow;
 
             Interlocked.Increment(ref this._skippedHeartbeats);
         }
@@ -3190,13 +3189,13 @@ namespace DSharpPlus
 
         internal void EventErrorHandler(string evname, Exception ex)
         {
-            this.DebugLogger.LogMessage(LogLevel.Error, "DSharpPlus", $"An {ex.GetType()} occurred in {evname}.", DateTime.Now, ex);
+            this.DebugLogger.LogMessage(LogLevel.Error, "DSharpPlus", $"An {ex.GetType()} occurred in {evname}.", this.Configuration.DefaultDateTime, ex);
             this._clientErrored.InvokeAsync(new ClientErrorEventArgs(this) { EventName = evname, Exception = ex }).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         private void Goof(string evname, Exception ex)
         {
-            this.DebugLogger.LogMessage(LogLevel.Critical, "DSharpPlus", $"An {ex.GetType()} occurred in the exception handler.", DateTime.Now, ex);
+            this.DebugLogger.LogMessage(LogLevel.Critical, "DSharpPlus", $"An {ex.GetType()} occurred in the exception handler.", this.Configuration.DefaultDateTime, ex);
         }
         #endregion
     }

--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -53,6 +53,11 @@ namespace DSharpPlus
         public bool UseRelativeRatelimit { internal get; set; } = true;
 
         /// <summary>
+        /// <para>Sets the default date time used by the internal debug logger.</para>
+        /// </summary>
+        public DateTime DefaultDateTime { internal get; set; } = DateTime.Now;
+
+        /// <summary>
         /// <para>Allows you to overwrite the time format used by the internal debug logger.</para>
         /// <para>Only applicable when <see cref="UseInternalLogHandler"/> is set to true. Defaults to ISO 8601-like format.</para>
         /// </summary>
@@ -164,6 +169,7 @@ namespace DSharpPlus
             this.LogLevel = other.LogLevel;
             this.UseInternalLogHandler = other.UseInternalLogHandler;
             this.UseRelativeRatelimit = other.UseRelativeRatelimit;
+            this.DefaultDateTime = other.DefaultDateTime;
             this.DateTimeFormat = other.DateTimeFormat;
             this.LargeThreshold = other.LargeThreshold;
             this.AutoReconnect = other.AutoReconnect;

--- a/DSharpPlus/DiscordShardedClient.cs
+++ b/DSharpPlus/DiscordShardedClient.cs
@@ -501,13 +501,13 @@ namespace DSharpPlus
 
         internal void EventErrorHandler(string evname, Exception ex)
         {
-            this.DebugLogger.LogMessage(LogLevel.Error, "DSharpPlus", $"An {ex.GetType()} occured in {evname}.", DateTime.Now);
+            this.DebugLogger.LogMessage(LogLevel.Error, "DSharpPlus", $"An {ex.GetType()} occured in {evname}.", this.Config.DefaultDateTime);
             this._clientErrored.InvokeAsync(new ClientErrorEventArgs(null) { EventName = evname, Exception = ex }).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         private void Goof(string evname, Exception ex)
         {
-            this.DebugLogger.LogMessage(LogLevel.Critical, "DSharpPlus", $"An {ex.GetType()} occured in the exception handler.", DateTime.Now);
+            this.DebugLogger.LogMessage(LogLevel.Critical, "DSharpPlus", $"An {ex.GetType()} occured in the exception handler.", this.Config.DefaultDateTime);
         }
         #endregion
 
@@ -646,7 +646,7 @@ namespace DSharpPlus
         public async Task StartAsync()
         {
             var shardc = await this.InitializeShardsAsync().ConfigureAwait(false);
-            this.DebugLogger.LogMessage(LogLevel.Info, "Autoshard", $"Booting {shardc.ToString(CultureInfo.InvariantCulture)} shards", DateTime.Now);
+            this.DebugLogger.LogMessage(LogLevel.Info, "Autoshard", $"Booting {shardc.ToString(CultureInfo.InvariantCulture)} shards", this.Config.DefaultDateTime);
 
             for (var i = 0; i < shardc; i++)
             {
@@ -716,7 +716,7 @@ namespace DSharpPlus
                 client.DebugLogger.LogMessageReceived += this.DebugLogger_LogMessageReceived;
                 
                 await client.ConnectAsync().ConfigureAwait(false);
-                this.DebugLogger.LogMessage(LogLevel.Info, "Autoshard", $"Booted shard {i.ToString(CultureInfo.InvariantCulture)}", DateTime.Now);
+                this.DebugLogger.LogMessage(LogLevel.Info, "Autoshard", $"Booted shard {i.ToString(CultureInfo.InvariantCulture)}", this.Config.DefaultDateTime);
 
                 if (this._currentUser == null)
                     this._currentUser = client.CurrentUser;

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -1124,7 +1124,7 @@ namespace DSharpPlus.Entities
                                     break;
 
                                 default:
-                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in guild update: {xc.Key}; this should be reported to devs", DateTime.Now);
+                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in guild update: {xc.Key}; this should be reported to devs", this.Discord.Configuration.DefaultDateTime);
                                     break;
                             }
                         }
@@ -1211,7 +1211,7 @@ namespace DSharpPlus.Entities
                                     break;
 
                                 default:
-                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in channel update: {xc.Key}; this should be reported to devs", DateTime.Now);
+                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in channel update: {xc.Key}; this should be reported to devs", this.Discord.Configuration.DefaultDateTime);
                                     break;
                             }
                         }
@@ -1273,7 +1273,7 @@ namespace DSharpPlus.Entities
                                     break;
 
                                 default:
-                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in overwrite update: {xc.Key}; this should be reported to devs", DateTime.Now);
+                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in overwrite update: {xc.Key}; this should be reported to devs", this.Discord.Configuration.DefaultDateTime);
                                     break;
                             }
                         }
@@ -1347,7 +1347,7 @@ namespace DSharpPlus.Entities
                                     break;
 
                                 default:
-                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in member update: {xc.Key}; this should be reported to devs", DateTime.Now);
+                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in member update: {xc.Key}; this should be reported to devs", this.Discord.Configuration.DefaultDateTime);
                                     break;
                             }
                         }
@@ -1418,7 +1418,7 @@ namespace DSharpPlus.Entities
                                     break;
 
                                 default:
-                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in role update: {xc.Key}; this should be reported to devs", DateTime.Now);
+                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in role update: {xc.Key}; this should be reported to devs", this.Discord.Configuration.DefaultDateTime);
                                     break;
                             }
                         }
@@ -1530,7 +1530,7 @@ namespace DSharpPlus.Entities
                                     break;
 
                                 default:
-                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in invite update: {xc.Key}; this should be reported to devs", DateTime.Now);
+                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in invite update: {xc.Key}; this should be reported to devs", this.Discord.Configuration.DefaultDateTime);
                                     break;
                             }
                         }
@@ -1590,7 +1590,7 @@ namespace DSharpPlus.Entities
                                     break;
 
                                 default:
-                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in webhook update: {xc.Key}; this should be reported to devs", DateTime.Now);
+                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in webhook update: {xc.Key}; this should be reported to devs", this.Discord.Configuration.DefaultDateTime);
                                     break;
                             }
                         }
@@ -1618,7 +1618,7 @@ namespace DSharpPlus.Entities
                                     break;
 
                                 default:
-                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in emoji update: {xc.Key}; this should be reported to devs", DateTime.Now);
+                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in emoji update: {xc.Key}; this should be reported to devs", this.Discord.Configuration.DefaultDateTime);
                                     break;
                             }
                         }
@@ -1746,14 +1746,14 @@ namespace DSharpPlus.Entities
                                     break;
 
                                 default:
-                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in integration update: {xc.Key}; this should be reported to devs", DateTime.Now);
+                                    this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown key in integration update: {xc.Key}; this should be reported to devs", this.Discord.Configuration.DefaultDateTime);
                                     break;
                             }
                         }
                         break;
 
                     default:
-                        this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown audit log action type: {((int)xac.ActionType).ToString(CultureInfo.InvariantCulture)}; this should be reported to devs", DateTime.Now);
+                        this.Discord.DebugLogger.LogMessage(LogLevel.Warning, "DSharpPlus", $"Unknown audit log action type: {((int)xac.ActionType).ToString(CultureInfo.InvariantCulture)}; this should be reported to devs", this.Discord.Configuration.DefaultDateTime);
                         break;
                 }
 

--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -123,7 +123,7 @@ namespace DSharpPlus.Net
                     if (Interlocked.Decrement(ref bucket._remaining) < 0)
 #pragma warning restore 420 // blaze it
                     {
-                        request.Discord?.DebugLogger?.LogMessage(LogLevel.Debug, "REST", $"Request for {bucket}. Blocking.", DateTime.Now);
+                        request.Discord?.DebugLogger?.LogMessage(LogLevel.Debug, "REST", $"Request for {bucket}. Blocking.", this.Discord.Configuration.DefaultDateTime);
                         var delay = bucket.Reset - now;
                         var resetDate = bucket.Reset;
 
@@ -135,21 +135,21 @@ namespace DSharpPlus.Net
 
                         if (delay < new TimeSpan(-TimeSpan.TicksPerMinute))
                         {
-                            request.Discord?.DebugLogger?.LogMessage(LogLevel.Error, "REST", "Failed to retrieve ratelimits. Giving up and allowing next request for bucket.", DateTime.Now);
+                            request.Discord?.DebugLogger?.LogMessage(LogLevel.Error, "REST", "Failed to retrieve ratelimits. Giving up and allowing next request for bucket.", this.Discord.Configuration.DefaultDateTime);
                             bucket._remaining = 1;
                         }
 
                         if (delay < TimeSpan.Zero)
                             delay = TimeSpan.FromMilliseconds(100);
 
-                        request.Discord?.DebugLogger?.LogMessage(LogLevel.Warning, "REST", $"Pre-emptive ratelimit triggered. Waiting until {resetDate:yyyy-MM-dd HH:mm:ss zzz} ({delay:c}).", DateTime.Now);
+                        request.Discord?.DebugLogger?.LogMessage(LogLevel.Warning, "REST", $"Pre-emptive ratelimit triggered. Waiting until {resetDate:yyyy-MM-dd HH:mm:ss zzz} ({delay:c}).", this.Discord.Configuration.DefaultDateTime);
                         request.Discord?.DebugLogger?.LogTaskFault(Task.Delay(delay).ContinueWith(_ => this.ExecuteRequestAsync(request, null, null)), LogLevel.Error, "RESET", "Error while executing request: ");
                         return;
                     }
-                    request.Discord?.DebugLogger?.LogMessage(LogLevel.Debug, "REST", $"Request for {bucket}. Allowing.", DateTime.Now);
+                    request.Discord?.DebugLogger?.LogMessage(LogLevel.Debug, "REST", $"Request for {bucket}. Allowing.", this.Discord.Configuration.DefaultDateTime);
                 }
                 else
-                    request.Discord?.DebugLogger?.LogMessage(LogLevel.Debug, "REST", $"Initial request for {bucket}. Allowing.", DateTime.Now);
+                    request.Discord?.DebugLogger?.LogMessage(LogLevel.Debug, "REST", $"Initial request for {bucket}. Allowing.", this.Discord.Configuration.DefaultDateTime);
 
                 var req = this.BuildRequest(request);
                 var response = new RestResponse();
@@ -166,7 +166,7 @@ namespace DSharpPlus.Net
                 }
                 catch (HttpRequestException httpex)
                 {
-                    request.Discord?.DebugLogger?.LogMessage(LogLevel.Error, "REST", $"Request to {request.Url} triggered an HttpException: {httpex.Message}", DateTime.Now);
+                    request.Discord?.DebugLogger?.LogMessage(LogLevel.Error, "REST", $"Request to {request.Url} triggered an HttpException: {httpex.Message}", this.Discord.Configuration.DefaultDateTime);
                     request.SetFaulted(httpex);
                     this.FailInitialRateLimitTest(bucket, ratelimitTcs);
                     return;
@@ -204,7 +204,7 @@ namespace DSharpPlus.Net
                         {
                             if (global)
                             {
-                                request.Discord?.DebugLogger?.LogMessage(LogLevel.Error, "REST", "Global ratelimit hit, cooling down", DateTime.Now);
+                                request.Discord?.DebugLogger?.LogMessage(LogLevel.Error, "REST", "Global ratelimit hit, cooling down", this.Discord.Configuration.DefaultDateTime);
                                 try
                                 {
                                     this.GlobalRateLimitEvent.Reset();
@@ -219,7 +219,7 @@ namespace DSharpPlus.Net
                             }
                             else
                             {
-                                request.Discord?.DebugLogger?.LogMessage(LogLevel.Error, "REST", $"Ratelimit hit, requeueing request to {request.Url}", DateTime.Now);
+                                request.Discord?.DebugLogger?.LogMessage(LogLevel.Error, "REST", $"Ratelimit hit, requeueing request to {request.Url}", this.Discord.Configuration.DefaultDateTime);
                                 await wait.ConfigureAwait(false);
                                 request.Discord?.DebugLogger?.LogTaskFault(this.ExecuteRequestAsync(request, bucket, ratelimitTcs), LogLevel.Error, "REST", "Error while retrying request: ");
                             }
@@ -236,7 +236,7 @@ namespace DSharpPlus.Net
             }
             catch (Exception ex)
             {
-                request.Discord?.DebugLogger?.LogMessage(LogLevel.Error, "REST", $"Request to {request.Url} triggered an {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}", DateTime.Now);
+                request.Discord?.DebugLogger?.LogMessage(LogLevel.Error, "REST", $"Request to {request.Url} triggered an {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}", this.Discord.Configuration.DefaultDateTime);
 
                 // if something went wrong and we couldn't get rate limits for the first request here, allow the next request to run
                 if (bucket != null && ratelimitTcs != null && bucket._limitTesting != 0)
@@ -307,7 +307,7 @@ namespace DSharpPlus.Net
 
             if (request is MultipartWebRequest mprequest)
             {
-                string boundary = "---------------------------" + DateTime.Now.Ticks.ToString("x");
+                string boundary = "---------------------------" + this.Discord.Configuration.DefaultDateTime.Ticks.ToString("x");
 
                 req.Headers.Add("Connection", "keep-alive");
                 req.Headers.Add("Keep-Alive", "600");


### PR DESCRIPTION
# Summary
Added new DiscordConfiguration option `DefaultDateTime`.

# Details
Changed all of the `DateTime.Now` instances in the code to the new `DefaultDateTime` config option. 
By default `DefaultDateTime = DateTime.Now` but can be changed to whatever the user prefers (like `DateTime.UtcNow`). 

Changed all of the relevant code in all files containing `DateTime.Now` or `DateTimeOffset.Now` (only if needed, f.e in `DSharpPlus/DiscordClient.cs`) to the `DefaultDateTime` config option.

Replaced multiple instances of `this.DebugLogger` to `this.Client.DebugLogger` (or alike, f.e `this._client.DebugLogger` or `this.Discord.DebugLogger`).

Also replaced the `private DebugLogger Logger` field in file `DSharpPlus.Lavalink/LavalinkRest.cs` with a `private DiscordClient Client` field to get access to the `DiscordClient`'s `DiscordConfiguration`, and made the appropriate changes to _hopefully_ not break any logging.