### PR TITLE
Fix WS disconnection and disposal issues.

### DIFF
--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -391,7 +391,7 @@ namespace DSharpPlus.Lavalink
 
         private async Task WebSocket_OnConnect()
         {
-            this.Discord.DebugLogger.LogMessage(LogLevel.Info, "Lavalink", "Connection established", DateTime.Now);
+            this.Discord.DebugLogger.LogMessage(LogLevel.Info, "Lavalink", "Connection established.", DateTime.Now);
 
             if (this.Configuration.ResumeKey != null)
                 await this.SendPayloadAsync(new LavalinkConfigureResume(this.Configuration.ResumeKey, this.Configuration.ResumeTimeout)).ConfigureAwait(false);

--- a/DSharpPlus/Net/WebSocket/WebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient.cs
@@ -108,9 +108,6 @@ namespace DSharpPlus.Net.WebSocket
             // Ensure that messages cannot be sent
             await this._senderLock.WaitAsync().ConfigureAwait(false);
 
-            if (this._isConnected)
-                this._isConnected = false;
-
             try
             {
                 this._isClientClose = true;
@@ -118,7 +115,10 @@ namespace DSharpPlus.Net.WebSocket
                     await this._ws.CloseOutputAsync((WebSocketCloseStatus)code, message, CancellationToken.None).ConfigureAwait(false);
 
                 if (this._receiverTask != null)
-                    await this._receiverTask.ConfigureAwait(false); // Ensure that receving completed
+                    await this._receiverTask.ConfigureAwait(false); // Ensure that receiving completed
+
+                if (this._isConnected)
+                    this._isConnected = false;
 
                 // Cancel all running tasks
                 if (this._socketTokenSource != null)
@@ -256,9 +256,6 @@ namespace DSharpPlus.Net.WebSocket
                                 await this._ws.CloseOutputAsync(code, result.CloseStatusDescription, CancellationToken.None).ConfigureAwait(false);
                             }
 
-                            if (this._isConnected)
-                                this._isConnected = false;
-
                             await this._disconnected.InvokeAsync(new SocketCloseEventArgs(null) { CloseCode = (int)result.CloseStatus, CloseMessage = result.CloseStatusDescription }).ConfigureAwait(false);
                             break;
                         }
@@ -267,9 +264,6 @@ namespace DSharpPlus.Net.WebSocket
             }
             catch (Exception ex)
             {
-                if (this._isConnected)
-                    this._isConnected = false;
-
                 await this._exceptionThrown.InvokeAsync(new SocketErrorEventArgs(null) { Exception = ex }).ConfigureAwait(false);
                 await this._disconnected.InvokeAsync(new SocketCloseEventArgs(null) { CloseCode = -1, CloseMessage = "" }).ConfigureAwait(false);
             }

--- a/DSharpPlus/Net/WebSocket/WebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient.cs
@@ -121,17 +121,12 @@ namespace DSharpPlus.Net.WebSocket
                     this._isConnected = false;
 
                 // Cancel all running tasks
-                if (this._socketTokenSource != null)
-                {
-                    this._socketTokenSource.Cancel();
-                    this._socketTokenSource.Dispose();
-                }
+                this._socketTokenSource?.Cancel();
+                this._socketTokenSource?.Dispose();
 
-                if (this._receiverTokenSource != null)
-                {
-                    this._receiverTokenSource.Cancel();
-                    this._receiverTokenSource.Dispose();
-                }
+                this._receiverTokenSource?.Cancel();
+                this._receiverTokenSource?.Dispose();
+
             }
             catch { }
             finally


### PR DESCRIPTION
# Summary
Fixes #596
Fixes #561 

# Details
This PR simplified the `_isConnected` handling by having it being set to false in DisconnectAsync, as that is always called when the receiver loop is broken.

Confirmed that this also solves the deadlock with dispose when ready fires.
