### PR TITLE
Fixed empty mention array

### DIFF
--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -49,14 +49,17 @@ namespace DSharpPlus.Test
         public async Task MentionablesAsync(CommandContext ctx, DiscordUser user)
         {
             string content = $"Hey, {user.Mention}! Listen!";
-            await ctx.Channel.SendMessageAsync("Default Behaviour: " + content);
-            await ctx.Channel.SendMessageAsync("Empty Mention Array: " + content, mentions: new IMention[0]);
-            await ctx.Channel.SendMessageAsync("UserMention(user): " + content, mentions: new IMention[] { new UserMention(user) });
-            await ctx.Channel.SendMessageAsync("UserMention(SomeoneElse): " + content, mentions: new IMention[] { new UserMention(545836271960850454L) });
-            await ctx.Channel.SendMessageAsync("UserMention(): " + content, mentions: new IMention[] { new UserMention() });
-            await ctx.Channel.SendMessageAsync("Everyone(): " + content, mentions: new IMention[] { new EveryoneMention() });
-            await ctx.Channel.SendMessageAsync("User Mention Everyone & Self: " + content, mentions: new IMention[] { new UserMention(), new UserMention(user) });
-            await ctx.Channel.SendMessageAsync("UserMention.All: " + content, mentions: new IMention[] { UserMention.All });
+            await ctx.Channel.SendMessageAsync("✔ should ping, ❌ should not ping.");                                                                                           
+
+            await ctx.Channel.SendMessageAsync("✔ Default Behaviour: " + content);                                                                                            //Should ping User
+            await ctx.Channel.SendMessageAsync("✔ UserMention(user): " + content, mentions: new IMention[] { new UserMention(user) });                                        //Should ping user
+            await ctx.Channel.SendMessageAsync("✔ UserMention(): " + content, mentions: new IMention[] { new UserMention() });                                                //Should ping user
+            await ctx.Channel.SendMessageAsync("✔ User Mention Everyone & Self: " + content, mentions: new IMention[] { new UserMention(), new UserMention(user) });          //Should ping user
+            await ctx.Channel.SendMessageAsync("✔ UserMention.All: " + content, mentions: new IMention[] { UserMention.All });                                                //Should ping user
+            
+            await ctx.Channel.SendMessageAsync("❌ Empty Mention Array: " + content, mentions: new IMention[0]);                                                               //Should ping no one
+            await ctx.Channel.SendMessageAsync("❌ UserMention(SomeoneElse): " + content, mentions: new IMention[] { new UserMention(545836271960850454L) });                  //Should ping no one (@user was not pinged)
+            await ctx.Channel.SendMessageAsync("❌ Everyone(): " + content, mentions: new IMention[] { new EveryoneMention() });                                               //Should ping no one (@everyone was not pinged)
         }
     }
 }

--- a/DSharpPlus/Entities/DiscordMentions.cs
+++ b/DSharpPlus/Entities/DiscordMentions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
@@ -35,6 +36,19 @@ namespace DSharpPlus.Entities
 
         internal DiscordMentions(IEnumerable<IMention> mentions)
         {
+            //Null check just to be safe
+            if (mentions == null) return;
+
+            //If we have no item in our mentions, its likely to be a empty array. 
+            // This is a special case were we want parse to be a empty array
+            // Doing this allows for "no parsing"
+            if (!mentions.Any())
+            {
+                Parse = new string[0];
+                return;
+            }
+
+            //Prepare a list of allowed IDs. We will be adding to these IDs.
             HashSet<ulong> roles = new HashSet<ulong>();
             HashSet<ulong> users = new HashSet<ulong>();
             HashSet<string> parse = new HashSet<string>();
@@ -74,6 +88,7 @@ namespace DSharpPlus.Entities
             if (!parse.Contains(ParseRoles) && roles.Count > 0)
                 Roles = roles;
 
+            //If we have a empty parse aray, we don't want to add it.
             if (parse.Count > 0)
                 Parse = parse;
         }


### PR DESCRIPTION
# Summary
Mentionables failed to account for empty arrays. In this situation, it should ping nothing.

# Details
An additional check has been placed when creating the mentionable payload to add a empty Parse array when there is no items in the IEnumerable

# Notes
I have tested it and it works as expected. The test command `D# mention @user` has been updated to indicate when it should ping and when it shouldn't.