### PR TITLE
Made code work

### DIFF
--- a/docs/articles/interactivity/intro.md
+++ b/docs/articles/interactivity/intro.md
@@ -32,8 +32,8 @@ This is what you're going to do. Below the respond code, add the following:
 ```cs
 var interactivity = ctx.Client.GetInteractivityModule();
 var msg = await interactivity.WaitForMessageAsync(xm => xm.Author.Id == ctx.User.Id && xm.Content.ToLower() == "how are you?", TimeSpan.FromMinutes(1));
-if (msg != null)
-	await ctx.RespondAsync($"I'm fine, thank you!");
+if (msg.Result != null)
+	await ctx.RespondAsync("I'm fine, thank you!");
 ```
 
 Let's quickly dissect the code.


### PR DESCRIPTION
# Summary
WaitForMessageAsync returns InteractivityResult<DiscordMessage> not just DiscordMessage
Also removed the $ before the string, not needed in this situation

# Details
WaitForMessageAsync returns InteractivityResult<DiscordMessage> not just DiscordMessage
Also removed the $ before the string, not needed in this situation
# Changes proposed
WaitForMessageAsync returns InteractivityResult<DiscordMessage> not just DiscordMessage
Also removed the $ before the string, not needed in this situation

# Notes
This pull request format is dumb, all three fields are basically the same thing