### PR TITLE
Fixed REST client ratelimit issues

### DIFF
--- a/DSharpPlus/Net/RateLimitBucket.cs
+++ b/DSharpPlus/Net/RateLimitBucket.cs
@@ -179,5 +179,14 @@ namespace DSharpPlus.Net
 
             this._limitResetting = 0;
         }
+
+        internal void SetInitialValues(int usesLeft, DateTimeOffset newReset)
+        {
+            this._remaining = usesLeft;
+            this._nextReset = newReset.UtcTicks;
+            this._limitValid = true;
+            this._limitTestFinished = null;
+            this._limitTesting = 0;
+        }
     }
 }

--- a/docs/articles/voice/send.md
+++ b/docs/articles/voice/send.md
@@ -58,15 +58,11 @@ I encourage you to try and solve both of these issues yourself, however if you g
 [Command("join")]
 public async Task Join(CommandContext ctx)
 {
-	var vnc = vnext.GetConnection(ctx.Guild);
-        if (vnc != null)
-		throw new InvalidOperationException("Already connected in this guild.");
-
 	var chn = ctx.Member?.VoiceState?.Channel;
 	if (chn == null)
 		throw new InvalidOperationException("You need to be in a voice channel.");
 
-	await chn.ConnectAsync();
+	vnc = await chn.ConnectAsync();
 	await ctx.RespondAsync("👌");
 }
 
@@ -103,7 +99,7 @@ What you want to do right now, is something along these lines:
 
 * Get the VoiceNext client.
 * Check if the bot is connected.
-* Fail if already is.
+* Fail if not.
 * Check if the specified file exists.
 * Fail if not.
 

--- a/docs/articles/voice/send.md
+++ b/docs/articles/voice/send.md
@@ -58,11 +58,15 @@ I encourage you to try and solve both of these issues yourself, however if you g
 [Command("join")]
 public async Task Join(CommandContext ctx)
 {
+	var vnc = vnext.GetConnection(ctx.Guild);
+        if (vnc != null)
+		throw new InvalidOperationException("Already connected in this guild.");
+
 	var chn = ctx.Member?.VoiceState?.Channel;
 	if (chn == null)
 		throw new InvalidOperationException("You need to be in a voice channel.");
 
-	vnc = await chn.ConnectAsync();
+	await chn.ConnectAsync();
 	await ctx.RespondAsync("👌");
 }
 
@@ -99,7 +103,7 @@ What you want to do right now, is something along these lines:
 
 * Get the VoiceNext client.
 * Check if the bot is connected.
-* Fail if not.
+* Fail if already is.
 * Check if the specified file exists.
 * Fail if not.
 


### PR DESCRIPTION
Summary
Fixes #470 and implements support for cycling buckets.

# Details
This fixes a long time bug with the REST client which previously decremented atomically without headers. This would cause the client to assume it was using a request when in reality it was reset to its initial state, and never update it, which would then make it get stuck in a loop for a minute. Additionally, this now handles whenever the delete messages route [continuously switches buckets](https://github.com/discord/discord-api-docs/issues/1295).

# Changes proposed
* Prevents the rest client from atomically decrementing without headers.
* Adds support for cycling buckets.