### PR TITLE
[ci skip] Update VoiceNext audio transmission guide

### DIFF
--- a/docs/articles/voice/send.md
+++ b/docs/articles/voice/send.md
@@ -58,6 +58,10 @@ I encourage you to try and solve both of these issues yourself, however if you g
 [Command("join")]
 public async Task Join(CommandContext ctx)
 {
+	var vnc = vnext.GetConnection(ctx.Guild);
+        if (vnc != null)
+		throw new InvalidOperationException("Already connected in this guild.");
+
 	var chn = ctx.Member?.VoiceState?.Channel;
 	if (chn == null)
 		throw new InvalidOperationException("You need to be in a voice channel.");
@@ -99,7 +103,7 @@ What you want to do right now, is something along these lines:
 
 * Get the VoiceNext client.
 * Check if the bot is connected.
-* Fail if not.
+* Fail if already is.
 * Check if the specified file exists.
 * Fail if not.
 

--- a/docs/articles/voice/send.md
+++ b/docs/articles/voice/send.md
@@ -62,7 +62,7 @@ public async Task Join(CommandContext ctx)
 	if (chn == null)
 		throw new InvalidOperationException("You need to be in a voice channel.");
 
-	vnc = await chn.ConnectAsync();
+	await chn.ConnectAsync();
 	await ctx.RespondAsync("👌");
 }
 


### PR DESCRIPTION
The variable vnc doesnt exist in that context

Make sure you familiarize yourself with our contributing guidelines.

# Summary
Fixes a mistake in the Vnext article

# Details
There was a varible that doesnt exist mentioned in the join command example

# Changes proposed
* Fixing that misleading line

# Notes
Someone got confused by this, thats why I changed it (Dont know why that other line counts as edited, it has 0 changes)