### PR TITLE
Add ability to change channel with ModifyWebhookAsync

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -998,29 +998,31 @@ namespace DSharpPlus
         /// Modifies a webhook
         /// </summary>
         /// <param name="webhook_id">Webhook id</param>
+        /// <param name="channelId">The new channel id the webhook should be moved to.</param>
         /// <param name="name">New webhook name</param>
         /// <param name="base64_avatar">New webhook avatar (base64)</param>
         /// <param name="reason">Reason why this webhook was modified</param>
         /// <returns></returns>
-        public Task<DiscordWebhook> ModifyWebhookAsync(ulong webhook_id, string name, string base64_avatar, string reason)
-            => this.ApiClient.ModifyWebhookAsync(webhook_id, name, base64_avatar, reason);
+        public Task<DiscordWebhook> ModifyWebhookAsync(ulong webhook_id, ulong channelId, string name, string base64_avatar, string reason)
+            => this.ApiClient.ModifyWebhookAsync(webhook_id, channelId, name, base64_avatar, reason);
 
         /// <summary>
         /// Modifies a webhook
         /// </summary>
         /// <param name="webhook_id">Webhook id</param>
+        /// <param name="channelId">The new channel id the webhook should be moved to.</param>
         /// <param name="name">New webhook name</param>
         /// <param name="avatar">New webhook avatar</param>
         /// <param name="reason">Reason why this webhook was modified</param>
         /// <returns></returns>
-        public Task<DiscordWebhook> ModifyWebhookAsync(ulong webhook_id, string name, Stream avatar, string reason)
+        public Task<DiscordWebhook> ModifyWebhookAsync(ulong webhook_id, ulong channelId, string name, Stream avatar, string reason)
         {
             string av64 = null;
             if (avatar != null)
                 using (var imgtool = new ImageTool(avatar))
                     av64 = imgtool.GetBase64();
 
-            return this.ApiClient.ModifyWebhookAsync(webhook_id, name, av64, reason);
+            return this.ApiClient.ModifyWebhookAsync(webhook_id, channelId, name, av64, reason);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -64,8 +64,9 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="name">New default name for this webhook.</param>
         /// <param name="avatar">New avatar for this webhook.</param>
+        /// <param name="channelId">The new channel id to move the webhook to.</param>
         /// <returns>The modified webhook.</returns>
-        public Task<DiscordWebhook> ModifyAsync(string name = null, Optional<Stream> avatar = default)
+        public Task<DiscordWebhook> ModifyAsync(string name = null, Optional<Stream> avatar = default, ulong? channelId = null)
         {
             var avatarb64 = Optional.FromNoValue<string>();
             if (avatar.HasValue && avatar.Value != null)
@@ -73,8 +74,10 @@ namespace DSharpPlus.Entities
                     avatarb64 = imgtool.GetBase64();
             else if (avatar.HasValue)
                 avatarb64 = null;
-                    
-            return this.Discord.ApiClient.ModifyWebhookAsync(this.Id, name, avatarb64, Token);
+
+            var newChannelId = channelId.HasValue ? channelId.Value : this.ChannelId;
+
+            return this.Discord.ApiClient.ModifyWebhookAsync(newChannelId, this.Id, name, avatarb64, Token);
         }
 
         /// <summary>

--- a/DSharpPlus/Net/Abstractions/RestWebhookPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/RestWebhookPayloads.cs
@@ -12,6 +12,9 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("avatar", NullValueHandling = NullValueHandling.Include)]
         public string AvatarBase64 { get; set; }
 
+        [JsonProperty("channel_id")]
+        public ulong ChannelId { get; set; }
+
         [JsonProperty]
         public bool AvatarSet { get; set; }
 

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1596,13 +1596,14 @@ namespace DSharpPlus.Net
             return ret;
         }
 
-        internal async Task<DiscordWebhook> ModifyWebhookAsync(ulong webhook_id, string name, Optional<string> base64_avatar, string reason)
+        internal async Task<DiscordWebhook> ModifyWebhookAsync(ulong webhook_id, ulong channelId, string name, Optional<string> base64_avatar, string reason)
         {
             var pld = new RestWebhookPayload
             {
                 Name = name,
                 AvatarBase64 = base64_avatar.HasValue ? base64_avatar.Value : null,
-                AvatarSet = base64_avatar.HasValue
+                AvatarSet = base64_avatar.HasValue,
+                ChannelId = channelId
             };
 
             var headers = new Dictionary<string, string>();


### PR DESCRIPTION
# Summary
Adds the ability to switch a webhook's channel as per https://discord.com/developers/docs/resources/webhook#modify-webhook.

# Details
Adds a new ulong parameter to both the webhook method and non token methods in the rest client to change the webhook channel id.

# Changes proposed
* Adds new channel id parameter to `ModifyAsync()` in the `DiscordWebhook`
* Adds new channel id parameter to the non token modify webhook methods in the rest client.