### PR TITLE
Add exception handling for 500 status codes.

### DIFF
--- a/DSharpPlus/Exceptions/ServerErrorException.cs
+++ b/DSharpPlus/Exceptions/ServerErrorException.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using DSharpPlus.Net;
+
+namespace DSharpPlus.Exceptions
+{
+    /// <summary>
+    /// Represents an exception thrown when Discord returns an Internal Server Error.
+    /// </summary>
+    public class ServerErrorException : Exception
+    {
+        /// <summary>
+        /// Gets the request that caused the exception.
+        /// </summary>
+        public BaseRestRequest WebRequest { get; internal set; }
+
+        /// <summary>
+        /// Gets the response to the request.
+        /// </summary>
+        public RestResponse WebResponse { get; internal set; }
+
+        /// <summary>
+        /// Gets the JSON received.
+        /// </summary>
+        public string JsonMessage { get; internal set; }
+
+        internal ServerErrorException(BaseRestRequest request, RestResponse response) : base("Internal Server Error: " + response.ResponseCode)
+        {
+            this.WebRequest = request;
+            this.WebResponse = response;
+
+            try
+            {
+                var j = JObject.Parse(response.Response);
+
+                if (j["message"] != null)
+                    JsonMessage = j["message"].ToString();
+            }
+            catch (Exception) { }
+        }
+    }
+}

--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -224,6 +224,10 @@ namespace DSharpPlus.Net
                             return;
                         }
                         break;
+
+                    case 500:
+                        ex = new ServerErrorException(request, response);
+                        break;
                 }
 
                 if (ex != null)


### PR DESCRIPTION
# Summary
Fixes #623.

# Details
This PR adds a new exception type to handle when Discord throws an internal server error after making a request.

# Changes proposed
* Add new exception type
* Add 500 handling to rest client.