### PR TITLE
Fix null ref thrown for CollectEventArgs

### DIFF
--- a/DSharpPlus.Interactivity/EventHandling/Requests/CollectRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/CollectRequest.cs
@@ -49,8 +49,12 @@ namespace DSharpPlus.Interactivity.EventHandling
             this._ct.Dispose();
             this._tcs = null;
             this._predicate = null;
-            this._collected.Clear();
-            this._collected = null;
+
+            if (this._collected != null)
+            {
+                this._collected.Clear();
+                this._collected = null;
+            }
         }
     }
 }


### PR DESCRIPTION
# Summary
Fixes #621.

# Details
This adds a null check at the bottom of `NullCheck.Dispose()` to prevent `Clear()` from being called if null when the global timeout is called.

# Changes proposed
* Adds null check in `CollectRequest.Dispose()`