### PR TITLE
Fix ArgumentOfRangeException with Discord message intents.

### DIFF
--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -47,7 +47,7 @@ namespace DSharpPlus.Test
                 ShardId = shardid,
                 ShardCount = this.Config.ShardCount,
                 MessageCacheSize = 2048,
-                LogTimestampFormat = "dd-MM-yyyy HH:mm:ss zzz",
+                LogTimestampFormat = "dd-MM-yyyy HH:mm:ss zzz"
             };
             Discord = new DiscordClient(dcfg);
 

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -47,7 +47,8 @@ namespace DSharpPlus.Test
                 ShardId = shardid,
                 ShardCount = this.Config.ShardCount,
                 MessageCacheSize = 2048,
-                LogTimestampFormat = "dd-MM-yyyy HH:mm:ss zzz"
+                LogTimestampFormat = "dd-MM-yyyy HH:mm:ss zzz",
+                Intents = DiscordIntents.All.RemoveIntent(DiscordIntents.GuildMessages | DiscordIntents.DirectMessages)
             };
             Discord = new DiscordClient(dcfg);
 

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -48,7 +48,6 @@ namespace DSharpPlus.Test
                 ShardCount = this.Config.ShardCount,
                 MessageCacheSize = 2048,
                 LogTimestampFormat = "dd-MM-yyyy HH:mm:ss zzz",
-                Intents = DiscordIntents.All.RemoveIntent(DiscordIntents.GuildMessages | DiscordIntents.DirectMessages)
             };
             Discord = new DiscordClient(dcfg);
 

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -287,7 +287,7 @@ namespace DSharpPlus
                     this.Logger.LogWarning(LoggerEvents.WebSocketReceive, "Unknown event: {0}\npayload: {1}", payload.EventName, payload.Data);
                     break;
 
-                    #endregion
+                #endregion
             }
         }
 

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -287,7 +287,7 @@ namespace DSharpPlus
                     this.Logger.LogWarning(LoggerEvents.WebSocketReceive, "Unknown event: {0}\npayload: {1}", payload.EventName, payload.Data);
                     break;
 
-                #endregion
+                    #endregion
             }
         }
 
@@ -1131,14 +1131,15 @@ namespace DSharpPlus
 
         internal async Task OnMessageAckEventAsync(DiscordChannel chn, ulong messageId)
         {
-            DiscordMessage msg = null;
-            if (this.MessageCache?.TryGet(xm => xm.Id == messageId && xm.ChannelId == chn.Id, out msg) != true)
+            if (this.MessageCache == null || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == chn.Id, out var msg))
+            {
                 msg = new DiscordMessage
                 {
                     Id = messageId,
                     ChannelId = chn.Id,
                     Discord = this,
                 };
+            }
 
             await this._messageAcknowledged.InvokeAsync(new MessageAcknowledgeEventArgs(this) { Message = msg }).ConfigureAwait(false);
         }
@@ -1202,7 +1203,7 @@ namespace DSharpPlus
                 xr.Emoji.Discord = this;
 
             if (this.Configuration.MessageCacheSize > 0 && message.Channel != null)
-                this.MessageCache.Add(message);
+                this.MessageCache?.Add(message);
 
             MessageCreateEventArgs ea = new MessageCreateEventArgs(this)
             {
@@ -1223,7 +1224,9 @@ namespace DSharpPlus
             var event_message = message;
 
             DiscordMessage oldmsg = null;
-            if (this.Configuration.MessageCacheSize == 0 || !this.MessageCache.TryGet(xm => xm.Id == event_message.Id && xm.ChannelId == event_message.ChannelId, out message))
+            if (this.Configuration.MessageCacheSize == 0 
+                || this.MessageCache == null
+                || !this.MessageCache.TryGet(xm => xm.Id == event_message.Id && xm.ChannelId == event_message.ChannelId, out message))
             {
                 message = event_message;
                 guild = message.Channel?.Guild;
@@ -1308,11 +1311,14 @@ namespace DSharpPlus
             var channel = this.InternalGetCachedChannel(channelId);
             var guild = this.InternalGetCachedGuild(guildId);
 
-            if (channel == null || this.Configuration.MessageCacheSize == 0 ||
-                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
+            if (channel == null 
+                || this.Configuration.MessageCacheSize == 0 
+                || this.MessageCache == null
+                || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
             {
                 msg = new DiscordMessage
                 {
+
                     Id = messageId,
                     ChannelId = channelId,
                     Discord = this,
@@ -1320,7 +1326,7 @@ namespace DSharpPlus
             }
 
             if (this.Configuration.MessageCacheSize > 0)
-                this.MessageCache.Remove(xm => xm.Id == msg.Id && xm.ChannelId == channelId);
+                this.MessageCache?.Remove(xm => xm.Id == msg.Id && xm.ChannelId == channelId);
 
             var ea = new MessageDeleteEventArgs(this)
             {
@@ -1338,8 +1344,10 @@ namespace DSharpPlus
             var msgs = new List<DiscordMessage>(messageIds.Length);
             foreach (var messageId in messageIds)
             {
-                if (channel == null || this.Configuration.MessageCacheSize == 0 ||
-                    !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
+                if (channel == null 
+                    || this.Configuration.MessageCacheSize == 0 
+                    || this.MessageCache == null
+                    || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
                 {
                     msg = new DiscordMessage
                     {
@@ -1349,7 +1357,7 @@ namespace DSharpPlus
                     };
                 }
                 if (this.Configuration.MessageCacheSize > 0)
-                    this.MessageCache.Remove(xm => xm.Id == msg.Id && xm.ChannelId == channelId);
+                    this.MessageCache?.Remove(xm => xm.Id == msg.Id && xm.ChannelId == channelId);
                 msgs.Add(msg);
             }
 
@@ -1384,8 +1392,10 @@ namespace DSharpPlus
                     ? member
                     : new DiscordMember(usr) { Discord = this, _guild_id = channel.GuildId };
 
-            if (channel == null || this.Configuration.MessageCacheSize == 0 ||
-                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
+            if (channel == null 
+                || this.Configuration.MessageCacheSize == 0 
+                || this.MessageCache == null
+                || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
             {
                 msg = new DiscordMessage
                 {
@@ -1436,8 +1446,10 @@ namespace DSharpPlus
                     ? member
                     : new DiscordMember(usr) { Discord = this, _guild_id = channel.GuildId };
 
-            if (channel == null || this.Configuration.MessageCacheSize == 0 ||
-                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
+            if (channel == null 
+                || this.Configuration.MessageCacheSize == 0 
+                || this.MessageCache == null
+                || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
             {
                 msg = new DiscordMessage
                 {
@@ -1478,8 +1490,10 @@ namespace DSharpPlus
         {
             var channel = this.InternalGetCachedChannel(channelId);
 
-            if (channel == null || this.Configuration.MessageCacheSize == 0 ||
-                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
+            if (channel == null 
+                || this.Configuration.MessageCacheSize == 0 
+                || this.MessageCache == null
+                || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
             {
                 msg = new DiscordMessage
                 {
@@ -1507,8 +1521,10 @@ namespace DSharpPlus
             var guild = this.InternalGetCachedGuild(guildId);
             var channel = this.InternalGetCachedChannel(channelId);
 
-            if (channel == null || this.Configuration.MessageCacheSize == 0 ||
-                !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
+            if (channel == null 
+                || this.Configuration.MessageCacheSize == 0 
+                || this.MessageCache == null
+                || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
             {
                 msg = new DiscordMessage
                 {

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -119,7 +119,7 @@ namespace DSharpPlus
                 if (intents.HasValue)
                     this.MessageCache = intents.Value.HasIntent(DiscordIntents.GuildMessages) || intents.Value.HasIntent(DiscordIntents.DirectMessages)
                         ? new RingBuffer<DiscordMessage>(this.Configuration.MessageCacheSize)
-                        : new RingBuffer<DiscordMessage>(0);
+                        : null;
                 else
                     this.MessageCache = new RingBuffer<DiscordMessage>(this.Configuration.MessageCacheSize); //This will need to be changed once intents become mandatory.
             }

--- a/DSharpPlus/Clients/DiscordShardedClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.Events.cs
@@ -359,16 +359,6 @@ namespace DSharpPlus
         private AsyncEvent<MessageCreateEventArgs> _messageCreated;
 
         /// <summary>
-        /// Fired when message is acknowledged by the user.
-        /// </summary>
-        public event AsyncEventHandler<MessageAcknowledgeEventArgs> MessageAcknowledged
-        {
-            add => this._messageAcknowledged.Register(value);
-            remove => this._messageAcknowledged.Unregister(value);
-        }
-        private AsyncEvent<MessageAcknowledgeEventArgs> _messageAcknowledged;
-
-        /// <summary>
         /// Fired when a message is updated.
         /// </summary>
         public event AsyncEventHandler<MessageUpdateEventArgs> MessageUpdated

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -307,8 +307,13 @@ namespace DSharpPlus.Entities
         /// <returns></returns>
         public async Task<DiscordMessage> GetMessageAsync(ulong id)
         {
-            if (this.Discord.Configuration.MessageCacheSize > 0 && this.Discord is DiscordClient dc && dc.MessageCache.TryGet(xm => xm.Id == id && xm.ChannelId == this.Id, out var msg))
+            if (this.Discord.Configuration.MessageCacheSize > 0 
+                && this.Discord is DiscordClient dc 
+                && dc.MessageCache != null 
+                && dc.MessageCache.TryGet(xm => xm.Id == id && xm.ChannelId == this.Id, out var msg))
+            {
                 return msg;
+            }
 
             return await this.Discord.ApiClient.GetMessageAsync(Id, id).ConfigureAwait(false);
         }

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -1657,11 +1657,16 @@ namespace DSharpPlus.Entities
 
                             if (entrymsg.Channel != null)
                             {
-                                DiscordMessage msg = null;
-                                if (this.Discord is DiscordClient dc && dc.MessageCache?.TryGet(xm => xm.Id == xac.TargetId.Value && xm.ChannelId == entrymsg.Channel.Id, out msg) == true)
+                                if (this.Discord is DiscordClient dc
+                                    && dc.MessageCache != null
+                                    && dc.MessageCache.TryGet(xm => xm.Id == xac.TargetId.Value && xm.ChannelId == entrymsg.Channel.Id, out var msg))
+                                {
                                     entrymsg.Target = msg;
+                                }
                                 else
+                                {
                                     entrymsg.Target = new DiscordMessage { Discord = this.Discord, Id = xac.TargetId.Value };
+                                }
                             }
                             break;
                         }
@@ -1680,7 +1685,8 @@ namespace DSharpPlus.Entities
 
                             if (xac.Options != null)
                             {
-                                dc.MessageCache.TryGet(x => x.Id == xac.Options.MessageId && x.ChannelId == xac.Options.ChannelId, out var message);
+                                DiscordMessage message = default;
+                                dc.MessageCache?.TryGet(x => x.Id == xac.Options.MessageId && x.ChannelId == xac.Options.ChannelId, out message);
 
                                 entrypin.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
                                 entrypin.Message = message ?? new DiscordMessage { Id = xac.Options.MessageId, Discord = this.Discord };

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -311,7 +311,7 @@ namespace DSharpPlus.Entities
 
             else reference.Channel = channel;
 
-            if (client.MessageCache.TryGet(m => m.Id == messageId.Value && m.ChannelId == channelId, out var msg))
+            if (client.MessageCache != null && client.MessageCache.TryGet(m => m.Id == messageId.Value && m.ChannelId == channelId, out var msg))
                 reference.Message = msg;
 
             else


### PR DESCRIPTION
# Summary
Fixes #633 

# Details
This PR fixes the above issue by having the message cache be null rather than have it be 0 sized when supplying message intents. It also adds the appropriate null checks.

# Changes proposed
* Makes the internal message cache null
* Adds appropriate null checks.
* Removes an obsolete user event from the DiscordShardedClient (not sure how it got there).