### PR TITLE
Implement HTTP Handling for the DiscordShardedClient

### DIFF
--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -270,7 +270,7 @@ namespace DSharpPlus
 
                 if (code == 401 || code == 403)
                 {
-                    throw new Exception($"Authentication failed, check your token and try again: {code}");
+                    throw new Exception($"Authentication failed, check your token and try again: {code} {msg.ReasonPhrase}");
                 }
                 else if (code == 429)
                 {
@@ -287,11 +287,11 @@ namespace DSharpPlus
                 }
                 else if (code >= 500)
                 {
-                    throw new Exception($"Internal Server Error: {code}");
+                    throw new Exception($"Internal Server Error: {code} {msg.ReasonPhrase}");
                 }
                 else
                 {
-                    throw new Exception($"An unsuccessful HTTP status code was encountered: {code}");
+                    throw new Exception($"An unsuccessful HTTP status code was encountered: {code} {msg.ReasonPhrase}");
                 }
             }
         }

--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -264,7 +264,6 @@ namespace DSharpPlus
 
             return info;
 
-
             async Task<bool> HandleHttpError(string reqUrl, HttpResponseMessage msg)
             {
                 var code = (int)msg.StatusCode;
@@ -294,7 +293,6 @@ namespace DSharpPlus
                 {
                     throw new Exception($"An unsuccessful HTTP status code was encountered: {code}");
                 }
-
             }
         }
 

--- a/DSharpPlus/Logging/LoggerEvents.cs
+++ b/DSharpPlus/Logging/LoggerEvents.cs
@@ -120,7 +120,7 @@ namespace DSharpPlus
         /// <summary>
         /// Events pertaining to the <see cref="DiscordShardedClient"/>'s shards not initializing correctly.
         /// </summary>
-        public static EventId ShardClientFailure { get; } = new EventId(122, nameof(ShardClientFailure));
+        public static EventId ShardClientError { get; } = new EventId(122, nameof(ShardClientError));
 
         /// <summary>
         /// Events containing raw payloads, as they're received from Discord's REST API.


### PR DESCRIPTION
# Summary
Fixes #634.

# Details
This PR introduces proper HTTP handling for the GET gateway/bot method in the DiscordSharded client, in the event of an unsuccessful HTTP status code. It also implements a rate limiter to delay and retry the request if a 429 is encountered. 

# Changes proposed
* Add proper unsuccessful HTTP handling to the sharded client.