### PR TITLE
Fixes cnext injection on inherited properties.

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
@@ -354,7 +354,7 @@ namespace DSharpPlus.CommandsNext
             var moduleInstance = Activator.CreateInstance(t, args);
 
             // inject into properties
-            var props = ti.DeclaredProperties.Where(xp => xp.CanWrite && xp.SetMethod != null && !xp.SetMethod.IsStatic && xp.SetMethod.IsPublic);
+            var props = t.GetRuntimeProperties().Where(xp => xp.CanWrite && xp.SetMethod != null && !xp.SetMethod.IsStatic && xp.SetMethod.IsPublic);
             foreach (var prop in props)
             {
                 if (prop.GetCustomAttribute<DontInjectAttribute>() != null)
@@ -368,7 +368,7 @@ namespace DSharpPlus.CommandsNext
             }
 
             // inject into fields
-            var fields = ti.DeclaredFields.Where(xf => !xf.IsInitOnly && !xf.IsStatic && xf.IsPublic);
+            var fields = t.GetRuntimeFields().Where(xf => !xf.IsInitOnly && !xf.IsStatic && xf.IsPublic);
             foreach (var field in fields)
             {
                 if (field.GetCustomAttribute<DontInjectAttribute>() != null)


### PR DESCRIPTION
# Summary
Allow CommandsNextUtilities.CreateInstance to inject into inherited properties.

# Details
Currently cnext doesn't properly handle injection into inherited properties.  
This PR fixes it by changing `TypeInfo.DeclaredProperties` / `TypeInfo.DeclaredFields` to `Type.GetRuntimeProperties` / `Type.GetRuntimeFields` since `Type.GetRuntime*` correctly handle inheritance, while `TypeInfo.Declared*` doesn't.

# Changes proposed
As it currently stands the following field when accessed by a command through its superclass will result on a `null` value.
```cs
public abstract class CustomCommandModule : BaseCommandModule {
    public BotConfig Config;
    // Config gets injected and its usable here, but due to the use case its not what you'd want.
}
```
```cs
public class ACommand : CustomCommandModule {
// Here Config is null, because BotConfig Config is inherited rather than declared here.
// With this fix, `Config` becomes usable here.
}
```
This can be used, for example, passing local custom data to many groups without code duplication.

# Notes