### PR TITLE
Add overloads of reaction methods accepting a string parameter for the emoji

### DIFF
--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -493,7 +493,7 @@ namespace DSharpPlus.Entities
         /// <param name="user">Member you want to remove the reaction for</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
-        public Task DeleteReactionAsync(DiscordEmoji emoji, DiscordUser user, string reason = null) 
+        public Task DeleteReactionAsync(string emoji, DiscordUser user, string reason = null) 
             => this.Discord.ApiClient.DeleteUserReactionAsync(this.ChannelId, this.Id, user.Id, EmojiReactionString(emoji), reason);
 
         /// <summary>
@@ -527,7 +527,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="emoji">String representation of the emoji to clear, be it unicode or name:id.</param>
         /// <returns></returns>
-        public Task DeleteReactionsEmojiAsync(DiscordEmoji emoji)
+        public Task DeleteReactionsEmojiAsync(string emoji)
             => this.Discord.ApiClient.DeleteReactionsEmojiAsync(this.ChannelId, this.Id, EmojiReactionString(emoji));
 
         private async Task<IReadOnlyList<DiscordUser>> GetReactionsInternalAsync(DiscordEmoji emoji, int limit = 25, ulong? after = null)

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using System.Globalization;
@@ -434,32 +435,66 @@ namespace DSharpPlus.Entities
 
             return this.Discord.ApiClient.UploadFilesAsync(this.ChannelId, files, content, tts, embed, mentions);
         }
+	
+	private static readonly Regex guildEmojiRegex = new Regex(@"^<?a?:?([a-zA-Z0-9_]+:[0-9]+)>?$");
+	
+	private string EmojiReactionString(string emoji) // From an emoji's mention string form into a reaction request string form
+	{
+	    var match = guildEmojiRegex.Match(text.Trim());
+	    return match.Success ? match.Groups[1].Value : emoji;
+	}
 
         /// <summary>
         /// Creates a reaction to this message
         /// </summary>
-        /// <param name="emoji">The emoji you want to react with, either an emoji or name:id</param>
+        /// <param name="emoji">The emoji you want to react with</param>
         /// <returns></returns>
         public Task CreateReactionAsync(DiscordEmoji emoji) 
             => this.Discord.ApiClient.CreateReactionAsync(this.ChannelId, this.Id, emoji.ToReactionString());
+	    
+	/// <summary>
+        /// Creates a reaction to this message
+        /// </summary>
+        /// <param name="emoji">The string representation of the emoji you want to react with, be it unicode or name:id</param>
+        /// <returns></returns>
+        public Task CreateReactionAsync(string emoji)
+            => this.Discord.ApiClient.CreateReactionAsync(this.ChannelId, this.Id, EmojiReactionString(emoji));
 
         /// <summary>
         /// Deletes your own reaction
         /// </summary>
-        /// <param name="emoji">Emoji for the reaction you want to remove, either an emoji or name:id</param>
+        /// <param name="emoji">Emoji for the reaction you want to remove</param>
         /// <returns></returns>
         public Task DeleteOwnReactionAsync(DiscordEmoji emoji) 
             => this.Discord.ApiClient.DeleteOwnReactionAsync(this.ChannelId, this.Id, emoji.ToReactionString());
+	    
+	/// <summary>
+        /// Deletes your own reaction
+        /// </summary>
+        /// <param name="emoji">String representation of the emoji for the reaction you want to remove, be it unicode or name:id</param>
+        /// <returns></returns>
+        public Task DeleteOwnReactionAsync(string emoji)
+	    => this.Discord.ApiClient.DeleteOwnReactionAsync(this.ChannelId, this.Id, EmojiReactionString(emoji));
 
         /// <summary>
         /// Deletes another user's reaction.
         /// </summary>
-        /// <param name="emoji">Emoji for the reaction you want to remove, either an emoji or name:id.</param>
+        /// <param name="emoji">Emoji for the reaction you want to remove</param>
         /// <param name="user">Member you want to remove the reaction for</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns></returns>
         public Task DeleteReactionAsync(DiscordEmoji emoji, DiscordUser user, string reason = null) 
             => this.Discord.ApiClient.DeleteUserReactionAsync(this.ChannelId, this.Id, user.Id, emoji.ToReactionString(), reason);
+	    
+	/// <summary>
+        /// Deletes another user's reaction.
+        /// </summary>
+        /// <param name="emoji">String representation of the emoji for the reaction you want to remove, be it unicode or name:id.</param>
+        /// <param name="user">Member you want to remove the reaction for</param>
+        /// <param name="reason">Reason for audit logs.</param>
+        /// <returns></returns>
+        public Task DeleteReactionAsync(DiscordEmoji emoji, DiscordUser user, string reason = null) 
+            => this.Discord.ApiClient.DeleteUserReactionAsync(this.ChannelId, this.Id, user.Id, EmojiReactionString(emoji), reason);
 
         /// <summary>
         /// Gets users that reacted with this emoji.
@@ -482,10 +517,18 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Deletes all reactions of a specific reaction for this message.
         /// </summary>
-        /// <param name="emoji">The emoji to clear, either an emoji or name:id.</param>
+        /// <param name="emoji">The emoji to clear</param>
         /// <returns></returns>
         public Task DeleteReactionsEmojiAsync(DiscordEmoji emoji)
             => this.Discord.ApiClient.DeleteReactionsEmojiAsync(this.ChannelId, this.Id, emoji.ToReactionString());
+	    
+	/// <summary>
+        /// Deletes all reactions of a specific reaction for this message.
+        /// </summary>
+        /// <param name="emoji">String representation of the emoji to clear, be it unicode or name:id.</param>
+        /// <returns></returns>
+        public Task DeleteReactionsEmojiAsync(DiscordEmoji emoji)
+            => this.Discord.ApiClient.DeleteReactionsEmojiAsync(this.ChannelId, this.Id, EmojiReactionString(emoji));
 
         private async Task<IReadOnlyList<DiscordUser>> GetReactionsInternalAsync(DiscordEmoji emoji, int limit = 25, ulong? after = null)
         {

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -438,7 +438,7 @@ namespace DSharpPlus.Entities
 	
 	private static readonly Regex guildEmojiRegex = new Regex(@"^<?a?:?([a-zA-Z0-9_]+:[0-9]+)>?$");
 	
-	private string EmojiReactionString(string emoji) // From an emoji's mention string form into a reaction request string form
+	private static string EmojiReactionString(string emoji) // From an emoji's mention string form into a reaction request string form
 	{
 	    var match = guildEmojiRegex.Match(text.Trim());
 	    return match.Success ? match.Groups[1].Value : emoji;

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -440,7 +440,7 @@ namespace DSharpPlus.Entities
 	
 	private static string EmojiReactionString(string emoji) // From an emoji's mention string form into a reaction request string form
 	{
-	    var match = guildEmojiRegex.Match(text.Trim());
+	    var match = guildEmojiRegex.Match(emoji.Trim());
 	    return match.Success ? match.Groups[1].Value : emoji;
 	}
 


### PR DESCRIPTION
# Summary
Implements overloads for CreateReactionAsync, DeleteOwnReactionAsync, DeleteReactionAsync and DeleteReactionsEmojiAsync accepting a string parameter.

# Reasoning
You only need to know the unicode representation (or the name and ID) of an emoji/guild emoji to be able to use it in reactions. Giving the user the option to use a string instead of the more complex DiscordEmoji object increases flexibility, versatility and elegance. I believe this feature was clearly missing from the library, as it appears it was even intended for these overloads to exist.

# Details
Adds a private static regex member and a private static method to convert a guild emoji string from `<a:name:id>` (standard mention) into `name:id` (valid for internal reaction requests). Does nothing if it was already `name:id` or if it was a unicode emoji.

This method is then used in all the new method overloads.

# Notes
I tested the regex here: https://regexr.com/5d2gs