### PR TITLE
Fixes Exceptions Received in VoiceNext Voice Receive

### DIFF
--- a/DSharpPlus.VoiceNext/EventArgs/VoiceReceiveEventArgs.cs
+++ b/DSharpPlus.VoiceNext/EventArgs/VoiceReceiveEventArgs.cs
@@ -14,10 +14,14 @@ namespace DSharpPlus.VoiceNext.EventArgs
         /// </summary>
         public uint SSRC { get; internal set; }
 
+        #nullable enable
+
         /// <summary>
         /// Gets the user that sent the audio data.
         /// </summary>
-        public DiscordUser User { get; internal set; }
+        public DiscordUser? User { get; internal set; }
+
+        #nullable disable
 
         /// <summary>
         /// Gets the received voice data, decoded to PCM format.

--- a/DSharpPlus.VoiceNext/EventArgs/VoiceReceiveEventArgs.cs
+++ b/DSharpPlus.VoiceNext/EventArgs/VoiceReceiveEventArgs.cs
@@ -14,14 +14,14 @@ namespace DSharpPlus.VoiceNext.EventArgs
         /// </summary>
         public uint SSRC { get; internal set; }
 
-        #nullable enable
+#pragma warning disable CS8632
 
         /// <summary>
         /// Gets the user that sent the audio data.
         /// </summary>
         public DiscordUser? User { get; internal set; }
 
-        #nullable disable
+#pragma warning restore
 
         /// <summary>
         /// Gets the received voice data, decoded to PCM format.

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -419,7 +419,7 @@ namespace DSharpPlus.VoiceNext
 
             this.Rtp.DecodeHeader(data, out var sequence, out var timestamp, out var ssrc, out var hasExtension);
 
-            if(!this.TransmittingSSRCs.TryGetValue(ssrc, out var vtx))
+            if (!this.TransmittingSSRCs.TryGetValue(ssrc, out var vtx))
             {
                 var decoder = Opus.CreateDecoder();
 

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -419,7 +419,17 @@ namespace DSharpPlus.VoiceNext
 
             this.Rtp.DecodeHeader(data, out var sequence, out var timestamp, out var ssrc, out var hasExtension);
 
-            var vtx = this.TransmittingSSRCs[ssrc];
+            if(!this.TransmittingSSRCs.TryGetValue(ssrc, out var vtx))
+            {
+                var decoder = Opus.CreateDecoder();
+
+                vtx = new AudioSender(ssrc, decoder)
+                {
+                    // user isn't present as we haven't received a speaking event yet.
+                    User = null
+                };
+            }
+
             voiceSender = vtx;
             if (sequence <= vtx.LastSequence) // out-of-order packet; discard
                 return false;


### PR DESCRIPTION
# Summary
Fixes #493.

# Details
The exception was thrown due to a race condition between the UDP client and Voice WS, in that the UDP was trying to access the SSRC cache before it had the correct SSRC, which is only added by the WS. This PR fixes that by creating a new audio sender with a null user, as there cannot be anything blocking to request the user or wait for the correct SSRC.

# Changes proposed
* Fix key not found exception by creating a new AudioSender with a null user.

# Notes
I don't believe this fixed the user cache exception as well, as that is a much larger issue out of the scope of this PR.