### PR TITLE
Fix User Instance Not Being Found in the MessageReactionAdded event.

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1389,12 +1389,10 @@ namespace DSharpPlus
             emoji.Discord = this;
 
             DiscordUser usr = default;
-            DiscordMember mbr = default;
 
             if (tMember != null)
             {
-                usr = new DiscordUser(tMember.User) { Discord = this};
-                mbr = new DiscordMember(usr) { Discord = this, _guild_id = guildId.Value};
+                usr = new DiscordUser(tMember.User) { Discord = this };
 
                 this.UserCache.AddOrUpdate(userId, usr, (id, old) =>
                 {
@@ -1403,6 +1401,8 @@ namespace DSharpPlus
                     old.AvatarHash = usr.AvatarHash;
                     return old;
                 });
+
+                usr = new DiscordMember(tMember) { Discord = this, _guild_id = guildId.Value };
             }
             else
             {
@@ -1446,7 +1446,6 @@ namespace DSharpPlus
             {
                 Message = msg,
                 User = usr,
-                Member = mbr,
                 Guild = guild,
                 Emoji = emoji
             };

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -37,7 +37,9 @@ namespace DSharpPlus
             DiscordChannel chn;
             ulong gid;
             ulong cid;
-            TransportUser usr;
+            TransportUser usr = default;
+            TransportMember mbr = default;
+            JToken rawMbr = default;
 
             switch (payload.EventName.ToLowerInvariant())
             {
@@ -220,10 +222,10 @@ namespace DSharpPlus
                 #region Message Reaction
 
                 case "message_reaction_add":
-                    TransportMember mbr = default;
+                    rawMbr = dat["member"];
 
-                    if (dat["member"] != null)
-                        mbr = dat["member"].ToObject<TransportMember>();
+                    if (rawMbr != null)
+                        mbr = rawMbr.ToObject<TransportMember>();
 
                     await OnMessageReactionAddAsync((ulong)dat["user_id"], (ulong)dat["message_id"], (ulong)dat["channel_id"], (ulong?)dat["guild_id"], mbr, dat["emoji"].ToObject<DiscordEmoji>()).ConfigureAwait(false);
                     break;

--- a/DSharpPlus/Entities/DiscordVoiceState.cs
+++ b/DSharpPlus/Entities/DiscordVoiceState.cs
@@ -45,6 +45,7 @@ namespace DSharpPlus.Entities
 
 		/// <summary>
 		/// Gets the user associated with this voice state.
+		/// <para>This can be cast to a <see cref="DiscordMember"/> if this voice state was in a guild.</para>
 		/// </summary>
 		[JsonIgnore]
 		public DiscordUser User

--- a/DSharpPlus/EventArgs/MessageReactionAddEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageReactionAddEventArgs.cs
@@ -28,6 +28,11 @@ namespace DSharpPlus.EventArgs
         public DiscordUser User { get; internal set; }
 
         /// <summary>
+        /// Gets the member who created the reaction, if in a guild.
+        /// </summary>
+        public DiscordMember Member { get; internal set; }
+
+        /// <summary>
         /// Gets the guild in which the reaction was added.
         /// </summary>
         public DiscordGuild Guild { get; internal set; }

--- a/DSharpPlus/EventArgs/MessageReactionAddEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageReactionAddEventArgs.cs
@@ -24,13 +24,9 @@ namespace DSharpPlus.EventArgs
 
         /// <summary>
         /// Gets the user who created the reaction.
+        /// <para>This can be cast to a <see cref="DiscordMember"/> if the reaction was in a guild.</para>
         /// </summary>
         public DiscordUser User { get; internal set; }
-
-        /// <summary>
-        /// Gets the member who created the reaction, if in a guild.
-        /// </summary>
-        public DiscordMember Member { get; internal set; }
 
         /// <summary>
         /// Gets the guild in which the reaction was added.


### PR DESCRIPTION
# Summary
Fixes #581.

# Details
This PR fixes an issue of a key not found exception being thrown in the message reaction added event by automatically updating it with the member object sent with the event. This also allows the `.User` property in the reaction added event args to be cast to a DiscordMember

# Changes proposed
* Automatically update user cache with member instance passed from the event.
* Allow the respective event args to be cast to a member.
* Made changes to XML docs for those event args and the `DiscordVoiceState` to inform that the user object is castable.