### PR TITLE
Add Member Support for Typing Start Event.

### DIFF
--- a/DSharpPlus/EventArgs/TypingStartEventArgs.cs
+++ b/DSharpPlus/EventArgs/TypingStartEventArgs.cs
@@ -15,6 +15,7 @@ namespace DSharpPlus.EventArgs
 
         /// <summary>
         /// Gets the user that started typing.
+        /// <para>This can be cast to a <see cref="DiscordMember"/> if the typing occurred in a guild.</para>
         /// </summary>
         public DiscordUser User { get; internal set; }
 


### PR DESCRIPTION
# Summary
This PR adds the member object available in the [typing start event](https://discord.com/developers/docs/topics/gateway#typing-start).

# Details
This adds the ability for the user object in the event args to be cast to a member if the typing occurred in a guild as well as update the user cache with the full member object. This will be very useful for using intents with CommandsNext.

# Changes proposed
* Add ability for user property in event args to be cast to a member
* Cache the member object in the user cache.

# Notes
When testing I noticed the new async event handler has a few typos in the error message: 
`An event handler caused the invokation of asynchronous event to time out.`

I believe this should instead be:
`An event handler caused the invocation of the asynchronous event to time out.` 