### PR TITLE
Fix message being spammed for each shard when booting up

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -153,7 +153,7 @@ namespace DSharpPlus.CommandsNext
 
             if (this.Config.UseDefaultCommandHandler)
                 this.Client.MessageCreated += this.HandleCommandsAsync;
-            else
+            else if (!this.Client._isShard)
                 this.Client.Logger.LogWarning(CommandsNextEvents.Misc, "Not attaching default command handler - if this is intentional, you can ignore this message");
 
             if (this.Config.EnableDefaultHelp)


### PR DESCRIPTION
# Summary
Fixes "Not attaching default command handler" message being sent for each shard.

# Changes proposed
Do not display it when the user isn't sharding. Actually, I'm not even sure if this message is required at all, since using another command handler requires to manually set up the config accordingly anyway.