### PR TITLE
Add and improve extension methods.

### DIFF
--- a/DSharpPlus.CommandsNext/ExtensionMethods.cs
+++ b/DSharpPlus.CommandsNext/ExtensionMethods.cs
@@ -74,16 +74,17 @@ namespace DSharpPlus.CommandsNext
         /// </summary>
         /// <param name="client">Client to get CommandsNext instances from.</param>
         /// <returns>A dictionary of the modules, indexed by shard id.</returns>
-        public static IReadOnlyDictionary<int, CommandsNextExtension> GetCommandsNext(this DiscordShardedClient client)
+        public static async Task<IReadOnlyDictionary<int, CommandsNextExtension>> GetCommandsNextAsync(this DiscordShardedClient client)
         {
-            var modules = new Dictionary<int, CommandsNextExtension>();
-
-            client.InitializeShardsAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            await client.InitializeShardsAsync().ConfigureAwait(false);
+            var extensions = new Dictionary<int, CommandsNextExtension>();            
 
             foreach (var shard in client.ShardClients.Select(xkvp => xkvp.Value))
-                modules.Add(shard.ShardId, shard.GetExtension<CommandsNextExtension>());
+            {
+                extensions.Add(shard.ShardId, shard.GetExtension<CommandsNextExtension>());
+            }
 
-            return new ReadOnlyDictionary<int, CommandsNextExtension>(modules);
+            return new ReadOnlyDictionary<int, CommandsNextExtension>(extensions);
         }
     }
 }

--- a/DSharpPlus.Lavalink/DiscordClientExtensions.cs
+++ b/DSharpPlus.Lavalink/DiscordClientExtensions.cs
@@ -62,6 +62,24 @@ namespace DSharpPlus.Lavalink
             => client.GetExtension<LavalinkExtension>();
 
         /// <summary>
+        /// Retrieves a <see cref="LavalinkExtension"/> instance for each shard.
+        /// </summary>
+        /// <param name="client">The shard client to retrieve <see cref="LavalinkExtension"/> instances from.</param>
+        /// <returns>A dictionary containing <see cref="LavalinkExtension"/> instances for each shard.</returns>
+        public static async Task<IReadOnlyDictionary<int, LavalinkExtension>> GetLavalinkAsync(this DiscordShardedClient client)
+        {
+            await client.InitializeShardsAsync().ConfigureAwait(false);
+            var extensions = new Dictionary<int, LavalinkExtension>();
+
+            foreach (var shard in client.ShardClients.Values)
+            {
+                extensions.Add(shard.ShardId, shard.GetExtension<LavalinkExtension>());
+            }
+
+            return new ReadOnlyDictionary<int, LavalinkExtension>(extensions);
+        }
+
+        /// <summary>
         /// Connects to this voice channel using Lavalink.
         /// </summary>
         /// <param name="channel">Channel to connect to.</param>

--- a/DSharpPlus.VoiceNext/DiscordClientExtensions.cs
+++ b/DSharpPlus.VoiceNext/DiscordClientExtensions.cs
@@ -65,6 +65,24 @@ namespace DSharpPlus.VoiceNext
             => client.GetExtension<VoiceNextExtension>();
 
         /// <summary>
+        /// Retrieves a <see cref="VoiceNextExtension"/> instance for each shard.
+        /// </summary>
+        /// <param name="client">The shard client to retrieve <see cref="VoiceNextExtension"/> instances from.</param>
+        /// <returns>A dictionary containing <see cref="VoiceNextExtension"/> instances for each shard.</returns>
+        public static async Task<IReadOnlyDictionary<int, VoiceNextExtension>> GetVoiceNextAsync(this DiscordShardedClient client)
+        {
+            await client.InitializeShardsAsync().ConfigureAwait(false);
+            var extensions = new Dictionary<int, VoiceNextExtension>();
+
+            foreach (var shard in client.ShardClients.Values)
+            {
+                extensions.Add(shard.ShardId, shard.GetExtension<VoiceNextExtension>());
+            }
+
+            return new ReadOnlyDictionary<int, VoiceNextExtension>(extensions);
+        }
+
+        /// <summary>
         /// Connects to this voice channel using VoiceNext.
         /// </summary>
         /// <param name="channel">Channel to connect to.</param>


### PR DESCRIPTION
# Details
This PR aims to bring an extension method from `DSharpPlus.CommandsNext` in line with the changes in #649, as well as introduce a similar extension method missing from  `DSharpPlus.Lavalink` and `DSharpPlus.VoiceNext`.

# Changes proposed
* Added missing `GetVoiceNextAsync(DiscordShardedClient)` extension method for *VoiceNext*.
* Added missing `GetLavalinkAsync(DiscordShardedClient)` extension method for `DSharpPlus.Lavalink`.
* GetCommandsNext(DiscordShardedClient) from *CommandsNext* now awaits its shard initialization call.
  - This resulted in a change of return type to `Task<IReadOnlyDictionary<int, CommandsNextExtension>>`
  - The above resulted in a rename to *GetCommandsNextAsync*