### PR TITLE
Sanity check Webhook AvatarHash

### DIFF
--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -49,7 +49,7 @@ namespace DSharpPlus.Entities
         /// Gets the default avatar url for this webhook.
         /// </summary>
         public string AvatarUrl 
-            => !string.IsNullOrWhiteSpace(this.AvatarHash) ? $"https://cdn.discordapp.com/avatars/{this.Id}/{this.AvatarHash}.png?size=1024" : nu;
+            => !string.IsNullOrWhiteSpace(this.AvatarHash) ? $"https://cdn.discordapp.com/avatars/{this.Id}/{this.AvatarHash}.png?size=1024" : null;
 
         /// <summary>
         /// Gets the secure token of this webhook.

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -48,8 +48,8 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the default avatar url for this webhook.
         /// </summary>
-        public string AvatarUrl 
-            => $"https://cdn.discordapp.com/avatars/{this.Id}/{this.AvatarHash}.png?size=1024";
+        public string AvatarUrl
+            => !string.IsNullOrWhiteSpace(this.AvatarHash) ? $"https://cdn.discordapp.com/avatars/{this.Id}/{this.AvatarHash}.png?size=1024" : null;
 
         /// <summary>
         /// Gets the secure token of this webhook.
@@ -92,7 +92,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the webhook does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task DeleteAsync() 
+        public Task DeleteAsync()
             => this.Discord.ApiClient.DeleteWebhookAsync(this.Id, Token);
 
         /// <summary>
@@ -104,7 +104,8 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> ExecuteAsync(DiscordWebhookBuilder builder)
             => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookAsync(this.Id, this.Token, builder.Content,
-                builder.Username.HasValue ? builder.Username.Value : this.Name, builder.AvatarUrl.HasValue ? builder.AvatarUrl.Value : this.AvatarUrl, 
+                builder.Username.HasValue ? builder.Username.Value : this.Name,
+                builder.AvatarUrl.HasValue ? builder.AvatarUrl.Value : this.AvatarUrl,
                 builder.IsTTS, builder.Embeds, builder.Files, builder.Mentions);
 
         /// <summary>
@@ -115,7 +116,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the webhook does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task ExecuteSlackAsync(string json) 
+        public Task ExecuteSlackAsync(string json)
             => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookSlackAsync(Id, Token, json);
 
         /// <summary>
@@ -126,7 +127,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the webhook does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task ExecuteGithubAsync(string json) 
+        public Task ExecuteGithubAsync(string json)
             => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookGithubAsync(Id, Token, json);
 
         /// <summary>
@@ -190,7 +191,7 @@ namespace DSharpPlus.Entities
         /// <param name="e1">First webhook to compare.</param>
         /// <param name="e2">Second webhook to compare.</param>
         /// <returns>Whether the two webhooks are not equal.</returns>
-        public static bool operator !=(DiscordWebhook e1, DiscordWebhook e2) 
+        public static bool operator !=(DiscordWebhook e1, DiscordWebhook e2)
             => !(e1 == e2);
     }
 }

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -48,8 +48,8 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the default avatar url for this webhook.
         /// </summary>
-        public string AvatarUrl
-            => !string.IsNullOrWhiteSpace(this.AvatarHash) ? $"https://cdn.discordapp.com/avatars/{this.Id}/{this.AvatarHash}.png?size=1024" : null;
+        public string AvatarUrl 
+            => !string.IsNullOrWhiteSpace(this.AvatarHash) ? $"https://cdn.discordapp.com/avatars/{this.Id}/{this.AvatarHash}.png?size=1024" : nu;
 
         /// <summary>
         /// Gets the secure token of this webhook.
@@ -92,7 +92,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the webhook does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task DeleteAsync()
+        public Task DeleteAsync() 
             => this.Discord.ApiClient.DeleteWebhookAsync(this.Id, Token);
 
         /// <summary>
@@ -104,8 +104,8 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> ExecuteAsync(DiscordWebhookBuilder builder)
             => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookAsync(this.Id, this.Token, builder.Content,
-                builder.Username.HasValue ? builder.Username.Value : this.Name,
-                builder.AvatarUrl.HasValue ? builder.AvatarUrl.Value : this.AvatarUrl,
+                builder.Username.HasValue ? builder.Username.Value : this.Name, 
+                builder.AvatarUrl.HasValue ? builder.AvatarUrl.Value : this.AvatarUrl, 
                 builder.IsTTS, builder.Embeds, builder.Files, builder.Mentions);
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the webhook does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task ExecuteSlackAsync(string json)
+        public Task ExecuteSlackAsync(string json) 
             => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookSlackAsync(Id, Token, json);
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the webhook does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task ExecuteGithubAsync(string json)
+        public Task ExecuteGithubAsync(string json) 
             => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookGithubAsync(Id, Token, json);
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace DSharpPlus.Entities
         /// <param name="e1">First webhook to compare.</param>
         /// <param name="e2">Second webhook to compare.</param>
         /// <returns>Whether the two webhooks are not equal.</returns>
-        public static bool operator !=(DiscordWebhook e1, DiscordWebhook e2)
+        public static bool operator !=(DiscordWebhook e1, DiscordWebhook e2) 
             => !(e1 == e2);
     }
 }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1796,8 +1796,8 @@ namespace DSharpPlus.Net
             var pld = new RestWebhookExecutePayload
             {
                 Content = content,
-                Username = username.HasValue && !string.IsNullOrWhiteSpace(username.Value) ? username.Value : null,
-                AvatarUrl = avatar_url.HasValue && !string.IsNullOrWhiteSpace(avatar_url.Value) ? avatar_url.Value : null,
+                Username = username.HasValue ? username.Value : null,
+                AvatarUrl = avatar_url.HasValue ? avatar_url.Value : null,
                 IsTTS = tts,
                 Embeds = embeds
             };

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1796,8 +1796,8 @@ namespace DSharpPlus.Net
             var pld = new RestWebhookExecutePayload
             {
                 Content = content,
-                Username = username.HasValue ? username.Value : null,
-                AvatarUrl = avatar_url.HasValue ? avatar_url.Value : null,
+                Username = username.HasValue && !string.IsNullOrWhiteSpace(username.Value) ? username.Value : null,
+                AvatarUrl = avatar_url.HasValue && !string.IsNullOrWhiteSpace(avatar_url.Value) ? avatar_url.Value : null,
                 IsTTS = tts,
                 Embeds = embeds
             };


### PR DESCRIPTION
# Summary
Fixes #666 by making sure `AvatarHash` is specified before blindly using the URL, this also makes `AvatarUrl` return null if there is no hash 

This makes sense to me as there is no url if there is no hash, but maybe it makes more sense to return a default avatar like `DiscordUser`? I'm open to suggestions here

# Notes
God this template is too long for teensy patches like this, I also apologise for spawning satan upon this pull request.