### PR TITLE
Adds logging functionality for the webhook client.

### DIFF
--- a/DSharpPlus/Clients/BaseDiscordClient.cs
+++ b/DSharpPlus/Clients/BaseDiscordClient.cs
@@ -69,17 +69,18 @@ namespace DSharpPlus
         protected BaseDiscordClient(DiscordConfiguration config)
         {
             this.Configuration = new DiscordConfiguration(config);
-            this.ApiClient = new DiscordApiClient(this);
-            this.UserCache = new ConcurrentDictionary<ulong, DiscordUser>();
-            this.InternalVoiceRegions = new ConcurrentDictionary<string, DiscordVoiceRegion>();
-            this._voice_regions_lazy = new Lazy<IReadOnlyDictionary<string, DiscordVoiceRegion>>(() => new ReadOnlyDictionary<string, DiscordVoiceRegion>(this.InternalVoiceRegions));
-            
+
             if (this.Configuration.LoggerFactory == null)
             {
                 this.Configuration.LoggerFactory = new DefaultLoggerFactory();
                 this.Configuration.LoggerFactory.AddProvider(new DefaultLoggerProvider(this));
             }
             this.Logger = this.Configuration.LoggerFactory.CreateLogger<BaseDiscordClient>();
+
+            this.ApiClient = new DiscordApiClient(this);
+            this.UserCache = new ConcurrentDictionary<ulong, DiscordUser>();
+            this.InternalVoiceRegions = new ConcurrentDictionary<string, DiscordVoiceRegion>();
+            this._voice_regions_lazy = new Lazy<IReadOnlyDictionary<string, DiscordVoiceRegion>>(() => new ReadOnlyDictionary<string, DiscordVoiceRegion>(this.InternalVoiceRegions));
 
             var a = typeof(DiscordClient).GetTypeInfo().Assembly;
 

--- a/DSharpPlus/Clients/DiscordWebhookClient.cs
+++ b/DSharpPlus/Clients/DiscordWebhookClient.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using DSharpPlus.Entities;
 using DSharpPlus.Exceptions;
 using DSharpPlus.Net;
+using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus
 {
@@ -38,30 +39,42 @@ namespace DSharpPlus
         internal List<DiscordWebhook> _hooks;
         internal DiscordApiClient _apiclient;
 
+        internal LogLevel _minimumLogLevel;
+        internal string _logTimestampFormat;
+
         /// <summary>
         /// Creates a new webhook client.
         /// </summary>
         public DiscordWebhookClient()
-            : this(null)
+            : this(null, null)
         { }
 
         /// <summary>
-        /// Creates a new webhook client, with specified HTTP proxy settings.
-        /// </summary>
-        /// <param name="proxy">Proxy to use for HTTP connections.</param>
-        public DiscordWebhookClient(IWebProxy proxy)
-            : this(proxy, TimeSpan.FromSeconds(10))
-        { }
-
-        /// <summary>
-        /// Creates a new webhook client, with specified HTTP proxy and timeout settings.
+        /// Creates a new webhook client, with specified HTTP proxy, timeout, and logging settings.
         /// </summary>
         /// <param name="proxy">Proxy to use for HTTP connections.</param>
         /// <param name="timeout">Timeout to use for HTTP requests. Set to <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> to disable timeouts.</param>
         /// <param name="useRelativeRateLimit">Whether to use the system clock for computing rate limit resets. See <see cref="DiscordConfiguration.UseRelativeRatelimit"/> for more details.</param>
-        public DiscordWebhookClient(IWebProxy proxy, TimeSpan timeout, bool useRelativeRateLimit = true)
+        /// <param name="loggerFactory">The optional logging factory to use for this client.</param>
+        /// <param name="minimumLogLevel">The minimum logging level for messages.</param>
+        /// <param name="logTimestampFormat">The timestamp format to use for the logger.</param>
+        public DiscordWebhookClient(IWebProxy proxy = null, TimeSpan? timeout = null, bool useRelativeRateLimit = true, 
+            ILoggerFactory loggerFactory = null, LogLevel minimumLogLevel = LogLevel.Information, string logTimestampFormat = "yyyy-MM-dd HH:mm:ss zzz")
         {
-            this._apiclient = new DiscordApiClient(proxy, timeout, useRelativeRateLimit);
+            this._minimumLogLevel = minimumLogLevel;
+            this._logTimestampFormat = logTimestampFormat;
+
+            if (loggerFactory == null)
+            {
+                loggerFactory = new DefaultLoggerFactory();
+                loggerFactory.AddProvider(new DefaultLoggerProvider(this));
+            }
+
+            var logger = loggerFactory.CreateLogger<DiscordWebhookClient>();
+
+            var parsedTimeout = timeout ?? TimeSpan.FromSeconds(10);
+
+            this._apiclient = new DiscordApiClient(proxy, parsedTimeout, useRelativeRateLimit, logger);
             this._hooks = new List<DiscordWebhook>();
             this.Webhooks = new ReadOnlyCollection<DiscordWebhook>(this._hooks);
         }

--- a/DSharpPlus/Logging/DefaultLoggerFactory.cs
+++ b/DSharpPlus/Logging/DefaultLoggerFactory.cs
@@ -19,8 +19,8 @@ namespace DSharpPlus
             if (this._isDisposed)
                 throw new InvalidOperationException("This logger factory is already disposed.");
 
-            if (categoryName != typeof(BaseDiscordClient).FullName)
-                throw new ArgumentException($"This factory can only provide instances of loggers for {typeof(BaseDiscordClient).FullName}.", nameof(categoryName));
+            if (categoryName != typeof(BaseDiscordClient).FullName && categoryName != typeof(DiscordWebhookClient).FullName)
+                throw new ArgumentException($"This factory can only provide instances of loggers for {typeof(BaseDiscordClient).FullName} or {typeof(DiscordWebhookClient).FullName}.", nameof(categoryName));
 
             return new CompositeDefaultLogger(this.Providers);
         }

--- a/DSharpPlus/Logging/DefaultLoggerProvider.cs
+++ b/DSharpPlus/Logging/DefaultLoggerProvider.cs
@@ -14,6 +14,10 @@ namespace DSharpPlus
             : this(client.Configuration.MinimumLogLevel, client.Configuration.LogTimestampFormat)
         { }
 
+        internal DefaultLoggerProvider(DiscordWebhookClient client)
+            : this(client._minimumLogLevel, client._logTimestampFormat)
+        { }
+
         internal DefaultLoggerProvider(LogLevel minLevel = LogLevel.Information, string timestampFormat = "yyyy-MM-dd HH:mm:ss zzz")
         {
             this.MinimumLevel = minLevel;
@@ -25,8 +29,8 @@ namespace DSharpPlus
             if (this._isDisposed)
                 throw new InvalidOperationException("This logger provider is already disposed.");
 
-            if (categoryName != typeof(BaseDiscordClient).FullName)
-                throw new ArgumentException($"This provider can only provide instances of loggers for {typeof(BaseDiscordClient).FullName}.", nameof(categoryName));
+            if (categoryName != typeof(BaseDiscordClient).FullName && categoryName != typeof(DiscordWebhookClient).FullName)
+                throw new ArgumentException($"This provider can only provide instances of loggers for {typeof(BaseDiscordClient).FullName} or {typeof(DiscordWebhookClient).FullName}.", nameof(categoryName));
 
             return new DefaultLogger(this.MinimumLevel, this.TimestampFormat);
         }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -30,9 +30,9 @@ namespace DSharpPlus.Net
             this.Rest = new RestClient(client);
         }
 
-        internal DiscordApiClient(IWebProxy proxy, TimeSpan timeout, bool useRelativeRateLimit) // This is for meta-clients, such as the webhook client
+        internal DiscordApiClient(IWebProxy proxy, TimeSpan timeout, bool useRelativeRateLimit, ILogger logger) // This is for meta-clients, such as the webhook client
         {
-            this.Rest = new RestClient(proxy, timeout, useRelativeRateLimit);
+            this.Rest = new RestClient(proxy, timeout, useRelativeRateLimit, logger);
         }
 
         private static string BuildQueryString(IDictionary<string, string> values, bool post = false)

--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -289,7 +289,7 @@ namespace DSharpPlus
             return false;
         }
 
-        internal static void LogTaskFault(this Task task, ILogger<BaseDiscordClient> logger, LogLevel level, EventId eventId, string message)
+        internal static void LogTaskFault(this Task task, ILogger logger, LogLevel level, EventId eventId, string message)
         {
             if (task == null)
                 throw new ArgumentNullException(nameof(task));
@@ -297,34 +297,7 @@ namespace DSharpPlus
             if (logger == null)
                 return;
 
-#if NETSTANDARD1_3
-            task.ContinueWith(t =>
-            {
-                switch (level)
-                {
-                    case LogLevel.Trace:
-                        logger.LogTrace(eventId, t.Exception, message);
-                        break;
-                    case LogLevel.Debug:
-                        logger.LogCritical(eventId, t.Exception, message);
-                        break;
-                    case LogLevel.Information:
-                        logger.LogInformation(eventId, t.Exception, message);
-                        break;
-                    case LogLevel.Warning:
-                        logger.LogWarning(eventId, t.Exception, message);
-                        break;
-                    case LogLevel.Error:
-                        logger.LogError(eventId, t.Exception, message);
-                        break;
-                    case LogLevel.Critical:
-                        logger.LogCritical(eventId, t.Exception, message);
-                        break;
-                }
-            });
-#else
             task.ContinueWith(t => logger.Log(level, eventId, t.Exception, message), TaskContinuationOptions.OnlyOnFaulted);
-#endif 
         }
 
         internal static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> kvp, out TKey key, out TValue value)


### PR DESCRIPTION
# Summary
This PR fixes a null ref thrown when making requests with the webhook client and adds logging capability for the requests made by the webhook client.

# Details
For my bucket hash PR, I forgot to take into account the possibility of the base discord client being null when doing bucket handling (which is the case with the webhook client). This was fixed by simply adding a logger property to the rest client, which will either be assigned to the BaseDiscordClient's or the WebhookClient's.

Users can also change their logger preferences (factory, level, format) through optional parameters in the WebhookClient's constructor. 

# Changes proposed
* Fixes null refs being thrown in rest client
* Adds configurability for the webhook client's logger.