### PR TITLE
[ci skip] Tweak to Lavalink Article

### DIFF
--- a/docs/articles/audio/lavalink/music_commands.md
+++ b/docs/articles/audio/lavalink/music_commands.md
@@ -86,6 +86,12 @@ namespace MyFirstMusicBot
         public async Task Join(CommandContext ctx, DiscordChannel channel)
         {
             var lava = ctx.Client.GetLavalink();
+            if (!lava.ConnectedNodes.Any())
+            {
+                await ctx.RespondAsync("The Lavalink connection is not established");
+                return;
+            }
+
             var node = lava.ConnectedNodes.Values.First();
 
             if (channel.Type != ChannelType.Voice)
@@ -102,6 +108,12 @@ namespace MyFirstMusicBot
         public async Task Leave(CommandContext ctx, DiscordChannel channel)
         {
             var lava = ctx.Client.GetLavalink();
+            if (!lava.ConnectedNodes.Any())
+            {
+                await ctx.RespondAsync("The Lavalink connection is not established");
+                return;
+            }
+
             var node = lava.ConnectedNodes.Values.First();
 
             if (channel.Type != ChannelType.Voice)

--- a/docs/articles/audio/lavalink/music_commands.md
+++ b/docs/articles/audio/lavalink/music_commands.md
@@ -110,7 +110,7 @@ namespace MyFirstMusicBot
                 return;
             }
 
-            var conn = node.GetConnection(channel.Guild);
+            var conn = node.GetGuildConnection(channel.Guild);
 
             if (conn == null)
             {


### PR DESCRIPTION
# Summary
Fixes a typo in the music commands article 

# Details

1. Fixes a typo in the music commands article where the method name was wrong.
1. Adds a guard to verify in the command that the lavalink connection is actually connected to nodes.