### PR TITLE
Update Migration Guide for 3.x to 4.x to include the logging changes.

### DIFF
--- a/docs/articles/migration/3x_to_4x.md
+++ b/docs/articles/migration/3x_to_4x.md
@@ -38,6 +38,19 @@ await role.UpdateAsync(x =>
 });
 ```
 
+### Logging Changes
+Logging was overhauled and now some of the Properties on @DSharpPlus.DiscordConfiguration along with 
+some of the events on @DSharpPlus.DiscordClient are Gone/Modified/Added.  Below is a listing of what changed:
+- **@DSharpPlus.DiscordConfiguration.LoggerFactory** - this is where you can specify your own logging factory 
+  to help augment the output of the log messages, redirect the output to other locations, etc
+- **@DSharpPlus.DiscordConfiguration.MinimumLogLevel**  -  this replaces LogLevel
+- **DebugLogger** - this has been removed.
+- **UseInternalLogHandler** - this has been removed.
+- **DebugLogMessageEventArgs** - this event has been removed.
+
+We have also created an [article](xref:beyond_basics_logging_default) on how to setup the new logger
+
+
 ### Other minor changes
 - **User DM handling** - Users can no longer be DM'd directly. Instead, you 
   will need to find a member object for the user you want to DM, then use the 


### PR DESCRIPTION
# Summary
Updates to the Migration guide for the logging changes.  Resolves partially #671 

# Details

1. Adds a section that describes the changes for logging from 3.x to 4.x