### PR TITLE
[ci-skip] Fixed typos in docs on first bot and hosting

### DIFF
--- a/docs/articles/basics/first_bot.md
+++ b/docs/articles/basics/first_bot.md
@@ -192,7 +192,7 @@ namespace MyFirstBot
                 TokenType = TokenType.Bot
             });
 
-            discord.MessageCreated += async e =>
+            discord.MessageCreated += async (s, e) =>
             {
                 if (e.Message.Content.ToLower().StartsWith("ping")) 
                     await e.Message.RespondAsync("pong!");

--- a/docs/articles/hosting.md
+++ b/docs/articles/hosting.md
@@ -71,8 +71,8 @@ Now that we have covered where you can possibly host your application, now lets 
 source control solutions out there are free and also offer some type of CI/CD intergration (paid and free).  Below are some of the 
 solutions that we recommend:
 
-* [**Azure Devops**]("https://azure.microsoft.com/en-us/services/devops/?nav=min"):  Allows for GIT source control hosting along with intergrated CI/CD
+* [**Azure Devops**](https://azure.microsoft.com/en-us/services/devops/?nav=min "Azure Devops"):  Allows for GIT source control hosting along with intergrated CI/CD
   pipelines to auto compile and publish your applications.  You can also use their CI/CD service if your code is hosted in a different source control enviorment like Github.
-* [**Github**]("https://github.com/") Allows for GIT source control hosting.  From here you can leverage many different CI/CD options to compile and publish your 
+* [**Github**](https://github.com/ "GitHub") Allows for GIT source control hosting.  From here you can leverage many different CI/CD options to compile and publish your 
   applications.
-* [**Bitbutcket**]("https://bitbucket.org/"):  Allows for GIT source control hosting along with intergrated CI/CD pipelines to auto compile and publish your applications.
+* [**Bitbucket**](https://bitbucket.org/ "Bitbucket"):  Allows for GIT source control hosting along with intergrated CI/CD pipelines to auto compile and publish your applications.


### PR DESCRIPTION
# Summary


# Details
There was a typo in the first bot tutorial where the event lambda didn't have a sender. 

There were some broken links in hosting.

# Changes proposed
* Added the sender to the lambda
* Fixed the broken links in the hosting.md.

# Notes
Should probably verify that I fixed the links correctly in the hosting.md.