### PR TITLE
Added handling for 5xx responses from Discord

### DIFF
--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -295,6 +295,9 @@ namespace DSharpPlus.Net
                         break;
 
                     case 500:
+                    case 502:
+                    case 503:
+                    case 504:
                         ex = new ServerErrorException(request, response);
                         break;
                 }


### PR DESCRIPTION
Properly handles HTTP 502, 503 and 504 errors from Discord by throwing a `ServerErrorException` instead of attempting (and usually failing) to parse it as a real response.