### PR TITLE
Fix Reconnect Bug when Disallowed/Malformed Intents are provided

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -185,7 +185,7 @@ namespace DSharpPlus
                     else
                         await this.ConnectAsync(this._status._activity, this._status.Status).ConfigureAwait(false);
                 }
-                else if(e.CloseCode != 4014 || e.CloseCode != 4013)
+                else
                 {
                     this.Logger.LogCritical(LoggerEvents.ConnectionClose, "Connection terminated ({0}, '{1}')", e.CloseCode, e.CloseMessage);
                 }

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -171,7 +171,9 @@ namespace DSharpPlus
                 this.Logger.LogDebug(LoggerEvents.ConnectionClose, "Connection closed ({0}, '{1}')", e.CloseCode, e.CloseMessage);
                 await this._socketClosed.InvokeAsync(this, e).ConfigureAwait(false);
 
-                if (this.Configuration.AutoReconnect)
+
+                //CloseCode 4014 is disallowed Intent and CloseCode 4013 is invalid Intent.  We Should not continuously reconnect per issue 682
+                if (this.Configuration.AutoReconnect && e.CloseCode != 4014 && e.CloseCode != 4013)
                 {
                     this.Logger.LogCritical(LoggerEvents.ConnectionClose, "Connection terminated ({0}, '{1}'), reconnecting", e.CloseCode, e.CloseMessage);
 
@@ -182,6 +184,10 @@ namespace DSharpPlus
                         await this.ConnectAsync(this._status._activity, this._status.Status, Utilities.GetDateTimeOffsetFromMilliseconds(this._status.IdleSince.Value)).ConfigureAwait(false);
                     else
                         await this.ConnectAsync(this._status._activity, this._status.Status).ConfigureAwait(false);
+                }
+                else if(e.CloseCode != 4014 || e.CloseCode != 4013)
+                {
+                    this.Logger.LogCritical(LoggerEvents.ConnectionClose, "Connection terminated ({0}, '{1}')", e.CloseCode, e.CloseMessage);
                 }
             }
         }

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -172,8 +172,8 @@ namespace DSharpPlus
                 await this._socketClosed.InvokeAsync(this, e).ConfigureAwait(false);
 
 
-                //CloseCode 4014 is disallowed Intent and CloseCode 4013 is invalid Intent.  We Should not continuously reconnect per issue 682
-                if (this.Configuration.AutoReconnect && e.CloseCode != 4014 && e.CloseCode != 4013)
+                
+                if (this.Configuration.AutoReconnect && (e.CloseCode < 4001 || e.CloseCode >= 5000))
                 {
                     this.Logger.LogCritical(LoggerEvents.ConnectionClose, "Connection terminated ({0}, '{1}'), reconnecting", e.CloseCode, e.CloseMessage);
 


### PR DESCRIPTION
# Summary
Fixes #682

# Details
Changes the Reconnect logic in SocketOnDisconnect to check the Close code.  If it is due to disallowed Intents or invalid ones, we will not reconnect.  Granted we should never hit a 4013 but placing it there as a saftey measure.