### PR TITLE
Implementation of Discord Stickers

### DIFF
--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -31,6 +31,7 @@ namespace DSharpPlus.Entities
             });
             this._mentionedUsersLazy = new Lazy<IReadOnlyList<DiscordUser>>(() => new ReadOnlyCollection<DiscordUser>(this._mentionedUsers));
             this._reactionsLazy = new Lazy<IReadOnlyList<DiscordReaction>>(() => new ReadOnlyCollection<DiscordReaction>(this._reactions));
+            this._stickersLazy = new Lazy<IReadOnlyList<DiscordMessageSticker>>(() => new ReadOnlyCollection<DiscordMessageSticker>(this._stickers));
             this._jumpLink = new Lazy<Uri>(() =>
             {
                 var gid = this.Channel is DiscordDmChannel ? "@me" : this.Channel.GuildId.ToString(CultureInfo.InvariantCulture);
@@ -55,6 +56,7 @@ namespace DSharpPlus.Entities
                 this._mentionedRoles = new List<DiscordRole>(other._mentionedRoles);
             this._mentionedUsers = new List<DiscordUser>(other._mentionedUsers);
             this._reactions = new List<DiscordReaction>(other._reactions);
+            this._stickers = new List<DiscordMessageSticker>(other._stickers);
 
             this.Author = other.Author;
             this.ChannelId = other.ChannelId;
@@ -275,6 +277,18 @@ namespace DSharpPlus.Entities
         [JsonIgnore]
         public Uri JumpLink => this._jumpLink.Value;
         private Lazy<Uri> _jumpLink;
+
+        /// <summary>
+        /// Gets stickers for this message.
+        /// </summary>
+        [JsonIgnore]
+        public IReadOnlyList<DiscordMessageSticker> Stickers
+            => this._stickersLazy.Value;
+
+        [JsonProperty("stickers", NullValueHandling = NullValueHandling.Ignore)]
+        internal List<DiscordMessageSticker> _stickers = new List<DiscordMessageSticker>();
+        [JsonIgnore]
+        private Lazy<IReadOnlyList<DiscordMessageSticker>> _stickersLazy;
 
         internal DiscordMessageReference InternalBuildMessageReference()
         {

--- a/DSharpPlus/Entities/DiscordMessageSticker.cs
+++ b/DSharpPlus/Entities/DiscordMessageSticker.cs
@@ -1,0 +1,65 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace DSharpPlus.Entities
+{
+    /// <summary>
+    /// Represents a Discord Sticker.
+    /// </summary>
+    public class DiscordMessageSticker : SnowflakeObject, IEquatable<DiscordMessageSticker>
+    {
+        /// <summary>
+        /// Gets the Pack ID of this sticker.
+        /// </summary>
+        [JsonProperty("pack_id", NullValueHandling = NullValueHandling.Ignore)]
+        public ulong PackId { get; internal set; }
+
+        /// <summary>
+        /// Gets the Name of the sticker.
+        /// </summary>
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        public string Name { get; internal set; }
+
+        /// <summary>
+        /// Gets the Description of the sticker.
+        /// </summary>
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets the list of tags for the sticker.
+        /// </summary>
+        [JsonProperty("tags", NullValueHandling = NullValueHandling.Ignore)]
+        public string[] Tags { get; set; }
+
+        /// <summary>
+        /// Gets the asset hash of the sticker.
+        /// </summary>
+        [JsonProperty("asset", NullValueHandling = NullValueHandling.Ignore)]
+        public string Asset { get; set; }
+
+        /// <summary>
+        /// Gets the preview asset hash of the sticker.
+        /// </summary>
+        [JsonProperty("preview_asset", NullValueHandling = NullValueHandling.Ignore)]
+        public string PreviewAsset { get; set; }
+
+        /// <summary>
+        /// Gets the Format type of the sticker.
+        /// </summary>
+        [JsonProperty("format_type", NullValueHandling = NullValueHandling.Ignore)]
+        public StickerFormat FormatType { get; set; }
+
+        public bool Equals(DiscordMessageSticker other)
+        {
+            return this.Id == other.Id;
+        }
+    }
+
+    public enum StickerFormat
+    {
+        PNG = 1,
+        APNG = 2,
+        LOTTIE = 3
+    }
+}


### PR DESCRIPTION
# Summary
This implements Discord Stickers as being tracked in #688 

# Notes
As of right now, bots cannot add stickers to a message object so we just need it filled.  ALSO this is completely untested as stickers are not live right now as of this moment but is more of a starting place for once as they are live