### PR TITLE
Add Missing Property for Discord Emoji

### DIFF
--- a/DSharpPlus/Entities/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/DiscordEmoji.cs
@@ -64,6 +64,9 @@ namespace DSharpPlus.Entities
             }
         }
 
+        [JsonProperty("available", NullValueHandling = NullValueHandling.Ignore)]
+        public bool IsAvailable { get; internal set; }
+
         internal DiscordEmoji()
         {
             this._rolesLazy = new Lazy<IReadOnlyList<ulong>>(() => new ReadOnlyCollection<ulong>(this._roles));

--- a/DSharpPlus/Entities/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/DiscordEmoji.cs
@@ -64,6 +64,9 @@ namespace DSharpPlus.Entities
             }
         }
 
+        /// <summary>
+        /// Gets whether the emoji is available for use.
+        /// </summary>
         [JsonProperty("available", NullValueHandling = NullValueHandling.Ignore)]
         public bool IsAvailable { get; internal set; }
 

--- a/DSharpPlus/Entities/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/DiscordEmoji.cs
@@ -66,7 +66,7 @@ namespace DSharpPlus.Entities
 
         /// <summary>
         /// Gets whether the emoji is available for use.  
-        /// An emoji can not be available due to loss of server boost.
+        /// An emoji may not be available due to loss of server boost.
         /// </summary>
         [JsonProperty("available", NullValueHandling = NullValueHandling.Ignore)]
         public bool IsAvailable { get; internal set; }

--- a/DSharpPlus/Entities/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/DiscordEmoji.cs
@@ -65,7 +65,8 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Gets whether the emoji is available for use.
+        /// Gets whether the emoji is available for use.  
+        /// An emoji can not be available due to loss of server boost.
         /// </summary>
         [JsonProperty("available", NullValueHandling = NullValueHandling.Ignore)]
         public bool IsAvailable { get; internal set; }


### PR DESCRIPTION
# Summary
Adds Missing available Property on DiscordEmoji.  

# Notes
I have tested that all my personal Guild emojis have the property filled correctly.  HOWEVER, I cannot test when may be false due to loss of Server Boosts as I cannot replicate myself.  If someone has a way of testing this possible occurrence, it would be greatly appreciated.  