### PR TITLE
Adds a Message Builder

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -708,16 +708,13 @@ namespace DSharpPlus.CommandsNext
 
                 var helpMessage = helpBuilder.Build();
 
-                if (!ctx.Config.DmHelp || ctx.Channel is DiscordDmChannel || ctx.Guild == null)
-                {
-                    await ctx.RespondAsync(helpMessage.Content, embed: helpMessage.Embed).ConfigureAwait(false);
-                }
+                var builder = new DiscordMessageBuilder().WithContent(helpMessage.Content).WithEmbed(helpMessage.Embed);
+
+                if (!ctx.Config.DmHelp || ctx.Channel is DiscordDmChannel || ctx.Guild == null) 
+                    await ctx.RespondAsync(builder).ConfigureAwait(false);
                 else
-                {
-                    var builder = new DiscordMessageBuilder().WithContent(helpMessage.Content).WithEmbed(helpMessage.Embed);
                     await ctx.Member.SendMessageAsync(builder).ConfigureAwait(false);
-                }
-                    
+
             }
         }
         #endregion

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -709,9 +709,15 @@ namespace DSharpPlus.CommandsNext
                 var helpMessage = helpBuilder.Build();
 
                 if (!ctx.Config.DmHelp || ctx.Channel is DiscordDmChannel || ctx.Guild == null)
+                {
                     await ctx.RespondAsync(helpMessage.Content, embed: helpMessage.Embed).ConfigureAwait(false);
+                }
                 else
-                    await ctx.Member.SendMessageAsync(helpMessage.Content, embed: helpMessage.Embed).ConfigureAwait(false);
+                {
+                    var builder = new DiscordMessageBuilder().WithContent(helpMessage.Content).WithEmbed(helpMessage.Embed);
+                    await ctx.Member.SendMessageAsync(builder).ConfigureAwait(false);
+                }
+                    
             }
         }
         #endregion

--- a/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
@@ -97,61 +97,25 @@ namespace DSharpPlus.CommandsNext
         /// Quickly respond to the message that triggered the command.
         /// </summary>
         /// <param name="content">Message to respond with.</param>
-        /// <param name="isTTS">Whether the message is to be spoken aloud.</param>
-        /// <param name="embed">Embed to attach.</param>
-        /// <param name="mentions">A list of mentions permitted to trigger a ping.</param>
         /// <returns></returns>
-        public Task<DiscordMessage> RespondAsync(string content = null, bool isTTS = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null) 
-            => this.Message.RespondAsync(content, isTTS, embed, mentions);
+        public Task<DiscordMessage> RespondAsync(string content)
+            => this.Message.RespondAsync(content);
 
         /// <summary>
-        /// Quickly respond with a file to the message that triggered the command.
+        /// Quickly respond to the message that triggered the command.
         /// </summary>
-        /// <param name="fileName">Name of the file to send.</param>
-        /// <param name="fileData">Stream containing the data to attach as a file.</param>
-        /// <param name="content">Message to respond with.</param>
-        /// <param name="isTTS">Whether the message is to be spoken aloud.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">A list of mentions permitted to trigger a ping.</param>
-        /// <returns>Message that was sent.</returns>
-        public Task<DiscordMessage> RespondWithFileAsync(string fileName, Stream fileData, string content = null, bool isTTS = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null) 
-            => this.Message.RespondWithFileAsync(fileName, fileData, content, isTTS, embed, mentions);
+        /// <param name="embed">Embed to attach.</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> RespondAsync(DiscordEmbed embed)
+            => this.Message.RespondAsync(embed);
 
         /// <summary>
-        /// Quickly respond with a file to the message that triggered the command.
+        /// Quickly respond to the message that triggered the command.
         /// </summary>
-        /// <param name="fileData">Stream containing the data to attach as a file.</param>
-        /// <param name="content">Message to respond with.</param>
-        /// <param name="isTTS">Whether the message is to be spoken aloud.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">A list of mentions permitted to trigger a ping.</param>
-        /// <returns>Message that was sent.</returns>
-        public Task<DiscordMessage> RespondWithFileAsync(FileStream fileData, string content = null, bool isTTS = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-            => this.Message.RespondWithFileAsync(fileData, content, isTTS, embed, mentions);
-
-        /// <summary>
-        /// Quickly respond with a file to the message that triggered the command.
-        /// </summary>
-        /// <param name="filePath">Path to the file to be attached to the message.</param>
-        /// <param name="content">Message to respond with.</param>
-        /// <param name="isTTS">Whether the message is to be spoken aloud.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">A list of mentions permitted to trigger a ping.</param>
-        /// <returns>Message that was sent.</returns>
-        public Task<DiscordMessage> RespondWithFileAsync(string filePath, string content = null, bool isTTS = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-            => this.Message.RespondWithFileAsync(filePath, content, isTTS, embed, mentions);
-
-        /// <summary>
-        /// Quickly respond with multiple files to the message that triggered the command.
-        /// </summary>
-        /// <param name="content">Message to respond with.</param>
-        /// <param name="files">Files to send.</param>
-        /// <param name="isTTS">Whether the message is to be spoken aloud.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">A list of mentions permitted to trigger a ping.</param>
-        /// <returns>Message that was sent.</returns>
-        public Task<DiscordMessage> RespondWithFilesAsync(Dictionary<string, Stream> files, string content = null, bool isTTS = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-            => this.Message.RespondWithFilesAsync(files, content, isTTS, embed, mentions);
+        /// <param name="builder">The Discord Mesage builder.</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> RespondAsync(DiscordMessageBuilder builder) 
+            => this.Message.RespondAsync(builder);
 
         /// <summary>
         /// Triggers typing in the channel containing the message that triggered the command.

--- a/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
@@ -112,6 +112,15 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Quickly respond to the message that triggered the command.
         /// </summary>
+        /// <param name="content">Message to respond with.</param>
+        /// <param name="embed">Embed to attach.</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> RespondAsync(string content, DiscordEmbed embed)
+            => this.Message.RespondAsync(content, embed);
+
+        /// <summary>
+        /// Quickly respond to the message that triggered the command.
+        /// </summary>
         /// <param name="builder">The Discord Mesage builder.</param>
         /// <returns></returns>
         public Task<DiscordMessage> RespondAsync(DiscordMessageBuilder builder) 

--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -171,7 +171,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             }
 
             var page = await p.GetPageAsync();
-            await new DiscordMessageBuilder().WithContent(page.Content).WithEmbed(page.Embed).ModifyMessageAsync(msg);
+            await new DiscordMessageBuilder().WithContent(page.Content).WithEmbed(page.Embed).ModifyAsync(msg);
         }
 
         ~Paginator()

--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -171,7 +171,11 @@ namespace DSharpPlus.Interactivity.EventHandling
             }
 
             var page = await p.GetPageAsync();
-            await new DiscordMessageBuilder().WithContent(page.Content).WithEmbed(page.Embed).ModifyAsync(msg);
+            var builder = new DiscordMessageBuilder()
+                .WithContent(page.Content)
+                .WithEmbed(page.Embed);
+
+            await builder.ModifyAsync(msg);
         }
 
         ~Paginator()

--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -171,7 +171,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             }
 
             var page = await p.GetPageAsync();
-            await msg.ModifyAsync(page.Content, page.Embed);
+            await new DiscordMessageBuilder().WithContent(page.Content).WithEmbed(page.Embed).ModifyMessageAsync(msg);
         }
 
         ~Paginator()

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -263,7 +263,7 @@ namespace DSharpPlus.Interactivity
             PaginationBehaviour? behaviour = default, PaginationDeletion? deletion = default, TimeSpan? timeoutoverride = null)
         {
             //var m = await c.SendMessageAsync(pages.First().Content, false, pages.First().Embed);
-            var m = await new DiscordMessageBuilder().WithContent(pages.First().Content).WithEmbed(pages.First().Embed).SendMessageToChannelAsync(c);
+            var m = await new DiscordMessageBuilder().WithContent(pages.First().Content).WithEmbed(pages.First().Embed).SendAsync(c);
             var timeout = timeoutoverride ?? Config.Timeout;
 
             var bhv = behaviour ?? this.Config.PaginationBehaviour;

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -262,8 +262,11 @@ namespace DSharpPlus.Interactivity
         public async Task SendPaginatedMessageAsync(DiscordChannel c, DiscordUser u, IEnumerable<Page> pages, PaginationEmojis emojis = null,
             PaginationBehaviour? behaviour = default, PaginationDeletion? deletion = default, TimeSpan? timeoutoverride = null)
         {
-            //var m = await c.SendMessageAsync(pages.First().Content, false, pages.First().Embed);
-            var m = await new DiscordMessageBuilder().WithContent(pages.First().Content).WithEmbed(pages.First().Embed).SendAsync(c);
+            var builder = new DiscordMessageBuilder()
+                .WithContent(pages.First().Content)
+                .WithEmbed(pages.First().Embed);
+            var m = await builder.SendAsync(c);
+
             var timeout = timeoutoverride ?? Config.Timeout;
 
             var bhv = behaviour ?? this.Config.PaginationBehaviour;

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -262,7 +262,8 @@ namespace DSharpPlus.Interactivity
         public async Task SendPaginatedMessageAsync(DiscordChannel c, DiscordUser u, IEnumerable<Page> pages, PaginationEmojis emojis = null,
             PaginationBehaviour? behaviour = default, PaginationDeletion? deletion = default, TimeSpan? timeoutoverride = null)
         {
-            var m = await c.SendMessageAsync(pages.First().Content, false, pages.First().Embed);
+            //var m = await c.SendMessageAsync(pages.First().Content, false, pages.First().Embed);
+            var m = await new DiscordMessageBuilder().WithContent(pages.First().Content).WithEmbed(pages.First().Embed).SendMessageToChannelAsync(c);
             var timeout = timeoutoverride ?? Config.Timeout;
 
             var bhv = behaviour ?? this.Config.PaginationBehaviour;

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -407,6 +407,16 @@ namespace DSharpPlus
         /// Sends a message
         /// </summary>
         /// <param name="channel_id">Channel id</param>
+        /// <param name="content">Message (text) content</param>
+        /// <param name="embed">Embed to attach</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, string content, DiscordEmbed embed)
+            => this.ApiClient.CreateMessageAsync(channel_id, content, null, embed, null);
+
+        /// <summary>
+        /// Sends a message
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
         /// <param name="builder">The Discord Mesage builder.</param>
         /// <returns></returns>
         public async Task<DiscordMessage> CreateMessageAsync(ulong channel_id, DiscordMessageBuilder builder)

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -390,39 +390,32 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="channel_id">Channel id</param>
         /// <param name="content">Message (text) content</param>
-        /// <param name="tts">Whether this message is a text-to-speech message</param>
-        /// <param name="embed">Embed to attach</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
         /// <returns></returns>
-        public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, string content, bool? tts, DiscordEmbed embed, IEnumerable<IMention> mentions)
-            => this.ApiClient.CreateMessageAsync(channel_id, content, tts, embed, mentions);
+        public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, string content)
+            => this.ApiClient.CreateMessageAsync(channel_id, content, false, null, null);
 
         /// <summary>
-        /// Uploads a file
+        /// Sends a message
         /// </summary>
         /// <param name="channel_id">Channel id</param>
-        /// <param name="file_data">File data</param>
-        /// <param name="file_name">File name</param>
-        /// <param name="content">Message (text) content</param>
-        /// <param name="tts">Whether this message is a text-to-speech message</param>
         /// <param name="embed">Embed to attach</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
         /// <returns></returns>
-        public Task<DiscordMessage> UploadFileAsync(ulong channel_id, Stream file_data, string file_name, string content, bool? tts, DiscordEmbed embed, IEnumerable<IMention> mentions)
-            => this.ApiClient.UploadFileAsync(channel_id, file_data, file_name, content, tts, embed, mentions);
+        public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, DiscordEmbed embed)
+            => this.ApiClient.CreateMessageAsync(channel_id, null, null, embed, null);
 
         /// <summary>
-        /// Uploads multiple files
+        /// Sends a message
         /// </summary>
         /// <param name="channel_id">Channel id</param>
-        /// <param name="files">Files to attach (filename, data)</param>
-        /// <param name="content">Message (text) content</param>
-        /// <param name="tts">Whether this message is a text-to-speech message</param>
-        /// <param name="embed">Embed to attach</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
+        /// <param name="builder">The Discord Mesage builder.</param>
         /// <returns></returns>
-        public Task<DiscordMessage> UploadFilesAsync(ulong channel_id, Dictionary<string, Stream> files, string content, bool? tts, DiscordEmbed embed, IEnumerable<IMention> mentions)
-            => this.ApiClient.UploadFilesAsync(channel_id, files, content, tts, embed, mentions);
+        public async Task<DiscordMessage> CreateMessageAsync(ulong channel_id, DiscordMessageBuilder builder)
+        {
+            if (builder.Files.Count() > 0)
+                return await this.ApiClient.UploadFilesAsync(channel_id, builder.Files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+            else
+                return await this.ApiClient.CreateMessageAsync(channel_id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+        }
 
         /// <summary>
         /// Gets channels from a guild

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -412,7 +412,7 @@ namespace DSharpPlus
         public async Task<DiscordMessage> CreateMessageAsync(ulong channel_id, DiscordMessageBuilder builder)
         {
             if (builder.Files.Count() > 0)
-                return await this.ApiClient.UploadFilesAsync(channel_id, builder.Files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return await this.ApiClient.UploadFilesAsync(channel_id, builder.Files.GroupBy(g => g.Key).ToDictionary(g => g.Key, g => g.First().Value), builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
             else
                 return await this.ApiClient.CreateMessageAsync(channel_id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
         }

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -452,10 +452,34 @@ namespace DSharpPlus
         /// <param name="channel_id">Channel id</param>
         /// <param name="message_id">Message id</param>
         /// <param name="content">New message content</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, Optional<string> content)
+            => this.ApiClient.EditMessageAsync(channel_id, message_id, content, default, default);
+
+        /// <summary>
+        /// Edits a message
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="message_id">Message id</param>
         /// <param name="embed">New message embed</param>
         /// <returns></returns>
-        public Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, Optional<string> content, Optional<DiscordEmbed> embed, IEnumerable<IMention> mentions)
-            => this.ApiClient.EditMessageAsync(channel_id, message_id, content, embed, mentions);
+        public Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, Optional<DiscordEmbed> embed)
+            => this.ApiClient.EditMessageAsync(channel_id, message_id, default, embed, default);
+
+        /// <summary>
+        /// Edits a message
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="message_id">Message id</param>
+        /// <param name="builder">The builder of the message to edit.</param>
+        /// <returns></returns>
+        public async Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, DiscordMessageBuilder builder)
+        {
+            if (builder.Files.Any())
+                throw new ArgumentException("You cannot add files when modifing a message.");
+
+            return await this.ApiClient.EditMessageAsync(channel_id, message_id, builder.Content, builder.Embed, builder.Mentions);
+        }
 
         /// <summary>
         /// Deletes a message

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -412,7 +412,7 @@ namespace DSharpPlus
         public async Task<DiscordMessage> CreateMessageAsync(ulong channel_id, DiscordMessageBuilder builder)
         {
             if (builder.Files.Count() > 0)
-                return await this.ApiClient.UploadFilesAsync(channel_id, builder.Files.GroupBy(g => g.Key).ToDictionary(g => g.Key, g => g.First().Value), builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return await this.ApiClient.UploadFilesAsync(channel_id, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
             else
                 return await this.ApiClient.CreateMessageAsync(channel_id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
         }

--- a/DSharpPlus.Test/ADumbFile.txt
+++ b/DSharpPlus.Test/ADumbFile.txt
@@ -1,0 +1,1 @@
+some dumb file.

--- a/DSharpPlus.Test/DSharpPlus.Test.csproj
+++ b/DSharpPlus.Test/DSharpPlus.Test.csproj
@@ -31,6 +31,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="ADumbFile.txt" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <Content Include="ADumbFile.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="2.3.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
   </ItemGroup>

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -42,19 +42,21 @@ namespace DSharpPlus.Test
             {
                 AutoReconnect = true,
                 LargeThreshold = 250,
-                MinimumLogLevel = LogLevel.Debug,
+                MinimumLogLevel = LogLevel.Warning,
                 Token = this.Config.Token,
                 TokenType = TokenType.Bot,
                 ShardId = shardid,
                 ShardCount = this.Config.ShardCount,
                 MessageCacheSize = 2048,
-                LogTimestampFormat = "dd-MM-yyyy HH:mm:ss zzz"
+                LogTimestampFormat = "dd-MM-yyyy HH:mm:ss zzz",
+                Intents = DiscordIntents.All
             };
             Discord = new DiscordClient(dcfg);
 
             // events
             Discord.Ready += this.Discord_Ready;
             Discord.GuildAvailable += this.Discord_GuildAvailable;
+            Discord.PresenceUpdated += this.Discord_PresenceUpdated;
             //Discord.ClientErrored += this.Discord_ClientErrored;
             Discord.SocketErrored += this.Discord_SocketError;
             Discord.GuildCreated += this.Discord_GuildCreated;
@@ -114,6 +116,12 @@ namespace DSharpPlus.Test
 
             //    _ = Task.Run(async () => await e.Message.RespondAsync(e.Message.Content));
             //};
+        }
+
+        private Task Discord_PresenceUpdated(DiscordClient client, PresenceUpdateEventArgs e)
+        {
+            client.Logger.LogInformation(TestBotEventId, "Presence updated: '{0}'", e.Activity.Name);
+            return Task.CompletedTask;
         }
 
         public async Task RunAsync()

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -42,14 +42,13 @@ namespace DSharpPlus.Test
             {
                 AutoReconnect = true,
                 LargeThreshold = 250,
-                MinimumLogLevel = LogLevel.Warning,
+                MinimumLogLevel = LogLevel.Debug,
                 Token = this.Config.Token,
                 TokenType = TokenType.Bot,
                 ShardId = shardid,
                 ShardCount = this.Config.ShardCount,
                 MessageCacheSize = 2048,
-                LogTimestampFormat = "dd-MM-yyyy HH:mm:ss zzz",
-                Intents = DiscordIntents.All
+                LogTimestampFormat = "dd-MM-yyyy HH:mm:ss zzz"
             };
             Discord = new DiscordClient(dcfg);
 

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -113,28 +113,51 @@ namespace DSharpPlus.Test
             await ctx.Channel.SendMessageAsync("✔ should ping, ❌ should not ping.");
 
             var test1Msg = await ctx.Channel.SendMessageAsync("✔ Default Behaviour: " + origcontent);
-            await test1Msg.ModifyAsync("✔ Default Behaviour: " + newContent);                                                                                                   //Should ping User
-                                    
-            var test2Msg = await ctx.Channel.SendMessageAsync("✔ UserMention(user): " + origcontent);                                                                           
-            await test2Msg.ModifyAsync("✔ UserMention(user): " + newContent, mentions: new IMention[] { new UserMention(user) });                                               //Should ping user
+            await new DiscordMessageBuilder()
+               .WithContent("✔ Default Behaviour: " + newContent)
+               .ModifyMessageAsync(test1Msg);                                                                                                                               //Should ping User
 
-            var test3Msg = await ctx.Channel.SendMessageAsync("✔ UserMention(): " + origcontent);                                                                               
-            await test3Msg.ModifyAsync("✔ UserMention(): " + newContent, mentions: new IMention[] { new UserMention() });                                                       //Should ping user
+            var test2Msg = await ctx.Channel.SendMessageAsync("✔ UserMention(user): " + origcontent);      
+            await new DiscordMessageBuilder()
+               .WithContent("✔ UserMention(user): " + newContent)
+               .HasAllowedMentions(new IMention[] { new UserMention(user) })
+               .ModifyMessageAsync(test2Msg);                                                                                                                               //Should ping user
+
+            var test3Msg = await ctx.Channel.SendMessageAsync("✔ UserMention(): " + origcontent);
+            await new DiscordMessageBuilder()
+               .WithContent("✔ UserMention(): " + newContent)
+               .HasAllowedMentions(new IMention[] { new UserMention() })
+               .ModifyMessageAsync(test3Msg);                                                                                                                               //Should ping user
 
             var test4Msg = await ctx.Channel.SendMessageAsync("✔ User Mention Everyone & Self: " + origcontent);
-            await test4Msg.ModifyAsync("✔ User Mention Everyone & Self: " + newContent, mentions: new IMention[] { new UserMention(), new UserMention(user) });                 //Should ping user
+            await new DiscordMessageBuilder()
+               .WithContent("✔ User Mention Everyone & Self: " + newContent)
+               .HasAllowedMentions(new IMention[] { new UserMention(), new UserMention(user) })
+               .ModifyMessageAsync(test4Msg);                                                                                                                               //Should ping user
 
             var test5Msg = await ctx.Channel.SendMessageAsync("✔ UserMention.All: " + origcontent);
-            await test5Msg.ModifyAsync("✔ UserMention.All: " + newContent, mentions: new IMention[] { UserMention.All });                                                       //Should ping user
-                                                          
+            await new DiscordMessageBuilder()
+               .WithContent("✔ UserMention.All: " + newContent)
+               .HasAllowedMentions(new IMention[] { UserMention.All })
+               .ModifyMessageAsync(test5Msg);                                                                                                                               //Should ping user
+
             var test6Msg = await ctx.Channel.SendMessageAsync("❌ Empty Mention Array: " + origcontent);
-            await test6Msg.ModifyAsync("❌ Empty Mention Array: " + newContent, mentions: new IMention[0]);                                                                      //Should ping no one
-             
+            await new DiscordMessageBuilder()
+               .WithContent("❌ Empty Mention Array: " + newContent)
+               .HasAllowedMentions(new IMention[0])
+               .ModifyMessageAsync(test6Msg);                                                                                                                               //Should ping no one
+
             var test7Msg = await ctx.Channel.SendMessageAsync("❌ UserMention(SomeoneElse): " + origcontent);
-            await test7Msg.ModifyAsync("❌ UserMention(SomeoneElse): " + newContent, mentions: new IMention[] { new UserMention(777677298316214324) });                          //Should ping no one (@user was not pinged)
-                                       
+            await new DiscordMessageBuilder()
+               .WithContent("❌ UserMention(SomeoneElse): " + newContent)
+               .HasAllowedMentions(new IMention[] { new UserMention(777677298316214324) })
+               .ModifyMessageAsync(test7Msg);                                                                                                                               //Should ping no one (@user was not pinged)
+
             var test8Msg = await ctx.Channel.SendMessageAsync("❌ Everyone(): " + origcontent);
-            await test8Msg.ModifyAsync("❌ Everyone(): " + newContent, mentions: new IMention[] { new EveryoneMention() });                                                      //Should ping no one (@everyone was not pinged)
+            await new DiscordMessageBuilder()
+               .WithContent("❌ Everyone(): " + newContent)
+               .HasAllowedMentions(new IMention[] { new EveryoneMention() })
+               .ModifyMessageAsync(test8Msg);                                                                                                                               //Should ping no one (@everyone was not pinged)
         }
     }
 }

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -66,14 +66,42 @@ namespace DSharpPlus.Test
             await ctx.Channel.SendMessageAsync("✔ should ping, ❌ should not ping.");                                                                                           
 
             await ctx.Channel.SendMessageAsync("✔ Default Behaviour: " + content);                                                                                            //Should ping User
-            await ctx.Channel.SendMessageAsync("✔ UserMention(user): " + content, mentions: new IMention[] { new UserMention(user) });                                        //Should ping user
-            await ctx.Channel.SendMessageAsync("✔ UserMention(): " + content, mentions: new IMention[] { new UserMention() });                                                //Should ping user
-            await ctx.Channel.SendMessageAsync("✔ User Mention Everyone & Self: " + content, mentions: new IMention[] { new UserMention(), new UserMention(user) });          //Should ping user
-            await ctx.Channel.SendMessageAsync("✔ UserMention.All: " + content, mentions: new IMention[] { UserMention.All });                                                //Should ping user
-            
-            await ctx.Channel.SendMessageAsync("❌ Empty Mention Array: " + content, mentions: new IMention[0]);                                                               //Should ping no one
-            await ctx.Channel.SendMessageAsync("❌ UserMention(SomeoneElse): " + content, mentions: new IMention[] { new UserMention(545836271960850454L) });                  //Should ping no one (@user was not pinged)
-            await ctx.Channel.SendMessageAsync("❌ Everyone(): " + content, mentions: new IMention[] { new EveryoneMention() });                                               //Should ping no one (@everyone was not pinged)
+
+            await new DiscordMessageBuilder()
+                .WithContent("✔ UserMention(user): " + content)
+                .HasAllowedMentions(new IMention[] { new UserMention(user) })
+                .SendMessageToChannelAsync(ctx.Channel);                                                                                                                      //Should ping user
+
+            await new DiscordMessageBuilder()
+                .WithContent("✔ UserMention(): " + content)
+                .HasAllowedMentions(new IMention[] { new UserMention() })
+                .SendMessageToChannelAsync(ctx.Channel);                                                                                                                      //Should ping user
+
+            await new DiscordMessageBuilder()
+                .WithContent("✔ User Mention Everyone & Self: " + content)
+                .HasAllowedMentions(new IMention[] { new UserMention(), new UserMention(user) })
+                .SendMessageToChannelAsync(ctx.Channel);                                                                                                                      //Should ping user
+
+
+            await new DiscordMessageBuilder()
+               .WithContent("✔ UserMention.All: " + content)
+               .HasAllowedMentions(new IMention[] { UserMention.All })
+               .SendMessageToChannelAsync(ctx.Channel);                                                                                                                       //Should ping user
+
+            await new DiscordMessageBuilder()
+               .WithContent("❌ Empty Mention Array: " + content)
+               .HasAllowedMentions(new IMention[0])
+               .SendMessageToChannelAsync(ctx.Channel);                                                                                                                       //Should ping no one
+
+            await new DiscordMessageBuilder()
+               .WithContent("❌ UserMention(SomeoneElse): " + content)
+               .HasAllowedMentions(new IMention[] { new UserMention(545836271960850454L) })
+               .SendMessageToChannelAsync(ctx.Channel);                                                                                                                       //Should ping no one (@user was not pinged)
+
+            await new DiscordMessageBuilder()
+               .WithContent("❌ Everyone():" + content)
+               .HasAllowedMentions(new IMention[] { new EveryoneMention() })
+               .SendMessageToChannelAsync(ctx.Channel);                                                                                                                       //Should ping no one (@everyone was not pinged)
         }
 
         [Command("editMention"), Description("Attempts to mention a user via edit message")]

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
@@ -158,6 +160,18 @@ namespace DSharpPlus.Test
                .WithContent("❌ Everyone(): " + newContent)
                .HasAllowedMentions(new IMention[] { new EveryoneMention() })
                .ModifyMessageAsync(test8Msg);                                                                                                                               //Should ping no one (@everyone was not pinged)
+        }
+
+        [Command("SendSomeFile")]
+        public async Task SendSomeFile(CommandContext ctx)
+        {
+            using (var fs = new FileStream("ADumbFile.txt", FileMode.Open, FileAccess.Read))
+            {
+                await new DiscordMessageBuilder()
+                    .WithContent("Here is a really dumb file that i am testing with.")
+                    .WithFiles(new Dictionary<string, Stream>() { { "ADumbFile.txt", fs } })
+                    .SendMessageToChannelAsync(ctx.Channel);
+            }
         }
     }
 }

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -169,9 +169,28 @@ namespace DSharpPlus.Test
             {
                 await new DiscordMessageBuilder()
                     .WithContent("Here is a really dumb file that i am testing with.")
-                    .WithFiles(new Dictionary<string, Stream>() { { "ADumbFile.txt", fs } })
+                    .WithFiles(new Dictionary<string, Stream>() { { "ADumbFile1.txt", fs } })
                     .SendAsync(ctx.Channel);
+
+                fs.Position = 0;
+
+                await new DiscordMessageBuilder()
+                    .WithContent("Here is a really dumb file that i am testing with.")
+                    .WithFile(fs)
+                    .SendAsync(ctx.Channel);
+
+                fs.Position = 0;
+
+                await new DiscordMessageBuilder()
+                    .WithContent("Here is a really dumb file that i am testing with.")
+                    .WithFile("ADumbFile2.txt", fs)
+                    .SendAsync(ctx.Channel);               
             }
+
+            await new DiscordMessageBuilder()
+                   .WithContent("Here is a really dumb file that i am testing with.")
+                   .WithFile("./ADumbFile.txt")
+                   .SendAsync(ctx.Channel);
         }
     }
 }

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -71,39 +71,39 @@ namespace DSharpPlus.Test
 
             await new DiscordMessageBuilder()
                 .WithContent("✔ UserMention(user): " + content)
-                .HasAllowedMentions(new IMention[] { new UserMention(user) })
-                .SendMessageToChannelAsync(ctx.Channel);                                                                                                                      //Should ping user
+                .WithAllowedMentions(new IMention[] { new UserMention(user) })
+                .SendAsync(ctx.Channel);                                                                                                                      //Should ping user
 
             await new DiscordMessageBuilder()
                 .WithContent("✔ UserMention(): " + content)
-                .HasAllowedMentions(new IMention[] { new UserMention() })
-                .SendMessageToChannelAsync(ctx.Channel);                                                                                                                      //Should ping user
+                .WithAllowedMentions(new IMention[] { new UserMention() })
+                .SendAsync(ctx.Channel);                                                                                                                      //Should ping user
 
             await new DiscordMessageBuilder()
                 .WithContent("✔ User Mention Everyone & Self: " + content)
-                .HasAllowedMentions(new IMention[] { new UserMention(), new UserMention(user) })
-                .SendMessageToChannelAsync(ctx.Channel);                                                                                                                      //Should ping user
+                .WithAllowedMentions(new IMention[] { new UserMention(), new UserMention(user) })
+                .SendAsync(ctx.Channel);                                                                                                                      //Should ping user
 
 
             await new DiscordMessageBuilder()
                .WithContent("✔ UserMention.All: " + content)
-               .HasAllowedMentions(new IMention[] { UserMention.All })
-               .SendMessageToChannelAsync(ctx.Channel);                                                                                                                       //Should ping user
+               .WithAllowedMentions(new IMention[] { UserMention.All })
+               .SendAsync(ctx.Channel);                                                                                                                       //Should ping user
 
             await new DiscordMessageBuilder()
                .WithContent("❌ Empty Mention Array: " + content)
-               .HasAllowedMentions(new IMention[0])
-               .SendMessageToChannelAsync(ctx.Channel);                                                                                                                       //Should ping no one
+               .WithAllowedMentions(new IMention[0])
+               .SendAsync(ctx.Channel);                                                                                                                       //Should ping no one
 
             await new DiscordMessageBuilder()
                .WithContent("❌ UserMention(SomeoneElse): " + content)
-               .HasAllowedMentions(new IMention[] { new UserMention(545836271960850454L) })
-               .SendMessageToChannelAsync(ctx.Channel);                                                                                                                       //Should ping no one (@user was not pinged)
+               .WithAllowedMentions(new IMention[] { new UserMention(545836271960850454L) })
+               .SendAsync(ctx.Channel);                                                                                                                       //Should ping no one (@user was not pinged)
 
             await new DiscordMessageBuilder()
                .WithContent("❌ Everyone():" + content)
-               .HasAllowedMentions(new IMention[] { new EveryoneMention() })
-               .SendMessageToChannelAsync(ctx.Channel);                                                                                                                       //Should ping no one (@everyone was not pinged)
+               .WithAllowedMentions(new IMention[] { new EveryoneMention() })
+               .SendAsync(ctx.Channel);                                                                                                                       //Should ping no one (@everyone was not pinged)
         }
 
         [Command("editMention"), Description("Attempts to mention a user via edit message")]
@@ -117,49 +117,49 @@ namespace DSharpPlus.Test
             var test1Msg = await ctx.Channel.SendMessageAsync("✔ Default Behaviour: " + origcontent);
             await new DiscordMessageBuilder()
                .WithContent("✔ Default Behaviour: " + newContent)
-               .ModifyMessageAsync(test1Msg);                                                                                                                               //Should ping User
+               .ModifyAsync(test1Msg);                                                                                                                               //Should ping User
 
             var test2Msg = await ctx.Channel.SendMessageAsync("✔ UserMention(user): " + origcontent);      
             await new DiscordMessageBuilder()
                .WithContent("✔ UserMention(user): " + newContent)
-               .HasAllowedMentions(new IMention[] { new UserMention(user) })
-               .ModifyMessageAsync(test2Msg);                                                                                                                               //Should ping user
+               .WithAllowedMentions(new IMention[] { new UserMention(user) })
+               .ModifyAsync(test2Msg);                                                                                                                               //Should ping user
 
             var test3Msg = await ctx.Channel.SendMessageAsync("✔ UserMention(): " + origcontent);
             await new DiscordMessageBuilder()
                .WithContent("✔ UserMention(): " + newContent)
-               .HasAllowedMentions(new IMention[] { new UserMention() })
-               .ModifyMessageAsync(test3Msg);                                                                                                                               //Should ping user
+               .WithAllowedMentions(new IMention[] { new UserMention() })
+               .ModifyAsync(test3Msg);                                                                                                                               //Should ping user
 
             var test4Msg = await ctx.Channel.SendMessageAsync("✔ User Mention Everyone & Self: " + origcontent);
             await new DiscordMessageBuilder()
                .WithContent("✔ User Mention Everyone & Self: " + newContent)
-               .HasAllowedMentions(new IMention[] { new UserMention(), new UserMention(user) })
-               .ModifyMessageAsync(test4Msg);                                                                                                                               //Should ping user
+               .WithAllowedMentions(new IMention[] { new UserMention(), new UserMention(user) })
+               .ModifyAsync(test4Msg);                                                                                                                               //Should ping user
 
             var test5Msg = await ctx.Channel.SendMessageAsync("✔ UserMention.All: " + origcontent);
             await new DiscordMessageBuilder()
                .WithContent("✔ UserMention.All: " + newContent)
-               .HasAllowedMentions(new IMention[] { UserMention.All })
-               .ModifyMessageAsync(test5Msg);                                                                                                                               //Should ping user
+               .WithAllowedMentions(new IMention[] { UserMention.All })
+               .ModifyAsync(test5Msg);                                                                                                                               //Should ping user
 
             var test6Msg = await ctx.Channel.SendMessageAsync("❌ Empty Mention Array: " + origcontent);
             await new DiscordMessageBuilder()
                .WithContent("❌ Empty Mention Array: " + newContent)
-               .HasAllowedMentions(new IMention[0])
-               .ModifyMessageAsync(test6Msg);                                                                                                                               //Should ping no one
+               .WithAllowedMentions(new IMention[0])
+               .ModifyAsync(test6Msg);                                                                                                                               //Should ping no one
 
             var test7Msg = await ctx.Channel.SendMessageAsync("❌ UserMention(SomeoneElse): " + origcontent);
             await new DiscordMessageBuilder()
                .WithContent("❌ UserMention(SomeoneElse): " + newContent)
-               .HasAllowedMentions(new IMention[] { new UserMention(777677298316214324) })
-               .ModifyMessageAsync(test7Msg);                                                                                                                               //Should ping no one (@user was not pinged)
+               .WithAllowedMentions(new IMention[] { new UserMention(777677298316214324) })
+               .ModifyAsync(test7Msg);                                                                                                                               //Should ping no one (@user was not pinged)
 
             var test8Msg = await ctx.Channel.SendMessageAsync("❌ Everyone(): " + origcontent);
             await new DiscordMessageBuilder()
                .WithContent("❌ Everyone(): " + newContent)
-               .HasAllowedMentions(new IMention[] { new EveryoneMention() })
-               .ModifyMessageAsync(test8Msg);                                                                                                                               //Should ping no one (@everyone was not pinged)
+               .WithAllowedMentions(new IMention[] { new EveryoneMention() })
+               .ModifyAsync(test8Msg);                                                                                                                               //Should ping no one (@everyone was not pinged)
         }
 
         [Command("SendSomeFile")]
@@ -170,7 +170,7 @@ namespace DSharpPlus.Test
                 await new DiscordMessageBuilder()
                     .WithContent("Here is a really dumb file that i am testing with.")
                     .WithFiles(new Dictionary<string, Stream>() { { "ADumbFile.txt", fs } })
-                    .SendMessageToChannelAsync(ctx.Channel);
+                    .SendAsync(ctx.Channel);
             }
         }
     }

--- a/DSharpPlus.Test/TestBotDynamicCommands.cs
+++ b/DSharpPlus.Test/TestBotDynamicCommands.cs
@@ -31,7 +31,7 @@ namespace DSharpPlus.Test
             // I hate this
             cs = $"[ModuleLifespan(ModuleLifespan.Transient)]\npublic sealed class DynamicCommands : BaseCommandModule\n{{\n{cs}\n}}";
 
-            msg = await ctx.RespondAsync("", embed: new DiscordEmbedBuilder()
+            msg = await ctx.RespondAsync(new DiscordEmbedBuilder()
                 .WithColor(new DiscordColor("#FF007F"))
                 .WithDescription("Compiling...")
                 .Build()).ConfigureAwait(false);

--- a/DSharpPlus.Test/TestBotEvalCommands.cs
+++ b/DSharpPlus.Test/TestBotEvalCommands.cs
@@ -25,7 +25,7 @@ namespace DSharpPlus.Test
 
             var cs = code.Substring(cs1, cs2 - cs1);
 
-            msg = await ctx.RespondAsync("", embed: new DiscordEmbedBuilder()
+            msg = await ctx.RespondAsync(embed: new DiscordEmbedBuilder()
                 .WithColor(new DiscordColor("#FF007F"))
                 .WithDescription("Evaluating...")
                 .Build()).ConfigureAwait(false);

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -399,7 +399,7 @@ namespace DSharpPlus
         public async Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, DiscordMessageBuilder builder)
         {
             if (builder.Files.Count() > 0)
-                return await this.ApiClient.UploadFilesAsync(channel.Id, builder.Files.GroupBy(g => g.Key).ToDictionary(g => g.Key, g => g.First().Value), builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return await this.ApiClient.UploadFilesAsync(channel.Id, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
             else
                 return await this.ApiClient.CreateMessageAsync(channel.Id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
         }

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -390,6 +390,20 @@ namespace DSharpPlus
         /// Sends a message
         /// </summary>
         /// <param name="channel">Channel to send to.</param>
+        /// <param name="content">Message content to send.</param>
+        /// <param name="embed">Embed to attach to the message.</param>
+        /// <returns>The Discord Message that was sent.</returns>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
+        /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        public Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, string content = null, DiscordEmbed embed = null)
+            => this.ApiClient.CreateMessageAsync(channel.Id, null, null, embed, null);
+
+        /// <summary>
+        /// Sends a message
+        /// </summary>
+        /// <param name="channel">Channel to send to.</param>
         /// <param name="builder">The Discord Mesage builder.</param>
         /// <returns>The Discord Message that was sent.</returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if TTS is false and <see cref="Permissions.SendTtsMessages"/> if TTS is true.</exception>

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -399,7 +399,7 @@ namespace DSharpPlus
         public async Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, DiscordMessageBuilder builder)
         {
             if (builder.Files.Count() > 0)
-                return await this.ApiClient.UploadFilesAsync(channel.Id, builder.Files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return await this.ApiClient.UploadFilesAsync(channel.Id, builder.Files.GroupBy(g => g.Key).ToDictionary(g => g.Key, g => g.First().Value), builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
             else
                 return await this.ApiClient.CreateMessageAsync(channel.Id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
         }

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -365,16 +365,44 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="channel">Channel to send to.</param>
         /// <param name="content">Message content to send.</param>
-        /// <param name="isTTS">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
         /// <returns>The Discord Message that was sent.</returns>
-        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if <paramref name="isTTS"/> is false and <see cref="Permissions.SendTtsMessages"/> if <paramref name="isTTS"/> is true.</exception>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, string content = null, bool isTTS = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-            => this.ApiClient.CreateMessageAsync(channel.Id, content, isTTS, embed, mentions);
+        public Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, string content = null)
+            => this.ApiClient.CreateMessageAsync(channel.Id, content, null, null, null);
+
+        /// <summary>
+        /// Sends a message
+        /// </summary>
+        /// <param name="channel">Channel to send to.</param>
+        /// <param name="embed">Embed to attach to the message.</param>
+        /// <returns>The Discord Message that was sent.</returns>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
+        /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        public Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, DiscordEmbed embed = null)
+            => this.ApiClient.CreateMessageAsync(channel.Id, null, null, embed, null);
+
+        /// <summary>
+        /// Sends a message
+        /// </summary>
+        /// <param name="channel">Channel to send to.</param>
+        /// <param name="builder">The Discord Mesage builder.</param>
+        /// <returns>The Discord Message that was sent.</returns>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if TTS is false and <see cref="Permissions.SendTtsMessages"/> if TTS is true.</exception>
+        /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        public async Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, DiscordMessageBuilder builder)
+        {
+            if (builder.Files.Count() > 0)
+                return await this.ApiClient.UploadFilesAsync(channel.Id, builder.Files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+            else
+                return await this.ApiClient.CreateMessageAsync(channel.Id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+        }
 
         /// <summary>
         /// Creates a guild. This requires the bot to be in less than 10 guilds total.

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -207,6 +207,24 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Sends a message to this channel.
         /// </summary>
+        /// <param name="embed">Embed to attach to the message.</param>
+        /// <param name="content">Content of the message to send.</param>
+        /// <returns>The sent message.</returns>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if TTS is true and <see cref="Permissions.SendTtsMessages"/> if TTS is true.</exception>
+        /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        public Task<DiscordMessage> SendMessageAsync(string content, DiscordEmbed embed)
+        {
+            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
+                throw new ArgumentException("Cannot send a text message to a non-text channel.");
+
+            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, null, embed, null);
+        }
+
+        /// <summary>
+        /// Sends a message to this channel.
+        /// </summary>
         /// <param name="builder">The builder with all the items to send.</param>
         /// <returns>The sent message.</returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission TTS is true and <see cref="Permissions.SendTtsMessages"/> if TTS is true.</exception>

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -175,7 +175,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="content">Content of the message to send.</param>
         /// <returns>The sent message.</returns>
-        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if TTS is true and <see cref="Permissions.SendTtsMessages"/> if <paramref name="tts"/> is true.</exception>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if TTS is true and <see cref="Permissions.SendTtsMessages"/> if TTS is true.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
@@ -192,7 +192,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="embed">Embed to attach to the message.</param>
         /// <returns>The sent message.</returns>
-        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if TTS is true and <see cref="Permissions.SendTtsMessages"/> if <paramref name="tts"/> is true.</exception>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if TTS is true and <see cref="Permissions.SendTtsMessages"/> if TTS is true.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
@@ -209,7 +209,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="builder">The builder with all the items to send.</param>
         /// <returns>The sent message.</returns>
-        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission TTS is true and <see cref="Permissions.SendTtsMessages"/> if <paramref name="tts"/> is true.</exception>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission TTS is true and <see cref="Permissions.SendTtsMessages"/> if TTS is true.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
@@ -217,6 +217,7 @@ namespace DSharpPlus.Entities
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
                 throw new ArgumentException("Cannot send a text message to a non-text channel.");
+
             return this.Discord.ApiClient.CreateMessageAsync(this.Id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
         }
 

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -181,6 +181,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        [Obsolete("Please use the new DiscordMessage Builder.  This method will be removed in a future version", false)]
         public Task<DiscordMessage> SendMessageAsync(string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
@@ -203,6 +204,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        [Obsolete("Please use the new DiscordMessage Builder.  This method will be removed in a future version", false)]
         public Task<DiscordMessage> SendFileAsync(string fileName, Stream fileData, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
@@ -246,6 +248,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        [Obsolete("Please use the new DiscordMessage Builder.  This method will be removed in a future version", false)]
         public async Task<DiscordMessage> SendFileAsync(string filePath, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
@@ -268,6 +271,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        [Obsolete("Please use the new DiscordMessage Builder.  This method will be removed in a future version", false)]
         public Task<DiscordMessage> SendMultipleFilesAsync(Dictionary<string, Stream> files, string content = "", bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
@@ -277,6 +281,31 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             return this.Discord.ApiClient.UploadFilesAsync(this.Id, files, content, tts, embed, mentions);
+        }
+
+        /// <summary>
+        /// Sends a Message.
+        /// </summary>
+        /// <param name="content">The content to send.</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> SendMessageAsync(string content)
+        {
+            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
+                throw new ArgumentException("Cannot send a text message to a non-text channel.");
+
+            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, null, null, null);
+        }
+
+        /// <summary>
+        /// Sends a Message
+        /// </summary>
+        /// <param name="builder">The builder with all the items to send.</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> SendMessageAsync(DiscordMessageBuilder builder)
+        {
+            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
+                throw new ArgumentException("Cannot send a text message to a non-text channel.");
+            return this.Discord.ApiClient.CreateMessageAsync(this.Id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
         }
 
         // Please send memes to Naamloos#2887 at discord <3 thank you

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -169,125 +169,16 @@ namespace DSharpPlus.Entities
         }
 
         #region Methods
+
         /// <summary>
         /// Sends a message to this channel.
         /// </summary>
         /// <param name="content">Content of the message to send.</param>
-        /// <param name="tts">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
         /// <returns>The sent message.</returns>
-        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if <paramref name="tts"/> is false and <see cref="Permissions.SendTtsMessages"/> if <paramref name="tts"/> is true.</exception>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if TTS is true and <see cref="Permissions.SendTtsMessages"/> if <paramref name="tts"/> is true.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        [Obsolete("Please use the new DiscordMessage Builder.  This method will be removed in a future version", false)]
-        public Task<DiscordMessage> SendMessageAsync(string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-        {
-            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a text message to a non-text channel.");
-            
-            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, tts, embed, mentions);
-        }
-
-        /// <summary>
-        /// Sends a message containing an attached file to this channel.
-        /// </summary>
-        /// <param name="fileData">Stream containing the data to attach to the message as a file.</param>
-        /// <param name="fileName">Name of the file to attach to the message.</param>
-        /// <param name="content">Content of the message to send.</param>
-        /// <param name="tts">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
-        /// <returns>The sent message.</returns>
-        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if <paramref name="tts"/> is false and <see cref="Permissions.SendTtsMessages"/> if <paramref name="tts"/> is true.</exception>
-        /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
-        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
-        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        [Obsolete("Please use the new DiscordMessage Builder.  This method will be removed in a future version", false)]
-        public Task<DiscordMessage> SendFileAsync(string fileName, Stream fileData, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-        {
-            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a file to a non-text channel.");
-
-            return this.Discord.ApiClient.UploadFileAsync(this.Id, fileData, fileName, content, tts, embed, mentions);
-        }
-
-        /// <summary>
-        /// Sends a message containing an attached file to this channel.
-        /// </summary>
-        /// <param name="fileData">Stream containing the data to attach to the message as a file.</param>
-        /// <param name="content">Content of the message to send.</param>
-        /// <param name="tts">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
-        /// <returns>The sent message.</returns>
-        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if <paramref name="tts"/> is false and <see cref="Permissions.SendTtsMessages"/> if <paramref name="tts"/> is true.</exception>
-        /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
-        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
-        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordMessage> SendFileAsync(FileStream fileData, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-        {
-            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a file to a non-text channel.");
-            
-            return this.Discord.ApiClient.UploadFileAsync(this.Id, fileData, Path.GetFileName(fileData.Name), content,
-                tts, embed, mentions);
-        }
-
-        /// <summary>
-        /// Sends a message containing an attached file to this channel.
-        /// </summary>
-        /// <param name="filePath">Path to the file to be attached to the message.</param>
-        /// <param name="content">Content of the message to send.</param>
-        /// <param name="tts">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
-        /// <returns>The sent message.</returns>
-        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if <paramref name="tts"/> is false and <see cref="Permissions.SendTtsMessages"/> if <paramref name="tts"/> is true.</exception>
-        /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
-        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
-        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        [Obsolete("Please use the new DiscordMessage Builder.  This method will be removed in a future version", false)]
-        public async Task<DiscordMessage> SendFileAsync(string filePath, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-        {
-            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a file to a non-text channel.");
-
-            using (var fs = File.OpenRead(filePath))
-                return await this.Discord.ApiClient.UploadFileAsync(this.Id, fs, Path.GetFileName(fs.Name), content, tts, embed, mentions).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Sends a message with several attached files to this channel.
-        /// </summary>
-        /// <param name="files">A filename to data stream mapping.</param>
-        /// <param name="content">Content of the message to send.</param>
-        /// <param name="tts">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
-        /// <returns>The sent message.</returns>
-        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if <paramref name="tts"/> is false and <see cref="Permissions.SendTtsMessages"/> if <paramref name="tts"/> is true.</exception>
-        /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
-        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
-        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        [Obsolete("Please use the new DiscordMessage Builder.  This method will be removed in a future version", false)]
-        public Task<DiscordMessage> SendMultipleFilesAsync(Dictionary<string, Stream> files, string content = "", bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-        {
-            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a file to a non-text channel.");
-
-            if (files.Count > 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            return this.Discord.ApiClient.UploadFilesAsync(this.Id, files, content, tts, embed, mentions);
-        }
-
-        /// <summary>
-        /// Sends a Message.
-        /// </summary>
-        /// <param name="content">The content to send.</param>
-        /// <returns></returns>
         public Task<DiscordMessage> SendMessageAsync(string content)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
@@ -297,10 +188,31 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Sends a Message
+        /// Sends a message to this channel.
+        /// </summary>
+        /// <param name="embed">Embed to attach to the message.</param>
+        /// <returns>The sent message.</returns>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission if TTS is true and <see cref="Permissions.SendTtsMessages"/> if <paramref name="tts"/> is true.</exception>
+        /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        public Task<DiscordMessage> SendMessageAsync(DiscordEmbed embed)
+        {
+            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
+                throw new ArgumentException("Cannot send a text message to a non-text channel.");
+
+            return this.Discord.ApiClient.CreateMessageAsync(this.Id, null, null, embed, null);
+        }
+
+        /// <summary>
+        /// Sends a message to this channel.
         /// </summary>
         /// <param name="builder">The builder with all the items to send.</param>
-        /// <returns></returns>
+        /// <returns>The sent message.</returns>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission TTS is true and <see cref="Permissions.SendTtsMessages"/> if <paramref name="tts"/> is true.</exception>
+        /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(DiscordMessageBuilder builder)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -219,7 +219,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send a text message to a non-text channel.");
 
             if (builder.Files.Count() > 0)
-                return this.Discord.ApiClient.UploadFilesAsync(this.Id, builder.Files.GroupBy(g => g.Key).ToDictionary(g => g.Key, g => g.First().Value), builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return this.Discord.ApiClient.UploadFilesAsync(this.Id, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
             else
                 return this.Discord.ApiClient.CreateMessageAsync(this.Id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
         }

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -218,7 +218,10 @@ namespace DSharpPlus.Entities
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
                 throw new ArgumentException("Cannot send a text message to a non-text channel.");
 
-            return this.Discord.ApiClient.CreateMessageAsync(this.Id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+            if (builder.Files.Count() > 0)
+                return this.Discord.ApiClient.UploadFilesAsync(this.Id, builder.Files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+            else
+                return this.Discord.ApiClient.CreateMessageAsync(this.Id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
         }
 
         // Please send memes to Naamloos#2887 at discord <3 thank you

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -219,7 +219,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send a text message to a non-text channel.");
 
             if (builder.Files.Count() > 0)
-                return this.Discord.ApiClient.UploadFilesAsync(this.Id, builder.Files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return this.Discord.ApiClient.UploadFilesAsync(this.Id, builder.Files.GroupBy(g => g.Key).ToDictionary(g => g.Key, g => g.First().Value), builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
             else
                 return this.Discord.ApiClient.CreateMessageAsync(this.Id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
         }

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -293,6 +293,25 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Sends a direct message to this member. Creates a direct message channel if one does not exist already.
         /// </summary>
+        /// <param name="content">Content of the message to send.</param>
+        /// <param name="embed">Embed to attach to the message.</param>
+        /// <returns>The sent message.</returns>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the member has the bot blocked, the member is no longer in the guild, or if the member has Allow DM from server members off.</exception>
+        /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        public async Task<DiscordMessage> SendMessageAsync(string content, DiscordEmbed embed)
+        {
+            if (this.IsBot && this.Discord.CurrentUser.IsBot)
+                throw new ArgumentException("Bots cannot DM each other.");
+
+            var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
+            return await chn.SendMessageAsync(content, embed).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Sends a direct message to this member. Creates a direct message channel if one does not exist already.
+        /// </summary>
         /// <param name="message">Builder to with the message.</param>
         /// <returns>The sent message.</returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the member has the bot blocked, the member is no longer in the guild, or if the member has Allow DM from server members off.</exception>

--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -258,105 +258,54 @@ namespace DSharpPlus.Entities
         /// Sends a direct message to this member. Creates a direct message channel if one does not exist already.
         /// </summary>
         /// <param name="content">Content of the message to send.</param>
-        /// <param name="is_tts">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
         /// <returns>The sent message.</returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the member has the bot blocked, the member is no longer in the guild, or if the member has Allow DM from server members off.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public async Task<DiscordMessage> SendMessageAsync(string content = null, bool is_tts = false, DiscordEmbed embed = null)
+        public async Task<DiscordMessage> SendMessageAsync(string content)
         {
             if (this.IsBot && this.Discord.CurrentUser.IsBot)
                 throw new ArgumentException("Bots cannot DM each other.");
             
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
-            return await chn.SendMessageAsync(content, is_tts, embed).ConfigureAwait(false);
+            return await chn.SendMessageAsync(content).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Sends a direct message with a file attached to this member. Creates a direct message channel if one does not exist already.
+        /// Sends a direct message to this member. Creates a direct message channel if one does not exist already.
         /// </summary>
-        /// <param name="fileData">Stream containing the data to attach as a file.</param>
-        /// <param name="fileName">Name of the file to attach.</param>
-        /// <param name="content">Content of the message to send.</param>
-        /// <param name="is_tts">Whether the message is to be read using TTS.</param>
         /// <param name="embed">Embed to attach to the message.</param>
         /// <returns>The sent message.</returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the member has the bot blocked, the member is no longer in the guild, or if the member has Allow DM from server members off.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public async Task<DiscordMessage> SendFileAsync(string fileName, Stream fileData, string content = null, bool is_tts = false, DiscordEmbed embed = null)
+        public async Task<DiscordMessage> SendMessageAsync(DiscordEmbed embed)
         {
             if (this.IsBot && this.Discord.CurrentUser.IsBot)
                 throw new ArgumentException("Bots cannot DM each other.");
-            
+
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
-            return await chn.SendFileAsync(fileName, fileData, content, is_tts, embed).ConfigureAwait(false);
+            return await chn.SendMessageAsync(embed).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Sends a direct message with a file attached to this member. Creates a direct message channel if one does not exist already.
+        /// Sends a direct message to this member. Creates a direct message channel if one does not exist already.
         /// </summary>
-        /// <param name="fileData">Stream containing the data to attach as a file.</param>
-        /// <param name="content">Content of the message to send.</param>
-        /// <param name="is_tts">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
+        /// <param name="message">Builder to with the message.</param>
         /// <returns>The sent message.</returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the member has the bot blocked, the member is no longer in the guild, or if the member has Allow DM from server members off.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public async Task<DiscordMessage> SendFileAsync(FileStream fileData, string content = null, bool is_tts = false, DiscordEmbed embed = null)
+        public async Task<DiscordMessage> SendMessageAsync(DiscordMessageBuilder message)
         {
             if (this.IsBot && this.Discord.CurrentUser.IsBot)
                 throw new ArgumentException("Bots cannot DM each other.");
 
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
-            return await chn.SendFileAsync(fileData, content, is_tts, embed).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Sends a direct message with a file attached to this member. Creates a direct message channel if one does not exist already.
-        /// </summary>
-        /// <param name="filePath">Path to the file to attach to the message.</param>
-        /// <param name="content">Content of the message to send.</param>
-        /// <param name="is_tts">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <returns>The sent message.</returns>
-        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the member has the bot blocked, the member is no longer in the guild, or if the member has Allow DM from server members off.</exception>
-        /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
-        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
-        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public async Task<DiscordMessage> SendFileAsync(string filePath, string content = null, bool is_tts = false, DiscordEmbed embed = null)
-        {
-            if (this.IsBot && this.Discord.CurrentUser.IsBot)
-                throw new ArgumentException("Bots cannot DM each other.");
-
-            var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
-            return await chn.SendFileAsync(filePath, content, is_tts, embed).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Sends a direct message with several files attached to this member. Creates a direct message channel if one does not exist already.
-        /// </summary>
-        /// <param name="files">Dictionary of filename to data stream containing the data to upload as files.</param>
-        /// <param name="content">Content of the message to send.</param>
-        /// <param name="is_tts">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <returns>The sent message.</returns>
-        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the member has the bot blocked, the member is no longer in the guild, or if the member has Allow DM from server members off.</exception>
-        /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
-        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
-        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public async Task<DiscordMessage> SendMultipleFilesAsync(Dictionary<string, Stream> files, string content = null, bool is_tts = false, DiscordEmbed embed = null)
-        {
-            if (this.IsBot && this.Discord.CurrentUser.IsBot)
-                throw new ArgumentException("Bots cannot DM each other.");
-
-            var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
-            return await chn.SendMultipleFilesAsync(files, content, is_tts, embed).ConfigureAwait(false);
+            return await chn.SendMessageAsync(message).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -465,83 +465,10 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMessage> RespondAsync(DiscordMessageBuilder builder)
         {
             if (builder.Files.Count() > 0)
-                return await this.Discord.ApiClient.UploadFilesAsync(this.ChannelId, builder.Files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return await this.Discord.ApiClient.UploadFilesAsync(this.ChannelId, builder.Files.GroupBy(g => g.Key).ToDictionary(g => g.Key, g=> g.First().Value), builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
             else
                 return await this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
         }
-
-        ///// <summary>
-        ///// Responds to the message with a file.
-        ///// </summary>
-        ///// <param name="fileName">Name of the file to be attached.</param>
-        ///// <param name="fileData">Stream containing the data to attach to the message as a file.</param>
-        ///// <param name="content">Message content to respond with.</param>
-        ///// <param name="tts">Whether the message is to be read using TTS.</param>
-        ///// <param name="embed">Embed to attach to the message.</param>
-        ///// <param name="mentions">Allowed mentions in the message</param>
-        ///// <returns>The sent message.</returns>
-        ///// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
-        ///// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
-        ///// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
-        ///// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        //public Task<DiscordMessage> RespondWithFileAsync(string fileName, Stream fileData, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-        //    => this.Discord.ApiClient.UploadFileAsync(this.ChannelId, fileData, fileName, content, tts, embed, mentions);
-
-        ///// <summary>
-        ///// Responds to the message with a file.
-        ///// </summary>
-        ///// <param name="fileData">Stream containing the data to attach to the message as a file.</param>
-        ///// <param name="content">Message content to respond with.</param>
-        ///// <param name="tts">Whether the message is to be read using TTS.</param>
-        ///// <param name="embed">Embed to attach to the message.</param>
-        ///// <param name="mentions">Allowed mentions in the message</param>
-        ///// <returns>The sent message.</returns>
-        ///// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
-        ///// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
-        ///// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
-        ///// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        //public Task<DiscordMessage> RespondWithFileAsync(FileStream fileData, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-        //    => this.Discord.ApiClient.UploadFileAsync(this.ChannelId, fileData, Path.GetFileName(fileData.Name), content, tts, embed, mentions);
-
-        ///// <summary>
-        ///// Responds to the message with a file.
-        ///// </summary>
-        ///// <param name="filePath">Path to the file to be attached to the message.</param>
-        ///// <param name="content">Message content to respond with.</param>
-        ///// <param name="tts">Whether the message is to be read using TTS.</param>
-        ///// <param name="embed">Embed to attach to the message.</param>
-        ///// <param name="mentions">Allowed mentions in the message</param>
-        ///// <returns>The sent message.</returns>
-        ///// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
-        ///// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
-        ///// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
-        ///// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        //public async Task<DiscordMessage> RespondWithFileAsync(string filePath, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-        //{
-        //    using (var fs = File.OpenRead(filePath))
-        //        return await this.Discord.ApiClient.UploadFileAsync(this.ChannelId, fs, Path.GetFileName(fs.Name), content, tts, embed, mentions).ConfigureAwait(false);
-        //}
-
-        ///// <summary>
-        ///// Responds to the message with several files.
-        ///// </summary>
-        ///// <param name="files">A filename to data stream mapping.</param>
-        ///// <param name="content">Message content to respond with.</param>
-        ///// <param name="tts">Whether the message is to be read using TTS.</param>
-        ///// <param name="embed">Embed to attach to the message.</param>
-        ///// <param name="mentions">Allowed mentions in the message</param>
-        ///// <returns>The sent message.</returns>
-        ///// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
-        ///// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
-        ///// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
-        ///// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        //public Task<DiscordMessage> RespondWithFilesAsync(Dictionary<string, Stream> files, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-        //{
-        //    if (files.Count > 10)
-        //        throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-        //    return this.Discord.ApiClient.UploadFilesAsync(this.ChannelId, files, content, tts, embed, mentions);
-        //}
 
         /// <summary>
         /// Creates a reaction to this message

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -347,15 +347,42 @@ namespace DSharpPlus.Entities
         /// Edits the message.
         /// </summary>
         /// <param name="content">New content.</param>
-        /// <param name="embed">New embed.</param>
-        /// <param name="mentions">Allowed mentions in the message.</param>
         /// <returns></returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client tried to modify a message not sent by them.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordMessage> ModifyAsync(Optional<string> content = default, Optional<DiscordEmbed> embed = default, IEnumerable<IMention> mentions = null) 
-            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, embed, mentions);
+        public Task<DiscordMessage> ModifyAsync(Optional<string> content) 
+            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, default, default);
+
+        /// <summary>
+        /// Edits the message.
+        /// </summary>
+        /// <param name="embed">New embed.</param>
+        /// <returns></returns>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client tried to modify a message not sent by them.</exception>
+        /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        public Task<DiscordMessage> ModifyAsync(Optional<DiscordEmbed> embed = default)
+            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, default, embed, default);
+
+        /// <summary>
+        /// Edits the message.
+        /// </summary>
+        /// <param name="builder">The builder of the message to edit.</param>
+        /// <returns></returns>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client tried to modify a message not sent by them.</exception>
+        /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        public async Task<DiscordMessage> ModifyAsync(DiscordMessageBuilder builder)
+        {
+            if (builder.Files.Any())
+                throw new ArgumentException("You cannot add files when modifing a message.");
+
+            return await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, builder.Content, builder.Embed, builder.Mentions);
+        }
 
         /// <summary>
         /// Deletes the message.

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -406,89 +406,115 @@ namespace DSharpPlus.Entities
         /// Responds to the message.
         /// </summary>
         /// <param name="content">Message content to respond with.</param>
-        /// <param name="tts">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
         /// <returns>The sent message.</returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordMessage> RespondAsync(string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null) 
-            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, content, tts, embed, mentions);
+        public Task<DiscordMessage> RespondAsync(string content) 
+            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, content, null, null, null);
 
         /// <summary>
-        /// Responds to the message with a file.
+        /// Responds to the message.
         /// </summary>
-        /// <param name="fileName">Name of the file to be attached.</param>
-        /// <param name="fileData">Stream containing the data to attach to the message as a file.</param>
-        /// <param name="content">Message content to respond with.</param>
-        /// <param name="tts">Whether the message is to be read using TTS.</param>
         /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
         /// <returns>The sent message.</returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordMessage> RespondWithFileAsync(string fileName, Stream fileData, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-            => this.Discord.ApiClient.UploadFileAsync(this.ChannelId, fileData, fileName, content, tts, embed, mentions);
+        public Task<DiscordMessage> RespondAsync(DiscordEmbed embed)
+            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, null, null, embed, null);
 
         /// <summary>
-        /// Responds to the message with a file.
+        /// Responds to the message.
         /// </summary>
-        /// <param name="fileData">Stream containing the data to attach to the message as a file.</param>
-        /// <param name="content">Message content to respond with.</param>
-        /// <param name="tts">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
+        /// <param name="builder">The Discord Mesage builder.</param>
         /// <returns>The sent message.</returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordMessage> RespondWithFileAsync(FileStream fileData, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-            => this.Discord.ApiClient.UploadFileAsync(this.ChannelId, fileData, Path.GetFileName(fileData.Name), content, tts, embed, mentions);
-
-        /// <summary>
-        /// Responds to the message with a file.
-        /// </summary>
-        /// <param name="filePath">Path to the file to be attached to the message.</param>
-        /// <param name="content">Message content to respond with.</param>
-        /// <param name="tts">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
-        /// <returns>The sent message.</returns>
-        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
-        /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
-        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
-        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public async Task<DiscordMessage> RespondWithFileAsync(string filePath, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
+        public async Task<DiscordMessage> RespondAsync(DiscordMessageBuilder builder)
         {
-            using (var fs = File.OpenRead(filePath))
-                return await this.Discord.ApiClient.UploadFileAsync(this.ChannelId, fs, Path.GetFileName(fs.Name), content, tts, embed, mentions).ConfigureAwait(false);
+            if (builder.Files.Count() > 0)
+                return await this.Discord.ApiClient.UploadFilesAsync(this.ChannelId, builder.Files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+            else
+                return await this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
         }
 
-        /// <summary>
-        /// Responds to the message with several files.
-        /// </summary>
-        /// <param name="files">A filename to data stream mapping.</param>
-        /// <param name="content">Message content to respond with.</param>
-        /// <param name="tts">Whether the message is to be read using TTS.</param>
-        /// <param name="embed">Embed to attach to the message.</param>
-        /// <param name="mentions">Allowed mentions in the message</param>
-        /// <returns>The sent message.</returns>
-        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
-        /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
-        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
-        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordMessage> RespondWithFilesAsync(Dictionary<string, Stream> files, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
-        {
-            if (files.Count > 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
+        ///// <summary>
+        ///// Responds to the message with a file.
+        ///// </summary>
+        ///// <param name="fileName">Name of the file to be attached.</param>
+        ///// <param name="fileData">Stream containing the data to attach to the message as a file.</param>
+        ///// <param name="content">Message content to respond with.</param>
+        ///// <param name="tts">Whether the message is to be read using TTS.</param>
+        ///// <param name="embed">Embed to attach to the message.</param>
+        ///// <param name="mentions">Allowed mentions in the message</param>
+        ///// <returns>The sent message.</returns>
+        ///// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
+        ///// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
+        ///// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        ///// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        //public Task<DiscordMessage> RespondWithFileAsync(string fileName, Stream fileData, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
+        //    => this.Discord.ApiClient.UploadFileAsync(this.ChannelId, fileData, fileName, content, tts, embed, mentions);
 
-            return this.Discord.ApiClient.UploadFilesAsync(this.ChannelId, files, content, tts, embed, mentions);
-        }
+        ///// <summary>
+        ///// Responds to the message with a file.
+        ///// </summary>
+        ///// <param name="fileData">Stream containing the data to attach to the message as a file.</param>
+        ///// <param name="content">Message content to respond with.</param>
+        ///// <param name="tts">Whether the message is to be read using TTS.</param>
+        ///// <param name="embed">Embed to attach to the message.</param>
+        ///// <param name="mentions">Allowed mentions in the message</param>
+        ///// <returns>The sent message.</returns>
+        ///// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
+        ///// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
+        ///// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        ///// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        //public Task<DiscordMessage> RespondWithFileAsync(FileStream fileData, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
+        //    => this.Discord.ApiClient.UploadFileAsync(this.ChannelId, fileData, Path.GetFileName(fileData.Name), content, tts, embed, mentions);
+
+        ///// <summary>
+        ///// Responds to the message with a file.
+        ///// </summary>
+        ///// <param name="filePath">Path to the file to be attached to the message.</param>
+        ///// <param name="content">Message content to respond with.</param>
+        ///// <param name="tts">Whether the message is to be read using TTS.</param>
+        ///// <param name="embed">Embed to attach to the message.</param>
+        ///// <param name="mentions">Allowed mentions in the message</param>
+        ///// <returns>The sent message.</returns>
+        ///// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
+        ///// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
+        ///// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        ///// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        //public async Task<DiscordMessage> RespondWithFileAsync(string filePath, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
+        //{
+        //    using (var fs = File.OpenRead(filePath))
+        //        return await this.Discord.ApiClient.UploadFileAsync(this.ChannelId, fs, Path.GetFileName(fs.Name), content, tts, embed, mentions).ConfigureAwait(false);
+        //}
+
+        ///// <summary>
+        ///// Responds to the message with several files.
+        ///// </summary>
+        ///// <param name="files">A filename to data stream mapping.</param>
+        ///// <param name="content">Message content to respond with.</param>
+        ///// <param name="tts">Whether the message is to be read using TTS.</param>
+        ///// <param name="embed">Embed to attach to the message.</param>
+        ///// <param name="mentions">Allowed mentions in the message</param>
+        ///// <returns>The sent message.</returns>
+        ///// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
+        ///// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
+        ///// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        ///// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        //public Task<DiscordMessage> RespondWithFilesAsync(Dictionary<string, Stream> files, string content = null, bool tts = false, DiscordEmbed embed = null, IEnumerable<IMention> mentions = null)
+        //{
+        //    if (files.Count > 10)
+        //        throw new ArgumentException("Cannot send more than 10 files with a single message.");
+
+        //    return this.Discord.ApiClient.UploadFilesAsync(this.ChannelId, files, content, tts, embed, mentions);
+        //}
 
         /// <summary>
         /// Creates a reaction to this message

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -370,6 +370,19 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Edits the message.
         /// </summary>
+        /// <param name="content">New content.</param>
+        /// <param name="embed">New embed.</param>
+        /// <returns></returns>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client tried to modify a message not sent by them.</exception>
+        /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        public Task<DiscordMessage> ModifyAsync(Optional<string> content, Optional<DiscordEmbed> embed = default)
+            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, embed, default);
+
+        /// <summary>
+        /// Edits the message.
+        /// </summary>
         /// <param name="builder">The builder of the message to edit.</param>
         /// <returns></returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client tried to modify a message not sent by them.</exception>

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -456,6 +456,19 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Responds to the message.
         /// </summary>
+        /// <param name="content">Message content to respond with.</param>
+        /// <param name="embed">Embed to attach to the message.</param>
+        /// <returns>The sent message.</returns>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>
+        /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        public Task<DiscordMessage> RespondAsync(string content, DiscordEmbed embed)
+            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, content, null, embed, null);
+
+        /// <summary>
+        /// Responds to the message.
+        /// </summary>
         /// <param name="builder">The Discord Mesage builder.</param>
         /// <returns>The sent message.</returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.SendMessages"/> permission.</exception>

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -465,7 +465,7 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMessage> RespondAsync(DiscordMessageBuilder builder)
         {
             if (builder.Files.Count() > 0)
-                return await this.Discord.ApiClient.UploadFilesAsync(this.ChannelId, builder.Files.GroupBy(g => g.Key).ToDictionary(g => g.Key, g=> g.First().Value), builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return await this.Discord.ApiClient.UploadFilesAsync(this.ChannelId, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
             else
                 return await this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
         }

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -22,7 +22,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets if the message should be TTS.
         /// </summary>
-        public bool IsTTS { get; private set; }
+        public bool IsTTS { get; private set; } = false;
 
         /// <summary>
         /// Gets the Allowed Mentions for the message to be sent. 
@@ -32,7 +32,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the Files to be sent in the Message.
         /// </summary>
-        public Dictionary<string, Stream> Files { get; private set; }
+        public Dictionary<string, Stream> Files { get; private set; } = new Dictionary<string, Stream>();
 
         /// <summary>
         /// Sets the Content of the Message.

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -1,47 +1,38 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace DSharpPlus.Entities
 {
+    /// <summary>
+    /// Constructs a Message to be sent.
+    /// </summary>
     public sealed class DiscordMessageBuilder
     {
         /// <summary>
         /// Gets the Message to be sent.
         /// </summary>
-        public string Content { get => _content; private set => _content = value; }
-
-        private string _content;
+        public string Content { get; private set; }
 
         /// <summary>
         /// Gets the Embed to be sent.
         /// </summary>
-        public DiscordEmbedBuilder Embed { get => _embed; private set => _embed = value; }
-
-        private DiscordEmbedBuilder _embed;
+        public DiscordEmbed Embed { get; private set; }
 
         /// <summary>
         /// Gets if the message should be TTS.
         /// </summary>
-        public bool IsTTS { get => _isTTS; private set => _isTTS = value; }
-
-        private bool _isTTS = false;
+        public bool IsTTS { get; private set; }
 
         /// <summary>
         /// Gets the Allowed Mentions for the message to be sent. 
         /// </summary>
-        public IEnumerable<IMention> Mentions { get => _mentions; private set => _mentions = value; }
-
-        private IEnumerable<IMention> _mentions;
+        public IEnumerable<IMention> Mentions { get; private set; }
 
         /// <summary>
         /// Gets the Files to be sent in the Message.
         /// </summary>
-        public Dictionary<string, Stream> Files { get => _files; private set => _files = value; }
-
-        private Dictionary<string, Stream> _files;
+        public Dictionary<string, Stream> Files { get; private set; }
 
         /// <summary>
         /// Sets the Content of the Message.
@@ -68,18 +59,18 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Sets if the message will have an Embed.
         /// </summary>
-        /// <param name="embedBuilder"></param>
+        /// <param name="embed">The embed that should be sent.</param>
         /// <returns></returns>
-        public DiscordMessageBuilder WithEmbed(DiscordEmbedBuilder embedBuilder)
+        public DiscordMessageBuilder WithEmbed(DiscordEmbed embed)
         {
-            this.Embed = embedBuilder;
+            this.Embed = embed;
             return this;
         }
 
         /// <summary>
         /// Sets if the message has allowed mentions.
         /// </summary>
-        /// <param name="allowedMentions"></param>
+        /// <param name="allowedMentions">The allowed Mentions that should be sent.</param>
         /// <returns></returns>
         public DiscordMessageBuilder HasAllowedMentions(IEnumerable<IMention> allowedMentions)
         {
@@ -90,7 +81,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Sets if the message has files to be sent.
         /// </summary>
-        /// <param name="files"></param>
+        /// <param name="files">The Files that should be sent.</param>
         /// <returns></returns>
         public DiscordMessageBuilder WithFiles(Dictionary<string, Stream> files)
         {
@@ -101,12 +92,11 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Sends the Message to a specific channel
         /// </summary>
-        /// <param name="channel">The c</param>
+        /// <param name="channel">The channel the message should be sent to.</param>
         /// <returns></returns>
-        public async Task SendMessageToChannel(DiscordChannel channel)
+        public async Task<DiscordMessage> SendMessageToChannelAsync(DiscordChannel channel)
         {
-            await channel.SendMessageAsync(this);
+            return await channel.SendMessageAsync(this);
         }
-
     }
 }

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -44,7 +45,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the Files to be sent in the Message.
         /// </summary>
-        public Dictionary<string, Stream> Files { get; private set; } = new Dictionary<string, Stream>();
+        public IReadOnlyDictionary<string, Stream> Files => this._files;
 
         /// <summary>
         /// Sets the Content of the Message.
@@ -109,6 +110,8 @@ namespace DSharpPlus.Entities
             return this;
         }
 
+        private Dictionary<string, Stream> _files = new Dictionary<string, Stream>();        
+
         /// <summary>
         /// Sets if the message has files to be sent.
         /// </summary>
@@ -117,9 +120,10 @@ namespace DSharpPlus.Entities
         /// <returns></returns>
         public DiscordMessageBuilder WithFile(string fileName, Stream stream)
         {
-            if(this.Files.Count() + 1 > 10)
+            if(this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
-            this.Files.Add(fileName, stream);
+
+            this._files.Add(fileName, stream);
 
             return this;
         }
@@ -131,10 +135,10 @@ namespace DSharpPlus.Entities
         /// <returns></returns>
         public DiscordMessageBuilder WithFile(FileStream stream)
         {
-            if (this.Files.Count() + 1 > 10)
+            if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this.Files.Add(stream.Name, stream);
+            this._files.Add(stream.Name, stream);
 
             return this;
         }
@@ -146,11 +150,11 @@ namespace DSharpPlus.Entities
         /// <returns></returns>
         public DiscordMessageBuilder WithFile(string filePath)
         {
-            if (this.Files.Count() + 1 > 10)
+            if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             var fs = File.OpenRead(filePath);
-            this.Files.Add(fs.Name, fs);
+            this._files.Add(fs.Name, fs);
 
             return this;
         }
@@ -162,10 +166,12 @@ namespace DSharpPlus.Entities
         /// <returns></returns>
         public DiscordMessageBuilder WithFiles(Dictionary<string, Stream> files)
         {
-            if (this.Files.Count() + files.Count() > 10)
+            if (this.Files.Count() + files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this.Files = files;
+            foreach (var file in files)
+                this._files.Add(file.Key, file.Value);
+
             return this;
         }
 

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -98,5 +98,15 @@ namespace DSharpPlus.Entities
         {
             return await channel.SendMessageAsync(this);
         }
+
+        /// <summary>
+        /// Sends the modified message.
+        /// </summary>
+        /// <param name="msg">The original Message to modify.</param>
+        /// <returns></returns>
+        public async Task<DiscordMessage> ModifyMessageAsync(DiscordMessage msg)
+        {
+            return await msg.ModifyAsync(this);
+        }
     }
 }

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DSharpPlus.Entities
+{
+    public sealed class DiscordMessageBuilder
+    {
+        /// <summary>
+        /// Gets the Message to be sent.
+        /// </summary>
+        public string Content { get => _content; private set => _content = value; }
+
+        private string _content;
+
+        /// <summary>
+        /// Gets the Embed to be sent.
+        /// </summary>
+        public DiscordEmbedBuilder Embed { get => _embed; private set => _embed = value; }
+
+        private DiscordEmbedBuilder _embed;
+
+        /// <summary>
+        /// Gets if the message should be TTS.
+        /// </summary>
+        public bool IsTTS { get => _isTTS; private set => _isTTS = value; }
+
+        private bool _isTTS = false;
+
+        /// <summary>
+        /// Gets the Allowed Mentions for the message to be sent. 
+        /// </summary>
+        public IEnumerable<IMention> Mentions { get => _mentions; private set => _mentions = value; }
+
+        private IEnumerable<IMention> _mentions;
+
+        /// <summary>
+        /// Gets the Files to be sent in the Message.
+        /// </summary>
+        public Dictionary<string, Stream> Files { get => _files; private set => _files = value; }
+
+        private Dictionary<string, Stream> _files;
+
+        /// <summary>
+        /// Sets the Content of the Message.
+        /// </summary>
+        /// <param name="content">The content to be set.</param>
+        /// <returns></returns>
+        public DiscordMessageBuilder WithContent(string content)
+        {
+            this.Content = content;
+            return this;
+        } 
+
+        /// <summary>
+        /// Sets if the message should be TTS.
+        /// </summary>
+        /// <param name="isTTS">If TTS should be set.</param>
+        /// <returns></returns>
+        public DiscordMessageBuilder HasTTS(bool isTTS)
+        {
+            this.IsTTS = isTTS;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets if the message will have an Embed.
+        /// </summary>
+        /// <param name="embedBuilder"></param>
+        /// <returns></returns>
+        public DiscordMessageBuilder WithEmbed(DiscordEmbedBuilder embedBuilder)
+        {
+            this.Embed = embedBuilder;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets if the message has allowed mentions.
+        /// </summary>
+        /// <param name="allowedMentions"></param>
+        /// <returns></returns>
+        public DiscordMessageBuilder HasAllowedMentions(IEnumerable<IMention> allowedMentions)
+        {
+            this.Mentions = allowedMentions;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets if the message has files to be sent.
+        /// </summary>
+        /// <param name="files"></param>
+        /// <returns></returns>
+        public DiscordMessageBuilder WithFiles(Dictionary<string, Stream> files)
+        {
+            this.Files = files;
+            return this;
+        }
+
+        /// <summary>
+        /// Sends the Message to a specific channel
+        /// </summary>
+        /// <param name="channel">The c</param>
+        /// <returns></returns>
+        public async Task SendMessageToChannel(DiscordChannel channel)
+        {
+            await channel.SendMessageAsync(this);
+        }
+
+    }
+}

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -72,7 +72,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="allowedMentions">The allowed Mentions that should be sent.</param>
         /// <returns></returns>
-        public DiscordMessageBuilder HasAllowedMentions(IEnumerable<IMention> allowedMentions)
+        public DiscordMessageBuilder WithAllowedMentions(IEnumerable<IMention> allowedMentions)
         {
             this.Mentions = allowedMentions;
             return this;
@@ -94,7 +94,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="channel">The channel the message should be sent to.</param>
         /// <returns></returns>
-        public async Task<DiscordMessage> SendMessageToChannelAsync(DiscordChannel channel)
+        public async Task<DiscordMessage> SendAsync(DiscordChannel channel)
         {
             return await channel.SendMessageAsync(this);
         }
@@ -104,7 +104,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="msg">The original Message to modify.</param>
         /// <returns></returns>
-        public async Task<DiscordMessage> ModifyMessageAsync(DiscordMessage msg)
+        public async Task<DiscordMessage> ModifyAsync(DiscordMessage msg)
         {
             return await msg.ModifyAsync(this);
         }

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -47,6 +47,8 @@ namespace DSharpPlus.Entities
         /// </summary>
         public IReadOnlyDictionary<string, Stream> Files => this._files;
 
+        internal Dictionary<string, Stream> _files = new Dictionary<string, Stream>();
+
         /// <summary>
         /// Sets the Content of the Message.
         /// </summary>
@@ -108,9 +110,7 @@ namespace DSharpPlus.Entities
                 this.Mentions = allowedMentions.ToList();
 
             return this;
-        }
-
-        private Dictionary<string, Stream> _files = new Dictionary<string, Stream>();        
+        }               
 
         /// <summary>
         /// Sets if the message has files to be sent.


### PR DESCRIPTION
# Summary
With the amount of params being added to SendMessageAsync (and soon more for inline replies) and also the ones specific for Files, I believe it is time to start considering a Builder for sending and Modifying Messages. 

# Changes proposed
* Removes all Public SendMessageAsync and SendFilesAsync Methods
* Replaces the above with 3 Methods
    * SendMessageAsync(string content)
    * SendMessageAsync(DiscordEmbed embed)
    * SendMessageAsync(DiscordMessageBuilder builder)
