### PR TITLE
Updated stop time JSON variable to match Lavalink code.

### DIFF
--- a/DSharpPlus.Lavalink/Entities/LavalinkCommands.cs
+++ b/DSharpPlus.Lavalink/Entities/LavalinkCommands.cs
@@ -47,7 +47,7 @@ namespace DSharpPlus.Lavalink.Entities
         [JsonProperty("startTime")]
         public long StartTime { get; }
 
-        [JsonProperty("stopTime")]
+        [JsonProperty("endTime")]
         public long StopTime { get; }
 
         public LavalinkPlayPartial(LavalinkGuildConnection lvl, LavalinkTrack track, TimeSpan start, TimeSpan stop)


### PR DESCRIPTION
# Summary
Fixes #696 

# Details
Changed `StopTime` `JsonProperty` from `stopTime` to `endTime`.

# Changes proposed
* Changed `StopTime` JSON property name to match with Lavalinks code.