### PR TITLE
fix: Prevent Guild Cache Error Being Called for Current User

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -533,12 +533,13 @@ namespace DSharpPlus
 
         internal DiscordGuild InternalGetCachedGuild(ulong? guildId)
         {
-            DiscordGuild foundGuild = default;
+            if(this._guilds != null && guildId.HasValue)
+            {
+                if (this._guilds.TryGetValue(guildId.Value, out var guild))
+                    return guild;
+            }
 
-            if (guildId.HasValue)
-                foundGuild = this._guilds?[guildId.Value];
-
-            return foundGuild;
+            return null;
         }
 
         private void UpdateMessage(DiscordMessage message, TransportUser author, DiscordGuild guild, TransportMember member)


### PR DESCRIPTION
# Summary
Ensures that the appropriate events are handled correctly when the current user leaves a guild.

# Details
When the bot leaves a guild, other events such as `guild integrations update` and `guild member removed` are fired either before or after `guild deleted`. This can lead to inconsistent state where the guild is already removed from the internal cache but the other events that rely on the guild from the cache are fired afterwards, leading to some socket errors. This PR solves this issue by ignoring the guild integrations update event if the guild is not found and also won't display the log error message 

# Changes proposed
* Ignore the guild integration update event if the guild can't be retrieved from cache
* Don't display the guild cache error message if it's the current user that left.