### PR TITLE
fix: Prevent potential nullrefs on channel update event.

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -511,30 +511,31 @@ namespace DSharpPlus
                     IsNSFW = channel_new.IsNSFW,
                     PerUserRateLimit = channel_new.PerUserRateLimit
                 };
+
+                channel_new.Bitrate = channel.Bitrate;
+                channel_new.Name = channel.Name;
+                channel_new.Position = channel.Position;
+                channel_new.Topic = channel.Topic;
+                channel_new.UserLimit = channel.UserLimit;
+                channel_new.ParentId = channel.ParentId;
+                channel_new.IsNSFW = channel.IsNSFW;
+                channel_new.PerUserRateLimit = channel.PerUserRateLimit;
+                channel_new.Type = channel.Type;
+
+                channel_new._permissionOverwrites.Clear();
+
+                foreach (var po in channel._permissionOverwrites)
+                {
+                    po.Discord = this;
+                    po._channel_id = channel.Id;
+                }
+
+                channel_new._permissionOverwrites.AddRange(channel._permissionOverwrites);
             }
-            else
+            else if(gld != null)
             {
                 gld._channels[channel.Id] = channel;
             }
-
-            channel_new.Bitrate = channel.Bitrate;
-            channel_new.Name = channel.Name;
-            channel_new.Position = channel.Position;
-            channel_new.Topic = channel.Topic;
-            channel_new.UserLimit = channel.UserLimit;
-            channel_new.ParentId = channel.ParentId;
-            channel_new.IsNSFW = channel.IsNSFW;
-            channel_new.PerUserRateLimit = channel.PerUserRateLimit;
-
-            channel_new._permissionOverwrites.Clear();
-
-            foreach (var po in channel._permissionOverwrites)
-            {
-                po.Discord = this;
-                po._channel_id = channel.Id;
-            }
-
-            channel_new._permissionOverwrites.AddRange(channel._permissionOverwrites);
 
             await this._channelUpdated.InvokeAsync(this, new ChannelUpdateEventArgs { ChannelAfter = channel_new, Guild = gld, ChannelBefore = channel_old }).ConfigureAwait(false);
         }


### PR DESCRIPTION
# Summary
Ensures null reference exceptions aren't encountered in the channel update event and also updates the channel type state. 

# Details
There were a few stack traces provided that showed a null reference exception occurring in this event, this PR attempts to prevent potential null refs from throwing.

Example stack trace: 

```
Socket handler suppressed an exception - System.NullReferenceException: Object reference not set to an instance of an object.
   at DSharpPlus.DiscordClient.OnChannelUpdateEventAsync(DiscordChannel channel)
   at DSharpPlus.DiscordClient.HandleDispatchAsync(GatewayPayload payload)
   at DSharpPlus.DiscordClient.HandleSocketMessageAsync(String data)
   at DSharpPlus.DiscordClient.<InternalConnectAsync>g__SocketOnMessage|330_1(IWebSocketClient sender, SocketMessageEventArgs e)
```  

I also made the channel type update with this event since this can be changed during the bot's uptime.

# Changes proposed
* Add null ref checks to channel update
* Add ability for channel type to be updated.