### PR TITLE
fix: Fix nullref thrown in RestClient disposal

### DIFF
--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -661,16 +661,16 @@ namespace DSharpPlus.Net
 
             this.GlobalRateLimitEvent.Reset();
 
-            if (!this._bucketCleanerTokenSource.IsCancellationRequested)
+            if (this._bucketCleanerTokenSource?.IsCancellationRequested == false)
             {
-                this._bucketCleanerTokenSource.Cancel();
+                this._bucketCleanerTokenSource?.Cancel();
                 this.Logger.LogDebug(LoggerEvents.RestCleaner, "Bucket cleaner task stopped.");
             }
 
             try
             {
-                this._cleanerTask.Dispose();
-                this.HttpClient.Dispose();
+                this._cleanerTask?.Dispose();
+                this.HttpClient?.Dispose();
             }
             catch { }
 

--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -642,7 +642,7 @@ namespace DSharpPlus.Net
                     break;
             }
 
-            if(!this._bucketCleanerTokenSource.IsCancellationRequested)
+            if (!this._bucketCleanerTokenSource.IsCancellationRequested)
                 this._bucketCleanerTokenSource.Cancel();
 
             this._cleanerRunning = false;
@@ -670,6 +670,7 @@ namespace DSharpPlus.Net
             try
             {
                 this._cleanerTask?.Dispose();
+                this._bucketCleanerTokenSource?.Dispose();
                 this.HttpClient?.Dispose();
             }
             catch { }


### PR DESCRIPTION
# Summary
Fixes #697 

# Details
If the client is immediately disposed at startup, the cancellation token is null and throws because there are no buckets in the rest client. This PR adds the appropriate null checks.

# Changes proposed
* Adds null checks to cancellation token in rest client disposal.