### PR TITLE
Fix stickers

### DIFF
--- a/DSharpPlus/Entities/DiscordMessageSticker.cs
+++ b/DSharpPlus/Entities/DiscordMessageSticker.cs
@@ -32,7 +32,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the list of tags for the sticker.
         /// </summary>
-        public string[] Tags => _internalTags.Split(',');
+        public string[] Tags => this._internalTags.Split(',');
 
         /// <summary>
         /// Gets the asset hash of the sticker.

--- a/DSharpPlus/Entities/DiscordMessageSticker.cs
+++ b/DSharpPlus/Entities/DiscordMessageSticker.cs
@@ -32,6 +32,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the list of tags for the sticker.
         /// </summary>
+        [JsonIgnore]
         public string[] Tags => this._internalTags.Split(',');
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordMessageSticker.cs
+++ b/DSharpPlus/Entities/DiscordMessageSticker.cs
@@ -8,6 +8,9 @@ namespace DSharpPlus.Entities
     /// </summary>
     public class DiscordMessageSticker : SnowflakeObject, IEquatable<DiscordMessageSticker>
     {
+        [JsonProperty("tags", NullValueHandling = NullValueHandling.Ignore)]
+        private string _tags;
+
         /// <summary>
         /// Gets the Pack ID of this sticker.
         /// </summary>
@@ -29,8 +32,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the list of tags for the sticker.
         /// </summary>
-        [JsonProperty("tags", NullValueHandling = NullValueHandling.Ignore)]
-        public string[] Tags { get; set; }
+        public string[] Tags => _tags.Split(',');
 
         /// <summary>
         /// Gets the asset hash of the sticker.

--- a/DSharpPlus/Entities/DiscordMessageSticker.cs
+++ b/DSharpPlus/Entities/DiscordMessageSticker.cs
@@ -9,7 +9,7 @@ namespace DSharpPlus.Entities
     public class DiscordMessageSticker : SnowflakeObject, IEquatable<DiscordMessageSticker>
     {
         [JsonProperty("tags", NullValueHandling = NullValueHandling.Ignore)]
-        private string _tags;
+        private string _internalTags;
 
         /// <summary>
         /// Gets the Pack ID of this sticker.
@@ -27,30 +27,30 @@ namespace DSharpPlus.Entities
         /// Gets the Description of the sticker.
         /// </summary>
         [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
-        public string Description { get; set; }
+        public string Description { get; internal set; }
 
         /// <summary>
         /// Gets the list of tags for the sticker.
         /// </summary>
-        public string[] Tags => _tags.Split(',');
+        public string[] Tags => _internalTags.Split(',');
 
         /// <summary>
         /// Gets the asset hash of the sticker.
         /// </summary>
         [JsonProperty("asset", NullValueHandling = NullValueHandling.Ignore)]
-        public string Asset { get; set; }
+        public string Asset { get; internal set; }
 
         /// <summary>
         /// Gets the preview asset hash of the sticker.
         /// </summary>
         [JsonProperty("preview_asset", NullValueHandling = NullValueHandling.Ignore)]
-        public string PreviewAsset { get; set; }
+        public string PreviewAsset { get; internal set; }
 
         /// <summary>
         /// Gets the Format type of the sticker.
         /// </summary>
         [JsonProperty("format_type", NullValueHandling = NullValueHandling.Ignore)]
-        public StickerFormat FormatType { get; set; }
+        public StickerFormat FormatType { get; internal set; }
 
         public bool Equals(DiscordMessageSticker other)
         {


### PR DESCRIPTION
# Summary
Fixes an issue where stickers wouldn't deserialise correctly.

# Details
The [documentation for stickers](https://discord.com/developers/docs/resources/channel#message-object-message-sticker-structure) says that `tags` is a comma separated list not an array, so I've modified the class store the string internally and provide a split list.

Also made some property setters which should've been `internal`, `internal`,