### PR TITLE
Make DiscordGuild OwnerId public

### DIFF
--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -77,7 +77,7 @@ namespace DSharpPlus.Entities
         /// Gets the ID of the guild's owner.
         /// </summary>
         [JsonProperty("owner_id", NullValueHandling = NullValueHandling.Ignore)]
-        internal ulong OwnerId { get; set; }
+        public ulong OwnerId { get; internal set; }
 
         /// <summary>
         /// Gets permissions for the user in the guild (does not include channel overrides)


### PR DESCRIPTION
# Summary
Changes `DiscordGuild.OwnerId` to public and make its setter `internal`.

# Details
Changed the accessibility of the `DiscordGuild.OwnerId` property to allow access of the raw owner ID `ulong` when needed. In certain situations, specifically when using the `DiscordRestClient`, the `DiscordGuild.Owner` is either `null` or will throw a `NullReferenceException` when attempting to access the value. Making the `OwnerId` public will allow for comparing a guilds owner with another user ID that may have been requested elsewhere, without need a Owner object that would not be available when using the `DiscordRestClient`.

For example, when using `DiscordRestClient.GetGuildAsync(ulong guildId)` to get a `DiscordGuild`, the `OwnerId` variable is returned with the request. However, accessing this value is impossible because attempting to use `DiscordGuild.Owner.Id` will result in a `NullReferenceException` as the `Owner` object can not be created.

# Changes proposed
* Make the `OwnerId` property of the `DiscordGuild` object public
* Make the setter for the `OwnerId` property `internal`

# Notes
*I failed to write the correct property name in the commit, `GuildId` is supposed to be `OwnerId`*