### PR TITLE
Enhancement: Use Streams rather than Strings for Serialization

### DIFF
--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -323,7 +323,14 @@ namespace DSharpPlus.Lavalink
 
             if (this.Discord.Configuration.MinimumLogLevel == LogLevel.Trace)
             {
-                using var sr = new StreamReader(et.Message, Utilities.UTF8);
+                var cs = new MemoryStream();
+
+                await et.Message.CopyToAsync(cs).ConfigureAwait(false);
+
+                cs.Seek(0, SeekOrigin.Begin);
+                et.Message.Seek(0, SeekOrigin.Begin);
+
+                using var sr = new StreamReader(cs, Utilities.UTF8);
 
                 this.Discord.Logger.LogTrace(LavalinkEvents.LavalinkWsRx, await sr.ReadToEndAsync());
             }

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -12,6 +12,7 @@ using DSharpPlus.Exceptions;
 using DSharpPlus.Lavalink.Entities;
 using DSharpPlus.Lavalink.EventArgs;
 using DSharpPlus.Net;
+using DSharpPlus.Net.Serialization;
 using DSharpPlus.Net.WebSocket;
 using Emzi0767.Utilities;
 using Microsoft.Extensions.Logging;
@@ -328,7 +329,7 @@ namespace DSharpPlus.Lavalink
             }
 
             var json = et.Message;
-            var jsonData =  DiscordApiClient.LoadJObject(json);
+            var jsonData =  DiscordJson.LoadJObject(json);
             switch (jsonData["op"].ToString())
             {
                 case "playerUpdate":

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -319,10 +320,15 @@ namespace DSharpPlus.Lavalink
                 return;
             }
 
-            this.Discord.Logger.LogTrace(LavalinkEvents.LavalinkWsRx, et.Message);
+            if (this.Discord.Configuration.MinimumLogLevel == LogLevel.Trace)
+            {
+                using var sr = new StreamReader(et.Message, Utilities.UTF8);
+
+                this.Discord.Logger.LogTrace(LavalinkEvents.LavalinkWsRx, await sr.ReadToEndAsync());
+            }
 
             var json = et.Message;
-            var jsonData = JObject.Parse(json);
+            var jsonData =  DiscordApiClient.LoadJObject(json);
             switch (jsonData["op"].ToString())
             {
                 case "playerUpdate":

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -336,7 +336,7 @@ namespace DSharpPlus.Lavalink
             }
 
             var json = et.Message;
-            var jsonData =  DiscordJson.LoadJObject(json);
+            var jsonData =  await DiscordJson.LoadJObjectAsync(json).ConfigureAwait(false);
             switch (jsonData["op"].ToString())
             {
                 case "playerUpdate":

--- a/DSharpPlus.Lavalink/LavalinkRestClient.cs
+++ b/DSharpPlus.Lavalink/LavalinkRestClient.cs
@@ -261,16 +261,18 @@ namespace DSharpPlus.Lavalink
             using (var req = await this._http.GetAsync(uri).ConfigureAwait(false))
             using (var res = await req.Content.ReadAsStreamAsync().ConfigureAwait(false))
             using (var sr = new StreamReader(res, Utilities.UTF8))
+            using (var jr = new JsonTextReader(sr))
             {
-                var json = await sr.ReadToEndAsync().ConfigureAwait(false);
                 if (!req.IsSuccessStatusCode)
                 {
-                    var jsonError = JToken.Parse(json) as JObject;
+                    var jsonError = await JObject.LoadAsync(jr);
                     this._logger?.LogError(LavalinkEvents.LavalinkDecodeError, "Unable to decode track strings: {0}", jsonError["message"]);
 
                     return null;
                 }
-                var track = JsonConvert.DeserializeObject<LavalinkTrack>(json);
+
+                var serializer = new JsonSerializer();
+                var track = serializer.Deserialize<LavalinkTrack>(jr);
                 return track;
             }
         }
@@ -282,16 +284,16 @@ namespace DSharpPlus.Lavalink
             using (var req = await this._http.PostAsync(uri, content).ConfigureAwait(false))
             using (var res = await req.Content.ReadAsStreamAsync().ConfigureAwait(false))
             using (var sr = new StreamReader(res, Utilities.UTF8))
+            using (var jr = new JsonTextReader(sr))
             {
-                var jsonIn = await sr.ReadToEndAsync().ConfigureAwait(false);
                 if (!req.IsSuccessStatusCode)
                 {
-                    var jsonError = JToken.Parse(jsonIn) as JObject;
+                    var jsonError = await JObject.LoadAsync(jr);
                     this._logger?.LogError(LavalinkEvents.LavalinkDecodeError, "Unable to decode track strings", jsonError["message"]);
                     return null;
                 }
 
-                var jarr = JToken.Parse(jsonIn) as JArray;
+                var jarr = await JArray.LoadAsync(jr);
                 var decodedTracks = new LavalinkTrack[jarr.Count];
 
                 for (var i = 0; i < decodedTracks.Length; i++)
@@ -315,10 +317,11 @@ namespace DSharpPlus.Lavalink
             using (var req = await this._http.GetAsync(uri).ConfigureAwait(false))
             using (var res = await req.Content.ReadAsStreamAsync().ConfigureAwait(false))
             using (var sr = new StreamReader(res, Utilities.UTF8))
+            using (var jr = new JsonTextReader(sr))
             {
-                var json = await sr.ReadToEndAsync().ConfigureAwait(false);
-                var status = JsonConvert.DeserializeObject<LavalinkRouteStatus>(json);
-                return status;
+
+                var serializer = new JsonSerializer();
+                return serializer.Deserialize<LavalinkRouteStatus>(jr);
             }
         }
 

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -460,6 +460,7 @@ namespace DSharpPlus
         /// <param name="message_id">Message id</param>
         /// <param name="content">New message content</param>
         /// <param name="embed">New message embed</param>
+        /// <param name="mentions">The roles/users to mention.</param>
         /// <returns></returns>
         public Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, Optional<string> content, Optional<DiscordEmbed> embed, IEnumerable<IMention> mentions)
             => this.ApiClient.EditMessageAsync(channel_id, message_id, content, embed, mentions);

--- a/DSharpPlus.Test/Program.cs
+++ b/DSharpPlus.Test/Program.cs
@@ -47,22 +47,6 @@ namespace DSharpPlus.Test
             
             await Task.WhenAll(tskl).ConfigureAwait(false);
 
-
-            /*
-
-            var dcfg = new DiscordConfiguration
-            {
-                AutoReconnect = true,
-                LargeThreshold = 250,
-                MinimumLogLevel = LogLevel.Debug,
-                TokenType = TokenType.Bot,
-                MessageCacheSize = 2048,
-                LogTimestampFormat = "dd-MM-yyyy HH:mm:ss zzz"
-            };
-            var Discord = new DiscordShardedClient(dcfg);
-
-            await Discord.StartAsync();
-            */
             try
             {
                 await Task.Delay(-1, CancelToken).ConfigureAwait(false);

--- a/DSharpPlus.Test/Program.cs
+++ b/DSharpPlus.Test/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Test
@@ -20,7 +21,6 @@ namespace DSharpPlus.Test
         public static async Task MainAsync(string[] args)
         {
             Console.CancelKeyPress += Console_CancelKeyPress;
-
             var cfg = new TestBotConfig();
             var json = string.Empty;
             if (!File.Exists("config.json"))
@@ -47,6 +47,22 @@ namespace DSharpPlus.Test
             
             await Task.WhenAll(tskl).ConfigureAwait(false);
 
+
+            /*
+
+            var dcfg = new DiscordConfiguration
+            {
+                AutoReconnect = true,
+                LargeThreshold = 250,
+                MinimumLogLevel = LogLevel.Debug,
+                TokenType = TokenType.Bot,
+                MessageCacheSize = 2048,
+                LogTimestampFormat = "dd-MM-yyyy HH:mm:ss zzz"
+            };
+            var Discord = new DiscordShardedClient(dcfg);
+
+            await Discord.StartAsync();
+            */
             try
             {
                 await Task.Delay(-1, CancelToken).ConfigureAwait(false);

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -8,7 +8,7 @@ namespace DSharpPlus.Test
 {
     public class TestBotCommands : BaseCommandModule
 	{
-		public static ConcurrentDictionary<ulong, string> PrefixSettings { get; } = new ConcurrentDictionary<ulong, string>();
+        public static ConcurrentDictionary<ulong, string> PrefixSettings { get; } = new ConcurrentDictionary<ulong, string>();
 
 		[Command("crosspost")]
 		public async Task CrosspostAsync(CommandContext ctx, DiscordChannel chn, DiscordMessage msg)
@@ -108,5 +108,16 @@ namespace DSharpPlus.Test
             var test8Msg = await ctx.Channel.SendMessageAsync("❌ Everyone(): " + origcontent);
             await test8Msg.ModifyAsync("❌ Everyone(): " + newContent, mentions: new IMention[] { new EveryoneMention() });                                                      //Should ping no one (@everyone was not pinged)
         }
+    }
+
+    [Group("tag")]
+    public class Tags : BaseCommandModule
+    {
+        [RequireGuild]
+        [Description("Gets a tag's content.")]
+        [GroupCommand]
+        [Command("get")]
+        [Aliases("retrieve")]
+        public async Task Get(CommandContext context, [RemainingText] string tagTitle) => context.RespondAsync("Hello world!");
     }
 }

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -109,15 +109,4 @@ namespace DSharpPlus.Test
             await test8Msg.ModifyAsync("❌ Everyone(): " + newContent, mentions: new IMention[] { new EveryoneMention() });                                                      //Should ping no one (@everyone was not pinged)
         }
     }
-
-    [Group("tag")]
-    public class Tags : BaseCommandModule
-    {
-        [RequireGuild]
-        [Description("Gets a tag's content.")]
-        [GroupCommand]
-        [Command("get")]
-        [Aliases("retrieve")]
-        public async Task Get(CommandContext context, [RemainingText] string tagTitle) => context.RespondAsync("Hello world!");
-    }
 }

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -140,7 +140,7 @@ namespace DSharpPlus
                         return;
                     }
 
-                    msg.Position = 0;
+                    msg.Seek(0, SeekOrigin.Begin);
 
                     if (this.Configuration.MinimumLogLevel == LogLevel.Trace)
                     {

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -146,7 +146,9 @@ namespace DSharpPlus
                     {
                         var cs = new MemoryStream();
                         await msg.CopyToAsync(cs).ConfigureAwait(false);
+
                         msg.Seek(0, SeekOrigin.Begin);
+                        cs.Seek(0, SeekOrigin.Begin);
 
                         using (var sr = new StreamReader(cs, Utilities.UTF8))
                         {

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -147,6 +147,7 @@ namespace DSharpPlus
                         using (var sr = new StreamReader(msg, Utilities.UTF8))
                         {
                             this.Logger.LogTrace(LoggerEvents.GatewayWsRx, sr.ReadToEnd());
+                            msg.Seek(0, SeekOrigin.Begin);
                         }
                     }
                 }

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -11,6 +11,7 @@ using DSharpPlus.EventArgs;
 using DSharpPlus.Net.Abstractions;
 using DSharpPlus.Net.WebSocket;
 using DSharpPlus.Net;
+using DSharpPlus.Net.Serialization;
 
 namespace DSharpPlus
 {
@@ -202,7 +203,7 @@ namespace DSharpPlus
 
         internal async Task HandleSocketMessageAsync(Stream data)
         {
-            var payload = DiscordApiClient.Deserialize<GatewayPayload>(data);
+            var payload = DiscordJson.Deserialize<GatewayPayload>(data);
             switch (payload.OpCode)
             {
                 case GatewayOpCode.Dispatch:

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -144,17 +144,20 @@ namespace DSharpPlus
 
                     if (this.Configuration.MinimumLogLevel == LogLevel.Trace)
                     {
-                        using (var sr = new StreamReader(msg, Utilities.UTF8))
+                        var cs = new MemoryStream();
+                        await msg.CopyToAsync(cs).ConfigureAwait(false);
+                        msg.Seek(0, SeekOrigin.Begin);
+
+                        using (var sr = new StreamReader(cs, Utilities.UTF8))
                         {
-                            this.Logger.LogTrace(LoggerEvents.GatewayWsRx, sr.ReadToEnd());
-                            msg.Seek(0, SeekOrigin.Begin);
+                            this.Logger.LogTrace(LoggerEvents.GatewayWsRx, await sr.ReadToEndAsync().ConfigureAwait(false));
                         }
                     }
                 }
 
                 try
                 {
-                    await this.HandleSocketMessageAsync(msg);
+                    await this.HandleSocketMessageAsync(msg).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -254,7 +254,7 @@ namespace DSharpPlus
             var timer = new Stopwatch();
             timer.Start();
 
-            var jo = JObject.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var jo = await DiscordApiClient.LoadJObjectAsync(await resp.Content.ReadAsStreamAsync().ConfigureAwait(false));
             var info = jo.ToObject<GatewayInfo>();
 
             //There is a delay from parsing here.

--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -15,6 +15,7 @@ using DSharpPlus.Net;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using Emzi0767.Utilities;
+using DSharpPlus.Net.Serialization;
 
 namespace DSharpPlus
 {
@@ -254,7 +255,7 @@ namespace DSharpPlus
             var timer = new Stopwatch();
             timer.Start();
 
-            var jo = await DiscordApiClient.LoadJObjectAsync(await resp.Content.ReadAsStreamAsync().ConfigureAwait(false));
+            var jo = await DiscordJson.LoadJObjectAsync(await resp.Content.ReadAsStreamAsync().ConfigureAwait(false));
             var info = jo.ToObject<GatewayInfo>();
 
             //There is a delay from parsing here.

--- a/DSharpPlus/EventArgs/WebSocketMessageEventArgs.cs
+++ b/DSharpPlus/EventArgs/WebSocketMessageEventArgs.cs
@@ -15,7 +15,7 @@ namespace DSharpPlus.EventArgs
     public sealed class SocketTextMessageEventArgs : SocketMessageEventArgs
     {
         /// <summary>
-        /// Gets the received message string.
+        /// Gets the received message stream.
         /// </summary>
         public MemoryStream Message { get; }
 

--- a/DSharpPlus/EventArgs/WebSocketMessageEventArgs.cs
+++ b/DSharpPlus/EventArgs/WebSocketMessageEventArgs.cs
@@ -1,4 +1,5 @@
 ﻿using Emzi0767.Utilities;
+using System.IO;
 
 namespace DSharpPlus.EventArgs
 {
@@ -16,13 +17,13 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the received message string.
         /// </summary>
-        public string Message { get; }
+        public MemoryStream Message { get; }
 
         /// <summary>
         /// Creates a new instance of text message event arguments.
         /// </summary>
         /// <param name="message">Received message string.</param>
-        public SocketTextMessageEventArgs(string message)
+        public SocketTextMessageEventArgs(MemoryStream message)
         {
             this.Message = message;
         }

--- a/DSharpPlus/Exceptions/BadRequestException.cs
+++ b/DSharpPlus/Exceptions/BadRequestException.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using DSharpPlus.Net;
 using Newtonsoft.Json;
+using DSharpPlus.Net.Serialization;
 
 namespace DSharpPlus.Exceptions
 {
@@ -33,10 +34,7 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                using var sr = new StreamReader(response.Response);
-                using var jr = new JsonTextReader(sr);
-
-                var j = JObject.Load(jr);
+                var j = DiscordJson.LoadJObject(response.Response);
 
                 if (j["message"] != null)
                     JsonMessage = j["message"].ToString();

--- a/DSharpPlus/Exceptions/BadRequestException.cs
+++ b/DSharpPlus/Exceptions/BadRequestException.cs
@@ -1,6 +1,8 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
+using System.IO;
 using DSharpPlus.Net;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Exceptions
 {
@@ -31,7 +33,10 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                JObject j = JObject.Parse(response.Response);
+                using var sr = new StreamReader(response.Response);
+                using var jr = new JsonTextReader(sr);
+
+                var j = JObject.Load(jr);
 
                 if (j["message"] != null)
                     JsonMessage = j["message"].ToString();

--- a/DSharpPlus/Exceptions/NotFoundException.cs
+++ b/DSharpPlus/Exceptions/NotFoundException.cs
@@ -3,6 +3,7 @@ using System;
 using DSharpPlus.Net;
 using System.IO;
 using Newtonsoft.Json;
+using DSharpPlus.Net.Serialization;
 
 namespace DSharpPlus.Exceptions
 {
@@ -33,10 +34,7 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                using var sr = new StreamReader(response.Response);
-                using var jr = new JsonTextReader(sr);
-
-                var j = JObject.Load(jr);
+                var j = DiscordJson.LoadJObject(response.Response);
 
                 if (j["message"] != null)
                     JsonMessage = j["message"].ToString();

--- a/DSharpPlus/Exceptions/NotFoundException.cs
+++ b/DSharpPlus/Exceptions/NotFoundException.cs
@@ -1,6 +1,8 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
 using DSharpPlus.Net;
+using System.IO;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Exceptions
 {
@@ -31,7 +33,10 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                JObject j = JObject.Parse(response.Response);
+                using var sr = new StreamReader(response.Response);
+                using var jr = new JsonTextReader(sr);
+
+                var j = JObject.Load(jr);
 
                 if (j["message"] != null)
                     JsonMessage = j["message"].ToString();

--- a/DSharpPlus/Exceptions/RateLimitException.cs
+++ b/DSharpPlus/Exceptions/RateLimitException.cs
@@ -31,7 +31,7 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                JObject j = JObject.Parse(response.Response);
+                JObject j = DiscordApiClient.LoadJObject(response.Response);
 
                 if (j["message"] != null)
                     JsonMessage = j["message"].ToString();

--- a/DSharpPlus/Exceptions/RateLimitException.cs
+++ b/DSharpPlus/Exceptions/RateLimitException.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
 using DSharpPlus.Net;
+using DSharpPlus.Net.Serialization;
 
 namespace DSharpPlus.Exceptions
 {
@@ -31,7 +32,7 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                JObject j = DiscordApiClient.LoadJObject(response.Response);
+                JObject j = DiscordJson.LoadJObject(response.Response);
 
                 if (j["message"] != null)
                     JsonMessage = j["message"].ToString();

--- a/DSharpPlus/Exceptions/RequestSizeException.cs
+++ b/DSharpPlus/Exceptions/RequestSizeException.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using DSharpPlus.Net;
 using System.IO;
 using Newtonsoft.Json;
+using DSharpPlus.Net.Serialization;
 
 namespace DSharpPlus.Exceptions
 {
@@ -33,10 +34,7 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                using var sr = new StreamReader(response.Response);
-                using var jr = new JsonTextReader(sr);
-
-                var j = JObject.Load(jr);
+                var j = DiscordJson.LoadJObject(response.Response);
 
                 if (j["message"] != null)
                     JsonMessage = j["message"].ToString();

--- a/DSharpPlus/Exceptions/RequestSizeException.cs
+++ b/DSharpPlus/Exceptions/RequestSizeException.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Newtonsoft.Json.Linq;
 using DSharpPlus.Net;
+using System.IO;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Exceptions
 {
@@ -31,7 +33,10 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                JObject j = JObject.Parse(response.Response);
+                using var sr = new StreamReader(response.Response);
+                using var jr = new JsonTextReader(sr);
+
+                var j = JObject.Load(jr);
 
                 if (j["message"] != null)
                     JsonMessage = j["message"].ToString();

--- a/DSharpPlus/Exceptions/ServerErrorException.cs
+++ b/DSharpPlus/Exceptions/ServerErrorException.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
 using DSharpPlus.Net;
+using DSharpPlus.Net.Serialization;
 
 namespace DSharpPlus.Exceptions
 {
@@ -31,7 +32,7 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                var j = DiscordApiClient.LoadJObject(response.Response);
+                var j = DiscordJson.LoadJObject(response.Response);
 
                 if (j["message"] != null)
                     JsonMessage = j["message"].ToString();

--- a/DSharpPlus/Exceptions/ServerErrorException.cs
+++ b/DSharpPlus/Exceptions/ServerErrorException.cs
@@ -31,7 +31,7 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                var j = JObject.Parse(response.Response);
+                var j = DiscordApiClient.LoadJObject(response.Response);
 
                 if (j["message"] != null)
                     JsonMessage = j["message"].ToString();

--- a/DSharpPlus/Exceptions/UnauthorizedException.cs
+++ b/DSharpPlus/Exceptions/UnauthorizedException.cs
@@ -32,7 +32,7 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                JObject j = DiscordJson.LoadJObject(response.Response);
+                var j = DiscordJson.LoadJObject(response.Response);
 
                 if (j["message"] != null)
                     JsonMessage = j["message"].ToString();

--- a/DSharpPlus/Exceptions/UnauthorizedException.cs
+++ b/DSharpPlus/Exceptions/UnauthorizedException.cs
@@ -31,7 +31,7 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                JObject j = JObject.Parse(response.Response);
+                JObject j = DiscordApiClient.LoadJObject(response.Response);
 
                 if (j["message"] != null)
                     JsonMessage = j["message"].ToString();

--- a/DSharpPlus/Exceptions/UnauthorizedException.cs
+++ b/DSharpPlus/Exceptions/UnauthorizedException.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
 using DSharpPlus.Net;
+using DSharpPlus.Net.Serialization;
 
 namespace DSharpPlus.Exceptions
 {
@@ -31,7 +32,7 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                JObject j = DiscordApiClient.LoadJObject(response.Response);
+                JObject j = DiscordJson.LoadJObject(response.Response);
 
                 if (j["message"] != null)
                     JsonMessage = j["message"].ToString();

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -153,9 +153,9 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var json = JObject.Parse(res.Response);
+            var json = await LoadJObjectAsync(res.Response);
             var raw_members = (JArray)json["members"];
-            var guild = JsonConvert.DeserializeObject<DiscordGuild>(res.Response);
+            var guild = Deserialize<DiscordGuild>(res.Response);
 
             if (this.Discord is DiscordClient dc)
                 await dc.OnGuildCreateEventAsync(guild, raw_members, null).ConfigureAwait(false);
@@ -210,9 +210,9 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var json = JObject.Parse(res.Response);
+            var json = await LoadJObjectAsync(res.Response);
             var rawMembers = (JArray)json["members"];
-            var guild = JsonConvert.DeserializeObject<DiscordGuild>(res.Response);
+            var guild = Deserialize<DiscordGuild>(res.Response);
             foreach (var r in guild._roles.Values)
                 r._guild_id = guild.Id;
 
@@ -229,7 +229,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var bans_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordBan>>(res.Response).Select(xb =>
+            var bans_raw = Deserialize<IEnumerable<DiscordBan>>(res.Response).Select(xb =>
             {
                 if (!this.Discord.TryGetCachedUserInternal(xb.RawUser.Id, out var usr))
                 {
@@ -309,7 +309,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var tm = JsonConvert.DeserializeObject<TransportMember>(res.Response);
+            var tm = Deserialize<TransportMember>(res.Response);
 
             return new DiscordMember(tm) { Discord = this.Discord, _guild_id = guild_id };
         }
@@ -328,7 +328,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var members_raw = JsonConvert.DeserializeObject<List<TransportMember>>(res.Response);
+            var members_raw = Deserialize<List<TransportMember>>(res.Response);
             return new ReadOnlyCollection<TransportMember>(members_raw);
         }
 
@@ -405,7 +405,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var audit_log_data_raw = JsonConvert.DeserializeObject<AuditLog>(res.Response);
+            var audit_log_data_raw = Deserialize<AuditLog>(res.Response);
 
             return audit_log_data_raw;
         }
@@ -418,7 +418,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var invite = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
+            var invite = Deserialize<DiscordInvite>(res.Response);
 
             return invite;
         }
@@ -431,11 +431,11 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordWidget>(res.Response);
+            var ret = Deserialize<DiscordWidget>(res.Response);
             ret.Discord = this.Discord;
             ret.Guild = this.Discord.Guilds[guild_id];
 
-            var json = JObject.Parse(res.Response);
+            var json = await LoadJObjectAsync(res.Response);
             var rawChannels = (JArray)json["channels"];
             if (ret.Guild == null)
             {
@@ -466,7 +466,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordWidgetSettings>(res.Response);
+            var ret = Deserialize<DiscordWidgetSettings>(res.Response);
             ret.Guild = this.Discord.Guilds[guild_id];
 
             return ret;
@@ -490,7 +490,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordWidgetSettings>(res.Response);
+            var ret = Deserialize<DiscordWidgetSettings>(res.Response);
             ret.Guild = this.Discord.Guilds[guild_id];
 
             return ret;
@@ -528,7 +528,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordChannel>(res.Response);
+            var ret = Deserialize<DiscordChannel>(res.Response);
             ret.Discord = this.Discord;
             foreach (var xo in ret._permissionOverwrites)
             {
@@ -572,7 +572,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordChannel>(res.Response);
+            var ret = Deserialize<DiscordChannel>(res.Response);
             ret.Discord = this.Discord;
             foreach (var xo in ret._permissionOverwrites)
             {
@@ -604,7 +604,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(JObject.Parse(res.Response));
+            var ret = this.PrepareMessage(await LoadJObjectAsync(res.Response));
 
             return ret;
         }
@@ -644,7 +644,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(JObject.Parse(res.Response));
+            var ret = this.PrepareMessage(await LoadJObjectAsync(res.Response));
 
             return ret;
         }
@@ -679,7 +679,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: file).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(JObject.Parse(res.Response));
+            var ret = this.PrepareMessage(await LoadJObjectAsync(res.Response));
 
             return ret;
         }
@@ -715,7 +715,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: files).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(JObject.Parse(res.Response));
+            var ret = this.PrepareMessage(await LoadJObjectAsync(res.Response));
 
             return ret;
         }
@@ -728,7 +728,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var channels_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordChannel>>(res.Response).Select(xc => { xc.Discord = this.Discord; return xc; });
+            var channels_raw = Deserialize<IEnumerable<DiscordChannel>>(res.Response).Select(xc => { xc.Discord = this.Discord; return xc; });
 
             foreach (var ret in channels_raw)
                 foreach (var xo in ret._permissionOverwrites)
@@ -758,7 +758,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var msgs_raw = JArray.Parse(res.Response);
+            var msgs_raw = await LoadJArrayAsync(res.Response);
             var msgs = new List<DiscordMessage>();
             foreach (var xj in msgs_raw)
                 msgs.Add(this.PrepareMessage(xj));
@@ -774,7 +774,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(JObject.Parse(res.Response));
+            var ret = this.PrepareMessage(await LoadJObjectAsync(res.Response));
 
             return ret;
         }
@@ -815,7 +815,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(JObject.Parse(res.Response));
+            var ret = this.PrepareMessage(await LoadJObjectAsync(res.Response));
 
             return ret;
         }
@@ -859,7 +859,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var invites_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordInvite>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
+            var invites_raw = Deserialize<IEnumerable<DiscordInvite>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
 
             return new ReadOnlyCollection<DiscordInvite>(new List<DiscordInvite>(invites_raw));
         }
@@ -884,7 +884,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
+            var ret = Deserialize<DiscordInvite>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -940,7 +940,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var msgs_raw = JArray.Parse(res.Response);
+            var msgs_raw = await LoadJArrayAsync(res.Response);
             var msgs = new List<DiscordMessage>();
             foreach (var xj in msgs_raw)
                 msgs.Add(this.PrepareMessage(xj));
@@ -1004,7 +1004,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordDmChannel>(res.Response);
+            var ret = Deserialize<DiscordDmChannel>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1023,7 +1023,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordDmChannel>(res.Response);
+            var ret = Deserialize<DiscordDmChannel>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1042,7 +1042,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld));
             
-            return JsonConvert.DeserializeObject<DiscordFollowedChannel>(response.Response);
+            return Deserialize<DiscordFollowedChannel>(response.Response);
         }
 
         internal async Task<DiscordMessage> CrosspostMessageAsync(ulong channel_id, ulong message_id)
@@ -1052,7 +1052,7 @@ namespace DSharpPlus.Net
 
             var url = Utilities.GetApiUriFor(path);
             var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route);
-            return JsonConvert.DeserializeObject<DiscordMessage>(response.Response);
+            return Deserialize<DiscordMessage>(response.Response);
         }
         
         #endregion
@@ -1072,7 +1072,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var user_raw = JsonConvert.DeserializeObject<TransportUser>(res.Response);
+            var user_raw = Deserialize<TransportUser>(res.Response);
             var duser = new DiscordUser(user_raw) { Discord = this.Discord };
 
             return duser;
@@ -1086,7 +1086,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var tm = JsonConvert.DeserializeObject<TransportMember>(res.Response);
+            var tm = Deserialize<TransportMember>(res.Response);
 
             var usr = new DiscordUser(tm.User) { Discord = this.Discord };
             usr = this.Discord.UserCache.AddOrUpdate(tm.User.Id, usr, (id, old) =>
@@ -1132,7 +1132,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var user_raw = JsonConvert.DeserializeObject<TransportUser>(res.Response);
+            var user_raw = Deserialize<TransportUser>(res.Response);
 
             return user_raw;
         }
@@ -1155,13 +1155,13 @@ namespace DSharpPlus.Net
 
             if (this.Discord is DiscordClient)
             {
-                var guilds_raw = JsonConvert.DeserializeObject<IEnumerable<RestUserGuild>>(res.Response);
+                var guilds_raw = Deserialize<IEnumerable<RestUserGuild>>(res.Response);
                 var glds = guilds_raw.Select(xug => (this.Discord as DiscordClient)?._guilds[xug.Id]);
                 return new ReadOnlyCollection<DiscordGuild>(new List<DiscordGuild>(glds));
             }
             else
             {
-                return new ReadOnlyCollection<DiscordGuild>(JsonConvert.DeserializeObject<List<DiscordGuild>>(res.Response));
+                return new ReadOnlyCollection<DiscordGuild>(Deserialize<List<DiscordGuild>>(res.Response));
             }
         }
 
@@ -1217,7 +1217,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var roles_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordRole>>(res.Response).Select(xr => { xr.Discord = this.Discord; xr._guild_id = guild_id; return xr; });
+            var roles_raw = Deserialize<IEnumerable<DiscordRole>>(res.Response).Select(xr => { xr.Discord = this.Discord; xr._guild_id = guild_id; return xr; });
 
             return new ReadOnlyCollection<DiscordRole>(new List<DiscordRole>(roles_raw));
         }
@@ -1234,9 +1234,9 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route, urlparams).ConfigureAwait(false);
 
-            var json = JObject.Parse(res.Response);
+            var json = await LoadJObjectAsync(res.Response);
             var rawMembers = (JArray)json["members"];
-            var guildRest = JsonConvert.DeserializeObject<DiscordGuild>(res.Response);
+            var guildRest = Deserialize<DiscordGuild>(res.Response);
             foreach (var r in guildRest._roles.Values)
                 r._guild_id = guildRest.Id;
 
@@ -1273,7 +1273,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordRole>(res.Response);
+            var ret = Deserialize<DiscordRole>(res.Response);
             ret.Discord = this.Discord;
             ret._guild_id = guild_id;
 
@@ -1314,7 +1314,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordRole>(res.Response);
+            var ret = Deserialize<DiscordRole>(res.Response);
             ret.Discord = this.Discord;
             ret._guild_id = guild_id;
 
@@ -1349,7 +1349,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, $"{BuildQueryString(urlparams)}{sb}");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var pruned = JsonConvert.DeserializeObject<RestGuildPruneResultPayload>(res.Response);
+            var pruned = Deserialize<RestGuildPruneResultPayload>(res.Response);
 
             return pruned.Pruned.Value;
         }
@@ -1385,7 +1385,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, $"{BuildQueryString(urlparams)}{sb}");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route).ConfigureAwait(false);
 
-            var pruned = JsonConvert.DeserializeObject<RestGuildPruneResultPayload>(res.Response);
+            var pruned = Deserialize<RestGuildPruneResultPayload>(res.Response);
 
             return pruned.Pruned;
         }
@@ -1400,7 +1400,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var integrations_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordIntegration>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
+            var integrations_raw = Deserialize<IEnumerable<DiscordIntegration>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
 
             return new ReadOnlyCollection<DiscordIntegration>(new List<DiscordIntegration>(integrations_raw));
         }
@@ -1413,7 +1413,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordGuildPreview>(res.Response);
+            var ret = Deserialize<DiscordGuildPreview>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1433,7 +1433,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordIntegration>(res.Response);
+            var ret = Deserialize<DiscordIntegration>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1454,7 +1454,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordIntegration>(res.Response);
+            var ret = Deserialize<DiscordIntegration>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1488,7 +1488,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var embed = JsonConvert.DeserializeObject<DiscordGuildEmbed>(res.Response);
+            var embed = Deserialize<DiscordGuildEmbed>(res.Response);
 
             return embed;
         }
@@ -1503,7 +1503,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(embed)).ConfigureAwait(false);
 
-            var embed_rest = JsonConvert.DeserializeObject<DiscordGuildEmbed>(res.Response);
+            var embed_rest = Deserialize<DiscordGuildEmbed>(res.Response);
 
             return embed_rest;
         }
@@ -1516,7 +1516,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var regions_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordVoiceRegion>>(res.Response);
+            var regions_raw = Deserialize<IEnumerable<DiscordVoiceRegion>>(res.Response);
 
             return new ReadOnlyCollection<DiscordVoiceRegion>(new List<DiscordVoiceRegion>(regions_raw));
         }
@@ -1529,7 +1529,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var invites_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordInvite>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
+            var invites_raw = Deserialize<IEnumerable<DiscordInvite>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
 
             return new ReadOnlyCollection<DiscordInvite>(new List<DiscordInvite>(invites_raw));
         }
@@ -1548,7 +1548,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
+            var ret = Deserialize<DiscordInvite>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1566,7 +1566,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route, headers).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
+            var ret = Deserialize<DiscordInvite>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1583,7 +1583,7 @@ namespace DSharpPlus.Net
          *     var bucket = this.Rest.GetBucket(0, MajorParameterType.Unbucketed, url, HttpRequestMethod.POST);
          *     var res = await this.DoRequestAsync(this.Discord, bucket, url, HttpRequestMethod.POST).ConfigureAwait(false);
          *     
-         *     var ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
+         *     var ret = Deserialize<DiscordInvite>(res.Response);
          *     ret.Discord = this.Discord;
          * 
          *     return ret;
@@ -1600,7 +1600,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var connections_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordConnection>>(res.Response).Select(xc => { xc.Discord = this.Discord; return xc; });
+            var connections_raw = Deserialize<IEnumerable<DiscordConnection>>(res.Response).Select(xc => { xc.Discord = this.Discord; return xc; });
 
             return new ReadOnlyCollection<DiscordConnection>(new List<DiscordConnection>(connections_raw));
         }
@@ -1615,7 +1615,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var regions = JsonConvert.DeserializeObject<IEnumerable<DiscordVoiceRegion>>(res.Response);
+            var regions = Deserialize<IEnumerable<DiscordVoiceRegion>>(res.Response);
 
             return new ReadOnlyCollection<DiscordVoiceRegion>(new List<DiscordVoiceRegion>(regions));
         }
@@ -1641,7 +1641,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
+            var ret = Deserialize<DiscordWebhook>(res.Response);
             ret.Discord = this.Discord;
             ret.ApiClient = this;
 
@@ -1656,7 +1656,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var webhooks_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordWebhook>>(res.Response).Select(xw => { xw.Discord = this.Discord; xw.ApiClient = this; return xw; });
+            var webhooks_raw = Deserialize<IEnumerable<DiscordWebhook>>(res.Response).Select(xw => { xw.Discord = this.Discord; xw.ApiClient = this; return xw; });
 
             return new ReadOnlyCollection<DiscordWebhook>(new List<DiscordWebhook>(webhooks_raw));
         }
@@ -1669,7 +1669,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var webhooks_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordWebhook>>(res.Response).Select(xw => { xw.Discord = this.Discord; xw.ApiClient = this; return xw; });
+            var webhooks_raw = Deserialize<IEnumerable<DiscordWebhook>>(res.Response).Select(xw => { xw.Discord = this.Discord; xw.ApiClient = this; return xw; });
 
             return new ReadOnlyCollection<DiscordWebhook>(new List<DiscordWebhook>(webhooks_raw));
         }
@@ -1682,7 +1682,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
+            var ret = Deserialize<DiscordWebhook>(res.Response);
             ret.Discord = this.Discord;
             ret.ApiClient = this;
 
@@ -1698,7 +1698,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
+            var ret = Deserialize<DiscordWebhook>(res.Response);
             ret.Token = webhook_token;
             ret.Id = webhook_id;
             ret.Discord = this.Discord;
@@ -1727,7 +1727,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
+            var ret = Deserialize<DiscordWebhook>(res.Response);
             ret.Discord = this.Discord;
             ret.ApiClient = this;
 
@@ -1752,7 +1752,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
+            var ret = Deserialize<DiscordWebhook>(res.Response);
             ret.Discord = this.Discord;
             ret.ApiClient = this;
 
@@ -1816,7 +1816,7 @@ namespace DSharpPlus.Net
 
             var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: files).ConfigureAwait(false);
-            var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
+            var ret = Deserialize<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
             return ret;
         }
@@ -1828,7 +1828,7 @@ namespace DSharpPlus.Net
 
             var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: json_payload);
-            var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
+            var ret = Deserialize<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
             return ret;
         }
@@ -1840,7 +1840,7 @@ namespace DSharpPlus.Net
 
             var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: json_payload);
-            var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
+            var ret = Deserialize<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
             return ret;
         }
@@ -1892,7 +1892,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, BuildQueryString(urlparams));
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var reacters_raw = JsonConvert.DeserializeObject<IEnumerable<TransportUser>>(res.Response);
+            var reacters_raw = Deserialize<IEnumerable<TransportUser>>(res.Response);
             var reacters = new List<DiscordUser>();
             foreach (var xr in reacters_raw)
             {
@@ -1943,7 +1943,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var emojisRaw = JsonConvert.DeserializeObject<IEnumerable<JObject>>(res.Response);
+            var emojisRaw = Deserialize<IEnumerable<JObject>>(res.Response);
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
             var users = new Dictionary<ulong, DiscordUser>();
@@ -1981,7 +1981,7 @@ namespace DSharpPlus.Net
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
-            var emoji_raw = JObject.Parse(res.Response);
+            var emoji_raw = await LoadJObjectAsync(res.Response);
             var emoji = emoji_raw.ToObject<DiscordGuildEmoji>();
             emoji.Guild = gld;
 
@@ -2013,7 +2013,7 @@ namespace DSharpPlus.Net
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
-            var emoji_raw = JObject.Parse(res.Response);
+            var emoji_raw = await LoadJObjectAsync(res.Response);
             var emoji = emoji_raw.ToObject<DiscordGuildEmoji>();
             emoji.Guild = gld;
 
@@ -2046,7 +2046,7 @@ namespace DSharpPlus.Net
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
-            var emoji_raw = JObject.Parse(res.Response);
+            var emoji_raw = await LoadJObjectAsync(res.Response);
             var emoji = emoji_raw.ToObject<DiscordGuildEmoji>();
             emoji.Guild = gld;
 
@@ -2086,7 +2086,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            return JsonConvert.DeserializeObject<TransportApplication>(res.Response);
+            return Deserialize<TransportApplication>(res.Response);
         }
 
         internal async Task<IReadOnlyList<DiscordApplicationAsset>> GetApplicationAssetsAsync(DiscordApplication application)
@@ -2097,7 +2097,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var assets = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationAsset>>(res.Response);
+            var assets = Deserialize<IEnumerable<DiscordApplicationAsset>>(res.Response);
             foreach (var asset in assets)
             {
                 asset.Discord = application.Discord;
@@ -2118,10 +2118,44 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route, headers).ConfigureAwait(false);
 
-            var info = JObject.Parse(res.Response).ToObject<GatewayInfo>();
+            var info = (await LoadJObjectAsync(res.Response)).ToObject<GatewayInfo>();
             info.SessionBucket.ResetAfter = DateTimeOffset.UtcNow + TimeSpan.FromMilliseconds(info.SessionBucket.resetAfter);
             return info;
         }
         #endregion
+
+        internal static T Deserialize<T>(Stream stream)
+        {
+            using var sr = new StreamReader(stream);
+            using var jtr = new JsonTextReader(sr);
+
+            var serializer = new JsonSerializer();
+
+            return serializer.Deserialize<T>(jtr);
+        }
+
+        internal static Task<JObject> LoadJObjectAsync(Stream stream)
+        {
+            using var sr = new StreamReader(stream);
+            using var jtr = new JsonTextReader(sr);
+
+            return JObject.LoadAsync(jtr);
+        }
+
+        internal static JObject LoadJObject(Stream stream)
+        {
+            using var sr = new StreamReader(stream);
+            using var jtr = new JsonTextReader(sr);
+
+            return JObject.Load(jtr);
+        }
+
+        internal static Task<JArray> LoadJArrayAsync(Stream stream)
+        {
+            using var sr = new StreamReader(stream);
+            using var jtr = new JsonTextReader(sr);
+
+            return JArray.LoadAsync(jtr);
+        }
     }
 }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -153,9 +153,9 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var json = await LoadJObjectAsync(res.Response);
+            var json = await DiscordJson.LoadJObjectAsync(res.Response);
             var raw_members = (JArray)json["members"];
-            var guild = Deserialize<DiscordGuild>(res.Response);
+            var guild = DiscordJson.Deserialize<DiscordGuild>(res.Response);
 
             if (this.Discord is DiscordClient dc)
                 await dc.OnGuildCreateEventAsync(guild, raw_members, null).ConfigureAwait(false);
@@ -210,9 +210,9 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var json = await LoadJObjectAsync(res.Response);
+            var json = await DiscordJson.LoadJObjectAsync(res.Response);
             var rawMembers = (JArray)json["members"];
-            var guild = Deserialize<DiscordGuild>(res.Response);
+            var guild = DiscordJson.Deserialize<DiscordGuild>(res.Response);
             foreach (var r in guild._roles.Values)
                 r._guild_id = guild.Id;
 
@@ -229,7 +229,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var bans_raw = Deserialize<IEnumerable<DiscordBan>>(res.Response).Select(xb =>
+            var bans_raw = DiscordJson.Deserialize<IEnumerable<DiscordBan>>(res.Response).Select(xb =>
             {
                 if (!this.Discord.TryGetCachedUserInternal(xb.RawUser.Id, out var usr))
                 {
@@ -309,7 +309,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var tm = Deserialize<TransportMember>(res.Response);
+            var tm = DiscordJson.Deserialize<TransportMember>(res.Response);
 
             return new DiscordMember(tm) { Discord = this.Discord, _guild_id = guild_id };
         }
@@ -328,7 +328,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var members_raw = Deserialize<List<TransportMember>>(res.Response);
+            var members_raw = DiscordJson.Deserialize<List<TransportMember>>(res.Response);
             return new ReadOnlyCollection<TransportMember>(members_raw);
         }
 
@@ -405,7 +405,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var audit_log_data_raw = Deserialize<AuditLog>(res.Response);
+            var audit_log_data_raw = DiscordJson.Deserialize<AuditLog>(res.Response);
 
             return audit_log_data_raw;
         }
@@ -418,7 +418,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var invite = Deserialize<DiscordInvite>(res.Response);
+            var invite = DiscordJson.Deserialize<DiscordInvite>(res.Response);
 
             return invite;
         }
@@ -431,11 +431,11 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordWidget>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordWidget>(res.Response);
             ret.Discord = this.Discord;
             ret.Guild = this.Discord.Guilds[guild_id];
 
-            var json = await LoadJObjectAsync(res.Response);
+            var json = await DiscordJson.LoadJObjectAsync(res.Response);
             var rawChannels = (JArray)json["channels"];
             if (ret.Guild == null)
             {
@@ -466,7 +466,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordWidgetSettings>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordWidgetSettings>(res.Response);
             ret.Guild = this.Discord.Guilds[guild_id];
 
             return ret;
@@ -490,7 +490,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordWidgetSettings>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordWidgetSettings>(res.Response);
             ret.Guild = this.Discord.Guilds[guild_id];
 
             return ret;
@@ -528,7 +528,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordChannel>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordChannel>(res.Response);
             ret.Discord = this.Discord;
             foreach (var xo in ret._permissionOverwrites)
             {
@@ -572,7 +572,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordChannel>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordChannel>(res.Response);
             ret.Discord = this.Discord;
             foreach (var xo in ret._permissionOverwrites)
             {
@@ -604,7 +604,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await LoadJObjectAsync(res.Response));
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response));
 
             return ret;
         }
@@ -644,7 +644,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await LoadJObjectAsync(res.Response));
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response));
 
             return ret;
         }
@@ -679,7 +679,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: file).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await LoadJObjectAsync(res.Response));
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response));
 
             return ret;
         }
@@ -715,7 +715,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: files).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await LoadJObjectAsync(res.Response));
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response));
 
             return ret;
         }
@@ -728,7 +728,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var channels_raw = Deserialize<IEnumerable<DiscordChannel>>(res.Response).Select(xc => { xc.Discord = this.Discord; return xc; });
+            var channels_raw = DiscordJson.Deserialize<IEnumerable<DiscordChannel>>(res.Response).Select(xc => { xc.Discord = this.Discord; return xc; });
 
             foreach (var ret in channels_raw)
                 foreach (var xo in ret._permissionOverwrites)
@@ -758,7 +758,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var msgs_raw = await LoadJArrayAsync(res.Response);
+            var msgs_raw = await DiscordJson.LoadJArrayAsync(res.Response);
             var msgs = new List<DiscordMessage>();
             foreach (var xj in msgs_raw)
                 msgs.Add(this.PrepareMessage(xj));
@@ -774,7 +774,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await LoadJObjectAsync(res.Response));
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response));
 
             return ret;
         }
@@ -815,7 +815,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await LoadJObjectAsync(res.Response));
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response));
 
             return ret;
         }
@@ -859,7 +859,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var invites_raw = Deserialize<IEnumerable<DiscordInvite>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
+            var invites_raw = DiscordJson.Deserialize<IEnumerable<DiscordInvite>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
 
             return new ReadOnlyCollection<DiscordInvite>(new List<DiscordInvite>(invites_raw));
         }
@@ -884,7 +884,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordInvite>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordInvite>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -940,7 +940,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var msgs_raw = await LoadJArrayAsync(res.Response);
+            var msgs_raw = await DiscordJson.LoadJArrayAsync(res.Response);
             var msgs = new List<DiscordMessage>();
             foreach (var xj in msgs_raw)
                 msgs.Add(this.PrepareMessage(xj));
@@ -1004,7 +1004,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordDmChannel>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordDmChannel>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1023,7 +1023,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordDmChannel>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordDmChannel>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1042,7 +1042,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld));
             
-            return Deserialize<DiscordFollowedChannel>(response.Response);
+            return DiscordJson.Deserialize<DiscordFollowedChannel>(response.Response);
         }
 
         internal async Task<DiscordMessage> CrosspostMessageAsync(ulong channel_id, ulong message_id)
@@ -1052,7 +1052,7 @@ namespace DSharpPlus.Net
 
             var url = Utilities.GetApiUriFor(path);
             var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route);
-            return Deserialize<DiscordMessage>(response.Response);
+            return DiscordJson.Deserialize<DiscordMessage>(response.Response);
         }
         
         #endregion
@@ -1072,7 +1072,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var user_raw = Deserialize<TransportUser>(res.Response);
+            var user_raw = DiscordJson.Deserialize<TransportUser>(res.Response);
             var duser = new DiscordUser(user_raw) { Discord = this.Discord };
 
             return duser;
@@ -1086,7 +1086,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var tm = Deserialize<TransportMember>(res.Response);
+            var tm = DiscordJson.Deserialize<TransportMember>(res.Response);
 
             var usr = new DiscordUser(tm.User) { Discord = this.Discord };
             usr = this.Discord.UserCache.AddOrUpdate(tm.User.Id, usr, (id, old) =>
@@ -1132,7 +1132,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var user_raw = Deserialize<TransportUser>(res.Response);
+            var user_raw = DiscordJson.Deserialize<TransportUser>(res.Response);
 
             return user_raw;
         }
@@ -1155,13 +1155,13 @@ namespace DSharpPlus.Net
 
             if (this.Discord is DiscordClient)
             {
-                var guilds_raw = Deserialize<IEnumerable<RestUserGuild>>(res.Response);
+                var guilds_raw = DiscordJson.Deserialize<IEnumerable<RestUserGuild>>(res.Response);
                 var glds = guilds_raw.Select(xug => (this.Discord as DiscordClient)?._guilds[xug.Id]);
                 return new ReadOnlyCollection<DiscordGuild>(new List<DiscordGuild>(glds));
             }
             else
             {
-                return new ReadOnlyCollection<DiscordGuild>(Deserialize<List<DiscordGuild>>(res.Response));
+                return new ReadOnlyCollection<DiscordGuild>(DiscordJson.Deserialize<List<DiscordGuild>>(res.Response));
             }
         }
 
@@ -1217,7 +1217,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var roles_raw = Deserialize<IEnumerable<DiscordRole>>(res.Response).Select(xr => { xr.Discord = this.Discord; xr._guild_id = guild_id; return xr; });
+            var roles_raw = DiscordJson.Deserialize<IEnumerable<DiscordRole>>(res.Response).Select(xr => { xr.Discord = this.Discord; xr._guild_id = guild_id; return xr; });
 
             return new ReadOnlyCollection<DiscordRole>(new List<DiscordRole>(roles_raw));
         }
@@ -1234,9 +1234,9 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route, urlparams).ConfigureAwait(false);
 
-            var json = await LoadJObjectAsync(res.Response);
+            var json = await DiscordJson.LoadJObjectAsync(res.Response);
             var rawMembers = (JArray)json["members"];
-            var guildRest = Deserialize<DiscordGuild>(res.Response);
+            var guildRest = DiscordJson.Deserialize<DiscordGuild>(res.Response);
             foreach (var r in guildRest._roles.Values)
                 r._guild_id = guildRest.Id;
 
@@ -1273,7 +1273,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordRole>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordRole>(res.Response);
             ret.Discord = this.Discord;
             ret._guild_id = guild_id;
 
@@ -1314,7 +1314,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordRole>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordRole>(res.Response);
             ret.Discord = this.Discord;
             ret._guild_id = guild_id;
 
@@ -1349,7 +1349,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, $"{BuildQueryString(urlparams)}{sb}");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var pruned = Deserialize<RestGuildPruneResultPayload>(res.Response);
+            var pruned = DiscordJson.Deserialize<RestGuildPruneResultPayload>(res.Response);
 
             return pruned.Pruned.Value;
         }
@@ -1385,7 +1385,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, $"{BuildQueryString(urlparams)}{sb}");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route).ConfigureAwait(false);
 
-            var pruned = Deserialize<RestGuildPruneResultPayload>(res.Response);
+            var pruned = DiscordJson.Deserialize<RestGuildPruneResultPayload>(res.Response);
 
             return pruned.Pruned;
         }
@@ -1400,7 +1400,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var integrations_raw = Deserialize<IEnumerable<DiscordIntegration>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
+            var integrations_raw = DiscordJson.Deserialize<IEnumerable<DiscordIntegration>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
 
             return new ReadOnlyCollection<DiscordIntegration>(new List<DiscordIntegration>(integrations_raw));
         }
@@ -1413,7 +1413,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordGuildPreview>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordGuildPreview>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1433,7 +1433,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordIntegration>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordIntegration>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1454,7 +1454,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordIntegration>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordIntegration>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1488,7 +1488,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var embed = Deserialize<DiscordGuildEmbed>(res.Response);
+            var embed = DiscordJson.Deserialize<DiscordGuildEmbed>(res.Response);
 
             return embed;
         }
@@ -1503,7 +1503,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(embed)).ConfigureAwait(false);
 
-            var embed_rest = Deserialize<DiscordGuildEmbed>(res.Response);
+            var embed_rest = DiscordJson.Deserialize<DiscordGuildEmbed>(res.Response);
 
             return embed_rest;
         }
@@ -1516,7 +1516,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var regions_raw = Deserialize<IEnumerable<DiscordVoiceRegion>>(res.Response);
+            var regions_raw = DiscordJson.Deserialize<IEnumerable<DiscordVoiceRegion>>(res.Response);
 
             return new ReadOnlyCollection<DiscordVoiceRegion>(new List<DiscordVoiceRegion>(regions_raw));
         }
@@ -1529,7 +1529,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var invites_raw = Deserialize<IEnumerable<DiscordInvite>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
+            var invites_raw = DiscordJson.Deserialize<IEnumerable<DiscordInvite>>(res.Response).Select(xi => { xi.Discord = this.Discord; return xi; });
 
             return new ReadOnlyCollection<DiscordInvite>(new List<DiscordInvite>(invites_raw));
         }
@@ -1548,7 +1548,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordInvite>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordInvite>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1566,7 +1566,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route, headers).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordInvite>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordInvite>(res.Response);
             ret.Discord = this.Discord;
 
             return ret;
@@ -1583,7 +1583,7 @@ namespace DSharpPlus.Net
          *     var bucket = this.Rest.GetBucket(0, MajorParameterType.Unbucketed, url, HttpRequestMethod.POST);
          *     var res = await this.DoRequestAsync(this.Discord, bucket, url, HttpRequestMethod.POST).ConfigureAwait(false);
          *     
-         *     var ret = Deserialize<DiscordInvite>(res.Response);
+         *     var ret = DiscordJson.Deserialize<DiscordInvite>(res.Response);
          *     ret.Discord = this.Discord;
          * 
          *     return ret;
@@ -1600,7 +1600,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var connections_raw = Deserialize<IEnumerable<DiscordConnection>>(res.Response).Select(xc => { xc.Discord = this.Discord; return xc; });
+            var connections_raw = DiscordJson.Deserialize<IEnumerable<DiscordConnection>>(res.Response).Select(xc => { xc.Discord = this.Discord; return xc; });
 
             return new ReadOnlyCollection<DiscordConnection>(new List<DiscordConnection>(connections_raw));
         }
@@ -1615,7 +1615,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var regions = Deserialize<IEnumerable<DiscordVoiceRegion>>(res.Response);
+            var regions = DiscordJson.Deserialize<IEnumerable<DiscordVoiceRegion>>(res.Response);
 
             return new ReadOnlyCollection<DiscordVoiceRegion>(new List<DiscordVoiceRegion>(regions));
         }
@@ -1641,7 +1641,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordWebhook>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordWebhook>(res.Response);
             ret.Discord = this.Discord;
             ret.ApiClient = this;
 
@@ -1656,7 +1656,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var webhooks_raw = Deserialize<IEnumerable<DiscordWebhook>>(res.Response).Select(xw => { xw.Discord = this.Discord; xw.ApiClient = this; return xw; });
+            var webhooks_raw = DiscordJson.Deserialize<IEnumerable<DiscordWebhook>>(res.Response).Select(xw => { xw.Discord = this.Discord; xw.ApiClient = this; return xw; });
 
             return new ReadOnlyCollection<DiscordWebhook>(new List<DiscordWebhook>(webhooks_raw));
         }
@@ -1669,7 +1669,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var webhooks_raw = Deserialize<IEnumerable<DiscordWebhook>>(res.Response).Select(xw => { xw.Discord = this.Discord; xw.ApiClient = this; return xw; });
+            var webhooks_raw = DiscordJson.Deserialize<IEnumerable<DiscordWebhook>>(res.Response).Select(xw => { xw.Discord = this.Discord; xw.ApiClient = this; return xw; });
 
             return new ReadOnlyCollection<DiscordWebhook>(new List<DiscordWebhook>(webhooks_raw));
         }
@@ -1682,7 +1682,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordWebhook>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordWebhook>(res.Response);
             ret.Discord = this.Discord;
             ret.ApiClient = this;
 
@@ -1698,7 +1698,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordWebhook>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordWebhook>(res.Response);
             ret.Token = webhook_token;
             ret.Id = webhook_id;
             ret.Discord = this.Discord;
@@ -1727,7 +1727,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordWebhook>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordWebhook>(res.Response);
             ret.Discord = this.Discord;
             ret.ApiClient = this;
 
@@ -1752,7 +1752,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = Deserialize<DiscordWebhook>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordWebhook>(res.Response);
             ret.Discord = this.Discord;
             ret.ApiClient = this;
 
@@ -1816,7 +1816,7 @@ namespace DSharpPlus.Net
 
             var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: files).ConfigureAwait(false);
-            var ret = Deserialize<DiscordMessage>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
             return ret;
         }
@@ -1828,7 +1828,7 @@ namespace DSharpPlus.Net
 
             var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: json_payload);
-            var ret = Deserialize<DiscordMessage>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
             return ret;
         }
@@ -1840,7 +1840,7 @@ namespace DSharpPlus.Net
 
             var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: json_payload);
-            var ret = Deserialize<DiscordMessage>(res.Response);
+            var ret = DiscordJson.Deserialize<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
             return ret;
         }
@@ -1892,7 +1892,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, BuildQueryString(urlparams));
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var reacters_raw = Deserialize<IEnumerable<TransportUser>>(res.Response);
+            var reacters_raw = DiscordJson.Deserialize<IEnumerable<TransportUser>>(res.Response);
             var reacters = new List<DiscordUser>();
             foreach (var xr in reacters_raw)
             {
@@ -1943,7 +1943,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var emojisRaw = Deserialize<IEnumerable<JObject>>(res.Response);
+            var emojisRaw = DiscordJson.Deserialize<IEnumerable<JObject>>(res.Response);
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
             var users = new Dictionary<ulong, DiscordUser>();
@@ -1981,7 +1981,7 @@ namespace DSharpPlus.Net
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
-            var emoji_raw = await LoadJObjectAsync(res.Response);
+            var emoji_raw = await DiscordJson.LoadJObjectAsync(res.Response);
             var emoji = emoji_raw.ToObject<DiscordGuildEmoji>();
             emoji.Guild = gld;
 
@@ -2013,7 +2013,7 @@ namespace DSharpPlus.Net
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
-            var emoji_raw = await LoadJObjectAsync(res.Response);
+            var emoji_raw = await DiscordJson.LoadJObjectAsync(res.Response);
             var emoji = emoji_raw.ToObject<DiscordGuildEmoji>();
             emoji.Guild = gld;
 
@@ -2046,7 +2046,7 @@ namespace DSharpPlus.Net
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
-            var emoji_raw = await LoadJObjectAsync(res.Response);
+            var emoji_raw = await DiscordJson.LoadJObjectAsync(res.Response);
             var emoji = emoji_raw.ToObject<DiscordGuildEmoji>();
             emoji.Guild = gld;
 
@@ -2086,7 +2086,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            return Deserialize<TransportApplication>(res.Response);
+            return DiscordJson.Deserialize<TransportApplication>(res.Response);
         }
 
         internal async Task<IReadOnlyList<DiscordApplicationAsset>> GetApplicationAssetsAsync(DiscordApplication application)
@@ -2097,7 +2097,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var assets = Deserialize<IEnumerable<DiscordApplicationAsset>>(res.Response);
+            var assets = DiscordJson.Deserialize<IEnumerable<DiscordApplicationAsset>>(res.Response);
             foreach (var asset in assets)
             {
                 asset.Discord = application.Discord;
@@ -2118,44 +2118,10 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route, headers).ConfigureAwait(false);
 
-            var info = (await LoadJObjectAsync(res.Response)).ToObject<GatewayInfo>();
+            var info = (await DiscordJson.LoadJObjectAsync(res.Response)).ToObject<GatewayInfo>();
             info.SessionBucket.ResetAfter = DateTimeOffset.UtcNow + TimeSpan.FromMilliseconds(info.SessionBucket.resetAfter);
             return info;
         }
         #endregion
-
-        internal static T Deserialize<T>(Stream stream)
-        {
-            using var sr = new StreamReader(stream);
-            using var jtr = new JsonTextReader(sr);
-
-            var serializer = new JsonSerializer();
-
-            return serializer.Deserialize<T>(jtr);
-        }
-
-        internal static Task<JObject> LoadJObjectAsync(Stream stream)
-        {
-            using var sr = new StreamReader(stream);
-            using var jtr = new JsonTextReader(sr);
-
-            return JObject.LoadAsync(jtr);
-        }
-
-        internal static JObject LoadJObject(Stream stream)
-        {
-            using var sr = new StreamReader(stream);
-            using var jtr = new JsonTextReader(sr);
-
-            return JObject.Load(jtr);
-        }
-
-        internal static Task<JArray> LoadJArrayAsync(Stream stream)
-        {
-            using var sr = new StreamReader(stream);
-            using var jtr = new JsonTextReader(sr);
-
-            return JArray.LoadAsync(jtr);
-        }
     }
 }

--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -219,13 +219,16 @@ namespace DSharpPlus.Net
 
                     var res = await HttpClient.SendAsync(req, CancellationToken.None).ConfigureAwait(false);
 
-                    var bts = await res.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
-                    var txt = Utilities.UTF8.GetString(bts, 0, bts.Length);
+                    if (this.Discord.Configuration.MinimumLogLevel == LogLevel.Trace)
+                    {
+                        var bts = await res.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                        var txt = Utilities.UTF8.GetString(bts, 0, bts.Length);
 
-                    this.Logger.LogTrace(LoggerEvents.RestRx, txt);
+                        this.Logger.LogTrace(LoggerEvents.RestRx, txt);
+                    }
 
                     response.Headers = res.Headers.ToDictionary(xh => xh.Key, xh => string.Join("\n", xh.Value), StringComparer.OrdinalIgnoreCase);
-                    response.Response = txt;
+                    response.Response = await res.Content.ReadAsStreamAsync().ConfigureAwait(false);
                     response.ResponseCode = (int)res.StatusCode;
                 }
                 catch (HttpRequestException httpex)

--- a/DSharpPlus/Net/RestResponse.cs
+++ b/DSharpPlus/Net/RestResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.IO;
+using System.Collections.Generic;
 
 namespace DSharpPlus.Net
 {
@@ -20,7 +21,7 @@ namespace DSharpPlus.Net
         /// <summary>
         /// Gets the contents of the response sent by the remote party.
         /// </summary>
-        public string Response { get; internal set; }
+        public Stream Response { get; internal set; }
 
         internal RestResponse() { }
     }

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading.Tasks;
 using DSharpPlus.Entities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -59,6 +60,40 @@ namespace DSharpPlus.Net.Serialization
                 jsonSerializer.Serialize(jsonTextWriter, value, type);
             }
             return stringWriter.ToString();
+        }
+
+        internal static T Deserialize<T>(Stream stream)
+        {
+            using var sr = new StreamReader(stream);
+            using var jtr = new JsonTextReader(sr);
+
+            var serializer = new JsonSerializer();
+
+            return Serializer.Deserialize<T>(jtr);
+        }
+
+        internal static Task<JObject> LoadJObjectAsync(Stream stream)
+        {
+            using var sr = new StreamReader(stream);
+            using var jtr = new JsonTextReader(sr);
+
+            return JObject.LoadAsync(jtr);
+        }
+
+        internal static JObject LoadJObject(Stream stream)
+        {
+            using var sr = new StreamReader(stream);
+            using var jtr = new JsonTextReader(sr);
+
+            return JObject.Load(jtr);
+        }
+
+        internal static Task<JArray> LoadJArrayAsync(Stream stream)
+        {
+            using var sr = new StreamReader(stream);
+            using var jtr = new JsonTextReader(sr);
+
+            return JArray.LoadAsync(jtr);
         }
     }
 }

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -67,8 +67,6 @@ namespace DSharpPlus.Net.Serialization
             using var sr = new StreamReader(stream);
             using var jtr = new JsonTextReader(sr);
 
-            var serializer = new JsonSerializer();
-
             return Serializer.Deserialize<T>(jtr);
         }
 

--- a/DSharpPlus/Net/WebSocket/PayloadDecompressor.cs
+++ b/DSharpPlus/Net/WebSocket/PayloadDecompressor.cs
@@ -38,7 +38,7 @@ namespace DSharpPlus.Net.WebSocket
                 this.CompressedStream.Write(compressed.Array, compressed.Offset, compressed.Count);
 
             this.CompressedStream.Flush();
-            this.CompressedStream.Position = 0;
+            this.CompressedStream.Seek(0, SeekOrigin.Begin);
 
             var cspan = compressed.AsSpan();
             var suffix = BinaryPrimitives.ReadUInt32BigEndian(cspan.Slice(cspan.Length - 4));
@@ -58,7 +58,7 @@ namespace DSharpPlus.Net.WebSocket
             catch { return false; }
             finally
             {
-                this.CompressedStream.Position = 0;
+                this.CompressedStream.Seek(0, SeekOrigin.Begin);
                 this.CompressedStream.SetLength(0);
 
                 if (this.CompressionLevel == GatewayCompressionLevel.Payload)

--- a/DSharpPlus/Net/WebSocket/WebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient.cs
@@ -239,10 +239,10 @@ namespace DSharpPlus.Net.WebSocket
                         if (result.MessageType == WebSocketMessageType.Binary)
                         {
                             var resultBytes = new byte[bs.Length];
-                            bs.Position = 0;
+                            bs.Seek(0, SeekOrigin.Begin);
                             bs.Read(resultBytes, 0, resultBytes.Length);
 
-                            bs.Position = 0;
+                            bs.Seek(0, SeekOrigin.Begin);
                             bs.SetLength(0);
 
                             await this._messageReceived.InvokeAsync(this, new SocketBinaryMessageEventArgs(resultBytes)).ConfigureAwait(false);

--- a/DSharpPlus/Net/WebSocket/WebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient.cs
@@ -250,7 +250,8 @@ namespace DSharpPlus.Net.WebSocket
                         else if (result.MessageType == WebSocketMessageType.Text)
                         {
                             bs.Seek(0, SeekOrigin.Begin);
-                            var cs = new MemoryStream();
+
+                            using var cs = new MemoryStream();
 
                             await bs.CopyToAsync(cs).ConfigureAwait(false);
                             cs.Seek(0, SeekOrigin.Begin);

--- a/DSharpPlus/Net/WebSocket/WebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient.cs
@@ -249,7 +249,13 @@ namespace DSharpPlus.Net.WebSocket
                         }
                         else if (result.MessageType == WebSocketMessageType.Text)
                         {
-                            await this._messageReceived.InvokeAsync(this, new SocketTextMessageEventArgs(bs)).ConfigureAwait(false);
+                            bs.Seek(0, SeekOrigin.Begin);
+                            var cs = new MemoryStream();
+
+                            await bs.CopyToAsync(cs).ConfigureAwait(false);
+                            cs.Seek(0, SeekOrigin.Begin);
+
+                            await this._messageReceived.InvokeAsync(this, new SocketTextMessageEventArgs(cs)).ConfigureAwait(false);
                         }
                         else // close
                         {


### PR DESCRIPTION
# Summary
Replaces JSON serialization/deserialzation of objects from strings to streams. 

# Details
This PR aims to optimize memory usage with JSON.net by passing it streams for deserialization rather than strings. This allows it to serialize parts of data at a time rather than the full string. I was only able to test this with a 10 shard bot, but I noticed a 50 MB reduction on memory usage on startup, which isn't much but is certainly an improvement. This should help the memory usage of larger bots.  

# Changes proposed
* Convert rest client and api client to receive streams rather than strings
* Convert WS to receive streams rather than strings