### PR TITLE
Add server templates in response to #659

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1226,7 +1226,9 @@ namespace DSharpPlus
         /// Gets a guild template by the code.
         /// </summary>
         /// <param name="code">The code of the template.</param>
-        /// <returns>The guild template for the code.</returns>
+        /// <returns>The guild template for the code.</returns>\
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordGuildTemplate> GetTemplateAsync(string code)
             => this.ApiClient.GetTemplateAsync(code);
         #endregion

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -56,6 +56,16 @@ namespace DSharpPlus
             => this.ApiClient.CreateGuildAsync(name, region_id, iconb64, verification_level, default_message_notifications);
 
         /// <summary>
+        /// Creates a guild from a template. This requires the bot to be in less than 10 guilds total.
+        /// </summary>
+        /// <param name="code">The template code.</param>
+        /// <param name="name">Name of the guild.</param>
+        /// <param name="icon">Stream containing the icon for the guild.</param>
+        /// <returns>The created guild.</returns>
+        public Task<DiscordGuild> CreateGuildFromTemplateAsync(string code, string name, string icon)
+            => this.ApiClient.CreateGuildFromTemplateAsync(code, name, icon);
+
+        /// <summary>
         /// Deletes a guild
         /// </summary>
         /// <param name="id">guild id</param>
@@ -1211,6 +1221,14 @@ namespace DSharpPlus
         /// <returns></returns>
         public Task<IReadOnlyList<DiscordApplicationAsset>> GetApplicationAssetsAsync(DiscordApplication application)
             => this.ApiClient.GetApplicationAssetsAsync(application);
+
+        /// <summary>
+        /// Gets a guild template by the code.
+        /// </summary>
+        /// <param name="code">The code of the template.</param>
+        /// <returns>The guild template for the code.</returns>
+        public Task<DiscordGuildTemplate> GetTemplateAsync(string code)
+            => this.ApiClient.GetTemplateAsync(code);
         #endregion
 
         private bool disposed;

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -326,17 +326,6 @@ namespace DSharpPlus
 
         #region Public REST Methods
         /// <summary>
-        /// Gets a guild template by the code.
-        /// </summary>
-        /// <param name="code">The code of the template</param>
-        /// <returns></returns>
-        public async Task<DiscordGuildTemplate> GetTemplateAsync(string code)
-        {
-            var template = await this.ApiClient.GetTemplateAsync(code);
-            return template;
-        }
-        
-        /// <summary>
         /// Gets a user
         /// </summary>
         /// <param name="userId">Id of the user</param>

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -402,6 +402,25 @@ namespace DSharpPlus
         }
 
         /// <summary>
+        /// Creates a guild from a template. This requires the bot to be in less than 10 guilds total.
+        /// </summary>
+        /// <param name="code">The template code.</param>
+        /// <param name="name">Name of the guild.</param>
+        /// <param name="icon">Stream containing the icon for the guild.</param>
+        /// <returns>The created guild.</returns>
+        public Task<DiscordGuild> CreateGuildFromTemplateAsync(string code, string name, Optional<Stream> icon = default)
+        {
+            var iconb64 = Optional.FromNoValue<string>();
+            if (icon.HasValue && icon.Value != null)
+                using (var imgtool = new ImageTool(icon.Value))
+                    iconb64 = imgtool.GetBase64();
+            else if (icon.HasValue)
+                iconb64 = null;
+
+            return this.ApiClient.CreateGuildFromTemplateAsync(code, name, iconb64);
+        }
+
+        /// <summary>
         /// Gets a guild.
         /// <para>Setting <paramref name="withCounts"/> to true will make a REST request.</para>
         /// </summary>
@@ -513,6 +532,14 @@ namespace DSharpPlus
             this.CurrentUser.AvatarHash = usr.AvatarHash;
             return this.CurrentUser;
         }
+
+        /// <summary>
+        /// Gets a guild template by the code.
+        /// </summary>
+        /// <param name="code">The code of the template.</param>
+        /// <returns>The guild template for the code.</returns>
+        public Task<DiscordGuildTemplate> GetTemplateAsync(string code)
+            => this.ApiClient.GetTemplateAsync(code);
         #endregion
 
         #region Internal Caching Methods

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -408,6 +408,8 @@ namespace DSharpPlus
         /// <param name="name">Name of the guild.</param>
         /// <param name="icon">Stream containing the icon for the guild.</param>
         /// <returns>The created guild.</returns>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordGuild> CreateGuildFromTemplateAsync(string code, string name, Optional<Stream> icon = default)
         {
             var iconb64 = Optional.FromNoValue<string>();
@@ -538,6 +540,8 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="code">The code of the template.</param>
         /// <returns>The guild template for the code.</returns>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordGuildTemplate> GetTemplateAsync(string code)
             => this.ApiClient.GetTemplateAsync(code);
         #endregion

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -326,6 +326,17 @@ namespace DSharpPlus
 
         #region Public REST Methods
         /// <summary>
+        /// Gets a guild template by the code.
+        /// </summary>
+        /// <param name="code">The code of the template</param>
+        /// <returns></returns>
+        public async Task<DiscordGuildTemplate> GetTemplateAsync(string code)
+        {
+            var template = await this.ApiClient.GetTemplateAsync(code);
+            return template;
+        }
+        
+        /// <summary>
         /// Gets a user
         /// </summary>
         /// <param name="userId">Id of the user</param>

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -2078,6 +2078,8 @@ namespace DSharpPlus.Entities
         /// Gets all of this guild's templates.
         /// </summary>
         /// <returns>All of the guild's templates.</returns>
+        /// <exception cref="Exceptions.UnauthorizedException">Throws when the client does not have the <see cref="Permissions.ManageGuild"/> permission.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<IReadOnlyList<DiscordGuildTemplate>> GetTemplatesAsync()
             => this.Discord.ApiClient.GetGuildTemplatesAsync(this.Id);
 
@@ -2087,6 +2089,9 @@ namespace DSharpPlus.Entities
         /// <param name="name">Name of the template.</param>
         /// <param name="description">Description of the template.</param>
         /// <returns>The template created.</returns>
+        /// <exception cref="Exceptions.BadRequestException">Throws when a template already exists for the guild or a null parameter is provided for the name.</exception>
+        /// <exception cref="Exceptions.UnauthorizedException">Throws when the client does not have the <see cref="Permissions.ManageGuild"/> permission.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordGuildTemplate> CreateTemplateAsync(string name, string description = null)
             => this.Discord.ApiClient.CreateGuildTemplateAsync(this.Id, name, description);
 
@@ -2095,6 +2100,9 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="code">The code of the template to sync.</param>
         /// <returns>The template synced.</returns>
+        /// <exception cref="Exceptions.NotFoundException">Throws when the template for the code cannot be found</exception>
+        /// <exception cref="Exceptions.UnauthorizedException">Throws when the client does not have the <see cref="Permissions.ManageGuild"/> permission.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordGuildTemplate> SyncTemplateAsync(string code)
             => this.Discord.ApiClient.SyncGuildTemplateAsync(this.Id, code);
 
@@ -2105,6 +2113,9 @@ namespace DSharpPlus.Entities
         /// <param name="name">Name of the template.</param>
         /// <param name="description">Description of the template.</param>
         /// <returns>The template modified.</returns>
+        /// <exception cref="Exceptions.NotFoundException">Throws when the template for the code cannot be found</exception>
+        /// <exception cref="Exceptions.UnauthorizedException">Throws when the client does not have the <see cref="Permissions.ManageGuild"/> permission.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordGuildTemplate> ModifyTemplateAsync(string code, string name = null, string description = null)
             => this.Discord.ApiClient.ModifyGuildTemplateAsync(this.Id, code, name, description);
 
@@ -2113,6 +2124,9 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="code">The code of the template to delete.</param>
         /// <returns>The deleted template.</returns>
+        /// <exception cref="Exceptions.NotFoundException">Throws when the template for the code cannot be found</exception>
+        /// <exception cref="Exceptions.UnauthorizedException">Throws when the client does not have the <see cref="Permissions.ManageGuild"/> permission.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordGuildTemplate> DeleteTemplateAsync(string code)
             => this.Discord.ApiClient.DeleteGuildTemplateAsync(this.Id, code);
         #endregion

--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -2073,6 +2073,48 @@ namespace DSharpPlus.Entities
         /// <returns>The newly modified widget settings</returns>
         public Task<DiscordWidgetSettings> ModifyWidgetSettingsAsync(bool? isEnabled = null, DiscordChannel channel = null, string reason = null)
             => this.Discord.ApiClient.ModifyGuildWidgetSettingsAsync(this.Id, isEnabled, channel?.Id, reason);
+
+        /// <summary>
+        /// Gets all of this guild's templates.
+        /// </summary>
+        /// <returns>All of the guild's templates.</returns>
+        public Task<IReadOnlyList<DiscordGuildTemplate>> GetTemplatesAsync()
+            => this.Discord.ApiClient.GetGuildTemplatesAsync(this.Id);
+
+        /// <summary>
+        /// Creates a guild template.
+        /// </summary>
+        /// <param name="name">Name of the template.</param>
+        /// <param name="description">Description of the template.</param>
+        /// <returns>The template created.</returns>
+        public Task<DiscordGuildTemplate> CreateTemplateAsync(string name, string description = null)
+            => this.Discord.ApiClient.CreateGuildTemplateAsync(this.Id, name, description);
+
+        /// <summary>
+        /// Syncs the template to the current guild's state.
+        /// </summary>
+        /// <param name="code">The code of the template to sync.</param>
+        /// <returns>The template synced.</returns>
+        public Task<DiscordGuildTemplate> SyncTemplateAsync(string code)
+            => this.Discord.ApiClient.SyncGuildTemplateAsync(this.Id, code);
+
+        /// <summary>
+        /// Modifies the template's metadata.
+        /// </summary>
+        /// <param name="code">The template's code.</param>
+        /// <param name="name">Name of the template.</param>
+        /// <param name="description">Description of the template.</param>
+        /// <returns>The template modified.</returns>
+        public Task<DiscordGuildTemplate> ModifyTemplateAsync(string code, string name = null, string description = null)
+            => this.Discord.ApiClient.ModifyGuildTemplateAsync(this.Id, code, name, description);
+
+        /// <summary>
+        /// Deletes the template.
+        /// </summary>
+        /// <param name="code">The code of the template to delete.</param>
+        /// <returns>The deleted template.</returns>
+        public Task<DiscordGuildTemplate> DeleteTemplateAsync(string code)
+            => this.Discord.ApiClient.DeleteGuildTemplateAsync(this.Id, code);
         #endregion
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordGuildTemplate.cs
+++ b/DSharpPlus/Entities/DiscordGuildTemplate.cs
@@ -63,7 +63,7 @@ namespace DSharpPlus.Entities
         /// Gets the source guild.
         /// </summary>
         [JsonProperty("serialized_source_guild", NullValueHandling = NullValueHandling.Ignore)]
-        public DiscordGuild SourceGuild { get; internal set; }
+        public DiscordTemplateGuild SourceGuild { get; internal set; }
 
         /// <summary>
         /// Gets whether the template has unsynced changes.

--- a/DSharpPlus/Entities/DiscordGuildTemplate.cs
+++ b/DSharpPlus/Entities/DiscordGuildTemplate.cs
@@ -1,0 +1,74 @@
+using System;
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Entities
+{
+    public class DiscordGuildTemplate : SnowflakeObject
+    {
+        /// <summary>
+        /// Gets the template code.
+        /// </summary>
+        [JsonProperty("code", NullValueHandling = NullValueHandling.Ignore)]
+        public string Code { get; internal set; }
+
+        /// <summary>
+        /// Gets the name of the template.
+        /// </summary>
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        public string Name { get; internal set; }
+
+        /// <summary>
+        /// Gets the description of the template.
+        /// </summary>
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
+        public string Description { get; internal set; }
+
+        /// <summary>
+        /// Gets the number of times the template has been used.
+        /// </summary>
+        [JsonProperty("usage_count", NullValueHandling = NullValueHandling.Ignore)]
+        public int UsageCount { get; internal set; }
+
+        /// <summary>
+        /// Gets the ID of the creator of the template.
+        /// </summary>
+        [JsonProperty("creator_id", NullValueHandling = NullValueHandling.Ignore)]
+        public ulong CreatorId { get; internal set; }
+
+        /// <summary>
+        /// Gets the creator of the template.
+        /// </summary>
+        [JsonProperty("creator", NullValueHandling = NullValueHandling.Ignore)]
+        public DiscordUser Creator { get; internal set; }
+
+        /// <summary>
+        /// Date the template was created.
+        /// </summary>
+        [JsonProperty("created_at", NullValueHandling = NullValueHandling.Ignore)]
+        public DateTimeOffset CreatedAt { get; internal set; }
+
+        /// <summary>
+        /// Date the template was updated.
+        /// </summary>
+        [JsonProperty("updated_at", NullValueHandling = NullValueHandling.Ignore)]
+        public DateTimeOffset UpdatedAt { get; internal set; }
+
+        /// <summary>
+        /// Gets the ID of the source guild.
+        /// </summary>
+        [JsonProperty("source_guild_id", NullValueHandling = NullValueHandling.Ignore)]
+        public ulong SourceGuildId { get; internal set; }
+
+        /// <summary>
+        /// Gets the source guild.
+        /// </summary>
+        [JsonProperty("serialized_source_guild", NullValueHandling = NullValueHandling.Ignore)]
+        public DiscordGuild SourceGuild { get; internal set; }
+
+        /// <summary>
+        /// Gets whether the template has unsynced changes.
+        /// </summary>
+        [JsonProperty("is_dirty", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsDirty { get; internal set; }
+    }
+}

--- a/DSharpPlus/Entities/DiscordTemplateGuild.cs
+++ b/DSharpPlus/Entities/DiscordTemplateGuild.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using DSharpPlus.Net.Serialization;
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Entities
+{
+    public class DiscordTemplateGuild : SnowflakeObject
+    {
+        /// <summary>
+        /// Gets the guild's name.
+        /// </summary>
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        public string Name { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild description, when applicable.
+        /// </summary>
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
+        public string Description { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild's voice region ID.
+        /// </summary>
+        [JsonProperty("region", NullValueHandling = NullValueHandling.Ignore)]
+        public string VoiceRegionId { get; set; }
+
+        /// <summary>
+        /// Gets the guild's verification level.
+        /// </summary>
+        [JsonProperty("verification_level", NullValueHandling = NullValueHandling.Ignore)]
+        public VerificationLevel VerificationLevel { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild's default notification settings.
+        /// </summary>
+        [JsonProperty("default_message_notifications", NullValueHandling = NullValueHandling.Ignore)]
+        public DefaultMessageNotifications DefaultMessageNotifications { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild's explicit content filter settings.
+        /// </summary>
+        [JsonProperty("explicit_content_filter", NullValueHandling = NullValueHandling.Ignore)]
+        public ExplicitContentFilter ExplicitContentFilter { get; internal set; }
+
+        /// <summary>
+        /// Gets the preferred locale of this guild.
+        /// <para>This is used for server discovery and notices from Discord. Defaults to en-US.</para>
+        /// </summary>
+        [JsonProperty("preferred_locale", NullValueHandling = NullValueHandling.Ignore)]
+        public string PreferredLocale {get; internal set;}
+
+        /// <summary>
+        /// Gets the guild's AFK timeout.
+        /// </summary>
+        [JsonProperty("afk_timeout", NullValueHandling = NullValueHandling.Ignore)]
+        public int AfkTimeout { get; internal set; }
+
+        /// <summary>
+        /// Gets a collection of this guild's roles.
+        /// </summary>
+        [JsonIgnore]
+        public IReadOnlyDictionary<ulong, DiscordRole> Roles => new ReadOnlyConcurrentDictionary<ulong, DiscordRole>(this._roles);
+
+        [JsonProperty("roles", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(SnowflakeArrayAsDictionaryJsonConverter))]
+        internal ConcurrentDictionary<ulong, DiscordRole> _roles;
+
+        /// <summary>
+        /// Gets a dictionary of all the channels associated with this guild. The dictionary's key is the channel ID.
+        /// </summary>
+        [JsonIgnore]
+        public IReadOnlyDictionary<ulong, DiscordChannel> Channels => new ReadOnlyConcurrentDictionary<ulong, DiscordChannel>(this._channels);
+
+        [JsonProperty("channels", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(SnowflakeArrayAsDictionaryJsonConverter))]
+        internal ConcurrentDictionary<ulong, DiscordChannel> _channels;
+
+        [JsonProperty("afk_channel_id", NullValueHandling = NullValueHandling.Ignore)]
+        internal ulong AfkChannelId { get; set; } = 0;
+
+        /// <summary>
+        /// Gets the guild's AFK voice channel.
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel AfkChannel
+            => this.GetChannel(this.AfkChannelId);
+
+        [JsonProperty("system_channel_id", NullValueHandling = NullValueHandling.Include)]
+        internal ulong? SystemChannelId { get; set; }
+
+        /// <summary>
+        /// Gets the channel where system messages (such as boost and welcome messages) are sent.
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel SystemChannel => this.SystemChannelId.HasValue
+            ? this.GetChannel(this.SystemChannelId.Value)
+            : null;
+
+        /// <summary>
+        /// Gets the settings for this guild's system channel.
+        /// </summary>
+        [JsonProperty("system_channel_flags")]
+        public SystemChannelFlags SystemChannelFlags { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild icon's hash.
+        /// </summary>
+        [JsonProperty("icon_hash")]
+        public string IconHash { get; internal set; }
+
+        /// <summary>
+        /// Gets a channel from this guild by its ID.
+        /// </summary>
+        /// <param name="id">ID of the channel to get.</param>
+        /// <returns>Requested channel.</returns>
+        public DiscordChannel GetChannel(ulong id)
+            => (this._channels != null && this._channels.TryGetValue(id, out var channel)) ? channel : null;
+    }
+}

--- a/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/RestGuildPayloads.cs
@@ -36,6 +36,15 @@ namespace DSharpPlus.Net.Abstractions
         public IEnumerable<RestChannelCreatePayload> Channels { get; set; }
     }
 
+    internal sealed class RestGuildCreateFromTemplatePayload
+    {
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        public string Name { get; set; }
+
+        [JsonProperty("icon", NullValueHandling = NullValueHandling.Include)]
+        public Optional<string> IconBase64 { get; set; }
+    }
+
     internal sealed class RestGuildModifyPayload
     {
         [JsonProperty("name")]
@@ -196,5 +205,14 @@ namespace DSharpPlus.Net.Abstractions
         
         [JsonProperty("channel_id", NullValueHandling = NullValueHandling.Ignore)]
         public ulong? ChannelId { get; set; }
+    }
+
+    internal class RestGuildTemplateCreatePayload
+    {
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Include)]
+        public string Name { get; set; }
+
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Include)]
+        public string Description { get; set; }
     }
 }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -162,6 +162,29 @@ namespace DSharpPlus.Net
             return guild;
         }
 
+        internal async Task<DiscordGuild> CreateGuildFromTemplateAsync(string template_code, string name, Optional<string> iconb64)
+        {
+            var pld = new RestGuildCreateFromTemplatePayload
+            {
+                Name = name,
+                IconBase64 = iconb64
+            };
+
+            var route = $"{Endpoints.GUILDS}{Endpoints.TEMPLATES}/:template_code";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { template_code }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
+
+            var json = JObject.Parse(res.Response);
+            var raw_members = (JArray)json["members"];
+            var guild = JsonConvert.DeserializeObject<DiscordGuild>(res.Response);
+
+            if (this.Discord is DiscordClient dc)
+                await dc.OnGuildCreateEventAsync(guild, raw_members, null).ConfigureAwait(false);
+            return guild;
+        }
+
         internal async Task DeleteGuildAsync(ulong guild_id)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id";
@@ -1392,6 +1415,97 @@ namespace DSharpPlus.Net
         #endregion
 
         #region GuildVarious
+        internal async Task<DiscordGuildTemplate> GetTemplateAsync(string code)
+        {
+            var route = $"{Endpoints.GUILDS}{Endpoints.TEMPLATES}/:code";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { code }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
+
+            var templates_raw = JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response);
+
+            return templates_raw;
+        }
+
+        internal async Task<IReadOnlyList<DiscordGuildTemplate>> GetGuildTemplatesAsync(ulong guild_id)
+        {
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.TEMPLATES}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
+
+            var templates_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordGuildTemplate>>(res.Response);
+
+            return new ReadOnlyCollection<DiscordGuildTemplate>(new List<DiscordGuildTemplate>(templates_raw));
+        }
+
+        internal async Task<DiscordGuildTemplate> CreateGuildTemplateAsync(ulong guild_id, string name, string description)
+        {
+            var pld = new RestGuildTemplateCreatePayload
+            {
+                Name = name,
+                Description = description
+            };
+
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.TEMPLATES}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
+
+            var ret = JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response);
+            ret.Discord = this.Discord;
+
+            return ret;
+        }
+
+        internal async Task<DiscordGuildTemplate> SyncGuildTemplateAsync(ulong guild_id, string template_code)
+        {
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.TEMPLATES}/:template_code";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { guild_id, template_code }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, route).ConfigureAwait(false);
+
+            var template_raw = JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response);
+
+            return template_raw;
+        }
+
+        internal async Task<DiscordGuildTemplate> ModifyGuildTemplateAsync(ulong guild_id, string template_code, string name, string description)
+        {
+            var pld = new RestGuildTemplateCreatePayload
+            {
+                Name = name,
+                Description = description
+            };
+
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.TEMPLATES}/:template_code";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, template_code }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
+
+            var template_raw = JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response);
+
+            return template_raw;
+        }
+
+        internal async Task<DiscordGuildTemplate> DeleteGuildTemplateAsync(ulong guild_id, string template_code)
+        {
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.TEMPLATES}/:template_code";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, template_code }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route).ConfigureAwait(false);
+
+            var template_raw = JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response);
+
+            return template_raw;
+        }
+
         internal async Task<IReadOnlyList<DiscordIntegration>> GetGuildIntegrationsAsync(ulong guild_id)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.INTEGRATIONS}";

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -2070,21 +2070,6 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
         #endregion
-            
-        #region Templates
-        internal async Task<DiscordGuildTemplate> GetTemplateAsync(string code)
-        {
-            var route = $"{Endpoints.GUILDS}/templates/:code";
-            var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { code }, out var path);
-
-            var url = Utilities.GetApiUriFor(path);
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
-
-            var template = JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response);
-
-            return template;
-        }
-        #endregion
 
         #region Misc
         internal Task<TransportApplication> GetCurrentApplicationInfoAsync()

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -2070,6 +2070,21 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
         #endregion
+            
+        #region Templates
+        internal async Task<DiscordGuildTemplate> GetTemplateAsync(string code)
+        {
+            var route = $"{Endpoints.GUILDS}/templates/:code";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { code }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
+
+            var template = JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response);
+
+            return template;
+        }
+        #endregion
 
         #region Misc
         internal Task<TransportApplication> GetCurrentApplicationInfoAsync()

--- a/DSharpPlus/Net/Endpoints.cs
+++ b/DSharpPlus/Net/Endpoints.cs
@@ -51,5 +51,6 @@
         public const string CROSSPOST = "/crosspost";
         public const string WIDGET = "/widget";
         public const string WIDGET_JSON = "/widget.json";
+        public const string TEMPLATES = "/templates";
     }
 }


### PR DESCRIPTION
# Summary
Addresses #659. Implements server templates.

# Details
Discord recently introduced server templates, with which you can create another guild from an existing guild, which copies over  channels, roles, and some other data like afk timeout and region. Implemented everything listed in the docs.

# Changes proposed
- Add the DiscordGuildTemplate object.
- Add the templates endpoint.
- Implement the GetTemplateAsync and CreateGuildFromTemplateAsync methods in DiscordClient and DiscordRestClient.
- Implement the GetTemplatesAsync, CreateTemplateAsync, ModifyTemplateAsync, SyncTemplateAsync and DeleteTemplateAsync methods in DiscordGuild.
- Create partial guild object DiscordTemplateGuild for the source guild in DiscordGuildTemplate.
- Add payloads for create template and create guild from template.

# Notes
Hope I did fine for my first PR