### PR TITLE
Aligns the Method Names to what they should be on Builders

### DIFF
--- a/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
+++ b/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
@@ -41,7 +41,7 @@ namespace DSharpPlus.CommandsNext.Converters
                 this.EmbedBuilder.WithDescription($"{this.EmbedBuilder.Description}\n\nThis group can be executed as a standalone command.");
 
             if (command.Aliases?.Any() == true)
-                this.EmbedBuilder.AddField("Aliases", string.Join(", ", command.Aliases.Select(Formatter.InlineCode)), false);
+                this.EmbedBuilder.WithField("Aliases", string.Join(", ", command.Aliases.Select(Formatter.InlineCode)), false);
 
             if (command.Overloads?.Any() == true)
             {
@@ -62,7 +62,7 @@ namespace DSharpPlus.CommandsNext.Converters
                     sb.Append('\n');
                 }
 
-                this.EmbedBuilder.AddField("Arguments", sb.ToString().Trim(), false);
+                this.EmbedBuilder.WithField("Arguments", sb.ToString().Trim(), false);
             }
 
             return this;
@@ -75,7 +75,7 @@ namespace DSharpPlus.CommandsNext.Converters
         /// <returns>This help formatter.</returns>
         public override BaseHelpFormatter WithSubcommands(IEnumerable<Command> subcommands)
         {
-            this.EmbedBuilder.AddField(this.Command != null ? "Subcommands" : "Commands", string.Join(", ", subcommands.Select(x => Formatter.InlineCode(x.Name))), false);
+            this.EmbedBuilder.WithField(this.Command != null ? "Subcommands" : "Commands", string.Join(", ", subcommands.Select(x => Formatter.InlineCode(x.Name))), false);
 
             return this;
         }

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -202,7 +202,7 @@ namespace DSharpPlus.Test
                     Timestamp = DateTime.UtcNow
                 };
                 embed.WithFooter(Discord.CurrentUser.Username, Discord.CurrentUser.AvatarUrl)
-                    .AddField("Message", ex.Message);
+                    .WithField("Message", ex.Message);
                 await e.Context.RespondAsync(embed: embed.Build());
             }
         }

--- a/DSharpPlus/Entities/DiscordEmbedBuilder.cs
+++ b/DSharpPlus/Entities/DiscordEmbedBuilder.cs
@@ -344,7 +344,7 @@ namespace DSharpPlus.Entities
         /// <param name="value">Value of the field to add.</param>
         /// <param name="inline">Whether the field is to be inline or not.</param>
         /// <returns>This embed builder.</returns>
-        public DiscordEmbedBuilder AddField(string name, string value, bool inline = false)
+        public DiscordEmbedBuilder WithField(string name, string value, bool inline = false)
         {
             if (string.IsNullOrWhiteSpace(name))
             {

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -112,7 +112,7 @@ namespace DSharpPlus.Entities
         /// Adds an embed to send at the execution of the webhook.
         /// </summary>
         /// <param name="embed">Embed to add.</param>
-        public DiscordWebhookBuilder AddEmbed(DiscordEmbed embed)
+        public DiscordWebhookBuilder WithEmbed(DiscordEmbed embed)
         {
             this._embeds.Add(embed);
             return this;
@@ -122,7 +122,7 @@ namespace DSharpPlus.Entities
         /// Adds the given embeds to send at the execution of the webhook.
         /// </summary>
         /// <param name="embeds">Embeds to add.</param>
-        public DiscordWebhookBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
+        public DiscordWebhookBuilder WithEmbeds(IEnumerable<DiscordEmbed> embeds)
         {
             this._embeds.AddRange(embeds);
             return this;
@@ -133,7 +133,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="filename">Name of the file.</param>
         /// <param name="data">File data.</param>
-        public DiscordWebhookBuilder AddFile(string filename, Stream data)
+        public DiscordWebhookBuilder WithFile(string filename, Stream data)
         {
             this._files[filename] = data;
             return this;
@@ -143,7 +143,7 @@ namespace DSharpPlus.Entities
         /// Adds the given files to send at the execution of the webhook.
         /// </summary>
         /// <param name="files">Dictionary of file name and file data.</param>
-        public DiscordWebhookBuilder AddFiles(Dictionary<string, Stream> files)
+        public DiscordWebhookBuilder WithFiles(Dictionary<string, Stream> files)
         {
             foreach (var file in files)
             {
@@ -156,7 +156,7 @@ namespace DSharpPlus.Entities
         /// Adds the mention to the mentions to parse, etc. at the execution of the webhook.
         /// </summary>
         /// <param name="mention">Mention to add.</param>
-        public DiscordWebhookBuilder AddMention(IMention mention)
+        public DiscordWebhookBuilder WithMention(IMention mention)
         {
             this._mentions.Add(mention);
             return this;
@@ -166,7 +166,7 @@ namespace DSharpPlus.Entities
         /// Adds the mentions to the mentions to parse, etc. at the execution of the webhook.
         /// </summary>
         /// <param name="mentions">Mentions to add.</param>
-        public DiscordWebhookBuilder AddMentions(IEnumerable<IMention> mentions)
+        public DiscordWebhookBuilder WithMentions(IEnumerable<IMention> mentions)
         {
             this._mentions.AddRange(mentions);
             return this;


### PR DESCRIPTION
# Summary
Aligns the other builder's method names to what they should be.

# Details
With the Message Builder being brought in in #695 , we need to align the other builders to the correct naming based on grammar.  Since we need to assume in most instances an embed/message/etc, are not already created in discord (ie, we are not modifying), the correct grammar would be with and not add (you add to something that already exists).  