### PR TITLE
Added ConfigureAwait statements where needed

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -214,7 +214,7 @@ namespace DSharpPlus.CommandsNext
                 return;
             }
 
-            _ = Task.Run(async () => await this.ExecuteCommandAsync(ctx));
+            _ = Task.Run(async () => await this.ExecuteCommandAsync(ctx).ConfigureAwait(false));
         }
 
         /// <summary>

--- a/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
@@ -242,7 +242,7 @@ namespace DSharpPlus.CommandsNext.Converters
                 if (chn == null)
                     return Optional.FromNoValue<DiscordMessage>();
 
-                var msg = await chn.GetMessageAsync(mid);
+                var msg = await chn.GetMessageAsync(mid).ConfigureAwait(false);
                 return msg != null ? Optional.FromValue(msg) : Optional.FromNoValue<DiscordMessage>();
             }
 

--- a/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
@@ -51,7 +51,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             this._matchrequests.Add(request);
             try
             {
-                result = await request._tcs.Task;
+                result = await request._tcs.Task.ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
@@ -71,7 +71,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             this._collectrequests.Add(request);
             try
             {
-                await request._tcs.Task;
+                await request._tcs.Task.ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -28,13 +28,13 @@ namespace DSharpPlus.Interactivity.EventHandling
 
         public async Task DoPaginationAsync(IPaginationRequest request)
         {
-            await ResetReactionsAsync(request);
+            await ResetReactionsAsync(request).ConfigureAwait(false);
             this._requests.Add(request);
             try
             {
                 var tcs = await request.GetTaskCompletionSourceAsync();
-                await tcs.Task;
-                await request.DoCleanupAsync();
+                await tcs.Task.ConfigureAwait(false);
+                await request.DoCleanupAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -59,7 +59,7 @@ namespace DSharpPlus.Interactivity.EventHandling
                 {
                     if (eventargs.User.Id == usr.Id)
                     {
-                        await PaginateAsync(req, eventargs.Emoji);
+                        await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
                     }
                     else if (eventargs.User.Id != _client.CurrentUser.Id)
                     {
@@ -69,7 +69,7 @@ namespace DSharpPlus.Interactivity.EventHandling
                            eventargs.Emoji != emojis.SkipRight &&
                            eventargs.Emoji != emojis.Stop)
                         {
-                            await msg.DeleteReactionAsync(eventargs.Emoji, eventargs.User);
+                            await msg.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
                         }
                     }
                 }
@@ -89,7 +89,7 @@ namespace DSharpPlus.Interactivity.EventHandling
                 {
                     if (eventargs.User.Id == usr.Id)
                     {
-                        await PaginateAsync(req, eventargs.Emoji);
+                        await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
                     }
                     if (eventargs.Emoji != emojis.Left &&
                            eventargs.Emoji != emojis.SkipLeft &&
@@ -97,7 +97,7 @@ namespace DSharpPlus.Interactivity.EventHandling
                            eventargs.Emoji != emojis.SkipRight &&
                            eventargs.Emoji != emojis.Stop)
                     {
-                        await msg.DeleteReactionAsync(eventargs.Emoji, eventargs.User);
+                        await msg.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
                     }
                 }
             }
@@ -112,7 +112,7 @@ namespace DSharpPlus.Interactivity.EventHandling
 
                 if (msg.Id == eventargs.Message.Id)
                 {
-                    await ResetReactionsAsync(req);
+                    await ResetReactionsAsync(req).ConfigureAwait(false);
                 }
             }
         }
@@ -135,19 +135,19 @@ namespace DSharpPlus.Interactivity.EventHandling
             var mbr = gld?.CurrentMember;
 
             if (mbr != null /* == is guild and cache is valid */ && (chn.PermissionsFor(mbr) & Permissions.ManageChannels) != 0) /* == has permissions */
-                await msg.DeleteAllReactionsAsync("Pagination");
+                await msg.DeleteAllReactionsAsync("Pagination").ConfigureAwait(false);
             // ENDOF: 403 fix
 
             if (emojis.SkipLeft != null)
-                await msg.CreateReactionAsync(emojis.SkipLeft);
+                await msg.CreateReactionAsync(emojis.SkipLeft).ConfigureAwait(false);
             if (emojis.Left != null)
-                await msg.CreateReactionAsync(emojis.Left);
+                await msg.CreateReactionAsync(emojis.Left).ConfigureAwait(false);
             if (emojis.Right != null)
-                await msg.CreateReactionAsync(emojis.Right);
+                await msg.CreateReactionAsync(emojis.Right).ConfigureAwait(false);
             if (emojis.SkipRight != null)
-                await msg.CreateReactionAsync(emojis.SkipRight);
+                await msg.CreateReactionAsync(emojis.SkipRight).ConfigureAwait(false);
             if (emojis.Stop != null)
-                await msg.CreateReactionAsync(emojis.Stop);
+                await msg.CreateReactionAsync(emojis.Stop).ConfigureAwait(false);
         }
 
         async Task PaginateAsync(IPaginationRequest p, DiscordEmoji emoji)
@@ -156,13 +156,13 @@ namespace DSharpPlus.Interactivity.EventHandling
             var msg = await p.GetMessageAsync();
 
             if (emoji == emojis.SkipLeft)
-                await p.SkipLeftAsync();
+                await p.SkipLeftAsync().ConfigureAwait(false);
             else if (emoji == emojis.Left)
-                await p.PreviousPageAsync();
+                await p.PreviousPageAsync().ConfigureAwait(false);
             else if (emoji == emojis.Right)
-                await p.NextPageAsync();
+                await p.NextPageAsync().ConfigureAwait(false);
             else if (emoji == emojis.SkipRight)
-                await p.SkipRightAsync();
+                await p.SkipRightAsync().ConfigureAwait(false);
             else if (emoji == emojis.Stop)
             {
                 var tcs = await p.GetTaskCompletionSourceAsync();
@@ -175,7 +175,7 @@ namespace DSharpPlus.Interactivity.EventHandling
                 .WithContent(page.Content)
                 .WithEmbed(page.Embed);
 
-            await builder.ModifyAsync(msg);
+            await builder.ModifyAsync(msg).ConfigureAwait(false);
         }
 
         ~Paginator()

--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -32,7 +32,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             this._requests.Add(request);
             try
             {
-                var tcs = await request.GetTaskCompletionSourceAsync();
+                var tcs = await request.GetTaskCompletionSourceAsync().ConfigureAwait(false);
                 await tcs.Task.ConfigureAwait(false);
                 await request.DoCleanupAsync().ConfigureAwait(false);
             }
@@ -51,9 +51,9 @@ namespace DSharpPlus.Interactivity.EventHandling
             await Task.Yield();
             foreach (var req in _requests)
             {
-                var emojis = await req.GetEmojisAsync();
-                var msg = await req.GetMessageAsync();
-                var usr = await req.GetUserAsync();
+                var emojis = await req.GetEmojisAsync().ConfigureAwait(false);
+                var msg = await req.GetMessageAsync().ConfigureAwait(false);
+                var usr = await req.GetUserAsync().ConfigureAwait(false);
 
                 if (msg.Id == eventargs.Message.Id)
                 {
@@ -81,9 +81,9 @@ namespace DSharpPlus.Interactivity.EventHandling
             await Task.Yield();
             foreach (var req in _requests)
             {
-                var emojis = await req.GetEmojisAsync();
-                var msg = await req.GetMessageAsync();
-                var usr = await req.GetUserAsync();
+                var emojis = await req.GetEmojisAsync().ConfigureAwait(false);
+                var msg = await req.GetMessageAsync().ConfigureAwait(false);
+                var usr = await req.GetUserAsync().ConfigureAwait(false);
 
                 if (msg.Id == eventargs.Message.Id)
                 {
@@ -108,7 +108,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             await Task.Yield();
             foreach (var req in _requests)
             {
-                var msg = await req.GetMessageAsync();
+                var msg = await req.GetMessageAsync().ConfigureAwait(false);
 
                 if (msg.Id == eventargs.Message.Id)
                 {
@@ -119,8 +119,8 @@ namespace DSharpPlus.Interactivity.EventHandling
 
         async Task ResetReactionsAsync(IPaginationRequest p)
         {
-            var msg = await p.GetMessageAsync();
-            var emojis = await p.GetEmojisAsync();
+            var msg = await p.GetMessageAsync().ConfigureAwait(false);
+            var emojis = await p.GetEmojisAsync().ConfigureAwait(false);
 
             // Test permissions to avoid a 403:
             // https://totally-not.a-sketchy.site/3pXpRLK.png
@@ -152,8 +152,8 @@ namespace DSharpPlus.Interactivity.EventHandling
 
         async Task PaginateAsync(IPaginationRequest p, DiscordEmoji emoji)
         {
-            var emojis = await p.GetEmojisAsync();
-            var msg = await p.GetMessageAsync();
+            var emojis = await p.GetEmojisAsync().ConfigureAwait(false);
+            var msg = await p.GetMessageAsync().ConfigureAwait(false);
 
             if (emoji == emojis.SkipLeft)
                 await p.SkipLeftAsync().ConfigureAwait(false);
@@ -165,12 +165,12 @@ namespace DSharpPlus.Interactivity.EventHandling
                 await p.SkipRightAsync().ConfigureAwait(false);
             else if (emoji == emojis.Stop)
             {
-                var tcs = await p.GetTaskCompletionSourceAsync();
+                var tcs = await p.GetTaskCompletionSourceAsync().ConfigureAwait(false);
                 tcs.TrySetResult(true);
                 return;
             }
 
-            var page = await p.GetPageAsync();
+            var page = await p.GetPageAsync().ConfigureAwait(false);
             var builder = new DiscordMessageBuilder()
                 .WithContent(page.Content)
                 .WithEmbed(page.Embed);

--- a/DSharpPlus.Interactivity/EventHandling/Poller.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Poller.cs
@@ -64,7 +64,7 @@ namespace DSharpPlus.Interactivity.EventHandling
                     }
                     else
                     {
-                        var member = await eventargs.Channel.Guild.GetMemberAsync(client.CurrentUser.Id);
+                        var member = await eventargs.Channel.Guild.GetMemberAsync(client.CurrentUser.Id).ConfigureAwait(false);
                         if(eventargs.Channel.PermissionsFor(member).HasPermission(Permissions.ManageMessages))
                             await eventargs.Message.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
                     }

--- a/DSharpPlus.Interactivity/EventHandling/Poller.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Poller.cs
@@ -34,7 +34,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             this._requests.Add(request);
             try
             {
-                await request._tcs.Task;
+                await request._tcs.Task.ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -66,7 +66,7 @@ namespace DSharpPlus.Interactivity.EventHandling
                     {
                         var member = await eventargs.Channel.Guild.GetMemberAsync(client.CurrentUser.Id);
                         if(eventargs.Channel.PermissionsFor(member).HasPermission(Permissions.ManageMessages))
-                            await eventargs.Message.DeleteReactionAsync(eventargs.Emoji, eventargs.User);
+                            await eventargs.Message.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
                     }
                 }
             }

--- a/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
@@ -70,7 +70,7 @@ namespace DSharpPlus.Interactivity.EventHandling
 
             try
             {
-                await request._tcs.Task;
+                await request._tcs.Task.ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/DSharpPlus.Interactivity/EventHandling/Requests/PaginationRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/PaginationRequest.cs
@@ -147,11 +147,11 @@ namespace DSharpPlus.Interactivity.EventHandling
             switch (_deletion)
             {
                 case PaginationDeletion.DeleteEmojis:
-                    await _message.DeleteAllReactionsAsync();
+                    await _message.DeleteAllReactionsAsync().ConfigureAwait(false);
                     break;
 
                 case PaginationDeletion.DeleteMessage:
-                    await _message.DeleteAsync();
+                    await _message.DeleteAsync().ConfigureAwait(false);
                     break;
 
                 case PaginationDeletion.KeepEmojis:

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -66,10 +66,10 @@ namespace DSharpPlus.Interactivity
             {
                 await m.CreateReactionAsync(em).ConfigureAwait(false);
             }
-            var res = await Poller.DoPollAsync(new PollRequest(m, timeout ?? this.Config.Timeout, emojis));
+            var res = await Poller.DoPollAsync(new PollRequest(m, timeout ?? this.Config.Timeout, emojis)).ConfigureAwait(false);
 
             var pollbehaviour = behaviour ?? this.Config.PollBehaviour;
-            var thismember = await m.Channel.Guild.GetMemberAsync(Client.CurrentUser.Id);
+            var thismember = await m.Channel.Guild.GetMemberAsync(Client.CurrentUser.Id).ConfigureAwait(false);
 
             if (pollbehaviour == PollBehaviour.DeleteEmojis && m.Channel.PermissionsFor(thismember).HasPermission(Permissions.ManageMessages))
                 await m.DeleteAllReactionsAsync().ConfigureAwait(false);
@@ -90,7 +90,7 @@ namespace DSharpPlus.Interactivity
                 throw new InvalidOperationException("No message intents are enabled.");
 
             var timeout = timeoutoverride ?? Config.Timeout;
-            var returns = await this.MessageCreatedWaiter.WaitForMatch(new MatchRequest<MessageCreateEventArgs>(x => predicate(x.Message), timeout));
+            var returns = await this.MessageCreatedWaiter.WaitForMatch(new MatchRequest<MessageCreateEventArgs>(x => predicate(x.Message), timeout)).ConfigureAwait(false);
 
             return new InteractivityResult<DiscordMessage>(returns == null, returns?.Message);
         }
@@ -108,7 +108,7 @@ namespace DSharpPlus.Interactivity
                 throw new InvalidOperationException("No reaction intents are enabled.");
 
             var timeout = timeoutoverride ?? Config.Timeout;
-            var returns = await this.MessageReactionAddWaiter.WaitForMatch(new MatchRequest<MessageReactionAddEventArgs>(x => predicate(x), timeout));
+            var returns = await this.MessageReactionAddWaiter.WaitForMatch(new MatchRequest<MessageReactionAddEventArgs>(x => predicate(x), timeout)).ConfigureAwait(false);
 
             return new InteractivityResult<MessageReactionAddEventArgs>(returns == null, returns);
         }
@@ -122,7 +122,7 @@ namespace DSharpPlus.Interactivity
         /// <returns></returns>
         public async Task<InteractivityResult<MessageReactionAddEventArgs>> WaitForReactionAsync(DiscordMessage message, DiscordUser user,
             TimeSpan? timeoutoverride = null)
-            => await WaitForReactionAsync(x => x.User.Id == user.Id && x.Message.Id == message.Id, timeoutoverride);
+            => await WaitForReactionAsync(x => x.User.Id == user.Id && x.Message.Id == message.Id, timeoutoverride).ConfigureAwait(false);
 
         /// <summary>
         /// Waits for a specific reaction.
@@ -134,7 +134,7 @@ namespace DSharpPlus.Interactivity
         /// <returns></returns>
         public async Task<InteractivityResult<MessageReactionAddEventArgs>> WaitForReactionAsync(Func<MessageReactionAddEventArgs, bool> predicate, 
             DiscordMessage message, DiscordUser user, TimeSpan? timeoutoverride = null)
-            => await WaitForReactionAsync(x => predicate(x) && x.User.Id == user.Id && x.Message.Id == message.Id, timeoutoverride);
+            => await WaitForReactionAsync(x => predicate(x) && x.User.Id == user.Id && x.Message.Id == message.Id, timeoutoverride).ConfigureAwait(false);
 
         /// <summary>
         /// Waits for a specific reaction.
@@ -145,7 +145,7 @@ namespace DSharpPlus.Interactivity
         /// <returns></returns>
         public async Task<InteractivityResult<MessageReactionAddEventArgs>> WaitForReactionAsync(Func<MessageReactionAddEventArgs, bool> predicate,
             DiscordUser user, TimeSpan? timeoutoverride = null)
-            => await WaitForReactionAsync(x => predicate(x) && x.User.Id == user.Id, timeoutoverride);
+            => await WaitForReactionAsync(x => predicate(x) && x.User.Id == user.Id, timeoutoverride).ConfigureAwait(false);
 
         /// <summary>
         /// Waits for a user to start typing.
@@ -162,7 +162,8 @@ namespace DSharpPlus.Interactivity
 
             var timeout = timeoutoverride ?? Config.Timeout;
             var returns = await this.TypingStartWaiter.WaitForMatch(
-                new MatchRequest<TypingStartEventArgs>(x => x.User.Id == user.Id && x.Channel.Id == channel.Id, timeout));
+                new MatchRequest<TypingStartEventArgs>(x => x.User.Id == user.Id && x.Channel.Id == channel.Id, timeout))
+                .ConfigureAwait(false);
 
             return new InteractivityResult<TypingStartEventArgs>(returns == null, returns);
         }
@@ -180,7 +181,8 @@ namespace DSharpPlus.Interactivity
 
             var timeout = timeoutoverride ?? Config.Timeout;
             var returns = await this.TypingStartWaiter.WaitForMatch(
-                new MatchRequest<TypingStartEventArgs>(x => x.User.Id == user.Id, timeout));
+                new MatchRequest<TypingStartEventArgs>(x => x.User.Id == user.Id, timeout))
+                .ConfigureAwait(false);
 
             return new InteractivityResult<TypingStartEventArgs>(returns == null, returns);
         }
@@ -198,7 +200,8 @@ namespace DSharpPlus.Interactivity
 
             var timeout = timeoutoverride ?? Config.Timeout;
             var returns = await this.TypingStartWaiter.WaitForMatch(
-                new MatchRequest<TypingStartEventArgs>(x => x.Channel.Id == channel.Id, timeout));
+                new MatchRequest<TypingStartEventArgs>(x => x.Channel.Id == channel.Id, timeout))
+                .ConfigureAwait(false);
 
             return new InteractivityResult<TypingStartEventArgs>(returns == null, returns);
         }
@@ -215,7 +218,7 @@ namespace DSharpPlus.Interactivity
                 throw new InvalidOperationException("No reaction intents are enabled.");
 
             var timeout = timeoutoverride ?? Config.Timeout;
-            var collection = await ReactionCollector.CollectAsync(new ReactionCollectRequest(m, timeout));
+            var collection = await ReactionCollector.CollectAsync(new ReactionCollectRequest(m, timeout)).ConfigureAwait(false);
             return new ReadOnlyCollection<Reaction>(collection.ToList());
         }
 
@@ -232,7 +235,7 @@ namespace DSharpPlus.Interactivity
 
             using (var waiter = new EventWaiter<T>(this.Client))
             {
-                var res = await waiter.WaitForMatch(new MatchRequest<T>(predicate, timeout));
+                var res = await waiter.WaitForMatch(new MatchRequest<T>(predicate, timeout)).ConfigureAwait(false);
                 return new InteractivityResult<T>(res == null, res);
             }
         }
@@ -243,7 +246,7 @@ namespace DSharpPlus.Interactivity
 
             using (var waiter = new EventWaiter<T>(this.Client))
             {
-                var res = await waiter.CollectMatches(new CollectRequest<T>(predicate, timeout));
+                var res = await waiter.CollectMatches(new CollectRequest<T>(predicate, timeout)).ConfigureAwait(false);
                 return res;
             }
         }
@@ -265,7 +268,7 @@ namespace DSharpPlus.Interactivity
             var builder = new DiscordMessageBuilder()
                 .WithContent(pages.First().Content)
                 .WithEmbed(pages.First().Embed);
-            var m = await builder.SendAsync(c);
+            var m = await builder.SendAsync(c).ConfigureAwait(false);
 
             var timeout = timeoutoverride ?? Config.Timeout;
 

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -64,7 +64,7 @@ namespace DSharpPlus.Interactivity
 
             foreach(var em in emojis)
             {
-                await m.CreateReactionAsync(em);
+                await m.CreateReactionAsync(em).ConfigureAwait(false);
             }
             var res = await Poller.DoPollAsync(new PollRequest(m, timeout ?? this.Config.Timeout, emojis));
 
@@ -72,7 +72,7 @@ namespace DSharpPlus.Interactivity
             var thismember = await m.Channel.Guild.GetMemberAsync(Client.CurrentUser.Id);
 
             if (pollbehaviour == PollBehaviour.DeleteEmojis && m.Channel.PermissionsFor(thismember).HasPermission(Permissions.ManageMessages))
-                await m.DeleteAllReactionsAsync();
+                await m.DeleteAllReactionsAsync().ConfigureAwait(false);
 
             return new ReadOnlyCollection<PollEmoji>(res.ToList());
         }
@@ -275,7 +275,7 @@ namespace DSharpPlus.Interactivity
 
             var prequest = new PaginationRequest(m, u, bhv, del, ems, timeout, pages.ToArray());
 
-            await Paginator.DoPaginationAsync(prequest);
+            await Paginator.DoPaginationAsync(prequest).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -286,7 +286,7 @@ namespace DSharpPlus.Interactivity
         /// <returns></returns>
         public async Task WaitForCustomPaginationAsync(IPaginationRequest request)
         {
-            await Paginator.DoPaginationAsync(request);
+            await Paginator.DoPaginationAsync(request).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -332,7 +332,7 @@ namespace DSharpPlus.Lavalink
 
                 using var sr = new StreamReader(cs, Utilities.UTF8);
 
-                this.Discord.Logger.LogTrace(LavalinkEvents.LavalinkWsRx, await sr.ReadToEndAsync());
+                this.Discord.Logger.LogTrace(LavalinkEvents.LavalinkWsRx, await sr.ReadToEndAsync().ConfigureAwait(false));
             }
 
             var json = et.Message;

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -223,7 +223,7 @@ namespace DSharpPlus.Lavalink
                         this._backoff = MinimumBackoff;
                     }
 
-                    await this.WebSocket.ConnectAsync(new Uri(this.Configuration.SocketEndpoint.ToWebSocketString()));
+                    await this.WebSocket.ConnectAsync(new Uri(this.Configuration.SocketEndpoint.ToWebSocketString())).ConfigureAwait(false);
                     break;
                 }
                 catch (PlatformNotSupportedException)

--- a/DSharpPlus.Lavalink/LavalinkRestClient.cs
+++ b/DSharpPlus.Lavalink/LavalinkRestClient.cs
@@ -265,7 +265,7 @@ namespace DSharpPlus.Lavalink
             {
                 if (!req.IsSuccessStatusCode)
                 {
-                    var jsonError = await JObject.LoadAsync(jr);
+                    var jsonError = await JObject.LoadAsync(jr).ConfigureAwait(false);
                     this._logger?.LogError(LavalinkEvents.LavalinkDecodeError, "Unable to decode track strings: {0}", jsonError["message"]);
 
                     return null;
@@ -288,12 +288,12 @@ namespace DSharpPlus.Lavalink
             {
                 if (!req.IsSuccessStatusCode)
                 {
-                    var jsonError = await JObject.LoadAsync(jr);
+                    var jsonError = await JObject.LoadAsync(jr).ConfigureAwait(false);
                     this._logger?.LogError(LavalinkEvents.LavalinkDecodeError, "Unable to decode track strings", jsonError["message"]);
                     return null;
                 }
 
-                var jarr = await JArray.LoadAsync(jr);
+                var jarr = await JArray.LoadAsync(jr).ConfigureAwait(false);
                 var decodedTracks = new LavalinkTrack[jarr.Count];
 
                 for (var i = 0; i < decodedTracks.Length; i++)

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -422,9 +422,9 @@ namespace DSharpPlus
         public async Task<DiscordMessage> CreateMessageAsync(ulong channel_id, DiscordMessageBuilder builder)
         {
             if (builder.Files.Count() > 0)
-                return await this.ApiClient.UploadFilesAsync(channel_id, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return await this.ApiClient.UploadFilesAsync(channel_id, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions).ConfigureAwait(false);
             else
-                return await this.ApiClient.CreateMessageAsync(channel_id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return await this.ApiClient.CreateMessageAsync(channel_id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -489,7 +489,7 @@ namespace DSharpPlus
             if (builder.Files.Any())
                 throw new ArgumentException("You cannot add files when modifing a message.");
 
-            return await this.ApiClient.EditMessageAsync(channel_id, message_id, builder.Content, builder.Embed, builder.Mentions);
+            return await this.ApiClient.EditMessageAsync(channel_id, message_id, builder.Content, builder.Embed, builder.Mentions).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -67,7 +67,7 @@ namespace DSharpPlus.Test
             // For event timeout testing
             //Discord.GuildDownloadCompleted += async (s, e) =>
             //{
-            //    await Task.Delay(TimeSpan.FromSeconds(2));
+            //    await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
             //    throw new Exception("Flippin' tables");
             //};
 
@@ -113,7 +113,7 @@ namespace DSharpPlus.Test
             //    if (e.Message.Author.IsBot)
             //        return;
 
-            //    _ = Task.Run(async () => await e.Message.RespondAsync(e.Message.Content));
+            //    _ = Task.Run(async () => await e.Message.RespondAsync(e.Message.Content)).ConfigureAwait(false);
             //};
         }
 
@@ -203,7 +203,7 @@ namespace DSharpPlus.Test
                 };
                 embed.WithFooter(Discord.CurrentUser.Username, Discord.CurrentUser.AvatarUrl)
                     .AddField("Message", ex.Message);
-                await e.Context.RespondAsync(embed: embed.Build());
+                await e.Context.RespondAsync(embed: embed.Build()).ConfigureAwait(false);
             }
         }
 

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -15,15 +15,15 @@ namespace DSharpPlus.Test
 		[Command("crosspost")]
 		public async Task CrosspostAsync(CommandContext ctx, DiscordChannel chn, DiscordMessage msg)
 		{
-			var message = await chn.CrosspostMessageAsync(msg);
-			await ctx.RespondAsync($":ok_hand: Message published: {message.Id}");
+			var message = await chn.CrosspostMessageAsync(msg).ConfigureAwait(false);
+			await ctx.RespondAsync($":ok_hand: Message published: {message.Id}").ConfigureAwait(false);
 		}
 
 		[Command("follow")]
 		public async Task FollowAsync(CommandContext ctx, DiscordChannel channelToFollow, DiscordChannel targetChannel)
 		{
-			await channelToFollow.FollowAsync(targetChannel);
-			await ctx.RespondAsync($":ok_hand: Following channel {channelToFollow.Mention} into {targetChannel.Mention} (Guild: {targetChannel.Guild.Id})");
+			await channelToFollow.FollowAsync(targetChannel).ConfigureAwait(false);
+			await ctx.RespondAsync($":ok_hand: Following channel {channelToFollow.Mention} into {targetChannel.Mention} (Guild: {targetChannel.Guild.Id})").ConfigureAwait(false);
 		}
 
 		[Command("setprefix"), Aliases("channelprefix"), Description("Sets custom command prefix for current channel. The bot will still respond to the default one."), RequireOwner]
@@ -65,45 +65,52 @@ namespace DSharpPlus.Test
         public async Task MentionablesAsync(CommandContext ctx, DiscordUser user)
         {
             string content = $"Hey, {user.Mention}! Listen!";
-            await ctx.Channel.SendMessageAsync("✔ should ping, ❌ should not ping.");                                                                                           
+            await ctx.Channel.SendMessageAsync("✔ should ping, ❌ should not ping.").ConfigureAwait(false);                                                                                           
 
-            await ctx.Channel.SendMessageAsync("✔ Default Behaviour: " + content);                                                                                            //Should ping User
+            await ctx.Channel.SendMessageAsync("✔ Default Behaviour: " + content).ConfigureAwait(false);                                                                                            //Should ping User
 
             await new DiscordMessageBuilder()
                 .WithContent("✔ UserMention(user): " + content)
                 .WithAllowedMentions(new IMention[] { new UserMention(user) })
-                .SendAsync(ctx.Channel);                                                                                                                      //Should ping user
+                .SendAsync(ctx.Channel)
+                .ConfigureAwait(false);                                                                                                                      //Should ping user
 
             await new DiscordMessageBuilder()
                 .WithContent("✔ UserMention(): " + content)
                 .WithAllowedMentions(new IMention[] { new UserMention() })
-                .SendAsync(ctx.Channel);                                                                                                                      //Should ping user
+                .SendAsync(ctx.Channel)
+                .ConfigureAwait(false);                                                                                                                      //Should ping user
 
             await new DiscordMessageBuilder()
                 .WithContent("✔ User Mention Everyone & Self: " + content)
                 .WithAllowedMentions(new IMention[] { new UserMention(), new UserMention(user) })
-                .SendAsync(ctx.Channel);                                                                                                                      //Should ping user
+                .SendAsync(ctx.Channel)
+                .ConfigureAwait(false);                                                                                                                      //Should ping user
 
 
             await new DiscordMessageBuilder()
                .WithContent("✔ UserMention.All: " + content)
                .WithAllowedMentions(new IMention[] { UserMention.All })
-               .SendAsync(ctx.Channel);                                                                                                                       //Should ping user
+               .SendAsync(ctx.Channel)
+               .ConfigureAwait(false);                                                                                                                       //Should ping user
 
             await new DiscordMessageBuilder()
                .WithContent("❌ Empty Mention Array: " + content)
                .WithAllowedMentions(new IMention[0])
-               .SendAsync(ctx.Channel);                                                                                                                       //Should ping no one
+               .SendAsync(ctx.Channel)
+               .ConfigureAwait(false);                                                                                                                       //Should ping no one
 
             await new DiscordMessageBuilder()
                .WithContent("❌ UserMention(SomeoneElse): " + content)
                .WithAllowedMentions(new IMention[] { new UserMention(545836271960850454L) })
-               .SendAsync(ctx.Channel);                                                                                                                       //Should ping no one (@user was not pinged)
+               .SendAsync(ctx.Channel)
+               .ConfigureAwait(false);                                                                                                                       //Should ping no one (@user was not pinged)
 
             await new DiscordMessageBuilder()
                .WithContent("❌ Everyone():" + content)
                .WithAllowedMentions(new IMention[] { new EveryoneMention() })
-               .SendAsync(ctx.Channel);                                                                                                                       //Should ping no one (@everyone was not pinged)
+               .SendAsync(ctx.Channel)
+               .ConfigureAwait(false);                                                                                                                       //Should ping no one (@everyone was not pinged)
         }
 
         [Command("editMention"), Description("Attempts to mention a user via edit message")]
@@ -112,54 +119,62 @@ namespace DSharpPlus.Test
             string origcontent = $"Hey, silly! Listen!";
             string newContent = $"Hey, {user.Mention}! Listen!";
 
-            await ctx.Channel.SendMessageAsync("✔ should ping, ❌ should not ping.");
+            await ctx.Channel.SendMessageAsync("✔ should ping, ❌ should not ping.").ConfigureAwait(false);
 
-            var test1Msg = await ctx.Channel.SendMessageAsync("✔ Default Behaviour: " + origcontent);
+            var test1Msg = await ctx.Channel.SendMessageAsync("✔ Default Behaviour: " + origcontent).ConfigureAwait(false);
             await new DiscordMessageBuilder()
                .WithContent("✔ Default Behaviour: " + newContent)
-               .ModifyAsync(test1Msg);                                                                                                                               //Should ping User
+               .ModifyAsync(test1Msg)
+               .ConfigureAwait(false);                                                                                                                               //Should ping User
 
-            var test2Msg = await ctx.Channel.SendMessageAsync("✔ UserMention(user): " + origcontent);      
+            var test2Msg = await ctx.Channel.SendMessageAsync("✔ UserMention(user): " + origcontent).ConfigureAwait(false);      
             await new DiscordMessageBuilder()
                .WithContent("✔ UserMention(user): " + newContent)
                .WithAllowedMentions(new IMention[] { new UserMention(user) })
-               .ModifyAsync(test2Msg);                                                                                                                               //Should ping user
+               .ModifyAsync(test2Msg)
+               .ConfigureAwait(false);                                                                                                                               //Should ping user
 
-            var test3Msg = await ctx.Channel.SendMessageAsync("✔ UserMention(): " + origcontent);
+            var test3Msg = await ctx.Channel.SendMessageAsync("✔ UserMention(): " + origcontent).ConfigureAwait(false);
             await new DiscordMessageBuilder()
                .WithContent("✔ UserMention(): " + newContent)
                .WithAllowedMentions(new IMention[] { new UserMention() })
-               .ModifyAsync(test3Msg);                                                                                                                               //Should ping user
+               .ModifyAsync(test3Msg)
+               .ConfigureAwait(false);                                                                                                                               //Should ping user
 
-            var test4Msg = await ctx.Channel.SendMessageAsync("✔ User Mention Everyone & Self: " + origcontent);
+            var test4Msg = await ctx.Channel.SendMessageAsync("✔ User Mention Everyone & Self: " + origcontent).ConfigureAwait(false);
             await new DiscordMessageBuilder()
                .WithContent("✔ User Mention Everyone & Self: " + newContent)
                .WithAllowedMentions(new IMention[] { new UserMention(), new UserMention(user) })
-               .ModifyAsync(test4Msg);                                                                                                                               //Should ping user
+               .ModifyAsync(test4Msg)
+               .ConfigureAwait(false);                                                                                                                               //Should ping user
 
-            var test5Msg = await ctx.Channel.SendMessageAsync("✔ UserMention.All: " + origcontent);
+            var test5Msg = await ctx.Channel.SendMessageAsync("✔ UserMention.All: " + origcontent).ConfigureAwait(false);
             await new DiscordMessageBuilder()
                .WithContent("✔ UserMention.All: " + newContent)
                .WithAllowedMentions(new IMention[] { UserMention.All })
-               .ModifyAsync(test5Msg);                                                                                                                               //Should ping user
+               .ModifyAsync(test5Msg)
+               .ConfigureAwait(false);                                                                                                                               //Should ping user
 
-            var test6Msg = await ctx.Channel.SendMessageAsync("❌ Empty Mention Array: " + origcontent);
+            var test6Msg = await ctx.Channel.SendMessageAsync("❌ Empty Mention Array: " + origcontent).ConfigureAwait(false);
             await new DiscordMessageBuilder()
                .WithContent("❌ Empty Mention Array: " + newContent)
                .WithAllowedMentions(new IMention[0])
-               .ModifyAsync(test6Msg);                                                                                                                               //Should ping no one
+               .ModifyAsync(test6Msg)
+               .ConfigureAwait(false);                                                                                                                               //Should ping no one
 
-            var test7Msg = await ctx.Channel.SendMessageAsync("❌ UserMention(SomeoneElse): " + origcontent);
+            var test7Msg = await ctx.Channel.SendMessageAsync("❌ UserMention(SomeoneElse): " + origcontent).ConfigureAwait(false);
             await new DiscordMessageBuilder()
                .WithContent("❌ UserMention(SomeoneElse): " + newContent)
                .WithAllowedMentions(new IMention[] { new UserMention(777677298316214324) })
-               .ModifyAsync(test7Msg);                                                                                                                               //Should ping no one (@user was not pinged)
+               .ModifyAsync(test7Msg)
+               .ConfigureAwait(false);                                                                                                                               //Should ping no one (@user was not pinged)
 
-            var test8Msg = await ctx.Channel.SendMessageAsync("❌ Everyone(): " + origcontent);
+            var test8Msg = await ctx.Channel.SendMessageAsync("❌ Everyone(): " + origcontent).ConfigureAwait(false);
             await new DiscordMessageBuilder()
                .WithContent("❌ Everyone(): " + newContent)
                .WithAllowedMentions(new IMention[] { new EveryoneMention() })
-               .ModifyAsync(test8Msg);                                                                                                                               //Should ping no one (@everyone was not pinged)
+               .ModifyAsync(test8Msg)
+               .ConfigureAwait(false);                                                                                                                               //Should ping no one (@everyone was not pinged)
         }
 
         [Command("SendSomeFile")]
@@ -170,27 +185,31 @@ namespace DSharpPlus.Test
                 await new DiscordMessageBuilder()
                     .WithContent("Here is a really dumb file that i am testing with.")
                     .WithFiles(new Dictionary<string, Stream>() { { "ADumbFile1.txt", fs } })
-                    .SendAsync(ctx.Channel);
+                    .SendAsync(ctx.Channel)
+                    .ConfigureAwait(false);
 
                 fs.Position = 0;
 
                 await new DiscordMessageBuilder()
                     .WithContent("Here is a really dumb file that i am testing with.")
                     .WithFile(fs)
-                    .SendAsync(ctx.Channel);
+                    .SendAsync(ctx.Channel)
+                    .ConfigureAwait(false);
 
                 fs.Position = 0;
 
                 await new DiscordMessageBuilder()
                     .WithContent("Here is a really dumb file that i am testing with.")
                     .WithFile("ADumbFile2.txt", fs)
-                    .SendAsync(ctx.Channel);               
+                    .SendAsync(ctx.Channel)
+                    .ConfigureAwait(false);               
             }
 
             await new DiscordMessageBuilder()
                    .WithContent("Here is a really dumb file that i am testing with.")
                    .WithFile("./ADumbFile.txt")
-                   .SendAsync(ctx.Channel);
+                   .SendAsync(ctx.Channel)
+                   .ConfigureAwait(false);
         }
     }
 }

--- a/DSharpPlus.Test/TestBotLavaCommands.cs
+++ b/DSharpPlus.Test/TestBotLavaCommands.cs
@@ -86,7 +86,7 @@ namespace DSharpPlus.Test
                 return;
             }
 
-            this.LavalinkVoice = await this.Lavalink.ConnectAsync(vc);
+            this.LavalinkVoice = await this.Lavalink.ConnectAsync(vc).ConfigureAwait(false);
             this.LavalinkVoice.PlaybackFinished += this.LavalinkVoice_PlaybackFinished;
             this.LavalinkVoice.DiscordWebSocketClosed += (s, e) => ctx.RespondAsync("discord websocket close event");
             await ctx.RespondAsync("Connected.").ConfigureAwait(false);
@@ -120,7 +120,7 @@ namespace DSharpPlus.Test
 
             this.ContextChannel = ctx.Channel;
 
-            var trackLoad = await this.Lavalink.Rest.GetTracksAsync(uri);
+            var trackLoad = await this.Lavalink.Rest.GetTracksAsync(uri).ConfigureAwait(false);
             var track = trackLoad.Tracks.First();
             await this.LavalinkVoice.PlayAsync(track).ConfigureAwait(false);
 
@@ -133,7 +133,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            var trackLoad = await this.Lavalink.Rest.GetTracksAsync(new FileInfo(path));
+            var trackLoad = await this.Lavalink.Rest.GetTracksAsync(new FileInfo(path)).ConfigureAwait(false);
             var track = trackLoad.Tracks.First();
             await this.LavalinkVoice.PlayAsync(track).ConfigureAwait(false);
 
@@ -146,7 +146,7 @@ namespace DSharpPlus.Test
             if (this.Lavalink == null)
                 return;
 
-            var result = await this.Lavalink.Rest.GetTracksAsync(search, LavalinkSearchType.SoundCloud);
+            var result = await this.Lavalink.Rest.GetTracksAsync(search, LavalinkSearchType.SoundCloud).ConfigureAwait(false);
             var track = result.Tracks.First();
             await this.LavalinkVoice.PlayAsync(track).ConfigureAwait(false);
 
@@ -159,7 +159,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            var trackLoad = await this.Lavalink.Rest.GetTracksAsync(uri);
+            var trackLoad = await this.Lavalink.Rest.GetTracksAsync(uri).ConfigureAwait(false);
             var track = trackLoad.Tracks.First();
             await this.LavalinkVoice.PlayPartialAsync(track, start, stop).ConfigureAwait(false);
 

--- a/DSharpPlus.Test/TestBotLavaCommands.cs
+++ b/DSharpPlus.Test/TestBotLavaCommands.cs
@@ -122,7 +122,7 @@ namespace DSharpPlus.Test
 
             var trackLoad = await this.Lavalink.Rest.GetTracksAsync(uri);
             var track = trackLoad.Tracks.First();
-            await this.LavalinkVoice.PlayAsync(track);
+            await this.LavalinkVoice.PlayAsync(track).ConfigureAwait(false);
 
             await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.").ConfigureAwait(false);
         }
@@ -135,7 +135,7 @@ namespace DSharpPlus.Test
 
             var trackLoad = await this.Lavalink.Rest.GetTracksAsync(new FileInfo(path));
             var track = trackLoad.Tracks.First();
-            await this.LavalinkVoice.PlayAsync(track);
+            await this.LavalinkVoice.PlayAsync(track).ConfigureAwait(false);
 
             await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.").ConfigureAwait(false);
         }
@@ -148,9 +148,9 @@ namespace DSharpPlus.Test
 
             var result = await this.Lavalink.Rest.GetTracksAsync(search, LavalinkSearchType.SoundCloud);
             var track = result.Tracks.First();
-            await this.LavalinkVoice.PlayAsync(track);
+            await this.LavalinkVoice.PlayAsync(track).ConfigureAwait(false);
 
-            await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.");
+            await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.").ConfigureAwait(false);
         }
 
         [Command, Description("Queues tracks for playback.")]
@@ -161,7 +161,7 @@ namespace DSharpPlus.Test
 
             var trackLoad = await this.Lavalink.Rest.GetTracksAsync(uri);
             var track = trackLoad.Tracks.First();
-            await this.LavalinkVoice.PlayPartialAsync(track, start, stop);
+            await this.LavalinkVoice.PlayPartialAsync(track, start, stop).ConfigureAwait(false);
 
             await ctx.RespondAsync($"Now playing: {Formatter.Bold(Formatter.Sanitize(track.Title))} by {Formatter.Bold(Formatter.Sanitize(track.Author))}.").ConfigureAwait(false);
         }
@@ -172,7 +172,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            await this.LavalinkVoice.PauseAsync();
+            await this.LavalinkVoice.PauseAsync().ConfigureAwait(false);
             await ctx.RespondAsync("Paused.").ConfigureAwait(false);
         }
 
@@ -182,7 +182,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            await this.LavalinkVoice.ResumeAsync();
+            await this.LavalinkVoice.ResumeAsync().ConfigureAwait(false);
             await ctx.RespondAsync("Resumed.").ConfigureAwait(false);
         }
 
@@ -192,7 +192,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            await this.LavalinkVoice.StopAsync();
+            await this.LavalinkVoice.StopAsync().ConfigureAwait(false);
             await ctx.RespondAsync("Stopped.").ConfigureAwait(false);
         }
 
@@ -202,7 +202,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            await this.LavalinkVoice.SeekAsync(position);
+            await this.LavalinkVoice.SeekAsync(position).ConfigureAwait(false);
             await ctx.RespondAsync($"Seeking to {position}.").ConfigureAwait(false);
         }
 
@@ -212,7 +212,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            await this.LavalinkVoice.SetVolumeAsync(volume);
+            await this.LavalinkVoice.SetVolumeAsync(volume).ConfigureAwait(false);
             await ctx.RespondAsync($"Volume set to {volume}%.").ConfigureAwait(false);
         }
 
@@ -233,7 +233,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            await this.LavalinkVoice.ResetEqualizerAsync();
+            await this.LavalinkVoice.ResetEqualizerAsync().ConfigureAwait(false);
             await ctx.RespondAsync("All equalizer bands were reset.").ConfigureAwait(false);
         }
 
@@ -243,7 +243,7 @@ namespace DSharpPlus.Test
             if (this.LavalinkVoice == null)
                 return;
 
-            await this.LavalinkVoice.AdjustEqualizerAsync(new LavalinkBandAdjustment(band, gain));
+            await this.LavalinkVoice.AdjustEqualizerAsync(new LavalinkBandAdjustment(band, gain)).ConfigureAwait(false);
             await ctx.RespondAsync($"Band {band} adjusted by {gain}").ConfigureAwait(false);
         }
 

--- a/DSharpPlus.Test/TestBotPaginator.cs
+++ b/DSharpPlus.Test/TestBotPaginator.cs
@@ -36,7 +36,7 @@ namespace DSharpPlus.Test
 
         public async Task DoCleanupAsync()
         {
-            await this._msg.DeleteAsync();
+            await this._msg.DeleteAsync().ConfigureAwait(false);
         }
 
         public async Task<PaginationEmojis> GetEmojisAsync()

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -295,7 +295,7 @@ namespace DSharpPlus.VoiceNext
 
         internal async Task EnqueuePacketAsync(RawVoicePacket packet, CancellationToken token = default)
         {
-            await this.TransmitChannel.Writer.WriteAsync(packet, token);
+            await this.TransmitChannel.Writer.WriteAsync(packet, token).ConfigureAwait(false);
             this._queueCount++;
         }
 
@@ -418,7 +418,7 @@ namespace DSharpPlus.VoiceNext
                     {
                         var nullpacket = new byte[nullpcm.Length];
                         var nullpacketmem = nullpacket.AsMemory();
-                        await this.EnqueuePacketAsync(new RawVoicePacket(nullpacketmem, 20, true));
+                        await this.EnqueuePacketAsync(new RawVoicePacket(nullpacketmem, 20, true)).ConfigureAwait(false);
                     }
                 }
                 else if (_queueCount == 0)
@@ -770,7 +770,7 @@ namespace DSharpPlus.VoiceNext
 
                 await client.SendAsync(packet, packet.Length).ConfigureAwait(false);
 
-                await Task.Delay(5000, token);
+                await Task.Delay(5000, token).ConfigureAwait(false);
             }
         }
 
@@ -855,7 +855,7 @@ namespace DSharpPlus.VoiceNext
             {
                 var nullPcm = new byte[nullpcm.Length];
                 var nullpacketmem = nullPcm.AsMemory();
-                await this.EnqueuePacketAsync(new RawVoicePacket(nullpacketmem, 20, true));
+                await this.EnqueuePacketAsync(new RawVoicePacket(nullpacketmem, 20, true)).ConfigureAwait(false);
             }
 
             this.IsInitialized = true;

--- a/DSharpPlus.VoiceNext/VoiceTransmitSink.cs
+++ b/DSharpPlus.VoiceNext/VoiceTransmitSink.cs
@@ -74,7 +74,7 @@ namespace DSharpPlus.VoiceNext
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
         {
-            await WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken);
+            await WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace DSharpPlus.VoiceNext
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public async Task WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            await this.WriteSemaphore.WaitAsync(cancellationToken);
+            await this.WriteSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
 
             try
             {
@@ -114,7 +114,7 @@ namespace DSharpPlus.VoiceNext
                         var packetMemory = packet.AsMemory().Slice(0, PcmMemory.Length);
                         PcmMemory.CopyTo(packetMemory);
 
-                        await Connection.EnqueuePacketAsync(new RawVoicePacket(packetMemory, PcmBufferDuration, false, packet), cancellationToken);
+                        await Connection.EnqueuePacketAsync(new RawVoicePacket(packetMemory, PcmBufferDuration, false, packet), cancellationToken).ConfigureAwait(false);
                     }
                 }
             }
@@ -139,7 +139,7 @@ namespace DSharpPlus.VoiceNext
             var packetMemory = packet.AsMemory().Slice(0, pcm.Length);
             pcm.CopyTo(packetMemory);
 
-            await Connection.EnqueuePacketAsync(new RawVoicePacket(packetMemory, PcmBufferDuration, false, packet), cancellationToken);
+            await Connection.EnqueuePacketAsync(new RawVoicePacket(packetMemory, PcmBufferDuration, false, packet), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -413,9 +413,9 @@ namespace DSharpPlus
         public async Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, DiscordMessageBuilder builder)
         {
             if (builder.Files.Count() > 0)
-                return await this.ApiClient.UploadFilesAsync(channel.Id, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return await this.ApiClient.UploadFilesAsync(channel.Id, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions).ConfigureAwait(false);
             else
-                return await this.ApiClient.CreateMessageAsync(channel.Id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return await this.ApiClient.CreateMessageAsync(channel.Id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -255,7 +255,7 @@ namespace DSharpPlus
             var timer = new Stopwatch();
             timer.Start();
 
-            var jo = await DiscordJson.LoadJObjectAsync(await resp.Content.ReadAsStreamAsync().ConfigureAwait(false));
+            var jo = await DiscordJson.LoadJObjectAsync(await resp.Content.ReadAsStreamAsync().ConfigureAwait(false)).ConfigureAwait(false);
             var info = jo.ToObject<GatewayInfo>();
 
             //There is a delay from parsing here.

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -394,7 +394,7 @@ namespace DSharpPlus.Entities
             if (builder.Files.Any())
                 throw new ArgumentException("You cannot add files when modifing a message.");
 
-            return await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, builder.Content, builder.Embed, builder.Mentions);
+            return await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, builder.Content, builder.Embed, builder.Mentions).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -491,9 +491,9 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMessage> RespondAsync(DiscordMessageBuilder builder)
         {
             if (builder.Files.Count() > 0)
-                return await this.Discord.ApiClient.UploadFilesAsync(this.ChannelId, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return await this.Discord.ApiClient.UploadFilesAsync(this.ChannelId, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions).ConfigureAwait(false);
             else
-                return await this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions);
+                return await this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -182,7 +182,7 @@ namespace DSharpPlus.Entities
         /// <returns></returns>
         public async Task<DiscordMessage> SendAsync(DiscordChannel channel)
         {
-            return await channel.SendMessageAsync(this);
+            return await channel.SendMessageAsync(this).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace DSharpPlus.Entities
         /// <returns></returns>
         public async Task<DiscordMessage> ModifyAsync(DiscordMessage msg)
         {
-            return await msg.ModifyAsync(this);
+            return await msg.ModifyAsync(this).ConfigureAwait(false);
         }
     }
 }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -153,7 +153,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var json = await DiscordJson.LoadJObjectAsync(res.Response);
+            var json = await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false);
             var raw_members = (JArray)json["members"];
             var guild = DiscordJson.Deserialize<DiscordGuild>(res.Response);
 
@@ -210,7 +210,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var json = await DiscordJson.LoadJObjectAsync(res.Response);
+            var json = await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false);
             var rawMembers = (JArray)json["members"];
             var guild = DiscordJson.Deserialize<DiscordGuild>(res.Response);
             foreach (var r in guild._roles.Values)
@@ -435,7 +435,7 @@ namespace DSharpPlus.Net
             ret.Discord = this.Discord;
             ret.Guild = this.Discord.Guilds[guild_id];
 
-            var json = await DiscordJson.LoadJObjectAsync(res.Response);
+            var json = await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false);
             var rawChannels = (JArray)json["channels"];
             if (ret.Guild == null)
             {
@@ -604,7 +604,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response));
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response)).ConfigureAwait(false);
 
             return ret;
         }
@@ -644,7 +644,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response));
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response)).ConfigureAwait(false);
 
             return ret;
         }
@@ -679,7 +679,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: file).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response));
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false));
 
             return ret;
         }
@@ -715,7 +715,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: files).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response));
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false));
 
             return ret;
         }
@@ -758,7 +758,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var msgs_raw = await DiscordJson.LoadJArrayAsync(res.Response);
+            var msgs_raw = await DiscordJson.LoadJArrayAsync(res.Response).ConfigureAwait(false);
             var msgs = new List<DiscordMessage>();
             foreach (var xj in msgs_raw)
                 msgs.Add(this.PrepareMessage(xj));
@@ -774,7 +774,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response));
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false));
 
             return ret;
         }
@@ -815,7 +815,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response));
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false));
 
             return ret;
         }
@@ -940,7 +940,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var msgs_raw = await DiscordJson.LoadJArrayAsync(res.Response);
+            var msgs_raw = await DiscordJson.LoadJArrayAsync(res.Response).ConfigureAwait(false);
             var msgs = new List<DiscordMessage>();
             foreach (var xj in msgs_raw)
                 msgs.Add(this.PrepareMessage(xj));
@@ -1040,7 +1040,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new {channel_id}, out var path);
 
             var url = Utilities.GetApiUriFor(path);
-            var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld));
+            var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
             
             return DiscordJson.Deserialize<DiscordFollowedChannel>(response.Response);
         }
@@ -1051,7 +1051,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new {channel_id, message_id}, out var path);
 
             var url = Utilities.GetApiUriFor(path);
-            var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route);
+            var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route).ConfigureAwait(false);
             return DiscordJson.Deserialize<DiscordMessage>(response.Response);
         }
         
@@ -1234,7 +1234,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route, urlparams).ConfigureAwait(false);
 
-            var json = await DiscordJson.LoadJObjectAsync(res.Response);
+            var json = await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false);
             var rawMembers = (JArray)json["members"];
             var guildRest = DiscordJson.Deserialize<DiscordGuild>(res.Response);
             foreach (var r in guildRest._roles.Values)
@@ -1827,7 +1827,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
             var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: json_payload);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: json_payload).ConfigureAwait(false);
             var ret = DiscordJson.Deserialize<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
             return ret;
@@ -1839,7 +1839,7 @@ namespace DSharpPlus.Net
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
             var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
-            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: json_payload);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: json_payload).ConfigureAwait(false);
             var ret = DiscordJson.Deserialize<DiscordMessage>(res.Response);
             ret.Discord = this.Discord;
             return ret;
@@ -1981,7 +1981,7 @@ namespace DSharpPlus.Net
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
-            var emoji_raw = await DiscordJson.LoadJObjectAsync(res.Response);
+            var emoji_raw = await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false);
             var emoji = emoji_raw.ToObject<DiscordGuildEmoji>();
             emoji.Guild = gld;
 
@@ -2013,7 +2013,7 @@ namespace DSharpPlus.Net
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
-            var emoji_raw = await DiscordJson.LoadJObjectAsync(res.Response);
+            var emoji_raw = await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false);
             var emoji = emoji_raw.ToObject<DiscordGuildEmoji>();
             emoji.Guild = gld;
 
@@ -2046,7 +2046,7 @@ namespace DSharpPlus.Net
 
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
-            var emoji_raw = await DiscordJson.LoadJObjectAsync(res.Response);
+            var emoji_raw = await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false);
             var emoji = emoji_raw.ToObject<DiscordGuildEmoji>();
             emoji.Guild = gld;
 
@@ -2118,7 +2118,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route, headers).ConfigureAwait(false);
 
-            var info = (await DiscordJson.LoadJObjectAsync(res.Response)).ToObject<GatewayInfo>();
+            var info = (await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false)).ToObject<GatewayInfo>();
             info.SessionBucket.ResetAfter = DateTimeOffset.UtcNow + TimeSpan.FromMilliseconds(info.SessionBucket.resetAfter);
             return info;
         }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -604,7 +604,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response)).ConfigureAwait(false);
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false));
 
             return ret;
         }
@@ -644,7 +644,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response)).ConfigureAwait(false);
+            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false));
 
             return ret;
         }

--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -160,7 +160,7 @@ namespace DSharpPlus.Net
 
             try
             {
-                await this.GlobalRateLimitEvent.WaitAsync();
+                await this.GlobalRateLimitEvent.WaitAsync().ConfigureAwait(false);
 
                 if (bucket == null)
                     bucket = request.RateLimitBucket;
@@ -172,7 +172,7 @@ namespace DSharpPlus.Net
                 {
                     var now = DateTimeOffset.UtcNow;
 
-                    await bucket.TryResetLimitAsync(now);
+                    await bucket.TryResetLimitAsync(now).ConfigureAwait(false);
 
                     // Decrement the remaining number of requests as there can be other concurrent requests before this one finishes and has a chance to update the bucket
 #pragma warning disable 420 // interlocked access is always volatile
@@ -391,7 +391,7 @@ namespace DSharpPlus.Net
                 while (bucket._limitTesting != 0 && (waitTask = bucket._limitTestFinished) == null)
                     await Task.Yield(); 
                 if (waitTask != null)
-                    await waitTask;
+                    await waitTask.ConfigureAwait(false);
 
                 // if the request failed and the response did not have rate limit headers we have allow the next request and wait again, thus this is a loop here
             }

--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -166,7 +166,7 @@ namespace DSharpPlus.Net
                     bucket = request.RateLimitBucket;
 
                 if (ratelimitTcs == null)
-                    ratelimitTcs = await this.WaitForInitialRateLimit(bucket);
+                    ratelimitTcs = await this.WaitForInitialRateLimit(bucket).ConfigureAwait(false);
 
                 if (ratelimitTcs == null) // ckeck rate limit only if we are not the probe request
                 {


### PR DESCRIPTION
# Summary
Appends `.ConfigureAwait(false)` when needed

# Changes
- Updates any awaited call with a `.ConfigureAwait(false)` statement if it was previously missing it.

# Notes
I used this regex expression to sweep the document for any line that has await first and does not include `.ConfigureAwait(false)`: `^.*?await((?!ConfigureAwait\(false\)|Task.Yield\(\);).)*$` (case sensitive, or you will pick up false positives).

Then, for a final look I use this python script:
```python
split = test_data.splitlines()

for line in split:
  if "Task.Yield" in line or "CONTRIBUTING" in line or not line.endswith(';'):
    continue
  words = line.split(" ")
  awaitCounter = 0
  configCounter = 0
  for word in words:
    if word.endswith("await"):
      awaitCounter += 1
    if "ConfigureAwait(false)" in word:
      configCounter += 1
  if awaitCounter > configCounter:
    print(line)
```

Where test data is the result of searching `await` in the entire solution (see [this pastebin](https://pastebin.com/SSngq932)) to get any miss matches for the amount of `await` and `ConfigureAwait` statements and doubled checked those lines.