### PR TITLE
Add pending? property to DiscordMember

### DIFF
--- a/DSharpPlus/Entities/DiscordMember.cs
+++ b/DSharpPlus/Entities/DiscordMember.cs
@@ -38,6 +38,7 @@ namespace DSharpPlus.Entities
             this.JoinedAt = mbr.JoinedAt;
             this.Nickname = mbr.Nickname;
             this.PremiumSince = mbr.PremiumSince;
+            this.IsPending = mbr.IsPending;
 
             this._role_ids = mbr.Roles ?? new List<ulong>();
             this._role_ids_lazy = new Lazy<IReadOnlyList<ulong>>(() => new ReadOnlyCollection<ulong>(this._role_ids));
@@ -113,6 +114,12 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("is_muted", NullValueHandling = NullValueHandling.Ignore)]
         public bool IsMuted { get; internal set; }
+
+        /// <summary>
+        /// If the user has passed the guild's Membership Screening requirements
+        /// </summary>
+        [JsonProperty("pending", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsPending { get; internal set; }
 
         /// <summary>
         /// Gets this member's voice state.

--- a/DSharpPlus/Net/Abstractions/TransportMember.cs
+++ b/DSharpPlus/Net/Abstractions/TransportMember.cs
@@ -26,5 +26,8 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("premium_since", NullValueHandling = NullValueHandling.Ignore)]
         public DateTime? PremiumSince { get; internal set; }
+
+        [JsonProperty("pending", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsPending { get; internal set; }
     }
 }


### PR DESCRIPTION
# Summary
Fixes #719

# Details
Adds the pending? property to TransportMember and DiscordMember which signifies if the member fulfills to the membership screening requirements

# Changes proposed
* Added IsPending property to TransportMember and DiscordMember