### PR TITLE
Fix bug when u pass a mention in with a reply

### DIFF
--- a/DSharpPlus.Test/Reply.cs
+++ b/DSharpPlus.Test/Reply.cs
@@ -21,8 +21,10 @@ namespace DSharpPlus.Test
                 builder.WithContent($"You requested me to say \"{response}\"");
             }
 
+            builder.WithAllowedMention(UserMention.All);
+
             builder.WithReply(ctx.Message.Id, true);
-            await builder.SendAsync(ctx.Channel);
+            await ctx.RespondAsync(builder);
         }
 
         [Command, Priority(2)]

--- a/DSharpPlus/Entities/DiscordMentions.cs
+++ b/DSharpPlus/Entities/DiscordMentions.cs
@@ -51,6 +51,11 @@ namespace DSharpPlus.Entities
                 this.RepliedUser = mention;
                 return;
             }
+
+            if (mention)
+            {
+                this.RepliedUser = mention;
+            }
             
             
             //Prepare a list of allowed IDs. We will be adding to these IDs.


### PR DESCRIPTION
# Summary
Fixes #731 

# Notes
When you pass in any allowed_mentions when repling to a message, it will not pass the reply mention.  This fixes it