### PR TITLE
Blocking NRE - Add null check for referenced message 

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -217,16 +217,16 @@ namespace DSharpPlus
                     rawMbr = dat["member"];
 
                     if (rawMbr != null)
-                        mbr = rawMbr.ToObject<TransportMember>();                   
+                        mbr = rawMbr.ToObject<TransportMember>();
 
-                    if (rawRefMsg.HasValues)
+                    if (rawRefMsg != null && rawRefMsg.HasValues)
                     {
-                        if(rawRefMsg.SelectToken("author") != null)
+                        if (rawRefMsg.SelectToken("author") != null)
                         {
                             refUsr = rawRefMsg.SelectToken("author").ToObject<TransportUser>();
                         }
 
-                        if(rawRefMsg.SelectToken("member") != null)
+                        if (rawRefMsg.SelectToken("member") != null)
                         {
                             refMbr = rawRefMsg.SelectToken("member").ToObject<TransportMember>();
                         }


### PR DESCRIPTION
# Summary
Fixes NRE thrown by webhook messages.

# Details
Added a null check to the rawRefMsg