### PR TITLE
Cleanup Internal CreateMessage Methods

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -402,7 +402,7 @@ namespace DSharpPlus
         /// <param name="content">Message (text) content</param>
         /// <returns></returns>
         public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, string content)
-            => this.ApiClient.CreateMessageAsync(channel_id, content, false, null, null);
+            => this.ApiClient.CreateMessageAsync(channel_id, content, null);
 
         /// <summary>
         /// Sends a message
@@ -411,7 +411,7 @@ namespace DSharpPlus
         /// <param name="embed">Embed to attach</param>
         /// <returns></returns>
         public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, DiscordEmbed embed)
-            => this.ApiClient.CreateMessageAsync(channel_id, null, null, embed, null);
+            => this.ApiClient.CreateMessageAsync(channel_id, null, embed);
 
         /// <summary>
         /// Sends a message
@@ -421,7 +421,7 @@ namespace DSharpPlus
         /// <param name="embed">Embed to attach</param>
         /// <returns></returns>
         public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, string content, DiscordEmbed embed)
-            => this.ApiClient.CreateMessageAsync(channel_id, content, null, embed, null);
+            => this.ApiClient.CreateMessageAsync(channel_id, content, embed);
 
         /// <summary>
         /// Sends a message
@@ -429,13 +429,8 @@ namespace DSharpPlus
         /// <param name="channel_id">Channel id</param>
         /// <param name="builder">The Discord Mesage builder.</param>
         /// <returns></returns>
-        public async Task<DiscordMessage> CreateMessageAsync(ulong channel_id, DiscordMessageBuilder builder)
-        {
-            if (builder.Files.Count() > 0)
-                return await this.ApiClient.UploadFilesAsync(channel_id, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions, builder.MentionOnReply, builder.ReplyId).ConfigureAwait(false);
-            else
-                return await this.ApiClient.CreateMessageAsync(channel_id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions, builder.MentionOnReply, builder.ReplyId).ConfigureAwait(false);
-        }
+        public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, DiscordMessageBuilder builder)
+            => this.ApiClient.CreateMessageAsync(channel_id, builder);
 
         /// <summary>
         /// Gets channels from a guild

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -371,7 +371,7 @@ namespace DSharpPlus
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, string content = null)
-            => this.ApiClient.CreateMessageAsync(channel.Id, content, null, null, null);
+            => this.ApiClient.CreateMessageAsync(channel.Id, content, null);
 
         /// <summary>
         /// Sends a message
@@ -384,7 +384,7 @@ namespace DSharpPlus
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, DiscordEmbed embed = null)
-            => this.ApiClient.CreateMessageAsync(channel.Id, null, null, embed, null);
+            => this.ApiClient.CreateMessageAsync(channel.Id, null, embed);
 
         /// <summary>
         /// Sends a message
@@ -398,7 +398,7 @@ namespace DSharpPlus
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, string content = null, DiscordEmbed embed = null)
-            => this.ApiClient.CreateMessageAsync(channel.Id, null, null, embed, null);
+            => this.ApiClient.CreateMessageAsync(channel.Id, content, embed);
 
         /// <summary>
         /// Sends a message
@@ -410,13 +410,8 @@ namespace DSharpPlus
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public async Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, DiscordMessageBuilder builder)
-        {
-            if (builder.Files.Count() > 0)
-                return await this.ApiClient.UploadFilesAsync(channel.Id, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions, builder.MentionOnReply, builder.ReplyId).ConfigureAwait(false);
-            else
-                return await this.ApiClient.CreateMessageAsync(channel.Id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions, builder.MentionOnReply, builder.ReplyId).ConfigureAwait(false);
-        }
+        public Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, DiscordMessageBuilder builder)
+            => this.ApiClient.CreateMessageAsync(channel.Id, builder);
 
         /// <summary>
         /// Creates a guild. This requires the bot to be in less than 10 guilds total.

--- a/DSharpPlus/Entities/DiscordChannel.cs
+++ b/DSharpPlus/Entities/DiscordChannel.cs
@@ -184,7 +184,7 @@ namespace DSharpPlus.Entities
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
                 throw new ArgumentException("Cannot send a text message to a non-text channel.");
 
-            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, null, null, null);
+            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, null);
         }
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace DSharpPlus.Entities
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
                 throw new ArgumentException("Cannot send a text message to a non-text channel.");
 
-            return this.Discord.ApiClient.CreateMessageAsync(this.Id, null, null, embed, null);
+            return this.Discord.ApiClient.CreateMessageAsync(this.Id, null, embed);
         }
 
         /// <summary>
@@ -219,7 +219,7 @@ namespace DSharpPlus.Entities
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
                 throw new ArgumentException("Cannot send a text message to a non-text channel.");
 
-            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, null, embed, null);
+            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, embed);
         }
 
         /// <summary>
@@ -232,15 +232,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(DiscordMessageBuilder builder)
-        {
-            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a text message to a non-text channel.");
-
-            if (builder.Files.Count() > 0)
-                return this.Discord.ApiClient.UploadFilesAsync(this.Id, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions, builder.MentionOnReply, builder.ReplyId);
-            else
-                return this.Discord.ApiClient.CreateMessageAsync(this.Id, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions, builder.MentionOnReply, builder.ReplyId);
-        }
+            => this.Discord.ApiClient.CreateMessageAsync(this.Id, builder);
 
         // Please send memes to Naamloos#2887 at discord <3 thank you
 

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -458,7 +458,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> RespondAsync(string content) 
-            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, content, null, null, null);
+            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, content, null);
 
         /// <summary>
         /// Responds to the message.
@@ -470,7 +470,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> RespondAsync(DiscordEmbed embed)
-            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, null, null, embed, null);
+            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, null, embed);
 
         /// <summary>
         /// Responds to the message.
@@ -483,7 +483,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> RespondAsync(string content, DiscordEmbed embed)
-            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, content, null, embed, null);
+            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, content, embed);
 
         /// <summary>
         /// Responds to the message.
@@ -494,13 +494,8 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public async Task<DiscordMessage> RespondAsync(DiscordMessageBuilder builder)
-        {
-            if (builder.Files.Count() > 0)
-                return await this.Discord.ApiClient.UploadFilesAsync(this.ChannelId, builder._files, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions, builder.MentionOnReply, builder.ReplyId).ConfigureAwait(false);
-            else
-                return await this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, builder.Content, builder.IsTTS, builder.Embed, builder.Mentions, builder.MentionOnReply, builder.ReplyId).ConfigureAwait(false);
-        }
+        public Task<DiscordMessage> RespondAsync(DiscordMessageBuilder builder)
+            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, builder);
 
         /// <summary>
         /// Creates a reaction to this message

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -721,8 +721,7 @@ namespace DSharpPlus.Net
             return ret;
         }
 
-        internal async Task<DiscordMessage> CreateMessageAsync(ulong channel_id, string content, bool? tts,
-            DiscordEmbed embed, IEnumerable<IMention> mentions, bool mention = false, ulong? replyMessageId = null)
+        internal async Task<DiscordMessage> CreateMessageAsync(ulong channel_id, string content, DiscordEmbed embed)
         {
             if (content != null && content.Length > 2000)
                 throw new ArgumentException("Message content length cannot exceed 2000 characters.");
@@ -743,16 +742,10 @@ namespace DSharpPlus.Net
             {
                 HasContent = content != null,
                 Content = content,
-                IsTTS = tts,
+                IsTTS = false,
                 HasEmbed = embed != null,
                 Embed = embed
             };
-
-            if (replyMessageId != null) 
-                pld.MessageReference = new InternalDiscordMessageReference {messageId = replyMessageId};
-
-            if (mentions != null || replyMessageId != null)
-                pld.Mentions = new DiscordMentions(mentions ?? Mentions.None, mention);
             
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
@@ -765,81 +758,64 @@ namespace DSharpPlus.Net
             return ret;
         }
 
-        internal async Task<DiscordMessage> UploadFileAsync(ulong channel_id, Stream file_data, string file_name, string content, bool? tts, DiscordEmbed embed, IEnumerable<IMention> mentions, bool mention, ulong? replyMessageId)
+        internal async Task<DiscordMessage> CreateMessageAsync(ulong channel_id, DiscordMessageBuilder builder)
         {
-            var file = new Dictionary<string, Stream> { { file_name, file_data } };
-
-            if (content != null && content.Length > 2000)
+            if (builder.Content != null && builder.Content.Length > 2000)
                 throw new ArgumentException("Message content length cannot exceed 2000 characters.");
 
-            if (embed?.Timestamp != null)
-                embed.Timestamp = embed.Timestamp.Value.ToUniversalTime();
-
-            var values = new Dictionary<string, string>();
-            var pld = new RestChannelMessageCreateMultipartPayload
+            if (builder.Embed == null && !builder.Files.Any())
             {
-                Embed = embed,
-                Content = content,
-                IsTTS = tts
+                if (builder.Content == null)
+                    throw new ArgumentException("You must specify message content or an embed.");
+
+                if (builder.Content == "")
+                    throw new ArgumentException("Message content must not be empty.");
+            }
+
+            if (builder.Embed?.Timestamp != null)
+                builder.Embed.Timestamp = builder.Embed.Timestamp.Value.ToUniversalTime();
+
+            var pld = new RestChannelMessageCreatePayload
+            {
+                HasContent = builder.Content != null,
+                Content = builder.Content,
+                IsTTS = builder.IsTTS,
+                HasEmbed = builder.Embed != null,
+                Embed = builder.Embed
             };
 
-            if (mentions != null)
-                pld.Mentions = new DiscordMentions(mentions);
+            if (builder.ReplyId != null)
+                pld.MessageReference = new InternalDiscordMessageReference { messageId = builder.ReplyId };
 
-            if (replyMessageId != null) 
-                pld.MessageReference = new InternalDiscordMessageReference {messageId = replyMessageId};
-            
-            if (!string.IsNullOrEmpty(content) || embed != null || tts == true || mentions != null)
-                values["payload_json"] = DiscordJson.SerializeObject(pld);
+            if (builder.Mentions != null || builder.ReplyId != null)
+                pld.Mentions = new DiscordMentions(builder.Mentions ?? Mentions.None, builder.MentionOnReply);
 
-            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
-            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
-
-            var url = Utilities.GetApiUriFor(path);
-            var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: file).ConfigureAwait(false);
-
-            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false));
-
-            return ret;
-        }
-
-        internal async Task<DiscordMessage> UploadFilesAsync(ulong channel_id, Dictionary<string, Stream> files, string content, bool? tts, DiscordEmbed embed, IEnumerable<IMention> mentions, bool mention, ulong? replyMessageId)
-        {
-            if (embed?.Timestamp != null)
-                embed.Timestamp = embed.Timestamp.Value.ToUniversalTime();
-
-            if (content != null && content.Length > 2000)
-                throw new ArgumentException("Message content length cannot exceed 2000 characters.");
-
-            if (files.Count == 0 && string.IsNullOrEmpty(content) && embed == null)
-                throw new ArgumentException("You must specify content, an embed, or at least one file.");
-
-            var values = new Dictionary<string, string>();
-            var pld = new RestChannelMessageCreateMultipartPayload
+            if (builder.Files.Count == 0)
             {
-                Embed = embed,
-                Content = content,
-                IsTTS = tts
-            };
+                var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
+                var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            if (mentions != null)
-                pld.Mentions = new DiscordMentions(mentions);
+                var url = Utilities.GetApiUriFor(path);
+                var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
-            if (replyMessageId != null) 
-                pld.MessageReference = new InternalDiscordMessageReference {messageId = replyMessageId};
-            
-            if (!string.IsNullOrWhiteSpace(content) || embed != null || tts == true || mentions != null)
+                var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false));
+                return ret;
+            }
+            else
+            {
+                var values = new Dictionary<string, string>();
                 values["payload_json"] = DiscordJson.SerializeObject(pld);
 
-            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
-            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
+                var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
+                var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
-            var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: files).ConfigureAwait(false);
+                var url = Utilities.GetApiUriFor(path);
+                var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files).ConfigureAwait(false);
 
-            var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false));
+                var ret = this.PrepareMessage(await DiscordJson.LoadJObjectAsync(res.Response).ConfigureAwait(false));
 
-            return ret;
+                return ret;
+            }           
         }
 
         internal async Task<IReadOnlyList<DiscordChannel>> GetGuildChannelsAsync(ulong guild_id)


### PR DESCRIPTION
Cleans up the Internal CreateMessage Methods to use the builder if a Builder is Provided.  This Removes the Seperate UploadFile(s)Async Methods into one singular method.
