### PR TITLE
Fix: Properly reset stream index and length during text WS message

### DIFF
--- a/DSharpPlus/Net/WebSocket/WebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient.cs
@@ -256,6 +256,9 @@ namespace DSharpPlus.Net.WebSocket
                             await bs.CopyToAsync(cs).ConfigureAwait(false);
                             cs.Seek(0, SeekOrigin.Begin);
 
+                            bs.Seek(0, SeekOrigin.Begin);
+                            bs.SetLength(0);
+
                             await this._messageReceived.InvokeAsync(this, new SocketTextMessageEventArgs(cs)).ConfigureAwait(false);
                         }
                         else // close


### PR DESCRIPTION
# Summary
Fixes #744

# Details
I forgot to reset the stream index and length when a text WS message is received (such as from Lavalink). This PR properly resets the stream so it can be converted into a JSON object properly. 

# Changes proposed
* Properly reset stream index and length to 0 after receiving text message. 