### PR TITLE
Expose the 5,860 emoji names

### DIFF
--- a/DSharpPlus/Entities/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/DiscordEmoji.cs
@@ -237,8 +237,9 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="client"><see cref="BaseDiscordClient"/> to attach to the object.</param>
         /// <param name="name">Name of the emote to find, including colons (eg. :thinking:).</param>
+        /// <param name="includeGuilds">Should guild emojis be included in the search.</param>
         /// <returns>Create <see cref="DiscordEmoji"/> object.</returns>
-        public static DiscordEmoji FromName(BaseDiscordClient client, string name)
+        public static DiscordEmoji FromName(BaseDiscordClient client, string name, bool includeGuilds = true)
         {
             if (client == null)
                 throw new ArgumentNullException(nameof(client), "Client cannot be null.");
@@ -249,12 +250,15 @@ namespace DSharpPlus.Entities
             if (UnicodeEmojis.ContainsKey(name))
                 return new DiscordEmoji { Discord = client, Name = UnicodeEmojis[name] };
 
-            var allEmojis = client.Guilds.Values.SelectMany(xg => xg.Emojis.Values).OrderBy(xe => xe.Name);
+            if (includeGuilds)
+            {
+                var allEmojis = client.Guilds.Values.SelectMany(xg => xg.Emojis.Values).OrderBy(xe => xe.Name);
             
-            var ek = name.Substring(1, name.Length - 2);
-            foreach (var emoji in allEmojis)
-                if (emoji.Name == ek)
-                    return emoji;
+                var ek = name.Substring(1, name.Length - 2);
+                foreach (var emoji in allEmojis)
+                    if (emoji.Name == ek)
+                        return emoji;
+            }
 
             throw new ArgumentException("Invalid emoji name specified.", nameof(name));
         }


### PR DESCRIPTION
Expose the 5,860 emoji names. This helps, for example, in resolving emoji names while only considering specific guilds.

# Summary
Adds Discord.FromNameStandard, which does the same thing as Discord.FromName, but ignores guilds.

# Details
There's is currently no want to perform a name lookup that includes only standard names and a specific guild's emojis. This will make this and other things possible.

# Changes proposed
Adds Discord.FromNameStandard, which does the same thing as Discord.FromName, but ignores guilds.

# Notes
https://discord.com/channels/379378609942560770/379378610412191753/804104694220718140