### PR TITLE
Create pre-built method to make spoilered text

### DIFF
--- a/DSharpPlus/Formatter.cs
+++ b/DSharpPlus/Formatter.cs
@@ -47,6 +47,14 @@ namespace DSharpPlus
             => $"*{content}*";
 
         /// <summary>
+        /// Creates spoiler from text.
+        /// </summary>
+        /// <param name="content">Text to spoilerize.</param>
+        /// <returns>Formatted text.</returns>
+        public static string Spoiler(string content)
+            => $"||{content}||";
+
+        /// <summary>
         /// Creates underlined text.
         /// </summary>
         /// <param name="content">Text to underline.</param>

--- a/DSharpPlus/Formatter.cs
+++ b/DSharpPlus/Formatter.cs
@@ -10,8 +10,8 @@ namespace DSharpPlus
     /// </summary>
     public static class Formatter
     {
-        private static Regex MdSanitizeRegex { get; } = new Regex(@"([`\*_~<>\[\]\(\)""@\!\&#:])", RegexOptions.ECMAScript);
-        private static Regex MdStripRegex { get; } = new Regex(@"([`\*_~\[\]\(\)""]|<@\!?\d+>|<#\d+>|<@\&\d+>|<:[a-zA-Z0-9_\-]:\d+>)", RegexOptions.ECMAScript);
+        private static Regex MdSanitizeRegex { get; } = new Regex(@"([`\*_~<>\[\]\(\)""@\!\&#:\|])", RegexOptions.ECMAScript);
+        private static Regex MdStripRegex { get; } = new Regex(@"([`\*_~\[\]\(\)""\|]|<@\!?\d+>|<#\d+>|<@\&\d+>|<:[a-zA-Z0-9_\-]:\d+>)", RegexOptions.ECMAScript);
 
         /// <summary>
         /// Creates a block of code.


### PR DESCRIPTION
# Summary
Add Formatter.Spoiler method that marks text as spoiler.

# Notes
Maybe we should also strip spoiler's `||` in Formatter.Strip with MdStripRegex? 