### PR TITLE
Fix: Ensure user is cached before GuildMemberRemoved

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -961,6 +961,8 @@ namespace DSharpPlus
                 mbr = new DiscordMember(new DiscordUser(user)) { Discord = this, _guild_id = guild.Id };
             guild.MemberCount--;
 
+            _ = this.UserCache.AddOrUpdate(user.Id, mbr, (old, @new) => @new);
+
             var ea = new GuildMemberRemoveEventArgs
             {
                 Guild = guild,


### PR DESCRIPTION
# Summary
Fixes #713 

# Details
This PR fixes an issue with intents where the user properties would not be present when the member is removed. This is a result of the user properties not being in cache if the guild presences intent is not used. 

# Changes proposed
* Always cache user object from guild member removed. 