### PR TITLE
 Add pending property to GuildMemberUpdated

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -161,7 +161,7 @@ namespace DSharpPlus
 
                 case "guild_member_update":
                     gid = (ulong)dat["guild_id"];
-                    await OnGuildMemberUpdateEventAsync(dat["user"].ToObject<TransportUser>(), this._guilds[gid], dat["roles"].ToObject<IEnumerable<ulong>>(), (string)dat["nick"]).ConfigureAwait(false);
+                    await OnGuildMemberUpdateEventAsync(dat["user"].ToObject<TransportUser>(), this._guilds[gid], dat["roles"].ToObject<IEnumerable<ulong>>(), (string)dat["nick"], (bool?)dat["pending"]).ConfigureAwait(false);
                     break;
 
                 case "guild_members_chunk":
@@ -969,7 +969,7 @@ namespace DSharpPlus
             await this._guildMemberRemoved.InvokeAsync(this, ea).ConfigureAwait(false);
         }
 
-        internal async Task OnGuildMemberUpdateEventAsync(TransportUser user, DiscordGuild guild, IEnumerable<ulong> roles, string nick)
+        internal async Task OnGuildMemberUpdateEventAsync(TransportUser user, DiscordGuild guild, IEnumerable<ulong> roles, string nick, bool? pending)
         {
             var usr = new DiscordUser(user) { Discord = this };
             usr = this.UserCache.AddOrUpdate(user.Id, usr, (id, old) =>
@@ -984,9 +984,11 @@ namespace DSharpPlus
                 mbr = new DiscordMember(usr) { Discord = this, _guild_id = guild.Id };
 
             var nick_old = mbr.Nickname;
+            var pending_old = mbr.IsPending;
             var roles_old = new ReadOnlyCollection<DiscordRole>(new List<DiscordRole>(mbr.Roles));
 
             mbr.Nickname = nick;
+            mbr.IsPending = pending;
             mbr._role_ids.Clear();
             mbr._role_ids.AddRange(roles);
 
@@ -997,9 +999,11 @@ namespace DSharpPlus
 
                 NicknameAfter = mbr.Nickname,
                 RolesAfter = new ReadOnlyCollection<DiscordRole>(new List<DiscordRole>(mbr.Roles)),
+                PendingAfter = mbr.IsPending,
 
                 NicknameBefore = nick_old,
-                RolesBefore = roles_old
+                RolesBefore = roles_old,
+                PendingBefore = pending_old,
             };
             await this._guildMemberUpdated.InvokeAsync(this, ea).ConfigureAwait(false);
         }

--- a/DSharpPlus/EventArgs/GuildMemberUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/GuildMemberUpdateEventArgs.cs
@@ -33,6 +33,10 @@ namespace DSharpPlus.EventArgs
         /// </summary>
         public string NicknameBefore { get; internal set; }
 
+        public bool? PendingBefore { get; internal set; }
+
+        public bool? PendingAfter { get; internal set; }
+
         /// <summary>
         /// Gets the member that was updated.
         /// </summary>

--- a/DSharpPlus/EventArgs/GuildMemberUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/GuildMemberUpdateEventArgs.cs
@@ -33,8 +33,14 @@ namespace DSharpPlus.EventArgs
         /// </summary>
         public string NicknameBefore { get; internal set; }
 
+        /// <summary>
+        /// Gets whether the member had passed membership screening before the update
+        /// </summary>
         public bool? PendingBefore { get; internal set; }
 
+        /// <summary>
+        /// Gets whether the member had passed membership screening after the update
+        /// </summary>
         public bool? PendingAfter { get; internal set; }
 
         /// <summary>


### PR DESCRIPTION
# Summary
Adds the missing pending property to `GuildMemberUpdated`

# Details
Added a `PendingBefore` and `PendingAfter` property to the event args. This pr should also allow cache to update when a member goes through membership screening.

# Changes proposed
* Add `PendingBefore` and `PendingAfter` to `GuildMemberUpdateEventArgs`
* Make necessary changes to the internal `OnGuildMemberUpdateEventAsync` method

# Notes
Completely missed this when adding the property to `DiscordMember`