### PR TITLE
fix(message): Ensure skeleton channel is created if channel is not found in cache. 

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -616,6 +616,22 @@ namespace DSharpPlus
 
                 message.Author = this.UpdateUser(usr, guild?.Id, guild, member);
             }
+
+            var channel = this.InternalGetCachedChannel(message.ChannelId);
+
+            if (channel == null)
+            {
+                channel = new DiscordChannel
+                {
+                    Id = message.ChannelId,
+                    Discord = this
+                };
+
+                if (!message.GuildId.HasValue)
+                    channel.Type = ChannelType.Private;
+
+                message.Channel = channel;
+            }
         }
 
         private DiscordUser UpdateUser(DiscordUser usr, ulong? guildId, DiscordGuild guild, TransportMember mbr)
@@ -650,7 +666,7 @@ namespace DSharpPlus
                             guild._members.TryAdd(usr.Id, (DiscordMember)usr);
                         }
                     }
-                    else if ((intents.HasIntent(DiscordIntents.GuildPresences)) || this.Configuration.AlwaysCacheMembers) // we can attempt to update it if it's already in cache.
+                    else if (intents.HasIntent(DiscordIntents.GuildPresences) || this.Configuration.AlwaysCacheMembers) // we can attempt to update it if it's already in cache.
                     {
                         if (!intents.HasIntent(DiscordIntents.GuildMembers)) // no need to update if we already have the member events
                         {

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -74,8 +74,13 @@ namespace DSharpPlus.Entities
         /// Gets the channel in which the message was sent.
         /// </summary>
         [JsonIgnore]
-        public DiscordChannel Channel 
-            => (this.Discord as DiscordClient)?.InternalGetCachedChannel(this.ChannelId);
+        public DiscordChannel Channel
+        { 
+            get => (this.Discord as DiscordClient)?.InternalGetCachedChannel(this.ChannelId) ?? this._channel;
+            internal set => this._channel = value;
+        }
+
+        private DiscordChannel _channel; 
 
         /// <summary>
         /// Gets the ID of the channel in which the message was sent.
@@ -289,6 +294,9 @@ namespace DSharpPlus.Entities
         internal List<DiscordMessageSticker> _stickers = new List<DiscordMessageSticker>();
         [JsonIgnore]
         private Lazy<IReadOnlyList<DiscordMessageSticker>> _stickersLazy;
+
+        [JsonProperty("guild_id", NullValueHandling = NullValueHandling.Ignore)]
+        internal ulong? GuildId { get; set; }
 
         /// <summary>
         /// Gets the message object for the referenced message

--- a/DSharpPlus/EventArgs/MessageCreateEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageCreateEventArgs.cs
@@ -17,19 +17,19 @@ namespace DSharpPlus.EventArgs
         /// Gets the channel this message belongs to.
         /// </summary>
         public DiscordChannel Channel 
-            => Message.Channel;
+            => this.Message.Channel;
 
         /// <summary>
         /// Gets the guild this message belongs to.
         /// </summary>
         public DiscordGuild Guild 
-            => Channel.Guild;
+            => this.Channel.Guild;
 
         /// <summary>
         /// Gets the author of the message.
         /// </summary>
         public DiscordUser Author 
-            => Message.Author;
+            => this.Message.Author;
 
         /// <summary>
         /// Gets the collection of mentioned users.

--- a/DSharpPlus/EventArgs/MessageUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/MessageUpdateEventArgs.cs
@@ -22,19 +22,19 @@ namespace DSharpPlus.EventArgs
         /// Gets the channel this message belongs to.
         /// </summary>
         public DiscordChannel Channel 
-            => Message.Channel;
+            => this.Message.Channel;
 
         /// <summary>
         /// Gets the guild this message belongs to.
         /// </summary>
         public DiscordGuild Guild 
-            => Channel.Guild;
+            => this.Channel.Guild;
 
         /// <summary>
         /// Gets the author of the message.
         /// </summary>
         public DiscordUser Author 
-            => Message.Author;
+            => this.Message.Author;
 
         /// <summary>
         /// Gets the collection of mentioned users.


### PR DESCRIPTION
This PR fixes #754 by ensuring there is a skeleton channel in the event a channel object could not be fetched from cache. 