### PR TITLE
Add missing properties on DiscordInviteGuild

### DIFF
--- a/DSharpPlus/Entities/DiscordInviteGuild.cs
+++ b/DSharpPlus/Entities/DiscordInviteGuild.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Collections.Generic;
+using System.Globalization;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
@@ -30,7 +31,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the hash of guild's invite splash.
         /// </summary>
-        [JsonProperty("splash_name", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("splash", NullValueHandling = NullValueHandling.Ignore)]
         internal string SplashHash { get; set; }
 
         /// <summary>
@@ -39,6 +40,37 @@ namespace DSharpPlus.Entities
         [JsonIgnore]
         public string SplashUrl 
             => !string.IsNullOrWhiteSpace(this.SplashHash) ? $"https://cdn.discordapp.com/splashes/{this.Id.ToString(CultureInfo.InvariantCulture)}/{SplashHash}.jpg" : null;
+
+        /// <summary>
+        /// Gets the guild's banner hash, when applicable.
+        /// </summary>
+        [JsonProperty("banner", NullValueHandling = NullValueHandling.Ignore)]
+        public string Banner { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild's banner in url form.
+        /// </summary>
+        [JsonIgnore]
+        public string BannerUrl
+            => !string.IsNullOrWhiteSpace(this.Banner) ? $"https://cdn.discordapp.com/banners/{this.Id}/{this.Banner}" : null;
+
+        /// <summary>
+        /// Gets the guild description, when applicable.
+        /// </summary>
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
+        public string Description { get; internal set; }
+
+        /// <summary>
+        /// Gets a collection of this guild's features.
+        /// </summary>
+        [JsonProperty("features", NullValueHandling = NullValueHandling.Ignore)]
+        public IReadOnlyList<string> Features { get; internal set; }
+
+        /// <summary>
+        /// Gets vanity URL code for this guild, when applicable.
+        /// </summary>
+        [JsonProperty("vanity_url_code")]
+        public string VanityUrlCode { get; internal set; }
 
         internal DiscordInviteGuild() { }
     }

--- a/DSharpPlus/Entities/DiscordInviteGuild.cs
+++ b/DSharpPlus/Entities/DiscordInviteGuild.cs
@@ -67,6 +67,12 @@ namespace DSharpPlus.Entities
         public IReadOnlyList<string> Features { get; internal set; }
 
         /// <summary>
+        /// Gets the guild's verification level.
+        /// </summary>
+        [JsonProperty("verification_level", NullValueHandling = NullValueHandling.Ignore)]
+        public VerificationLevel VerificationLevel { get; internal set; }
+
+        /// <summary>
         /// Gets vanity URL code for this guild, when applicable.
         /// </summary>
         [JsonProperty("vanity_url_code")]


### PR DESCRIPTION
# Summary
Adds some missing properties on `DiscordInviteGuild`

# Details
I referenced the example invite object in the docs to add the missing properties, which were banner, description, features, verification level and vanity url code