### PR TITLE
fix(core): Don't add member objects to user cache.

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -938,11 +938,13 @@ namespace DSharpPlus
 
         internal async Task OnGuildMemberRemoveEventAsync(TransportUser user, DiscordGuild guild)
         {
+            var usr = new DiscordUser(user);
+
             if (!guild._members.TryRemove(user.Id, out var mbr))
-                mbr = new DiscordMember(new DiscordUser(user)) { Discord = this, _guild_id = guild.Id };
+                mbr = new DiscordMember(usr) { Discord = this, _guild_id = guild.Id };
             guild.MemberCount--;
 
-            _ = this.UserCache.AddOrUpdate(user.Id, mbr, (old, @new) => @new);
+            _ = this.UserCache.AddOrUpdate(user.Id, usr, (old, @new) => @new);
 
             var ea = new GuildMemberRemoveEventArgs
             {


### PR DESCRIPTION
This is a hotfix for an issue a user was experiencing in the guild. When GuildMemberRemoved is called, the handler stores the member object rather than the user one. This will cause a stack overflow when attempting to access that member's properties (e.g. username).