### PR TITLE
Don't add the reactions when the paginator has one page

### DIFF
--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -60,7 +60,25 @@ namespace DSharpPlus.Interactivity.EventHandling
                 {
                     if (eventargs.User.Id == usr.Id)
                     {
-                        await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                        if (req.PageCount > 1 &&
+                            (eventargs.Emoji == emojis.Left || 
+                             eventargs.Emoji == emojis.SkipLeft || 
+                             eventargs.Emoji == emojis.Right || 
+                             eventargs.Emoji == emojis.SkipRight ||
+                             eventargs.Emoji == emojis.Stop))
+                        {
+                            await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                        }
+                        else if (eventargs.Emoji == emojis.Stop &&
+                                 req is PaginationRequest paginationRequest &&
+                                 paginationRequest.PaginationDeletion == PaginationDeletion.DeleteMessage)
+                        {
+                            await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                        }
+                        else
+                        {
+                            await msg.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
+                        }
                     }
                     else if (eventargs.User.Id != _client.CurrentUser.Id)
                     {
@@ -90,15 +108,21 @@ namespace DSharpPlus.Interactivity.EventHandling
                 {
                     if (eventargs.User.Id == usr.Id)
                     {
-                        await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
-                    }
-                    if (eventargs.Emoji != emojis.Left &&
-                           eventargs.Emoji != emojis.SkipLeft &&
-                           eventargs.Emoji != emojis.Right &&
-                           eventargs.Emoji != emojis.SkipRight &&
-                           eventargs.Emoji != emojis.Stop)
-                    {
-                        await msg.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
+                        if (req.PageCount > 1 &&
+                            (eventargs.Emoji == emojis.Left || 
+                             eventargs.Emoji == emojis.SkipLeft || 
+                             eventargs.Emoji == emojis.Right || 
+                             eventargs.Emoji == emojis.SkipRight ||
+                             eventargs.Emoji == emojis.Stop))
+                        {
+                            await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                        }
+                        else if (eventargs.Emoji == emojis.Stop &&
+                                 req is PaginationRequest paginationRequest &&
+                                 paginationRequest.PaginationDeletion == PaginationDeletion.DeleteMessage)
+                        {
+                            await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                        }
                     }
                 }
             }

--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using ConcurrentCollections;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
+using DSharpPlus.Interactivity.Enums;
 using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus.Interactivity.EventHandling
@@ -138,16 +139,24 @@ namespace DSharpPlus.Interactivity.EventHandling
                 await msg.DeleteAllReactionsAsync("Pagination").ConfigureAwait(false);
             // ENDOF: 403 fix
 
-            if (emojis.SkipLeft != null)
-                await msg.CreateReactionAsync(emojis.SkipLeft).ConfigureAwait(false);
-            if (emojis.Left != null)
-                await msg.CreateReactionAsync(emojis.Left).ConfigureAwait(false);
-            if (emojis.Right != null)
-                await msg.CreateReactionAsync(emojis.Right).ConfigureAwait(false);
-            if (emojis.SkipRight != null)
-                await msg.CreateReactionAsync(emojis.SkipRight).ConfigureAwait(false);
-            if (emojis.Stop != null)
-                await msg.CreateReactionAsync(emojis.Stop).ConfigureAwait(false);
+            if (p.PageCount > 1)
+            {
+                if (emojis.SkipLeft != null)
+                    await msg.CreateReactionAsync(emojis.SkipLeft).ConfigureAwait(false);
+                if (emojis.Left != null)
+                    await msg.CreateReactionAsync(emojis.Left).ConfigureAwait(false);
+                if (emojis.Right != null)
+                    await msg.CreateReactionAsync(emojis.Right).ConfigureAwait(false);
+                if (emojis.SkipRight != null)
+                    await msg.CreateReactionAsync(emojis.SkipRight).ConfigureAwait(false);
+                if (emojis.Stop != null)
+                    await msg.CreateReactionAsync(emojis.Stop).ConfigureAwait(false);
+            }
+            else
+            {
+                if (emojis.Stop != null && p is PaginationRequest paginationRequest && paginationRequest.PaginationDeletion == PaginationDeletion.DeleteMessage)
+                    await msg.CreateReactionAsync(emojis.Stop).ConfigureAwait(false);
+            }
         }
 
         async Task PaginateAsync(IPaginationRequest p, DiscordEmoji emoji)

--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -152,10 +152,9 @@ namespace DSharpPlus.Interactivity.EventHandling
                 if (emojis.Stop != null)
                     await msg.CreateReactionAsync(emojis.Stop).ConfigureAwait(false);
             }
-            else
+            else if (emojis.Stop != null && p is PaginationRequest paginationRequest && paginationRequest.PaginationDeletion == PaginationDeletion.DeleteMessage)
             {
-                if (emojis.Stop != null && p is PaginationRequest paginationRequest && paginationRequest.PaginationDeletion == PaginationDeletion.DeleteMessage)
-                    await msg.CreateReactionAsync(emojis.Stop).ConfigureAwait(false);
+                await msg.CreateReactionAsync(emojis.Stop).ConfigureAwait(false);
             }
         }
 

--- a/DSharpPlus.Interactivity/EventHandling/Requests/IPaginationRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/IPaginationRequest.cs
@@ -6,6 +6,12 @@ namespace DSharpPlus.Interactivity.EventHandling
     public interface IPaginationRequest
     {
         /// <summary>
+        /// Returns the number of pages.
+        /// </summary>
+        /// <returns></returns>
+        int PageCount { get; }
+        
+        /// <summary>
         /// Returns the current page.
         /// </summary>
         /// <returns></returns>

--- a/DSharpPlus.Interactivity/EventHandling/Requests/PaginationRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/PaginationRequest.cs
@@ -51,6 +51,10 @@ namespace DSharpPlus.Interactivity.EventHandling
                 this._pages.Add(p);
             }
         }
+        
+        public int PageCount => _pages.Count;
+
+        public PaginationDeletion PaginationDeletion => _deletion;
 
         public async Task<Page> GetPageAsync()
         {


### PR DESCRIPTION
# Details
The reactions will not added when the paginator has one page.
Also the stop reaction is added only when the MessageDeletion is enabled or when the pages are greater than 1.

# Changes proposed
I added a `PageCount` property in the `IPaginationRequest` interface and `PaginationDeletion` property which gets the value of `_deletion` from the `PaginationRequest` class.

In the `Paginator` class I checked if the number of pages are greater than one or not. If true then add all the reactions. If not then add the stop reaction only when the `PaginationRequest` has the message deletion option. I didn't add this field in the `IPaginationRequest` interface but I will do it if you want it. I will edit if something is wrong.