### PR TITLE
Update DiscordClient to return a DiscordDmChannel if appropriate

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -630,7 +630,8 @@ namespace DSharpPlus
                     Type = ChannelType.Private
                 };
             }
-            else {
+            else 
+            {
                 channel = new DiscordChannel
                 {
                     Id = message.ChannelId,

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -619,19 +619,27 @@ namespace DSharpPlus
 
             var channel = this.InternalGetCachedChannel(message.ChannelId);
 
-            if (channel == null)
+            if (channel != null) return;
+            
+            if (!message.GuildId.HasValue)
             {
+                channel = new DiscordDmChannel
+                {
+                    Id = message.ChannelId,
+                    Discord = this,
+                    Type = ChannelType.Private
+                };
+                
+            }
+            else {
                 channel = new DiscordChannel
                 {
                     Id = message.ChannelId,
                     Discord = this
                 };
-
-                if (!message.GuildId.HasValue)
-                    channel.Type = ChannelType.Private;
-
-                message.Channel = channel;
             }
+            
+            message.Channel = channel;
         }
 
         private DiscordUser UpdateUser(DiscordUser usr, ulong? guildId, DiscordGuild guild, TransportMember mbr)

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -629,7 +629,6 @@ namespace DSharpPlus
                     Discord = this,
                     Type = ChannelType.Private
                 };
-                
             }
             else {
                 channel = new DiscordChannel


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Added a return for DiscordDmChannel instead of DiscordChannel

# Details
Build 793 fixed an issue with v8 not sending the channel object in DMs, however various places in the codebase type-check for a DiscordDmChannel, and 793 only provides a DiscordChannel, which causes various checks to fail.

# Changes proposed
Return DiscordDmChannel if the guild is null, else return a regular channel

# Notes
Any additional notes go here.