### PR TITLE
Fix File Lock in MessageBuilder Option 1

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -511,7 +511,7 @@ namespace DSharpPlus
         /// <returns></returns>
         public async Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, DiscordMessageBuilder builder)
         {
-            if (builder.Files.Any())
+            if (builder.StreamFiles.Any() && builder.FileNames.Any())
                 throw new ArgumentException("You cannot add files when modifing a message.");
 
             return await this.ApiClient.EditMessageAsync(channel_id, message_id, builder.Content, builder.Embed, builder.Mentions).ConfigureAwait(false);

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -211,5 +211,25 @@ namespace DSharpPlus.Test
                    .SendAsync(ctx.Channel)
                    .ConfigureAwait(false);
         }
+
+        [Command("CreateSomeFile")]
+        public async Task CreateSomeFile(CommandContext ctx, string fileName, [RemainingText]string fileBody)
+        {
+            using (var fs = new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite))
+            using (var sw = new StreamWriter(fs))
+            {
+                await sw.WriteAsync(fileBody);
+            }
+
+            using (var builder = new DiscordMessageBuilder())
+            {
+                builder.WithContent("Here is a really dumb file that i am testing with.");
+                builder.WithFile(fileName);
+
+                await builder.SendAsync(ctx.Channel);
+            }
+
+            File.Delete(fileName);
+        }
     }
 }

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -221,15 +221,27 @@ namespace DSharpPlus.Test
                 await sw.WriteAsync(fileBody);
             }
 
-            using (var builder = new DiscordMessageBuilder())
+            using (var fs = new FileStream($"another {fileName}", FileMode.Create, FileAccess.ReadWrite))
+            using (var sw = new StreamWriter(fs))
             {
-                builder.WithContent("Here is a really dumb file that i am testing with.");
-                builder.WithFile(fileName);
+                sw.AutoFlush = true;
+                await sw.WriteLineAsync(fileBody);
+                fs.Position = 0;
+                using (var builder = new DiscordMessageBuilder())
+                {
+                    
+                    builder.WithContent("Here is a really dumb file that i am testing with.");
+                    builder.WithFile(fileName);
+                    builder.WithFile(fs);
 
-                await builder.SendAsync(ctx.Channel);
+                    await builder.SendAsync(ctx.Channel);
+                }
+                //Testing to make sure the stream sent in is not disposed.
+
+                await sw.WriteLineAsync("Another" + fileBody);
             }
-
             File.Delete(fileName);
+            File.Delete("another " + fileName);
         }
     }
 }

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -227,15 +227,14 @@ namespace DSharpPlus.Test
                 sw.AutoFlush = true;
                 await sw.WriteLineAsync(fileBody);
                 fs.Position = 0;
-                using (var builder = new DiscordMessageBuilder())
-                {
-                    
-                    builder.WithContent("Here is a really dumb file that i am testing with.");
-                    builder.WithFile(fileName);
-                    builder.WithFile(fs);
 
-                    await builder.SendAsync(ctx.Channel);
-                }
+                var builder = new DiscordMessageBuilder();
+                builder.WithContent("Here is a really dumb file that i am testing with.");
+                builder.WithFile(fileName);
+                builder.WithFile(fs);
+
+                await builder.SendAsync(ctx.Channel);
+
                 //Testing to make sure the stream sent in is not disposed.
 
                 await sw.WriteLineAsync("Another" + fileBody);

--- a/DSharpPlus/Entities/DiscordMessage.cs
+++ b/DSharpPlus/Entities/DiscordMessage.cs
@@ -405,7 +405,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public async Task<DiscordMessage> ModifyAsync(DiscordMessageBuilder builder)
         {
-            if (builder.Files.Any())
+            if (builder.StreamFiles.Any())
                 throw new ArgumentException("You cannot add files when modifing a message.");
 
             return await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, builder.Content, builder.Embed, builder.Mentions).ConfigureAwait(false);

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -45,9 +45,10 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the Files to be sent in the Message.
         /// </summary>
-        public IReadOnlyDictionary<string, Stream> Files => this._files;
+        public IReadOnlyDictionary<string, Stream> Files => this._UserStreamFiles.Concat(_internalStreamFiles).ToDictionary(x => x.Key, x => x.Value);
 
-        internal Dictionary<string, Stream> _files = new Dictionary<string, Stream>();
+        internal Dictionary<string, Stream> _UserStreamFiles = new Dictionary<string, Stream>();
+        internal Dictionary<string, Stream> _internalStreamFiles = new Dictionary<string, Stream>();
         private bool disposedValue;
 
         /// <summary>
@@ -134,7 +135,7 @@ namespace DSharpPlus.Entities
             if(this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this._files.Add(fileName, stream);
+            this._UserStreamFiles.Add(fileName, stream);
 
             return this;
         }
@@ -149,7 +150,7 @@ namespace DSharpPlus.Entities
             if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this._files.Add(stream.Name, stream);
+            this._UserStreamFiles.Add(stream.Name, stream);
 
             return this;
         }
@@ -165,7 +166,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             var fs = File.OpenRead(filePath);
-            this._files.Add(fs.Name, fs);
+            this._internalStreamFiles.Add(fs.Name, fs);
 
             return this;
         }
@@ -181,7 +182,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             foreach (var file in files)
-                this._files.Add(file.Key, file.Value);
+                this._UserStreamFiles.Add(file.Key, file.Value);
 
             return this;
         }
@@ -226,7 +227,7 @@ namespace DSharpPlus.Entities
             {
                 if (disposing)
                 {
-                    foreach (var file in this.Files)
+                    foreach (var file in this._internalStreamFiles)
                     {
                         file.Value.Dispose();
                     }

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -10,7 +10,7 @@ namespace DSharpPlus.Entities
     /// <summary>
     /// Constructs a Message to be sent.
     /// </summary>
-    public sealed class DiscordMessageBuilder
+    public sealed class DiscordMessageBuilder : IDisposable
     {
         /// <summary>
         /// Gets or Sets the Message to be sent.
@@ -48,6 +48,7 @@ namespace DSharpPlus.Entities
         public IReadOnlyDictionary<string, Stream> Files => this._files;
 
         internal Dictionary<string, Stream> _files = new Dictionary<string, Stream>();
+        private bool disposedValue;
 
         /// <summary>
         /// Gets the Reply Message ID.
@@ -217,6 +218,38 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMessage> ModifyAsync(DiscordMessage msg)
         {
             return await msg.ModifyAsync(this).ConfigureAwait(false);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    foreach (var file in this.Files)
+                    {
+                        file.Value.Dispose();
+                    }
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                disposedValue = true;
+            }
+        }
+
+        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+        // ~DiscordMessageBuilder()
+        // {
+        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        //     Dispose(disposing: false);
+        // }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
# Summary
This fixes a bug in the message builder where it holds onto the stream after the message has been sent.  

# Changes proposed
* Make the Message Builder Disposable so when it gets disposed, we can release the filestream
