### PR TITLE
Fix File Lock in MessageBuilder Option 2

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1215,7 +1215,7 @@ namespace DSharpPlus
         /// <param name="builder">Webhook builder filled with data to send.</param>
         /// <returns></returns>
         public Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, DiscordWebhookBuilder builder)
-            => this.ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, builder.Content, builder.Username, builder.AvatarUrl, builder.IsTTS, builder.Embeds, builder.Files, builder.Mentions);
+            => this.ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, builder.Content, builder.Username, builder.AvatarUrl, builder.IsTTS, builder.Embeds, builder._files, builder.Mentions);
         #endregion
 
         #region Reactions

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -211,5 +211,25 @@ namespace DSharpPlus.Test
                    .SendAsync(ctx.Channel)
                    .ConfigureAwait(false);
         }
+
+        [Command("CreateSomeFile")]
+        public async Task CreateSomeFile(CommandContext ctx, string fileName, [RemainingText]string fileBody)
+        {
+            using (var fs = new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite))
+            using (var sw = new StreamWriter(fs))
+            {
+                await sw.WriteAsync(fileBody);
+            }
+
+            using (var builder = new DiscordMessageBuilder())
+            {
+                builder.WithContent("Here is a really dumb file that i am testing with.");
+                builder.WithFile(fileName);
+
+                await builder.SendAsync(ctx.Channel);
+            }
+
+            File.Delete(fileName);
+        }
     }
 }

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -221,15 +221,27 @@ namespace DSharpPlus.Test
                 await sw.WriteAsync(fileBody);
             }
 
-            using (var builder = new DiscordMessageBuilder())
+            using (var fs = new FileStream($"another {fileName}", FileMode.Create, FileAccess.ReadWrite))
+            using (var sw = new StreamWriter(fs))
             {
-                builder.WithContent("Here is a really dumb file that i am testing with.");
-                builder.WithFile(fileName);
+                sw.AutoFlush = true;
+                await sw.WriteLineAsync(fileBody);
+                fs.Position = 0;
+                using (var builder = new DiscordMessageBuilder())
+                {
+                    
+                    builder.WithContent("Here is a really dumb file that i am testing with.");
+                    builder.WithFile(fileName);
+                    builder.WithFile(fs);
 
-                await builder.SendAsync(ctx.Channel);
+                    await builder.SendAsync(ctx.Channel);
+                }
+                //Testing to make sure the stream sent in is not disposed.
+
+                await sw.WriteLineAsync("Another" + fileBody);
             }
-
             File.Delete(fileName);
+            File.Delete("another " + fileName);
         }
     }
 }

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -227,15 +227,12 @@ namespace DSharpPlus.Test
                 sw.AutoFlush = true;
                 await sw.WriteLineAsync(fileBody);
                 fs.Position = 0;
-                using (var builder = new DiscordMessageBuilder())
-                {
-                    
-                    builder.WithContent("Here is a really dumb file that i am testing with.");
-                    builder.WithFile(fileName);
-                    builder.WithFile(fs);
+                var builder = new DiscordMessageBuilder();
+                builder.WithContent("Here is a really dumb file that i am testing with.");
+                builder.WithFile(fileName);
+                builder.WithFile(fs);
 
-                    await builder.SendAsync(ctx.Channel);
-                }
+                await builder.SendAsync(ctx.Channel);
                 //Testing to make sure the stream sent in is not disposed.
 
                 await sw.WriteLineAsync("Another" + fileBody);

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -232,6 +232,11 @@ namespace DSharpPlus.Test
                 builder.WithFile(fileName);
                 builder.WithFile(fs);
 
+                foreach (var file in builder.Files)
+                {
+
+                }
+
                 await builder.SendAsync(ctx.Channel);
                 //Testing to make sure the stream sent in is not disposed.
 

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -45,10 +45,9 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the Files to be sent in the Message.
         /// </summary>
-        public IReadOnlyDictionary<string, DiscordFileBuilder> Files => this._UserStreamFiles.Concat(_internalStreamFiles).ToDictionary(x => x.Key, x => x.Value);
+        public IReadOnlyDictionary<string, DiscordFileBuilder> Files => this._files;
 
-        internal Dictionary<string, DiscordFileBuilder> _UserStreamFiles = new Dictionary<string, DiscordFileBuilder>();
-        internal Dictionary<string, DiscordFileBuilder> _internalStreamFiles = new Dictionary<string, DiscordFileBuilder>();
+        internal Dictionary<string, DiscordFileBuilder> _files = new Dictionary<string, DiscordFileBuilder>();
 
         /// <summary>
         /// Gets the Reply Message ID.
@@ -134,7 +133,7 @@ namespace DSharpPlus.Entities
             if(this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this._UserStreamFiles.Add(fileName, new DiscordFileBuilder(stream, true));
+            this._files.Add(fileName, new DiscordFileBuilder(stream, true));
 
             return this;
         }
@@ -149,7 +148,7 @@ namespace DSharpPlus.Entities
             if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this._UserStreamFiles.Add(stream.Name, new DiscordFileBuilder(stream, true));
+            this._files.Add(stream.Name, new DiscordFileBuilder(stream, true));
 
             return this;
         }
@@ -165,7 +164,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             var fs = File.OpenRead(filePath);
-            this._internalStreamFiles.Add(fs.Name, new DiscordFileBuilder(fs, false));
+            this._files.Add(fs.Name, new DiscordFileBuilder(fs, false));
 
             return this;
         }
@@ -181,7 +180,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             foreach (var file in files)
-                this._UserStreamFiles.Add(file.Key, new DiscordFileBuilder(file.Value, true));
+                this._files.Add(file.Key, new DiscordFileBuilder(file.Value, true));
 
             return this;
         }

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -45,7 +45,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the Files to be sent in the Message.
         /// </summary>
-        public IReadOnlyDictionary<string, DiscordFileBuilder> Files => this._files;
+        public IReadOnlyDictionary<string, Stream> Files => this._files.ToDictionary(x => x.Key, x => x.Value.Stream);
 
         internal Dictionary<string, DiscordFileBuilder> _files = new Dictionary<string, DiscordFileBuilder>();
 

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -45,9 +45,10 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the Files to be sent in the Message.
         /// </summary>
-        public IReadOnlyDictionary<string, Stream> Files => this._files;
+        public IReadOnlyDictionary<string, Stream> Files => this._UserStreamFiles.Concat(_internalStreamFiles).ToDictionary(x => x.Key, x => x.Value);
 
-        internal Dictionary<string, Stream> _files = new Dictionary<string, Stream>();
+        internal Dictionary<string, Stream> _UserStreamFiles = new Dictionary<string, Stream>();
+        internal Dictionary<string, Stream> _internalStreamFiles = new Dictionary<string, Stream>();
         private bool disposedValue;
 
         /// <summary>
@@ -134,7 +135,7 @@ namespace DSharpPlus.Entities
             if(this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this._files.Add(fileName, stream);
+            this._UserStreamFiles.Add(fileName, stream);
 
             return this;
         }
@@ -149,7 +150,7 @@ namespace DSharpPlus.Entities
             if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this._files.Add(stream.Name, stream);
+            this._UserStreamFiles.Add(stream.Name, stream);
 
             return this;
         }
@@ -165,7 +166,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             var fs = File.OpenRead(filePath);
-            this._files.Add(fs.Name, fs);
+            this._internalStreamFiles.Add(fs.Name, fs);
 
             return this;
         }
@@ -181,7 +182,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             foreach (var file in files)
-                this._files.Add(file.Key, file.Value);
+                this._UserStreamFiles.Add(file.Key, file.Value);
 
             return this;
         }
@@ -226,7 +227,7 @@ namespace DSharpPlus.Entities
             {
                 if (disposing)
                 {
-                    foreach (var file in this.Files)
+                    foreach (var file in this._internalStreamFiles)
                     {
                         file.Value.Dispose();
                     }

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -10,7 +10,7 @@ namespace DSharpPlus.Entities
     /// <summary>
     /// Constructs a Message to be sent.
     /// </summary>
-    public sealed class DiscordMessageBuilder
+    public sealed class DiscordMessageBuilder : IDisposable
     {
         /// <summary>
         /// Gets or Sets the Message to be sent.
@@ -48,6 +48,7 @@ namespace DSharpPlus.Entities
         public IReadOnlyDictionary<string, Stream> Files => this._files;
 
         internal Dictionary<string, Stream> _files = new Dictionary<string, Stream>();
+        private bool disposedValue;
 
         /// <summary>
         /// Gets the Reply Message ID.
@@ -217,6 +218,38 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMessage> ModifyAsync(DiscordMessage msg)
         {
             return await msg.ModifyAsync(this).ConfigureAwait(false);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    foreach (var file in this.Files)
+                    {
+                        file.Value.Dispose();
+                    }
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override finalizer
+                // TODO: set large fields to null
+                disposedValue = true;
+            }
+        }
+
+        // // TODO: override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+        // ~DiscordMessageBuilder()
+        // {
+        //     // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        //     Dispose(disposing: false);
+        // }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -45,9 +45,9 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the Files to be sent in the Message.
         /// </summary>
-        public IReadOnlyDictionary<string, Stream> Files => this._files.ToDictionary(x => x.Key, x => x.Value.Stream);
+        public IReadOnlyCollection<DiscordMessageFile> Files => this._files;
 
-        internal Dictionary<string, DiscordFileBuilder> _files = new Dictionary<string, DiscordFileBuilder>();
+        internal List<DiscordMessageFile> _files = new List<DiscordMessageFile>();
 
         /// <summary>
         /// Gets the Reply Message ID.
@@ -133,7 +133,7 @@ namespace DSharpPlus.Entities
             if(this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this._files.Add(fileName, new DiscordFileBuilder(stream, true));
+            this._files.Add(new DiscordMessageFile(fileName, stream, true));
 
             return this;
         }
@@ -148,7 +148,7 @@ namespace DSharpPlus.Entities
             if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this._files.Add(stream.Name, new DiscordFileBuilder(stream, true));
+            this._files.Add(new DiscordMessageFile(stream.Name, stream, true));
 
             return this;
         }
@@ -164,7 +164,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             var fs = File.OpenRead(filePath);
-            this._files.Add(fs.Name, new DiscordFileBuilder(fs, false));
+            this._files.Add(new DiscordMessageFile(fs.Name, fs, false));
 
             return this;
         }
@@ -180,7 +180,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             foreach (var file in files)
-                this._files.Add(file.Key, new DiscordFileBuilder(file.Value, true));
+                this._files.Add(new DiscordMessageFile(file.Key, file.Value, true));
 
             return this;
         }
@@ -218,17 +218,5 @@ namespace DSharpPlus.Entities
         {
             return await msg.ModifyAsync(this).ConfigureAwait(false);
         }
-    }
-
-    public struct DiscordFileBuilder
-    {
-        public DiscordFileBuilder(Stream stream, bool wasUserStream)
-        {
-            Stream = stream;
-            WasUserStream = wasUserStream;
-        }
-
-        public Stream Stream { get; set; }
-        internal bool WasUserStream { get; set; }
     }
 }

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -133,7 +133,10 @@ namespace DSharpPlus.Entities
             if(this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this._files.Add(new DiscordMessageFile(fileName, stream, true));
+            if (this._files.Any(x => x.FileName == fileName))
+                throw new ArgumentException("A File with that filename already exists");
+
+            this._files.Add(new DiscordMessageFile(fileName, stream, false));
 
             return this;
         }
@@ -148,7 +151,10 @@ namespace DSharpPlus.Entities
             if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this._files.Add(new DiscordMessageFile(stream.Name, stream, true));
+            if (this._files.Any(x => x.FileName == stream.Name))
+                throw new ArgumentException("A File with that filename already exists");
+
+            this._files.Add(new DiscordMessageFile(stream.Name, stream, false));
 
             return this;
         }
@@ -164,7 +170,11 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             var fs = File.OpenRead(filePath);
-            this._files.Add(new DiscordMessageFile(fs.Name, fs, false));
+
+            if (this._files.Any(x => x.FileName == fs.Name))
+                throw new ArgumentException("A File with that filename already exists");
+
+            this._files.Add(new DiscordMessageFile(fs.Name, fs, true));
 
             return this;
         }
@@ -180,7 +190,13 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             foreach (var file in files)
-                this._files.Add(new DiscordMessageFile(file.Key, file.Value, true));
+            {
+                if (this._files.Any(x => x.FileName == file.Key))
+                    throw new ArgumentException("A File with that filename already exists");
+
+                this._files.Add(new DiscordMessageFile(file.Key, file.Value, false));
+            }
+                
 
             return this;
         }

--- a/DSharpPlus/Entities/DiscordMessageFile.cs
+++ b/DSharpPlus/Entities/DiscordMessageFile.cs
@@ -2,17 +2,31 @@
 
 namespace DSharpPlus.Entities
 {
-    public struct DiscordMessageFile
+    /// <summary>
+    /// Represents the File that should be sent to Discord from the <see cref="DiscordMessageBuilder"/>.
+    /// </summary>
+    public class DiscordMessageFile
     {
-        public DiscordMessageFile(string fileName, Stream stream, bool wasUserStream)
+        internal DiscordMessageFile(string fileName, Stream stream, bool isDisposedInternally)
         {
             this.FileName = fileName;
             this.Stream = stream;
-            this.WasUserStream = wasUserStream;
+            this.IsDisposedInternally = isDisposedInternally;
         }
 
-        public string FileName { get; set; }
-        public Stream Stream { get; set; }
-        internal bool WasUserStream { get; set; }
+        /// <summary>
+        /// Gets or Sets the FileName of the File.
+        /// </summary>
+        public string FileName { get; internal set; }
+
+        /// <summary>
+        /// Gets or Sets the stream of the File.
+        /// </summary>
+        public Stream Stream { get; internal set; }
+
+        /// <summary>
+        /// Gets or Sets if the stream should be disposed by the library.
+        /// </summary>
+        internal bool IsDisposedInternally { get; set; }
     }
 }

--- a/DSharpPlus/Entities/DiscordMessageFile.cs
+++ b/DSharpPlus/Entities/DiscordMessageFile.cs
@@ -15,17 +15,17 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Gets or Sets the FileName of the File.
+        /// Gets the FileName of the File.
         /// </summary>
         public string FileName { get; internal set; }
 
         /// <summary>
-        /// Gets or Sets the stream of the File.
+        /// Gets the stream of the File.
         /// </summary>
         public Stream Stream { get; internal set; }
 
         /// <summary>
-        /// Gets or Sets if the stream should be disposed by the library.
+        /// Gets if the stream should be disposed by the library.
         /// </summary>
         internal bool IsDisposedInternally { get; set; }
     }

--- a/DSharpPlus/Entities/DiscordMessageFile.cs
+++ b/DSharpPlus/Entities/DiscordMessageFile.cs
@@ -1,0 +1,18 @@
+﻿using System.IO;
+
+namespace DSharpPlus.Entities
+{
+    public struct DiscordMessageFile
+    {
+        public DiscordMessageFile(string fileName, Stream stream, bool wasUserStream)
+        {
+            this.FileName = fileName;
+            this.Stream = stream;
+            this.WasUserStream = wasUserStream;
+        }
+
+        public string FileName { get; set; }
+        public Stream Stream { get; set; }
+        internal bool WasUserStream { get; set; }
+    }
+}

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -107,7 +107,7 @@ namespace DSharpPlus.Entities
             => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookAsync(this.Id, this.Token, builder.Content,
                 builder.Username.HasValue ? builder.Username.Value : this.Name, 
                 builder.AvatarUrl.HasValue ? builder.AvatarUrl.Value : this.AvatarUrl, 
-                builder.IsTTS, builder.Embeds, builder.Files, builder.Mentions);
+                builder.IsTTS, builder.Embeds, builder._files, builder.Mentions);
 
         /// <summary>
         /// Executes this webhook in Slack compatibility mode.

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -139,7 +139,10 @@ namespace DSharpPlus.Entities
             if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this._files.Add(new DiscordMessageFile(filename, data, true));
+            if (this._files.Any(x => x.FileName == filename))
+                throw new ArgumentException("A File with that filename already exists");
+
+            this._files.Add(new DiscordMessageFile(filename, data, false));
 
             return this;
         }
@@ -154,7 +157,13 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             foreach (var file in files)
-                this._files.Add(new DiscordMessageFile(file.Key, file.Value, true));
+            {
+                if (this._files.Any(x => x.FileName == file.Key))
+                    throw new ArgumentException("A File with that filename already exists");
+
+                this._files.Add(new DiscordMessageFile(file.Key, file.Value, false));
+            }
+                
 
             return this;
         }

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -50,10 +50,9 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Files to send on this webhook request.
         /// </summary>
-        public IReadOnlyDictionary<string, DiscordFileBuilder> Files => this._UserStreamFiles.Concat(_internalStreamFiles).ToDictionary(x => x.Key, x => x.Value);
+        public IReadOnlyDictionary<string, DiscordFileBuilder> Files => this._files;
 
-        internal Dictionary<string, DiscordFileBuilder> _UserStreamFiles = new Dictionary<string, DiscordFileBuilder>();
-        internal Dictionary<string, DiscordFileBuilder> _internalStreamFiles = new Dictionary<string, DiscordFileBuilder>();
+        internal Dictionary<string, DiscordFileBuilder> _files = new Dictionary<string, DiscordFileBuilder>();
 
         /// <summary>
         /// Mentions to send on this webhook request.
@@ -140,7 +139,7 @@ namespace DSharpPlus.Entities
             if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this._UserStreamFiles.Add(filename, new DiscordFileBuilder(data, true));
+            this._files.Add(filename, new DiscordFileBuilder(data, true));
 
             return this;
         }
@@ -155,7 +154,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             foreach (var file in files)
-                this._UserStreamFiles.Add(file.Key, new DiscordFileBuilder(file.Value, true));
+                this._files.Add(file.Key, new DiscordFileBuilder(file.Value, true));
 
             return this;
         }

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -50,7 +50,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Files to send on this webhook request.
         /// </summary>
-        public IReadOnlyDictionary<string, DiscordFileBuilder> Files => this._files;
+        public IReadOnlyDictionary<string, Stream> Files => this._files.ToDictionary(x => x.Key, x => x.Value.Stream);
 
         internal Dictionary<string, DiscordFileBuilder> _files = new Dictionary<string, DiscordFileBuilder>();
 

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -50,9 +50,9 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Files to send on this webhook request.
         /// </summary>
-        public IReadOnlyDictionary<string, Stream> Files => this._files.ToDictionary(x => x.Key, x => x.Value.Stream);
+        public IReadOnlyCollection<DiscordMessageFile> Files => this._files;
 
-        internal Dictionary<string, DiscordFileBuilder> _files = new Dictionary<string, DiscordFileBuilder>();
+        internal List<DiscordMessageFile> _files = new List<DiscordMessageFile>();
 
         /// <summary>
         /// Mentions to send on this webhook request.
@@ -139,7 +139,7 @@ namespace DSharpPlus.Entities
             if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            this._files.Add(filename, new DiscordFileBuilder(data, true));
+            this._files.Add(new DiscordMessageFile(filename, data, true));
 
             return this;
         }
@@ -154,7 +154,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             foreach (var file in files)
-                this._files.Add(file.Key, new DiscordFileBuilder(file.Value, true));
+                this._files.Add(new DiscordMessageFile(file.Key, file.Value, true));
 
             return this;
         }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -844,11 +844,11 @@ namespace DSharpPlus.Net
                 var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
                 var url = Utilities.GetApiUriFor(path);
-                var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files).ConfigureAwait(false);
+                var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder._files).ConfigureAwait(false);
 
                 var ret = this.PrepareMessage(JObject.Parse(res.Response));
 
-                foreach (var file in builder.Files.Where(x => !x.Value.WasUserStream))
+                foreach (var file in builder._files.Where(x => !x.Value.WasUserStream))
                 {
                     file.Value.Stream.Dispose();
                 }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -844,7 +844,7 @@ namespace DSharpPlus.Net
                 var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
                 var url = Utilities.GetApiUriFor(path);
-                var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder._files).ConfigureAwait(false);
+                var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files).ConfigureAwait(false);
 
                 var ret = this.PrepareMessage(JObject.Parse(res.Response));
 

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -848,7 +848,7 @@ namespace DSharpPlus.Net
 
                 var ret = this.PrepareMessage(JObject.Parse(res.Response));
 
-                foreach (var file in builder._files.Where(x => !x.WasUserStream))
+                foreach (var file in builder._files.Where(x => x.IsDisposedInternally))
                 {
                     file.Stream.Dispose();
                 }
@@ -1940,7 +1940,7 @@ namespace DSharpPlus.Net
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: files).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
 
-            foreach (var file in files.Where(x => !x.WasUserStream))
+            foreach (var file in files.Where(x => x.IsDisposedInternally))
             {
                 file.Stream.Dispose();
             }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -134,7 +134,7 @@ namespace DSharpPlus.Net
         }
 
         private Task<RestResponse> DoMultipartAsync(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, string route, IReadOnlyDictionary<string, string> headers = null, IReadOnlyDictionary<string, string> values = null,
-            IReadOnlyDictionary<string, Stream> files = null, double? ratelimitWaitOverride = null)
+            IReadOnlyDictionary<string, DiscordFileBuilder> files = null, double? ratelimitWaitOverride = null)
         {
             var req = new MultipartWebRequest(client, bucket, url, method, route, headers, values, files, ratelimitWaitOverride);
 
@@ -847,6 +847,11 @@ namespace DSharpPlus.Net
                 var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files).ConfigureAwait(false);
 
                 var ret = this.PrepareMessage(JObject.Parse(res.Response));
+
+                foreach (var file in builder.Files.Where(x => !x.Value.WasUserStream))
+                {
+                    file.Value.Stream.Dispose();
+                }
 
                 return ret;
             }
@@ -1902,7 +1907,7 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
-        internal async Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, Optional<string> username, Optional<string> avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, IReadOnlyDictionary<string, Stream> files, IEnumerable<IMention> mentions)
+        internal async Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, Optional<string> username, Optional<string> avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, IReadOnlyDictionary<string, DiscordFileBuilder> files, IEnumerable<IMention> mentions)
         {
             if (files?.Count == 0 && string.IsNullOrEmpty(content) && embeds == null)
                 throw new ArgumentException("You must specify content, an embed, or at least one file.");
@@ -1934,6 +1939,12 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: files).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
+
+            foreach (var file in files.Where(x => !x.Value.WasUserStream))
+            {
+                file.Value.Stream.Dispose();
+            }
+
             ret.Discord = this.Discord;
             return ret;
         }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -134,7 +134,7 @@ namespace DSharpPlus.Net
         }
 
         private Task<RestResponse> DoMultipartAsync(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, string route, IReadOnlyDictionary<string, string> headers = null, IReadOnlyDictionary<string, string> values = null,
-            IReadOnlyDictionary<string, DiscordFileBuilder> files = null, double? ratelimitWaitOverride = null)
+            IReadOnlyCollection<DiscordMessageFile> files = null, double? ratelimitWaitOverride = null)
         {
             var req = new MultipartWebRequest(client, bucket, url, method, route, headers, values, files, ratelimitWaitOverride);
 
@@ -848,9 +848,9 @@ namespace DSharpPlus.Net
 
                 var ret = this.PrepareMessage(JObject.Parse(res.Response));
 
-                foreach (var file in builder._files.Where(x => !x.Value.WasUserStream))
+                foreach (var file in builder._files.Where(x => !x.WasUserStream))
                 {
-                    file.Value.Stream.Dispose();
+                    file.Stream.Dispose();
                 }
 
                 return ret;
@@ -1907,7 +1907,7 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
-        internal async Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, Optional<string> username, Optional<string> avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, IReadOnlyDictionary<string, DiscordFileBuilder> files, IEnumerable<IMention> mentions)
+        internal async Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, Optional<string> username, Optional<string> avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, IReadOnlyCollection<DiscordMessageFile> files, IEnumerable<IMention> mentions)
         {
             if (files?.Count == 0 && string.IsNullOrEmpty(content) && embeds == null)
                 throw new ArgumentException("You must specify content, an embed, or at least one file.");
@@ -1940,9 +1940,9 @@ namespace DSharpPlus.Net
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: files).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
 
-            foreach (var file in files.Where(x => !x.Value.WasUserStream))
+            foreach (var file in files.Where(x => !x.WasUserStream))
             {
-                file.Value.Stream.Dispose();
+                file.Stream.Dispose();
             }
 
             ret.Discord = this.Discord;

--- a/DSharpPlus/Net/MultipartWebRequest.cs
+++ b/DSharpPlus/Net/MultipartWebRequest.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 
 namespace DSharpPlus.Net
 {
@@ -19,14 +20,14 @@ namespace DSharpPlus.Net
         /// <summary>
         /// Gets the dictionary of files attached to this request.
         /// </summary>
-        public IReadOnlyDictionary<string, DiscordFileBuilder> Files { get; }
+        public IReadOnlyDictionary<string, Stream> Files { get; }
 
         internal MultipartWebRequest(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, string route, IReadOnlyDictionary<string, string> headers = null, IReadOnlyDictionary<string, string> values = null, 
-            IReadOnlyDictionary<string, DiscordFileBuilder> files = null, double? ratelimit_wait_override = null)
+            IReadOnlyCollection<DiscordMessageFile> files = null, double? ratelimit_wait_override = null)
             : base(client, bucket, url, method, route, headers, ratelimit_wait_override)
         {
             this.Values = values;
-            this.Files = files;
+            this.Files = files.ToDictionary(x => x.FileName, x => x.Stream);
         }
     }
 }

--- a/DSharpPlus/Net/MultipartWebRequest.cs
+++ b/DSharpPlus/Net/MultipartWebRequest.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using DSharpPlus.Entities;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -18,10 +19,10 @@ namespace DSharpPlus.Net
         /// <summary>
         /// Gets the dictionary of files attached to this request.
         /// </summary>
-        public IReadOnlyDictionary<string, Stream> Files { get; }
+        public IReadOnlyDictionary<string, DiscordFileBuilder> Files { get; }
 
         internal MultipartWebRequest(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, string route, IReadOnlyDictionary<string, string> headers = null, IReadOnlyDictionary<string, string> values = null, 
-            IReadOnlyDictionary<string, Stream> files = null, double? ratelimit_wait_override = null)
+            IReadOnlyDictionary<string, DiscordFileBuilder> files = null, double? ratelimit_wait_override = null)
             : base(client, bucket, url, method, route, headers, ratelimit_wait_override)
         {
             this.Values = values;

--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -431,7 +431,7 @@ namespace DSharpPlus.Net
                 {
                     var i = 1;
                     foreach (var f in mprequest.Files)
-                        content.Add(new StreamContent(f.Value.Stream), $"file{(i++).ToString(CultureInfo.InvariantCulture)}", f.Key);
+                        content.Add(new StreamContent(f.Value), $"file{(i++).ToString(CultureInfo.InvariantCulture)}", f.Key);
                 }
 
                 req.Content = content;

--- a/DSharpPlus/Net/RestClient.cs
+++ b/DSharpPlus/Net/RestClient.cs
@@ -431,7 +431,7 @@ namespace DSharpPlus.Net
                 {
                     var i = 1;
                     foreach (var f in mprequest.Files)
-                        content.Add(new StreamContent(f.Value), $"file{(i++).ToString(CultureInfo.InvariantCulture)}", f.Key);
+                        content.Add(new StreamContent(f.Value.Stream), $"file{(i++).ToString(CultureInfo.InvariantCulture)}", f.Key);
                 }
 
                 req.Content = content;


### PR DESCRIPTION
# Summary
This fixes a bug in the message builder where it holds onto the stream after the message has been sent.  

# Changes proposed
* Make the Files property in the Message Builder have a struct to determine if the stream came from the user or not.  If not dispose once as the message is sent
