### PR TITLE
Builder Enhancements

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1215,7 +1215,7 @@ namespace DSharpPlus
         /// <param name="builder">Webhook builder filled with data to send.</param>
         /// <returns></returns>
         public Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, DiscordWebhookBuilder builder)
-            => this.ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, builder.Content, builder.Username, builder.AvatarUrl, builder.IsTTS, builder.Embeds, builder._files, builder.Mentions);
+            => this.ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, builder);
         #endregion
 
         #region Reactions

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -182,34 +183,64 @@ namespace DSharpPlus.Test
         {
             using (var fs = new FileStream("ADumbFile.txt", FileMode.Open, FileAccess.Read))
             {
-                await new DiscordMessageBuilder()
-                    .WithContent("Here is a really dumb file that i am testing with.")
-                    .WithFiles(new Dictionary<string, Stream>() { { "ADumbFile1.txt", fs } })
-                    .SendAsync(ctx.Channel)
-                    .ConfigureAwait(false);
+
+                // Verify that the lib resets the position when asked
+                var builder = new DiscordMessageBuilder()
+                    .WithContent("Testing the `Dictionary<string, stream>` Overload with resetting the postion turned on.")
+                    .WithFiles(new Dictionary<string, Stream>() { { "ADumbFile1.txt", fs }}, true);
+
+                await builder.SendAsync(ctx.Channel);
+                await builder.SendAsync(ctx.Channel);
+
+                builder.ClearMessageBuilder();
+
+                //Verify the lib doesnt reset the position.  THe file sent should have 0 bytes.
+                builder.WithContent("Testing the `WithFile(Dictionary<string, stream> files)` Overload with resetting the postion turned off  The 2nd file sent should have 0 bytes.")
+                    .WithFiles(new Dictionary<string, Stream>() { { "ADumbFile1.txt", fs } }, false);
+                
+                await builder.SendAsync(ctx.Channel);
+                await builder.SendAsync(ctx.Channel);
+
+                builder.ClearMessageBuilder();
 
                 fs.Position = 0;
 
-                await new DiscordMessageBuilder()
-                    .WithContent("Here is a really dumb file that i am testing with.")
-                    .WithFile(fs)
-                    .SendAsync(ctx.Channel)
-                    .ConfigureAwait(false);
+                // Verify that the lib resets the position when asked
+                builder.WithContent("Testing the `WithFile(Stream stream)` Overload with resetting the postion turned on.")
+                    .WithFile(fs, true);
 
+                await builder.SendAsync(ctx.Channel);
+                await builder.SendAsync(ctx.Channel);
+
+                builder.ClearMessageBuilder();
+
+                //Verify the lib doesnt reset the position.  THe file sent should have 0 bytes.
+                builder.WithContent("Testing the `WithFile(Stream stream)` Overload with resetting the postion turned off.  The 2nd file sent should have 0 bytes.")
+                    .WithFile(fs, false);
+
+                await builder.SendAsync(ctx.Channel);
+                await builder.SendAsync(ctx.Channel);
+
+                builder.ClearMessageBuilder();
                 fs.Position = 0;
 
-                await new DiscordMessageBuilder()
-                    .WithContent("Here is a really dumb file that i am testing with.")
-                    .WithFile("ADumbFile2.txt", fs)
-                    .SendAsync(ctx.Channel)
-                    .ConfigureAwait(false);               
+
+                // Verify that the lib resets the position when asked
+                builder.WithContent("Testing the `WithFile(string fileName, Stream stream)` Overload with resetting the postion turned on.")
+                    .WithFile("ADumbFile2.txt", fs, true);
+
+                await builder.SendAsync(ctx.Channel);
+                await builder.SendAsync(ctx.Channel);
+
+                builder.ClearMessageBuilder();
+
+                //Verify the lib doesnt reset the position.  THe file sent should have 0 bytes.
+                builder.WithContent("Testing the `WithFile(string fileName, Stream stream)` Overload with resetting the postion turned off.  The 2nd file sent should have 0 bytes.")
+                    .WithFile("ADumbFile2.txt", fs, false);
+
+                await builder.SendAsync(ctx.Channel);
+                await builder.SendAsync(ctx.Channel);         
             }
-
-            await new DiscordMessageBuilder()
-                   .WithContent("Here is a really dumb file that i am testing with.")
-                   .WithFile("./ADumbFile.txt")
-                   .SendAsync(ctx.Channel)
-                   .ConfigureAwait(false);
         }
 
         [Command("CreateSomeFile")]
@@ -229,7 +260,7 @@ namespace DSharpPlus.Test
                 fs.Position = 0;
                 var builder = new DiscordMessageBuilder();
                 builder.WithContent("Here is a really dumb file that i am testing with.");
-                builder.WithFile(fileName);
+                //builder.WithFile(fileName);
                 builder.WithFile(fs);
 
                 foreach (var file in builder.Files)
@@ -244,6 +275,75 @@ namespace DSharpPlus.Test
             }
             File.Delete(fileName);
             File.Delete("another " + fileName);
+        }
+
+        [Command("SendWebhookFiles")]
+        public async Task SendWebhookFiles(CommandContext ctx)
+        {
+            var webhook = await ctx.Channel.CreateWebhookAsync("webhook-test");
+
+            using (var fs = new FileStream("ADumbFile.txt", FileMode.Open, FileAccess.Read))
+            {
+
+                // Verify that the lib resets the position when asked
+                var builder = new DiscordWebhookBuilder()
+                    .WithContent("Testing the `AddFile(Dictionary<string, stream>)` Overload with resetting the postion turned on.")
+                    .AddFiles(new Dictionary<string, Stream>() { { "ADumbFile1.txt", fs } }, true);
+
+                await builder.SendWebhook(webhook);
+                await builder.SendWebhook(webhook);
+
+                builder.ClearWebhookBuilder();
+
+                //Verify the lib doesnt reset the position.  THe file sent should have 0 bytes.
+                builder.WithContent("Testing the `AddFile(Dictionary<string, stream> files)` Overload with resetting the postion turned off  The 2nd file sent should have 0 bytes.")
+                    .AddFiles(new Dictionary<string, Stream>() { { "ADumbFile1.txt", fs } }, false);
+
+                await builder.SendWebhook(webhook);
+                await builder.SendWebhook(webhook);
+
+                builder.ClearWebhookBuilder();
+
+                fs.Position = 0;
+
+                // Verify that the lib resets the position when asked
+                builder.WithContent("Testing the `AddFile(Stream stream)` Overload with resetting the postion turned on.")
+                    .AddFile(fs, true);
+
+                await builder.SendWebhook(webhook);
+                await builder.SendWebhook(webhook);
+
+                builder.ClearWebhookBuilder();
+
+                //Verify the lib doesnt reset the position.  THe file sent should have 0 bytes.
+                builder.WithContent("Testing the `AddFile(Stream stream)` Overload with resetting the postion turned off.  The 2nd file sent should have 0 bytes.")
+                    .AddFile(fs, false);
+
+                await builder.SendWebhook(webhook);
+                await builder.SendWebhook(webhook);
+
+                builder.ClearWebhookBuilder();
+                fs.Position = 0;
+
+
+                // Verify that the lib resets the position when asked
+                builder.WithContent("Testing the `AddFile(string fileName, Stream stream)` Overload with resetting the postion turned on.")
+                    .AddFile("ADumbFile2.txt", fs, true);
+
+                await builder.SendWebhook(webhook);
+                await builder.SendWebhook(webhook);
+
+                builder.ClearWebhookBuilder();
+
+                //Verify the lib doesnt reset the position.  THe file sent should have 0 bytes.
+                builder.WithContent("Testing the `AddFile(string fileName, Stream stream)` Overload with resetting the postion turned off.  The 2nd file sent should have 0 bytes.")
+                    .AddFile("ADumbFile2.txt", fs, false);
+
+                await builder.SendWebhook(webhook);
+                await builder.SendWebhook(webhook);
+            }
+
+            await webhook.DeleteAsync();
         }
     }
 }

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -291,8 +291,8 @@ namespace DSharpPlus.Test
                     .WithContent("Testing the `AddFile(Dictionary<string, stream>)` Overload with resetting the postion turned on.")
                     .AddFiles(new Dictionary<string, Stream>() { { "ADumbFile1.txt", fs } }, true);
 
-                await builder.SendWebhook(webhook);
-                await builder.SendWebhook(webhook);
+                await builder.SendAsync(webhook);
+                await builder.SendAsync(webhook);
 
                 builder.Clear();
 
@@ -300,8 +300,8 @@ namespace DSharpPlus.Test
                 builder.WithContent("Testing the `AddFile(Dictionary<string, stream> files)` Overload with resetting the postion turned off  The 2nd file sent should have 0 bytes.")
                     .AddFiles(new Dictionary<string, Stream>() { { "ADumbFile1.txt", fs } }, false);
 
-                await builder.SendWebhook(webhook);
-                await builder.SendWebhook(webhook);
+                await builder.SendAsync(webhook);
+                await builder.SendAsync(webhook);
 
                 builder.Clear();
 
@@ -311,8 +311,8 @@ namespace DSharpPlus.Test
                 builder.WithContent("Testing the `AddFile(Stream stream)` Overload with resetting the postion turned on.")
                     .AddFile(fs, true);
 
-                await builder.SendWebhook(webhook);
-                await builder.SendWebhook(webhook);
+                await builder.SendAsync(webhook);
+                await builder.SendAsync(webhook);
 
                 builder.Clear();
 
@@ -320,8 +320,8 @@ namespace DSharpPlus.Test
                 builder.WithContent("Testing the `AddFile(Stream stream)` Overload with resetting the postion turned off.  The 2nd file sent should have 0 bytes.")
                     .AddFile(fs, false);
 
-                await builder.SendWebhook(webhook);
-                await builder.SendWebhook(webhook);
+                await builder.SendAsync(webhook);
+                await builder.SendAsync(webhook);
 
                 builder.Clear();
                 fs.Position = 0;
@@ -331,8 +331,8 @@ namespace DSharpPlus.Test
                 builder.WithContent("Testing the `AddFile(string fileName, Stream stream)` Overload with resetting the postion turned on.")
                     .AddFile("ADumbFile2.txt", fs, true);
 
-                await builder.SendWebhook(webhook);
-                await builder.SendWebhook(webhook);
+                await builder.SendAsync(webhook);
+                await builder.SendAsync(webhook);
 
                 builder.Clear();
 
@@ -340,8 +340,8 @@ namespace DSharpPlus.Test
                 builder.WithContent("Testing the `AddFile(string fileName, Stream stream)` Overload with resetting the postion turned off.  The 2nd file sent should have 0 bytes.")
                     .AddFile("ADumbFile2.txt", fs, false);
 
-                await builder.SendWebhook(webhook);
-                await builder.SendWebhook(webhook);
+                await builder.SendAsync(webhook);
+                await builder.SendAsync(webhook);
             }
 
             await webhook.DeleteAsync();

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -127,8 +126,9 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="fileName">The fileName that the file should be sent as.</param>
         /// <param name="stream">The Stream to the file.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream poition to what it was after the file is sent.</param>
         /// <returns></returns>
-        public DiscordMessageBuilder WithFile(string fileName, Stream stream)
+        public DiscordMessageBuilder WithFile(string fileName, Stream stream, bool resetStreamPosition = false)
         {
             if(this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -136,7 +136,10 @@ namespace DSharpPlus.Entities
             if (this._files.Any(x => x.FileName == fileName))
                 throw new ArgumentException("A File with that filename already exists");
 
-            this._files.Add(new DiscordMessageFile(fileName, stream, false));
+            if(resetStreamPosition)
+                this._files.Add(new DiscordMessageFile(fileName, stream, stream.Position));
+            else
+                this._files.Add(new DiscordMessageFile(fileName, stream, null));            
 
             return this;
         }
@@ -145,8 +148,9 @@ namespace DSharpPlus.Entities
         /// Sets if the message has files to be sent.
         /// </summary>
         /// <param name="stream">The Stream to the file.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream poition to what it was after the file is sent.</param>
         /// <returns></returns>
-        public DiscordMessageBuilder WithFile(FileStream stream)
+        public DiscordMessageBuilder WithFile(FileStream stream, bool resetStreamPosition = false)
         {
             if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -154,27 +158,10 @@ namespace DSharpPlus.Entities
             if (this._files.Any(x => x.FileName == stream.Name))
                 throw new ArgumentException("A File with that filename already exists");
 
-            this._files.Add(new DiscordMessageFile(stream.Name, stream, false));
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets if the message has files to be sent.
-        /// </summary>
-        /// <param name="filePath">The path to the file.</param>
-        /// <returns></returns>
-        public DiscordMessageBuilder WithFile(string filePath)
-        {
-            if (this.Files.Count() >= 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            var fs = File.OpenRead(filePath);
-
-            if (this._files.Any(x => x.FileName == fs.Name))
-                throw new ArgumentException("A File with that filename already exists");
-
-            this._files.Add(new DiscordMessageFile(fs.Name, fs, true));
+            if (resetStreamPosition)
+                this._files.Add(new DiscordMessageFile(stream.Name, stream, stream.Position));
+            else
+                this._files.Add(new DiscordMessageFile(stream.Name, stream, null));
 
             return this;
         }
@@ -183,8 +170,9 @@ namespace DSharpPlus.Entities
         /// Sets if the message has files to be sent.
         /// </summary>
         /// <param name="files">The Files that should be sent.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream poition to what it was after the file is sent.</param>
         /// <returns></returns>
-        public DiscordMessageBuilder WithFiles(Dictionary<string, Stream> files)
+        public DiscordMessageBuilder WithFiles(Dictionary<string, Stream> files, bool resetStreamPosition = false)
         {
             if (this.Files.Count() + files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -194,7 +182,10 @@ namespace DSharpPlus.Entities
                 if (this._files.Any(x => x.FileName == file.Key))
                     throw new ArgumentException("A File with that filename already exists");
 
-                this._files.Add(new DiscordMessageFile(file.Key, file.Value, false));
+                if (resetStreamPosition)
+                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, file.Value.Position));
+                else
+                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, null));
             }
                 
 
@@ -233,6 +224,20 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMessage> ModifyAsync(DiscordMessage msg)
         {
             return await msg.ModifyAsync(this).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Allows for clearing the Message Builder so that it can be used again to send a new message.
+        /// </summary>
+        public void ClearMessageBuilder()
+        {
+            this.Content = "";
+            this.Embed = null;
+            this.IsTTS = false;
+            this.Mentions = null;
+            this._files = new List<DiscordMessageFile>();
+            this.ReplyId = null;
+            this.MentionOnReply = false;
         }
     }
 }

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -119,14 +119,14 @@ namespace DSharpPlus.Entities
                 this.Mentions = allowedMentions.ToList();
 
             return this;
-        }               
+        }
 
         /// <summary>
         /// Sets if the message has files to be sent.
         /// </summary>
         /// <param name="fileName">The fileName that the file should be sent as.</param>
         /// <param name="stream">The Stream to the file.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream poition to what it was after the file is sent.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns></returns>
         public DiscordMessageBuilder WithFile(string fileName, Stream stream, bool resetStreamPosition = false)
         {
@@ -148,7 +148,7 @@ namespace DSharpPlus.Entities
         /// Sets if the message has files to be sent.
         /// </summary>
         /// <param name="stream">The Stream to the file.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream poition to what it was after the file is sent.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns></returns>
         public DiscordMessageBuilder WithFile(FileStream stream, bool resetStreamPosition = false)
         {
@@ -170,7 +170,7 @@ namespace DSharpPlus.Entities
         /// Sets if the message has files to be sent.
         /// </summary>
         /// <param name="files">The Files that should be sent.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream poition to what it was after the file is sent.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns></returns>
         public DiscordMessageBuilder WithFiles(Dictionary<string, Stream> files, bool resetStreamPosition = false)
         {
@@ -229,7 +229,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Allows for clearing the Message Builder so that it can be used again to send a new message.
         /// </summary>
-        public void ClearMessageBuilder()
+        public void Clear()
         {
             this.Content = "";
             this.Embed = null;

--- a/DSharpPlus/Entities/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/DiscordMessageBuilder.cs
@@ -235,7 +235,7 @@ namespace DSharpPlus.Entities
             this.Embed = null;
             this.IsTTS = false;
             this.Mentions = null;
-            this._files = new List<DiscordMessageFile>();
+            this._files.Clear();
             this.ReplyId = null;
             this.MentionOnReply = false;
         }

--- a/DSharpPlus/Entities/DiscordMessageFile.cs
+++ b/DSharpPlus/Entities/DiscordMessageFile.cs
@@ -7,11 +7,11 @@ namespace DSharpPlus.Entities
     /// </summary>
     public class DiscordMessageFile
     {
-        internal DiscordMessageFile(string fileName, Stream stream, bool isDisposedInternally)
+        internal DiscordMessageFile(string fileName, Stream stream, long? resetPositionTo)
         {
             this.FileName = fileName;
             this.Stream = stream;
-            this.IsDisposedInternally = isDisposedInternally;
+            this.ResetPositionTo = resetPositionTo;
         }
 
         /// <summary>
@@ -25,8 +25,8 @@ namespace DSharpPlus.Entities
         public Stream Stream { get; internal set; }
 
         /// <summary>
-        /// Gets if the stream should be disposed by the library.
+        /// Gets the position the File should be reset to.
         /// </summary>
-        internal bool IsDisposedInternally { get; set; }
+        internal long? ResetPositionTo { get; set; }
     }
 }

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -104,10 +104,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> ExecuteAsync(DiscordWebhookBuilder builder)
-            => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookAsync(this.Id, this.Token, builder.Content,
-                builder.Username.HasValue ? builder.Username.Value : this.Name, 
-                builder.AvatarUrl.HasValue ? builder.AvatarUrl.Value : this.AvatarUrl, 
-                builder.IsTTS, builder.Embeds, builder._files, builder.Mentions);
+            => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookAsync(this.Id, this.Token, builder);
 
         /// <summary>
         /// Executes this webhook in Slack compatibility mode.

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -130,68 +130,28 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Sets if the message has files to be sent.
+        /// Adds a file to send at the execution of the webhook.
         /// </summary>
-        /// <param name="fileName">The fileName that the file should be sent as.</param>
-        /// <param name="stream">The Stream to the file.</param>
-        /// <returns></returns>
-        public DiscordWebhookBuilder WithFile(string fileName, Stream stream)
+        /// <param name="filename">Name of the file.</param>
+        /// <param name="data">File data.</param>
+        public DiscordWebhookBuilder AddFile(string filename, Stream data)
         {
             if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            if (this._files.Any(x => x.FileName == fileName))
+            if (this._files.Any(x => x.FileName == filename))
                 throw new ArgumentException("A File with that filename already exists");
 
-            this._files.Add(new DiscordMessageFile(fileName, stream, false));
+            this._files.Add(new DiscordMessageFile(filename, data, false));
 
             return this;
         }
 
         /// <summary>
-        /// Sets if the message has files to be sent.
+        /// Adds the given files to send at the execution of the webhook.
         /// </summary>
-        /// <param name="stream">The Stream to the file.</param>
-        /// <returns></returns>
-        public DiscordWebhookBuilder WithFile(FileStream stream)
-        {
-            if (this.Files.Count() >= 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            if (this._files.Any(x => x.FileName == stream.Name))
-                throw new ArgumentException("A File with that filename already exists");
-
-            this._files.Add(new DiscordMessageFile(stream.Name, stream, false));
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets if the message has files to be sent.
-        /// </summary>
-        /// <param name="filePath">The path to the file.</param>
-        /// <returns></returns>
-        public DiscordWebhookBuilder WithFile(string filePath)
-        {
-            if (this.Files.Count() >= 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            var fs = File.OpenRead(filePath);
-
-            if (this._files.Any(x => x.FileName == fs.Name))
-                throw new ArgumentException("A File with that filename already exists");
-
-            this._files.Add(new DiscordMessageFile(fs.Name, fs, true));
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets if the message has files to be sent.
-        /// </summary>
-        /// <param name="files">The Files that should be sent.</param>
-        /// <returns></returns>
-        public DiscordWebhookBuilder WithFiles(Dictionary<string, Stream> files)
+        /// <param name="files">Dictionary of file name and file data.</param>
+        public DiscordWebhookBuilder AddFiles(Dictionary<string, Stream> files)
         {
             if (this.Files.Count() + files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -203,7 +163,7 @@ namespace DSharpPlus.Entities
 
                 this._files.Add(new DiscordMessageFile(file.Key, file.Value, false));
             }
-
+                
 
             return this;
         }

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -130,28 +130,68 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Adds a file to send at the execution of the webhook.
+        /// Sets if the message has files to be sent.
         /// </summary>
-        /// <param name="filename">Name of the file.</param>
-        /// <param name="data">File data.</param>
-        public DiscordWebhookBuilder AddFile(string filename, Stream data)
+        /// <param name="fileName">The fileName that the file should be sent as.</param>
+        /// <param name="stream">The Stream to the file.</param>
+        /// <returns></returns>
+        public DiscordWebhookBuilder WithFile(string fileName, Stream stream)
         {
             if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
-            if (this._files.Any(x => x.FileName == filename))
+            if (this._files.Any(x => x.FileName == fileName))
                 throw new ArgumentException("A File with that filename already exists");
 
-            this._files.Add(new DiscordMessageFile(filename, data, false));
+            this._files.Add(new DiscordMessageFile(fileName, stream, false));
 
             return this;
         }
 
         /// <summary>
-        /// Adds the given files to send at the execution of the webhook.
+        /// Sets if the message has files to be sent.
         /// </summary>
-        /// <param name="files">Dictionary of file name and file data.</param>
-        public DiscordWebhookBuilder AddFiles(Dictionary<string, Stream> files)
+        /// <param name="stream">The Stream to the file.</param>
+        /// <returns></returns>
+        public DiscordWebhookBuilder WithFile(FileStream stream)
+        {
+            if (this.Files.Count() >= 10)
+                throw new ArgumentException("Cannot send more than 10 files with a single message.");
+
+            if (this._files.Any(x => x.FileName == stream.Name))
+                throw new ArgumentException("A File with that filename already exists");
+
+            this._files.Add(new DiscordMessageFile(stream.Name, stream, false));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets if the message has files to be sent.
+        /// </summary>
+        /// <param name="filePath">The path to the file.</param>
+        /// <returns></returns>
+        public DiscordWebhookBuilder WithFile(string filePath)
+        {
+            if (this.Files.Count() >= 10)
+                throw new ArgumentException("Cannot send more than 10 files with a single message.");
+
+            var fs = File.OpenRead(filePath);
+
+            if (this._files.Any(x => x.FileName == fs.Name))
+                throw new ArgumentException("A File with that filename already exists");
+
+            this._files.Add(new DiscordMessageFile(fs.Name, fs, true));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets if the message has files to be sent.
+        /// </summary>
+        /// <param name="files">The Files that should be sent.</param>
+        /// <returns></returns>
+        public DiscordWebhookBuilder WithFiles(Dictionary<string, Stream> files)
         {
             if (this.Files.Count() + files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -163,7 +203,7 @@ namespace DSharpPlus.Entities
 
                 this._files.Add(new DiscordMessageFile(file.Key, file.Value, false));
             }
-                
+
 
             return this;
         }

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -46,20 +46,20 @@ namespace DSharpPlus.Entities
         /// Embeds to send on this webhook request.
         /// </summary>
         public IReadOnlyList<DiscordEmbed> Embeds { get; }
-        private List<DiscordEmbed> _embeds = new List<DiscordEmbed>();
+        private readonly List<DiscordEmbed> _embeds = new List<DiscordEmbed>();
 
         /// <summary>
         /// Files to send on this webhook request.
         /// </summary>
         public IReadOnlyCollection<DiscordMessageFile> Files => this._files;
 
-        internal List<DiscordMessageFile> _files = new List<DiscordMessageFile>();
+        internal readonly List<DiscordMessageFile> _files = new List<DiscordMessageFile>();
 
         /// <summary>
         /// Mentions to send on this webhook request.
         /// </summary>
         public IEnumerable<IMention> Mentions { get; }
-        private List<IMention> _mentions = new List<IMention>();
+        private readonly List<IMention> _mentions = new List<IMention>();
 
         /// <summary>
         /// Constructs a new empty webhook request builder.
@@ -231,10 +231,10 @@ namespace DSharpPlus.Entities
         public void ClearWebhookBuilder()
         {
             this.Content = "";
-            this._embeds = new List<DiscordEmbed>();
+            this._embeds.Clear();
             this.IsTTS = false;
-            this._mentions = new List<IMention>();
-            this._files = new List<DiscordMessageFile>();
+            this._mentions.Clear();
+            this._files.Clear();
         }
     }
 }

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -135,7 +135,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="filename">Name of the file.</param>
         /// <param name="data">File data.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream poition to what it was after the file is sent.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         public DiscordWebhookBuilder AddFile(string filename, Stream data, bool resetStreamPosition = false)
         {
             if (this.Files.Count() >= 10)
@@ -156,7 +156,7 @@ namespace DSharpPlus.Entities
         /// Sets if the message has files to be sent.
         /// </summary>
         /// <param name="stream">The Stream to the file.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream poition to what it was after the file is sent.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns></returns>
         public DiscordWebhookBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
         {
@@ -178,7 +178,7 @@ namespace DSharpPlus.Entities
         /// Adds the given files to send at the execution of the webhook.
         /// </summary>
         /// <param name="files">Dictionary of file name and file data.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream poition to what it was after the file is sent.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         public DiscordWebhookBuilder AddFiles(Dictionary<string, Stream> files, bool resetStreamPosition = false)
         {
             if (this.Files.Count() + files.Count() >= 10)
@@ -228,7 +228,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Allows for clearing the Message Builder so that it can be used again to send a new message.
         /// </summary>
-        public void ClearWebhookBuilder()
+        public void Clear()
         {
             this.Content = "";
             this._embeds.Clear();

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -220,7 +220,7 @@ namespace DSharpPlus.Entities
         }
 
 
-        public async Task<DiscordMessage> SendWebhook(DiscordWebhook webhook)
+        public async Task<DiscordMessage> SendAsync(DiscordWebhook webhook)
         {
             return await webhook.ExecuteAsync(this);
         }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -848,9 +848,9 @@ namespace DSharpPlus.Net
 
                 var ret = this.PrepareMessage(JObject.Parse(res.Response));
 
-                foreach (var file in builder._files.Where(x => x.IsDisposedInternally))
+                foreach (var file in builder._files.Where(x => x.ResetPositionTo.HasValue))
                 {
-                    file.Stream.Dispose();
+                    file.Stream.Position = file.ResetPositionTo.Value;
                 }
 
                 return ret;
@@ -1940,9 +1940,9 @@ namespace DSharpPlus.Net
             var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
 
-            foreach (var file in builder.Files.Where(x => x.IsDisposedInternally))
+            foreach (var file in builder.Files.Where(x => x.ResetPositionTo.HasValue))
             {
-                file.Stream.Dispose();
+                file.Stream.Position = file.ResetPositionTo.Value;
             }
 
             ret.Discord = this.Discord;

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1907,40 +1907,40 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
-        internal async Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, string content, Optional<string> username, Optional<string> avatar_url, bool? tts, IEnumerable<DiscordEmbed> embeds, IReadOnlyCollection<DiscordMessageFile> files, IEnumerable<IMention> mentions)
+        internal async Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, DiscordWebhookBuilder builder)
         {
-            if (files?.Count == 0 && string.IsNullOrEmpty(content) && embeds == null)
+            if (builder.Files?.Count == 0 && string.IsNullOrEmpty(builder.Content) && builder.Embeds == null)
                 throw new ArgumentException("You must specify content, an embed, or at least one file.");
 
-            if (embeds != null)
-                foreach (var embed in embeds)
+            if (builder.Embeds != null)
+                foreach (var embed in builder.Embeds)
                     if (embed.Timestamp != null)
                         embed.Timestamp = embed.Timestamp.Value.ToUniversalTime();
 
             var values = new Dictionary<string, string>();
             var pld = new RestWebhookExecutePayload
             {
-                Content = content,
-                Username = username.HasValue ? username.Value : null,
-                AvatarUrl = avatar_url.HasValue ? avatar_url.Value : null,
-                IsTTS = tts,
-                Embeds = embeds
+                Content = builder.Content,
+                Username = builder.Username.HasValue ? builder.Username.Value : null,
+                AvatarUrl = builder.AvatarUrl.HasValue ? builder.AvatarUrl.Value : null,
+                IsTTS = builder.IsTTS,
+                Embeds = builder.Embeds
             };
 
-            if (mentions != null)
-                pld.Mentions = new DiscordMentions(mentions);
+            if (builder.Mentions != null)
+                pld.Mentions = new DiscordMentions(builder.Mentions);
 
-            if (!string.IsNullOrEmpty(content) || embeds?.Count() > 0 || tts == true || mentions != null)
+            if (!string.IsNullOrEmpty(builder.Content) || builder.Embeds?.Count() > 0 || builder.IsTTS == true || builder.Mentions != null)
                 values["payload_json"] = DiscordJson.SerializeObject(pld);
 
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
             var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
-            var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: files).ConfigureAwait(false);
+            var res = await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
 
-            foreach (var file in files.Where(x => x.IsDisposedInternally))
+            foreach (var file in builder.Files.Where(x => x.IsDisposedInternally))
             {
                 file.Stream.Dispose();
             }


### PR DESCRIPTION
# Summary
This enhances both the DiscordMessageBuilder and DiscordWebhookBuilder to have various changes

# Changes proposed
* Adds a Clear Method to both the DiscordMessageBuilder and DiscordWebhookBuilder so that they can be reused
* Removes the AddFile/WithFile overloads that takes a filePath
* Adds a param to the AddFile/WithFile Overloads that will allow for resetting the position of a File if it is requested.  This defaults to false
* Cleans up the internal methods of the Webhook Send so it will pass the builder the whole way through.
* Updates and adds the various tests that had to deal with this change.