### PR TITLE
Union Message Parsed Mentions with Discord Mention Lists

### DIFF
--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -42,7 +42,7 @@ namespace DSharpPlus.Test
             {
                 AutoReconnect = true,
                 LargeThreshold = 250,
-                MinimumLogLevel = LogLevel.Trace,
+                MinimumLogLevel = LogLevel.Debug,
                 Token = this.Config.Token,
                 TokenType = TokenType.Bot,
                 ShardId = shardid,

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -42,7 +42,7 @@ namespace DSharpPlus.Test
             {
                 AutoReconnect = true,
                 LargeThreshold = 250,
-                MinimumLogLevel = LogLevel.Debug,
+                MinimumLogLevel = LogLevel.Trace,
                 Token = this.Config.Token,
                 TokenType = TokenType.Bot,
                 ShardId = shardid,

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
@@ -244,6 +246,88 @@ namespace DSharpPlus.Test
             }
             File.Delete(fileName);
             File.Delete("another " + fileName);
+        }
+
+        [Command("chainreply")]
+        public async Task ChainReplyAsync(CommandContext ctx)
+        {
+            DiscordMessageBuilder builder = new DiscordMessageBuilder();
+
+            StringBuilder contentBuilder = new StringBuilder();
+
+            ulong reply = ctx.Message.Id;
+            bool ping = false;
+
+            if (ctx.Message.MessageType == MessageType.Reply)
+            {
+                contentBuilder.AppendLine("Chaining a reply");
+                reply = ctx.Message.ReferencedMessage.Id;
+                if (ping = ctx.Message.MentionedUsers.Contains(ctx.Message.ReferencedMessage.Author))
+                {
+                    contentBuilder.AppendLine("Pinging the user with the reply as it appears that is what you did.");
+                }
+                else
+                {
+                    contentBuilder.AppendLine("Not pinging the user as that does not appear to be what you did.");
+                }
+            }
+            else
+            {
+                contentBuilder.AppendLine("I mean, ok, you just tried to chain a non-existent reply but whatever.");
+            }
+
+            builder
+                .WithContent(contentBuilder.ToString())
+                .WithReply(reply, ping);
+
+            await ctx.RespondAsync(builder);
+        }
+
+        [Command("mentionusers")]
+        public async Task MentionAllMentionedUsers(CommandContext ctx, [RemainingText][Description("Just a string so that DSharpPlus will parse no matter what I say")] string mentionedUsers)
+        {
+            string content = "You didn't have any users to mention";
+            if (ctx.Message.MentionedUsers.Any())
+                content = string.Join(", ", ctx.Message.MentionedUsers.Select(usr => usr.Mention));
+
+            await ctx.RespondAsync(content);
+        }
+
+        [Command("mentionroles")]
+        public async Task MentionAllMentionedRoles(CommandContext ctx, [RemainingText][Description("Just a string so that DSharpPlus will parse no matter what I say")] string mentionedRoles)
+        {
+            string content = "You didn't have any roles to mention";
+            if (ctx.Message.MentionedRoles.Any())
+                content = string.Join(", ", ctx.Message.MentionedRoles.Select(role => role.Mention));
+
+            await ctx.RespondAsync(content);
+        }
+
+        [Command("mentionchannels")]
+        public async Task MentionChannels(CommandContext ctx, [RemainingText][Description("Just a string so that DSharpPlus will parse no matter what I say")] string mentionedChannels)
+        {
+            string content = "You didn't have any roles to mention";
+            if (ctx.Message.MentionedChannels.Any())
+                content = string.Join(", ", ctx.Message.MentionedChannels.Select(role => role.Mention));
+
+            await ctx.RespondAsync(content);
+        }
+
+        [Command("getmessagementions")]
+        public async Task GetMessageMentions(CommandContext ctx, ulong msgId)
+        {
+            DiscordMessage msg = await ctx.Channel.GetMessageAsync(msgId);
+            StringBuilder contentBuilder = new StringBuilder("You didn't mention any user, channel, or role.");
+
+            if (msg.MentionedUsers.Any() || msg.MentionedRoles.Any() || msg.MentionedChannels.Any())
+            {
+                contentBuilder.Clear();
+                contentBuilder.AppendLine(msg.MentionedUsers.Any() ? string.Join(", ", msg.MentionedUsers.Select(usr => usr.Mention)) : string.Empty);
+                contentBuilder.AppendLine(msg.MentionedChannels.Any() ? string.Join(", ", msg.MentionedChannels.Select(usr => usr.Mention)) : string.Empty);
+                contentBuilder.AppendLine(msg.MentionedRoles.Any() ? string.Join(", ", msg.MentionedRoles.Select(usr => usr.Mention)) : string.Empty);
+            }
+
+            await ctx.RespondAsync(contentBuilder.ToString());
         }
     }
 }

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -286,7 +286,7 @@ namespace DSharpPlus.Test
         [Command("mentionusers")]
         public async Task MentionAllMentionedUsers(CommandContext ctx, [RemainingText][Description("Just a string so that DSharpPlus will parse no matter what I say")] string mentionedUsers)
         {
-            string content = "You didn't have any users to mention";
+            var content = "You didn't have any users to mention";
             if (ctx.Message.MentionedUsers.Any())
                 content = string.Join(", ", ctx.Message.MentionedUsers.Select(usr => usr.Mention));
 
@@ -296,7 +296,7 @@ namespace DSharpPlus.Test
         [Command("mentionroles")]
         public async Task MentionAllMentionedRoles(CommandContext ctx, [RemainingText][Description("Just a string so that DSharpPlus will parse no matter what I say")] string mentionedRoles)
         {
-            string content = "You didn't have any roles to mention";
+            var content = "You didn't have any roles to mention";
             if (ctx.Message.MentionedRoles.Any())
                 content = string.Join(", ", ctx.Message.MentionedRoles.Select(role => role.Mention));
 
@@ -306,7 +306,7 @@ namespace DSharpPlus.Test
         [Command("mentionchannels")]
         public async Task MentionChannels(CommandContext ctx, [RemainingText][Description("Just a string so that DSharpPlus will parse no matter what I say")] string mentionedChannels)
         {
-            string content = "You didn't have any roles to mention";
+            var content = "You didn't have any channels to mention";
             if (ctx.Message.MentionedChannels.Any())
                 content = string.Join(", ", ctx.Message.MentionedChannels.Select(role => role.Mention));
 
@@ -316,8 +316,8 @@ namespace DSharpPlus.Test
         [Command("getmessagementions")]
         public async Task GetMessageMentions(CommandContext ctx, ulong msgId)
         {
-            DiscordMessage msg = await ctx.Channel.GetMessageAsync(msgId);
-            StringBuilder contentBuilder = new StringBuilder("You didn't mention any user, channel, or role.");
+            var msg = await ctx.Channel.GetMessageAsync(msgId);
+            var contentBuilder = new StringBuilder("You didn't mention any user, channel, or role.");
 
             if (msg.MentionedUsers.Any() || msg.MentionedRoles.Any() || msg.MentionedChannels.Any())
             {

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1196,7 +1196,7 @@ namespace DSharpPlus
         {
             message.Discord = this;
             this.PopulateMessageReactionsAndCache(message, author, member);
-            this.PopulateMentions(message, message.Channel?.Guild);
+            message.PopulateMentions();
 
             if (message.Channel == null && message.ChannelId == default)
                 this.Logger.LogWarning(LoggerEvents.WebSocketReceive, "Channel which the last message belongs to is not in cache - cache state might be invalid!");
@@ -1205,7 +1205,7 @@ namespace DSharpPlus
             {
                 message.ReferencedMessage.Discord = this;
                 PopulateMessageReactionsAndCache(message.ReferencedMessage, referenceAuthor, referenceMember);
-                PopulateMentions(message, message.ReferencedMessage.Channel?.Guild);
+                message.ReferencedMessage.PopulateMentions();
             }
 
             var ea = new MessageCreateEventArgs
@@ -1239,7 +1239,7 @@ namespace DSharpPlus
                 {
                     message.ReferencedMessage.Discord = this;
                     PopulateMessageReactionsAndCache(message.ReferencedMessage, referenceAuthor, referenceMember);
-                    PopulateMentions(message.ReferencedMessage, guild);
+                    message.ReferencedMessage.PopulateMentions();
                 }
             }
             else
@@ -1256,7 +1256,7 @@ namespace DSharpPlus
                 message.IsTTS = event_message.IsTTS;
             }
 
-            this.PopulateMentions(message, guild);
+            message.PopulateMentions();
 
             var ea = new MessageUpdateEventArgs
             {

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1196,7 +1196,7 @@ namespace DSharpPlus
         {
             message.Discord = this;
             this.PopulateMessageReactionsAndCache(message, author, member);
-            this.PopulateMessageMentions(message, message.Channel?.Guild);
+            this.PopulateMentions(message, message.Channel?.Guild);
 
             if (message.Channel == null && message.ChannelId == default)
                 this.Logger.LogWarning(LoggerEvents.WebSocketReceive, "Channel which the last message belongs to is not in cache - cache state might be invalid!");
@@ -1205,7 +1205,7 @@ namespace DSharpPlus
             {
                 message.ReferencedMessage.Discord = this;
                 PopulateMessageReactionsAndCache(message.ReferencedMessage, referenceAuthor, referenceMember);
-                PopulateMessageMentions(message, message.ReferencedMessage.Channel?.Guild);
+                PopulateMentions(message, message.ReferencedMessage.Channel?.Guild);
             }
 
             var ea = new MessageCreateEventArgs
@@ -1239,7 +1239,7 @@ namespace DSharpPlus
                 {
                     message.ReferencedMessage.Discord = this;
                     PopulateMessageReactionsAndCache(message.ReferencedMessage, referenceAuthor, referenceMember);
-                    PopulateMessageMentions(message.ReferencedMessage, guild);
+                    PopulateMentions(message.ReferencedMessage, guild);
                 }
             }
             else
@@ -1256,7 +1256,7 @@ namespace DSharpPlus
                 message.IsTTS = event_message.IsTTS;
             }
 
-            this.PopulateMessageMentions(message, guild);
+            this.PopulateMentions(message, guild);
 
             var ea = new MessageUpdateEventArgs
             {

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -810,42 +810,6 @@ namespace DSharpPlus
                 this.MessageCache?.Add(message);
         }
 
-        private void PopulateMentions(DiscordMessage message, DiscordGuild guild)
-        {
-            message._mentionedUsers ??= new List<DiscordUser>();
-            message._mentionedRoles ??= new List<DiscordRole>();
-            message._mentionedChannels ??= new List<DiscordChannel>();
-
-            HashSet<DiscordUser> mentionedUsers = new HashSet<DiscordUser>(new DiscordUserComparer());
-            if (guild != null)
-            {
-                foreach (DiscordUser usr in message._mentionedUsers)
-                {
-                    usr.Discord = this;
-                    this.UserCache.AddOrUpdate(usr.Id, usr, (id, old) =>
-                    {
-                        old.Username = usr.Username;
-                        old.Discriminator = usr.Discriminator;
-                        old.AvatarHash = usr.AvatarHash;
-                        return old;
-                    });
-
-                    mentionedUsers.Add(guild._members.TryGetValue(usr.Id, out var member) ? member : usr);
-                }
-            }
-            if (!string.IsNullOrWhiteSpace(message.Content))
-            {
-                mentionedUsers.UnionWith(Utilities.GetUserMentions(message).Select(this.GetCachedOrEmptyUserInternal));
-                if (guild != null)
-                {
-                    message._mentionedRoles = message._mentionedRoles.Union(Utilities.GetRoleMentions(message).Select(xid => guild.GetRole(xid))).ToList();
-                    message._mentionedChannels = message._mentionedChannels.Union(Utilities.GetChannelMentions(message).Select(xid => guild.GetChannel(xid))).ToList();
-                }
-            }
-
-            message._mentionedUsers = mentionedUsers.ToList();
-        }
-
 
         #endregion
 

--- a/DSharpPlus/Entities/DiscordUser.cs
+++ b/DSharpPlus/Entities/DiscordUser.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
 using DSharpPlus.Net.Abstractions;
@@ -291,5 +293,18 @@ namespace DSharpPlus.Entities
         /// <returns>Whether the two users are not equal.</returns>
         public static bool operator !=(DiscordUser e1, DiscordUser e2) 
             => !(e1 == e2);
+    }
+
+    internal class DiscordUserComparer : IEqualityComparer<DiscordUser>
+    {
+        public bool Equals(DiscordUser x, DiscordUser y)
+        {
+            return x.Equals(y);
+        }
+
+        public int GetHashCode(DiscordUser obj)
+        {
+            return obj.Id.GetHashCode();
+        }
     }
 }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -93,38 +93,7 @@ namespace DSharpPlus.Net
                 }
             }
 
-            ret._mentionedUsers ??= new List<DiscordUser>();
-            ret._mentionedRoles ??= new List<DiscordRole>();
-            ret._mentionedChannels ??= new List<DiscordChannel>();
-
-            HashSet<DiscordUser> mentionedUsers = new HashSet<DiscordUser>(new DiscordUserComparer());
-            if (guild != null)
-            {
-                foreach (DiscordUser usr in ret._mentionedUsers)
-                {
-                    usr.Discord = this.Discord;
-                    this.Discord.UserCache.AddOrUpdate(usr.Id, usr, (id, old) =>
-                    {
-                        old.Username = usr.Username;
-                        old.Discriminator = usr.Discriminator;
-                        old.AvatarHash = usr.AvatarHash;
-                        return old;
-                    });
-
-                    mentionedUsers.Add(guild._members.TryGetValue(usr.Id, out var member) ? member : usr);
-                }
-            }
-            if (!string.IsNullOrWhiteSpace(ret.Content))
-            {
-                mentionedUsers.UnionWith(Utilities.GetUserMentions(ret).Select(this.Discord.GetCachedOrEmptyUserInternal));
-                if (guild != null)
-                {
-                    ret._mentionedRoles = ret._mentionedRoles.Union(Utilities.GetRoleMentions(ret).Select(xid => guild.GetRole(xid))).ToList();
-                    ret._mentionedChannels = ret._mentionedChannels.Union(Utilities.GetChannelMentions(ret).Select(xid => guild.GetChannel(xid))).ToList();
-                }
-            }
-
-            ret._mentionedUsers = mentionedUsers.ToList();
+            ret.PopulateMentions();
 
             if (ret._reactions == null)
                 ret._reactions = new List<DiscordReaction>();


### PR DESCRIPTION
# Summary
Fixes #782 

# Details
This fixes #782 which prevents the reply mentioned user from showing up in the DSharpPlus MentionedUsers list by unioning the Discord provided Mention lists with the parsed mention lists. The reason that it was decided to union instead of only use the Discord provided lists is that users who are in the cache and are mentioned in a context outside of a guild where they are member are not sent by Discord. So, to circumvent that we parse the message mentions. To ensure that no changes occur for the other mention lists we also union them with whatever is parsed from the message. This allows us to respect old behavior while still ensuring that any Discord-provided data is used. 

One change was made that can easily be remedied, I set all Mention lists to empty lists rather than null. This is because the two separate behaviors didn't really make sense. Especially since Discord always sends the mentioned roles list (even if they don't always send the mention channels list) even if it's empty. So, for consistency's sake, it makes sense to just go ahead and provide empty lists instead. If y'all disagree just comment and let me know and I will change it. 

Also, I need to fix this, I forgot to set the MinimumLogLevel in the TestBot back to Debug. 😆 

# Changes proposed
* Added 4 test commands to test different aspects of the mention parsing and mention objects received from Discord
* Update the User Cache with the partial user objects received from Discord in the mention but only for users that are in some guild and not those that are in DMs. 
* Added a DiscordUserComparer so that I could use a HashSet for unioning the parsed mentions and the discord sent mentioned users together. 