### PR TITLE
Implicit operator for raw emoji string. 

### DIFF
--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -428,5 +428,25 @@ namespace DSharpPlus.Test
 
             await ctx.RespondAsync(contentBuilder.ToString());
         }
+
+        [Command("reactwithrawemojistring")]
+        public async Task ReactWithRawEmojiString(CommandContext ctx, string rawEmoji)
+        {
+            await ctx.Message.CreateReactionAsync(rawEmoji);
+        }
+
+        [Command("replywithrawemojistring")]
+        public async Task ReplyWithRawEmojiString(CommandContext ctx, ulong msgId = default)
+        {
+            if (msgId == 0)
+                msgId = ctx.Message.Id;
+
+            var emojisToReply = new DiscordEmoji[] { ":ok_hand:", ":thumbsup:", ":thumbsdown:", ":x:" };
+
+            foreach (var item in emojisToReply)
+                await ctx.RespondAsync(new DiscordMessageBuilder()
+                    .WithContent(item)
+                    .WithReply(msgId));
+        }
     }
 }

--- a/DSharpPlus/Entities/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/DiscordEmoji.cs
@@ -216,7 +216,7 @@ namespace DSharpPlus.Entities
                 }
             }
 
-            throw new ArgumentException("Invalid emoji name specified.", nameof(raw));
+            throw new ArgumentException("Invalid emoji specified.", nameof(raw));
         }
 
         /// <summary>


### PR DESCRIPTION
Implemented an way cast raw emoji string into discord emoji object, like `FromUnicode` method does. 

But just lookup name -> unicode then create an discordemoji instance and return it. Also i'm working on an parsing also guild emotes, using same regex from CNext. This will be helpful specially for reduce code every time we must need create an discord emoji object.

 I have made some tests seems nothing broken, and working. And as excepted when emoji does not exists, will trown an exception.
Also added another overload for `DiscordEmoji.FromName` that isn't required client (acts like `DiscordEmoji.FromUnicode`).

_This is also helpful for example using guild emotes in interactivity configuration._