### PR TITLE
Implement webhook message edit and delete endpoints

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1231,13 +1231,13 @@ namespace DSharpPlus
             => this.ApiClient.EditWebhookMessageAsync(webhook_id, webhook_token, messageId, content, embeds, mentions);
 
         /// <summary>
-        /// Deletes a message that was created by the webhook.
+        /// Deletes a message that was created by a webhook.
         /// </summary>
         /// <param name="webhook_id">Webhook id</param>
         /// <param name="webhook_token">Webhook token</param>
         /// <param name="messageId">The id of the message to delete</param>
         /// <returns></returns>
-        public Task DeleteMessageAsync(ulong webhook_id, string webhook_token, ulong messageId)
+        public Task DeleteWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong messageId)
             => this.ApiClient.DeleteWebhookMessageAsync(webhook_id, webhook_token, messageId);
         #endregion
 

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1226,7 +1226,7 @@ namespace DSharpPlus
         /// <param name="builder">The builder of the message to edit.</param>
         /// <returns>The modified <see cref="DiscordMessage"/></returns>
         public Task<DiscordMessage> EditWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong messageId, DiscordWebhookBuilder builder)
-            => this.ApiClient.EditWebhookMessageAsync(webhook_id, webhook_token, messageId, builder.Content, builder.Embeds, builder.Mentions);
+            => this.ApiClient.EditWebhookMessageAsync(webhook_id, webhook_token, messageId, builder);
 
         /// <summary>
         /// Deletes a message that was created by a webhook.

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1223,12 +1223,10 @@ namespace DSharpPlus
         /// <param name="webhook_id">Webhook id</param>
         /// <param name="webhook_token">Webhook token</param>
         /// <param name="messageId">The id of the message to edit.</param>
-        /// <param name="content">The content of the message.</param>
-        /// <param name="embeds">The embeds in the message.</param>
-        /// <param name="mentions">The allowed mentions in the message.</param>
+        /// <param name="builder">The builder of the message to edit.</param>
         /// <returns>The modified <see cref="DiscordMessage"/></returns>
-        public Task<DiscordMessage> EditWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong messageId, Optional<string> content, IEnumerable<DiscordEmbed> embeds = null, IEnumerable<IMention> mentions = null)
-            => this.ApiClient.EditWebhookMessageAsync(webhook_id, webhook_token, messageId, content, embeds, mentions);
+        public Task<DiscordMessage> EditWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong messageId, DiscordWebhookBuilder builder)
+            => this.ApiClient.EditWebhookMessageAsync(webhook_id, webhook_token, messageId, builder.Content, builder.Embeds, builder.Mentions);
 
         /// <summary>
         /// Deletes a message that was created by a webhook.

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1216,6 +1216,29 @@ namespace DSharpPlus
         /// <returns></returns>
         public Task<DiscordMessage> ExecuteWebhookAsync(ulong webhook_id, string webhook_token, DiscordWebhookBuilder builder)
             => this.ApiClient.ExecuteWebhookAsync(webhook_id, webhook_token, builder);
+
+        /// <summary>
+        /// Edits a previously-sent webhook message.
+        /// </summary>
+        /// <param name="webhook_id">Webhook id</param>
+        /// <param name="webhook_token">Webhook token</param>
+        /// <param name="messageId">The id of the message to edit.</param>
+        /// <param name="content">The content of the message.</param>
+        /// <param name="embeds">The embeds in the message.</param>
+        /// <param name="mentions">The allowed mentions in the message.</param>
+        /// <returns>The modified <see cref="DiscordMessage"/></returns>
+        public Task<DiscordMessage> EditWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong messageId, Optional<string> content, IEnumerable<DiscordEmbed> embeds = null, IEnumerable<IMention> mentions = null)
+            => this.ApiClient.EditWebhookMessageAsync(webhook_id, webhook_token, messageId, content, embeds, mentions);
+
+        /// <summary>
+        /// Deletes a message that was created by the webhook.
+        /// </summary>
+        /// <param name="webhook_id">Webhook id</param>
+        /// <param name="webhook_token">Webhook token</param>
+        /// <param name="messageId">The id of the message to delete</param>
+        /// <returns></returns>
+        public Task DeleteMessageAsync(ulong webhook_id, string webhook_token, ulong messageId)
+            => this.ApiClient.DeleteWebhookMessageAsync(webhook_id, webhook_token, messageId);
         #endregion
 
         #region Reactions

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -138,7 +138,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> EditMessageAsync(ulong messageId, DiscordWebhookBuilder builder)
-            => (this.Discord?.ApiClient ?? this.ApiClient).EditWebhookMessageAsync(this.Id, this.Token, messageId, builder.Content, builder.Embeds, builder.Mentions);
+            => (this.Discord?.ApiClient ?? this.ApiClient).EditWebhookMessageAsync(this.Id, this.Token, messageId, builder);
 
         /// <summary>
         /// Deletes a message that was created by the webhook.

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -129,6 +129,31 @@ namespace DSharpPlus.Entities
             => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookGithubAsync(Id, Token, json);
 
         /// <summary>
+        /// Edits a previously-sent webhook message.
+        /// </summary>
+        /// <param name="messageId">The id of the message to edit.</param>
+        /// <param name="content">The content of the message.</param>
+        /// <param name="embeds">The embeds in the message.</param>
+        /// <param name="mentions">The allowed mentions in the message.</param>
+        /// <returns>The modified <see cref="DiscordMessage"/></returns>
+        /// <exception cref="Exceptions.NotFoundException">Thrown when the webhook does not exist.</exception>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        public Task<DiscordMessage> EditMessageAsync(ulong messageId, Optional<string> content, IEnumerable<DiscordEmbed> embeds = null, IEnumerable<IMention> mentions = null)
+            => (this.Discord?.ApiClient ?? this.ApiClient).EditWebhookMessageAsync(this.Id, this.Token, messageId, content, embeds, mentions);
+
+        /// <summary>
+        /// Deletes a message that was created by the webhook.
+        /// </summary>
+        /// <param name="messageId">The id of the message to delete</param>
+        /// <returns></returns>
+        /// <exception cref="Exceptions.NotFoundException">Thrown when the webhook does not exist.</exception>
+        /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        public Task DeleteMessageAsync(ulong messageId)
+            => (this.Discord?.ApiClient ?? this.ApiClient).DeleteWebhookMessageAsync(this.Id, this.Token, messageId);
+
+        /// <summary>
         /// Checks whether this <see cref="DiscordWebhook"/> is equal to another object.
         /// </summary>
         /// <param name="obj">Object to compare to.</param>

--- a/DSharpPlus/Entities/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/DiscordWebhook.cs
@@ -132,15 +132,13 @@ namespace DSharpPlus.Entities
         /// Edits a previously-sent webhook message.
         /// </summary>
         /// <param name="messageId">The id of the message to edit.</param>
-        /// <param name="content">The content of the message.</param>
-        /// <param name="embeds">The embeds in the message.</param>
-        /// <param name="mentions">The allowed mentions in the message.</param>
+        /// <param name="builder">The builder of the message to edit.</param>
         /// <returns>The modified <see cref="DiscordMessage"/></returns>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the webhook does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordMessage> EditMessageAsync(ulong messageId, Optional<string> content, IEnumerable<DiscordEmbed> embeds = null, IEnumerable<IMention> mentions = null)
-            => (this.Discord?.ApiClient ?? this.ApiClient).EditWebhookMessageAsync(this.Id, this.Token, messageId, content, embeds, mentions);
+        public Task<DiscordMessage> EditMessageAsync(ulong messageId, DiscordWebhookBuilder builder)
+            => (this.Discord?.ApiClient ?? this.ApiClient).EditWebhookMessageAsync(this.Id, this.Token, messageId, builder.Content, builder.Embeds, builder.Mentions);
 
         /// <summary>
         /// Deletes a message that was created by the webhook.

--- a/DSharpPlus/Entities/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/DiscordWebhookBuilder.cs
@@ -219,14 +219,39 @@ namespace DSharpPlus.Entities
             return this;
         }
 
-
+        /// <summary>
+        /// Executes a webhook.
+        /// </summary>
+        /// <param name="webhook">The webhook that should be executed.</param>
+        /// <returns>The message sent</returns>
         public async Task<DiscordMessage> SendAsync(DiscordWebhook webhook)
         {
             return await webhook.ExecuteAsync(this);
         }
 
         /// <summary>
-        /// Allows for clearing the Message Builder so that it can be used again to send a new message.
+        /// Sends the modified webhook message.
+        /// </summary>
+        /// <param name="webhook">The webhook that should be executed.</param>
+        /// <param name="message">The message to modify.</param>
+        /// <returns>The modified message</returns>
+        public async Task<DiscordMessage> ModifyAsync(DiscordWebhook webhook, DiscordMessage message)
+        {
+            return await webhook.EditMessageAsync(message.Id, this);
+        }
+        /// <summary>
+        /// Sends the modified webhook message.
+        /// </summary>
+        /// <param name="webhook">The webhook that should be executed.</param>
+        /// <param name="messageId">The id of the message to modify.</param>
+        /// <returns>The modified message</returns>
+        public async Task<DiscordMessage> ModifyAsync(DiscordWebhook webhook, ulong messageId)
+        {
+            return await webhook.EditMessageAsync(messageId, this);
+        }
+
+        /// <summary>
+        /// Allows for clearing the Webhook Builder so that it can be used again to send a new message.
         /// </summary>
         public void Clear()
         {

--- a/DSharpPlus/Net/Abstractions/RestWebhookPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/RestWebhookPayloads.cs
@@ -42,4 +42,16 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("allowed_mentions", NullValueHandling = NullValueHandling.Ignore)]
         public DiscordMentions Mentions { get; set; }
     }
+
+    internal sealed class RestWebhookMessageEditPayload
+    {
+        [JsonProperty("content", NullValueHandling = NullValueHandling.Ignore)]
+        public Optional<string> Content { get; set; }
+
+        [JsonProperty("embeds", NullValueHandling = NullValueHandling.Ignore)]
+        public IEnumerable<DiscordEmbed> Embeds { get; set; }
+
+        [JsonProperty("allowed_mentions", NullValueHandling = NullValueHandling.Ignore)]
+        public IEnumerable<IMention> Mentions { get; set; }
+    }
 }

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1953,13 +1953,13 @@ namespace DSharpPlus.Net
             return ret;
         }
 
-        internal async Task<DiscordMessage> EditWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong message_id, Optional<string> content, IEnumerable<DiscordEmbed> embeds, IEnumerable<IMention> allowed_mentions)
+        internal async Task<DiscordMessage> EditWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong message_id, DiscordWebhookBuilder builder)
         {
             var pld = new RestWebhookMessageEditPayload
             {
-                Content = content,
-                Embeds = embeds,
-                Mentions = allowed_mentions
+                Content = builder.Content,
+                Embeds = builder.Embeds,
+                Mentions = builder.Mentions
             };
 
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.MESSAGES}/:message_id";

--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -1952,6 +1952,35 @@ namespace DSharpPlus.Net
             ret.Discord = this.Discord;
             return ret;
         }
+
+        internal async Task<DiscordMessage> EditWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong message_id, Optional<string> content, IEnumerable<DiscordEmbed> embeds, IEnumerable<IMention> allowed_mentions)
+        {
+            var pld = new RestWebhookMessageEditPayload
+            {
+                Content = content,
+                Embeds = embeds,
+                Mentions = allowed_mentions
+            };
+
+            var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.MESSAGES}/:message_id";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { webhook_id, webhook_token, message_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld));
+
+            var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
+            ret.Discord = this.Discord;
+            return ret;
+        }
+
+        internal async Task DeleteWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong message_id)
+        {
+            var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.MESSAGES}/:message_id";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { webhook_id, webhook_token, message_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route);
+        }
         #endregion
 
         #region Reactions


### PR DESCRIPTION
# Summary
Implements some missing webhook endpoints

# Details
I came across these because [some of the endpoints related to slash commands](https://discord.com/developers/docs/interactions/slash-commands#edit-followup-message) are based on these.

# Changes proposed
* Implement [edit webhook message](https://discord.com/developers/docs/resources/webhook#edit-webhook-message) and [delete webhook message](https://discord.com/developers/docs/resources/webhook#delete-webhook-message) endpoints