### PR TITLE
fix(guild): Don't require guild members intent for user cache.

### DIFF
--- a/DSharpPlus/Entities/DiscordGuild.cs
+++ b/DSharpPlus/Entities/DiscordGuild.cs
@@ -910,19 +910,14 @@ namespace DSharpPlus.Entities
                 {
                     var usr = new DiscordUser(xtm.User) { Discord = this.Discord };
 
-                    var intents = this.Discord.Configuration.Intents;
-
-                    if (intents.HasIntent(DiscordIntents.GuildMembers))
+                    usr = this.Discord.UserCache.AddOrUpdate(xtm.User.Id, usr, (id, old) =>
                     {
-                        usr = this.Discord.UserCache.AddOrUpdate(xtm.User.Id, usr, (id, old) =>
-                        {
-                            old.Username = usr.Username;
-                            old.Discord = usr.Discord;
-                            old.AvatarHash = usr.AvatarHash;
+                        old.Username = usr.Username;
+                        old.Discord = usr.Discord;
+                        old.AvatarHash = usr.AvatarHash;
 
-                            return old;
-                        });
-                    }
+                        return old;
+                    });
 
                     recmbr.Add(new DiscordMember(xtm) { Discord = this.Discord, _guild_id = this.Id });
                 }


### PR DESCRIPTION
# Summary
Fixes #790

# Details
This PR fixes an issue which may not cache a user object if the user doesn't have guild intents enabled, which would cause property issues with the returned member cache. 