### PR TITLE
Fix Interactivity Event Timeouts

### DIFF
--- a/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
@@ -86,9 +86,8 @@ namespace DSharpPlus.Interactivity.EventHandling
             return result;
         }
 
-        async Task HandleEvent(DiscordClient client, T eventargs)
+        private Task HandleEvent(DiscordClient client, T eventargs)
         {
-            await Task.Yield();
             if (!disposed)
             {
                 foreach (var req in _matchrequests)
@@ -110,6 +109,8 @@ namespace DSharpPlus.Interactivity.EventHandling
                     }
                 }
             }
+
+            return Task.CompletedTask;
         }
 
         ~EventWaiter()

--- a/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
@@ -97,10 +97,7 @@ namespace DSharpPlus.Interactivity.EventHandling
                         req._tcs.TrySetResult(eventargs);
                     }
                 }
-            }
 
-            if (!disposed)
-            {
                 foreach (var req in _collectrequests)
                 {
                     if (req._predicate(eventargs))

--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -47,102 +47,112 @@ namespace DSharpPlus.Interactivity.EventHandling
             }
         }
 
-        async Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventargs)
+        private Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventargs)
         {
-            await Task.Yield();
-            foreach (var req in _requests)
+            _ = Task.Run(async () =>
             {
-                var emojis = await req.GetEmojisAsync().ConfigureAwait(false);
-                var msg = await req.GetMessageAsync().ConfigureAwait(false);
-                var usr = await req.GetUserAsync().ConfigureAwait(false);
-
-                if (msg.Id == eventargs.Message.Id)
+                foreach (var req in _requests)
                 {
-                    if (eventargs.User.Id == usr.Id)
-                    {
-                        if (req.PageCount > 1 &&
-                            (eventargs.Emoji == emojis.Left || 
-                             eventargs.Emoji == emojis.SkipLeft || 
-                             eventargs.Emoji == emojis.Right || 
-                             eventargs.Emoji == emojis.SkipRight ||
-                             eventargs.Emoji == emojis.Stop))
-                        {
-                            await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
-                        }
-                        else if (eventargs.Emoji == emojis.Stop &&
-                                 req is PaginationRequest paginationRequest &&
-                                 paginationRequest.PaginationDeletion == PaginationDeletion.DeleteMessage)
-                        {
-                            await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
-                        }
-                        else
-                        {
-                            await msg.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
-                        }
-                    }
-                    else if (eventargs.User.Id != _client.CurrentUser.Id)
-                    {
-                        if (eventargs.Emoji != emojis.Left &&
-                           eventargs.Emoji != emojis.SkipLeft &&
-                           eventargs.Emoji != emojis.Right &&
-                           eventargs.Emoji != emojis.SkipRight &&
-                           eventargs.Emoji != emojis.Stop)
-                        {
-                            await msg.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
-                        }
-                    }
-                }
-            }
-        }
+                    var emojis = await req.GetEmojisAsync().ConfigureAwait(false);
+                    var msg = await req.GetMessageAsync().ConfigureAwait(false);
+                    var usr = await req.GetUserAsync().ConfigureAwait(false);
 
-        async Task HandleReactionRemove(DiscordClient client, MessageReactionRemoveEventArgs eventargs)
-        {
-            await Task.Yield();
-            foreach (var req in _requests)
-            {
-                var emojis = await req.GetEmojisAsync().ConfigureAwait(false);
-                var msg = await req.GetMessageAsync().ConfigureAwait(false);
-                var usr = await req.GetUserAsync().ConfigureAwait(false);
-
-                if (msg.Id == eventargs.Message.Id)
-                {
-                    if (eventargs.User.Id == usr.Id)
+                    if (msg.Id == eventargs.Message.Id)
                     {
-                        if (req.PageCount > 1 &&
-                            (eventargs.Emoji == emojis.Left || 
-                             eventargs.Emoji == emojis.SkipLeft || 
-                             eventargs.Emoji == emojis.Right || 
-                             eventargs.Emoji == emojis.SkipRight ||
-                             eventargs.Emoji == emojis.Stop))
+                        if (eventargs.User.Id == usr.Id)
                         {
-                            await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                            if (req.PageCount > 1 &&
+                                (eventargs.Emoji == emojis.Left ||
+                                 eventargs.Emoji == emojis.SkipLeft ||
+                                 eventargs.Emoji == emojis.Right ||
+                                 eventargs.Emoji == emojis.SkipRight ||
+                                 eventargs.Emoji == emojis.Stop))
+                            {
+                                await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                            }
+                            else if (eventargs.Emoji == emojis.Stop &&
+                                     req is PaginationRequest paginationRequest &&
+                                     paginationRequest.PaginationDeletion == PaginationDeletion.DeleteMessage)
+                            {
+                                await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                            }
+                            else
+                            {
+                                await msg.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
+                            }
                         }
-                        else if (eventargs.Emoji == emojis.Stop &&
-                                 req is PaginationRequest paginationRequest &&
-                                 paginationRequest.PaginationDeletion == PaginationDeletion.DeleteMessage)
+                        else if (eventargs.User.Id != _client.CurrentUser.Id)
                         {
-                            await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                            if (eventargs.Emoji != emojis.Left &&
+                               eventargs.Emoji != emojis.SkipLeft &&
+                               eventargs.Emoji != emojis.Right &&
+                               eventargs.Emoji != emojis.SkipRight &&
+                               eventargs.Emoji != emojis.Stop)
+                            {
+                                await msg.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
+                            }
                         }
                     }
                 }
-            }
+            });
+            return Task.CompletedTask;
         }
 
-        async Task HandleReactionClear(DiscordClient client, MessageReactionsClearEventArgs eventargs)
+        private Task HandleReactionRemove(DiscordClient client, MessageReactionRemoveEventArgs eventargs)
         {
-            await Task.Yield();
-            foreach (var req in _requests)
+            _ = Task.Run(async () =>
             {
-                var msg = await req.GetMessageAsync().ConfigureAwait(false);
-
-                if (msg.Id == eventargs.Message.Id)
+                foreach (var req in _requests)
                 {
-                    await ResetReactionsAsync(req).ConfigureAwait(false);
+                    var emojis = await req.GetEmojisAsync().ConfigureAwait(false);
+                    var msg = await req.GetMessageAsync().ConfigureAwait(false);
+                    var usr = await req.GetUserAsync().ConfigureAwait(false);
+
+                    if (msg.Id == eventargs.Message.Id)
+                    {
+                        if (eventargs.User.Id == usr.Id)
+                        {
+                            if (req.PageCount > 1 &&
+                                (eventargs.Emoji == emojis.Left ||
+                                 eventargs.Emoji == emojis.SkipLeft ||
+                                 eventargs.Emoji == emojis.Right ||
+                                 eventargs.Emoji == emojis.SkipRight ||
+                                 eventargs.Emoji == emojis.Stop))
+                            {
+                                await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                            }
+                            else if (eventargs.Emoji == emojis.Stop &&
+                                     req is PaginationRequest paginationRequest &&
+                                     paginationRequest.PaginationDeletion == PaginationDeletion.DeleteMessage)
+                            {
+                                await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                            }
+                        }
+                    }
                 }
-            }
+            });
+            return Task.CompletedTask;
         }
 
-        async Task ResetReactionsAsync(IPaginationRequest p)
+        private Task HandleReactionClear(DiscordClient client, MessageReactionsClearEventArgs eventargs)
+        {
+            _ = Task.Run(async () =>
+            {
+                foreach (var req in _requests)
+                {
+                    var msg = await req.GetMessageAsync().ConfigureAwait(false);
+
+                    if (msg.Id == eventargs.Message.Id)
+                    {
+                        await ResetReactionsAsync(req).ConfigureAwait(false);
+                    }
+                }
+            });
+
+            return Task.CompletedTask;
+        }
+
+        private async Task ResetReactionsAsync(IPaginationRequest p)
         {
             var msg = await p.GetMessageAsync().ConfigureAwait(false);
             var emojis = await p.GetEmojisAsync().ConfigureAwait(false);
@@ -182,7 +192,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             }
         }
 
-        async Task PaginateAsync(IPaginationRequest p, DiscordEmoji emoji)
+        private async Task PaginateAsync(IPaginationRequest p, DiscordEmoji emoji)
         {
             var emojis = await p.GetEmojisAsync().ConfigureAwait(false);
             var msg = await p.GetMessageAsync().ConfigureAwait(false);

--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -49,6 +49,9 @@ namespace DSharpPlus.Interactivity.EventHandling
 
         private Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventargs)
         {
+            if (_requests.Count == 0)
+                return Task.CompletedTask;
+
             _ = Task.Run(async () =>
             {
                 foreach (var req in _requests)
@@ -100,6 +103,9 @@ namespace DSharpPlus.Interactivity.EventHandling
 
         private Task HandleReactionRemove(DiscordClient client, MessageReactionRemoveEventArgs eventargs)
         {
+            if (_requests.Count == 0)
+                return Task.CompletedTask;
+
             _ = Task.Run(async () =>
             {
                 foreach (var req in _requests)
@@ -131,11 +137,15 @@ namespace DSharpPlus.Interactivity.EventHandling
                     }
                 }
             });
+
             return Task.CompletedTask;
         }
 
         private Task HandleReactionClear(DiscordClient client, MessageReactionsClearEventArgs eventargs)
         {
+            if (_requests.Count == 0)
+                return Task.CompletedTask;
+
             _ = Task.Run(async () =>
             {
                 foreach (var req in _requests)

--- a/DSharpPlus.Interactivity/EventHandling/Poller.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Poller.cs
@@ -51,6 +51,9 @@ namespace DSharpPlus.Interactivity.EventHandling
 
         private Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventargs)
         {
+            if (_requests.Count == 0)
+                return Task.CompletedTask;
+
             _ = Task.Run(async () =>
             {
                 foreach (var req in _requests)

--- a/DSharpPlus.Interactivity/EventHandling/Poller.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Poller.cs
@@ -49,32 +49,34 @@ namespace DSharpPlus.Interactivity.EventHandling
             return result;
         }
 
-        async Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventargs)
+        private Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventargs)
         {
-            await Task.Yield();
-            foreach (var req in _requests)
+            _ = Task.Run(async () =>
             {
-                // match message
-                if (req._message.Id == eventargs.Message.Id && req._message.ChannelId == eventargs.Channel.Id)
+                foreach (var req in _requests)
                 {
-                    if (req._emojis.Contains(eventargs.Emoji) && !req._collected.Any(x => x.Voted.Contains(eventargs.User)))
+                    // match message
+                    if (req._message.Id == eventargs.Message.Id && req._message.ChannelId == eventargs.Channel.Id)
                     {
-                        if (eventargs.User.Id != _client.CurrentUser.Id)
-                            req.AddReaction(eventargs.Emoji, eventargs.User);
-                    }
-                    else
-                    {
-                        var member = await eventargs.Channel.Guild.GetMemberAsync(client.CurrentUser.Id).ConfigureAwait(false);
-                        if(eventargs.Channel.PermissionsFor(member).HasPermission(Permissions.ManageMessages))
-                            await eventargs.Message.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
+                        if (req._emojis.Contains(eventargs.Emoji) && !req._collected.Any(x => x.Voted.Contains(eventargs.User)))
+                        {
+                            if (eventargs.User.Id != _client.CurrentUser.Id)
+                                req.AddReaction(eventargs.Emoji, eventargs.User);
+                        }
+                        else
+                        {
+                            var member = await eventargs.Channel.Guild.GetMemberAsync(client.CurrentUser.Id).ConfigureAwait(false);
+                            if (eventargs.Channel.PermissionsFor(member).HasPermission(Permissions.ManageMessages))
+                                await eventargs.Message.DeleteReactionAsync(eventargs.Emoji, eventargs.User).ConfigureAwait(false);
+                        }
                     }
                 }
-            }
+            });
+            return Task.CompletedTask;
         }
 
-        async Task HandleReactionRemove(DiscordClient client, MessageReactionRemoveEventArgs eventargs)
+        private Task HandleReactionRemove(DiscordClient client, MessageReactionRemoveEventArgs eventargs)
         {
-            await Task.Yield();
             foreach (var req in _requests)
             {
                 // match message
@@ -84,11 +86,11 @@ namespace DSharpPlus.Interactivity.EventHandling
                         req.RemoveReaction(eventargs.Emoji, eventargs.User);
                 }
             }
+            return Task.CompletedTask;
         }
 
-        async Task HandleReactionClear(DiscordClient client, MessageReactionsClearEventArgs eventargs)
+        private Task HandleReactionClear(DiscordClient client, MessageReactionsClearEventArgs eventargs)
         {
-            await Task.Yield();
             foreach (var req in _requests)
             {
                 // match message
@@ -97,6 +99,7 @@ namespace DSharpPlus.Interactivity.EventHandling
                     req.ClearCollected();
                 }
             }
+            return Task.CompletedTask;
         }
 
         ~Poller()

--- a/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
@@ -85,9 +85,8 @@ namespace DSharpPlus.Interactivity.EventHandling
             return result;
         }
 
-        async Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventargs)
+        private Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventargs)
         {
-            await Task.Yield();
             // foreach request add
             foreach(var req in _requests)
             {
@@ -110,11 +109,11 @@ namespace DSharpPlus.Interactivity.EventHandling
                     }
                 }
             }
+            return Task.CompletedTask;
         }
 
-        async Task HandleReactionRemove(DiscordClient client, MessageReactionRemoveEventArgs eventargs)
+        private Task HandleReactionRemove(DiscordClient client, MessageReactionRemoveEventArgs eventargs)
         {
-            await Task.Yield();
             // foreach request remove
             foreach (var req in _requests)
             {
@@ -130,11 +129,11 @@ namespace DSharpPlus.Interactivity.EventHandling
                     }
                 }
             }
+            return Task.CompletedTask;
         }
 
-        async Task HandleReactionClear(DiscordClient client, MessageReactionsClearEventArgs eventargs)
+        private Task HandleReactionClear(DiscordClient client, MessageReactionsClearEventArgs eventargs)
         {
-            await Task.Yield();
             // foreach request add
             foreach (var req in _requests)
             {
@@ -143,6 +142,7 @@ namespace DSharpPlus.Interactivity.EventHandling
                     req._collected.Clear();
                 }
             }
+            return Task.CompletedTask;
         }
 
         ~ReactionCollector()

--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -585,6 +585,12 @@ namespace DSharpPlus
         internal void EventErrorHandler<TSender, TArgs>(AsyncEvent<TSender, TArgs> asyncEvent, Exception ex, AsyncEventHandler<TSender, TArgs> handler, TSender sender, TArgs eventArgs)
             where TArgs : AsyncEventArgs
         {
+            if(ex is AsyncEventTimeoutException)
+            {
+                this.Logger.LogWarning(LoggerEvents.EventHandlerException, $"An event handler for {asyncEvent.Name} is taking too long to execute.\nat: {handler.Method}\nat: {handler.Method.DeclaringType}");
+                return;
+            }
+
             this.Logger.LogError(LoggerEvents.EventHandlerException, ex, "Event handler exception for event {0} thrown from {1} (defined in {2})", asyncEvent.Name, handler.Method, handler.Method.DeclaringType);
             this._clientErrored.InvokeAsync(this, new ClientErrorEventArgs { EventName = asyncEvent.Name, Exception = ex }).ConfigureAwait(false).GetAwaiter().GetResult();
         }

--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -587,7 +587,7 @@ namespace DSharpPlus
         {
             if(ex is AsyncEventTimeoutException)
             {
-                this.Logger.LogWarning(LoggerEvents.EventHandlerException, $"An event handler for {asyncEvent.Name} took too long to execute. Defined as \"{handler.Method.ToString().Replace(handler.Method.ReturnType.ToString(), "").TrimStart()}\" located in \"{handler.Method.DeclaringType}\"");
+                this.Logger.LogWarning(LoggerEvents.EventHandlerException, $"An event handler for {asyncEvent.Name} took too long to execute. Defined as \"{handler.Method.ToString().Replace(handler.Method.ReturnType.ToString(), "").TrimStart()}\" located in \"{handler.Method.DeclaringType}\".");
                 return;
             }
 

--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -587,7 +587,7 @@ namespace DSharpPlus
         {
             if(ex is AsyncEventTimeoutException)
             {
-                this.Logger.LogWarning(LoggerEvents.EventHandlerException, $"An event handler for {asyncEvent.Name} is taking too long to execute.\nat: {handler.Method}\nat: {handler.Method.DeclaringType}");
+                this.Logger.LogWarning(LoggerEvents.EventHandlerException, $"An event handler for {asyncEvent.Name} took too long to execute. Defined as \"{handler.Method.ToString().Replace(handler.Method.ReturnType.ToString(), "").TrimStart()}\" located in \"{handler.Method.DeclaringType}\"");
                 return;
             }
 

--- a/DSharpPlus/Clients/DiscordShardedClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.Events.cs
@@ -568,6 +568,12 @@ namespace DSharpPlus
         internal void EventErrorHandler<TArgs>(AsyncEvent<DiscordClient, TArgs> asyncEvent, Exception ex, AsyncEventHandler<DiscordClient, TArgs> handler, DiscordClient sender, TArgs eventArgs)
             where TArgs : AsyncEventArgs
         {
+            if (ex is AsyncEventTimeoutException)
+            {
+                this.Logger.LogWarning(LoggerEvents.EventHandlerException, $"An event handler for {asyncEvent.Name} took too long to execute. Defined as \"{handler.Method.ToString().Replace(handler.Method.ReturnType.ToString(), "").TrimStart()}\" located in \"{handler.Method.DeclaringType}\"");
+                return;
+            }
+
             this.Logger.LogError(LoggerEvents.EventHandlerException, ex, "Event handler exception for event {0} thrown from {1} (defined in {2})", asyncEvent.Name, handler.Method, handler.Method.DeclaringType);
             this._clientErrored.InvokeAsync(sender, new ClientErrorEventArgs { EventName = asyncEvent.Name, Exception = ex }).ConfigureAwait(false).GetAwaiter().GetResult();
         }

--- a/DSharpPlus/Clients/DiscordShardedClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.Events.cs
@@ -570,7 +570,7 @@ namespace DSharpPlus
         {
             if (ex is AsyncEventTimeoutException)
             {
-                this.Logger.LogWarning(LoggerEvents.EventHandlerException, $"An event handler for {asyncEvent.Name} took too long to execute. Defined as \"{handler.Method.ToString().Replace(handler.Method.ReturnType.ToString(), "").TrimStart()}\" located in \"{handler.Method.DeclaringType}\"");
+                this.Logger.LogWarning(LoggerEvents.EventHandlerException, $"An event handler for {asyncEvent.Name} took too long to execute. Defined as \"{handler.Method.ToString().Replace(handler.Method.ReturnType.ToString(), "").TrimStart()}\" located in \"{handler.Method.DeclaringType}\".");
                 return;
             }
 


### PR DESCRIPTION
# Summary
Fixes #781, #711.

# Details
This PR removes any possibility of the internal interactivity handlers throwing an async timeout exception. I also changed the timeout message to instead be a warning and state to the user that their handler is taking too long to execute.

# Changes proposed
* Fix interactivity event handlers
* Change timeout exception status message.