### PR TITLE
Adds missing ImageUrl copy in the copy ctor

### DIFF
--- a/DSharpPlus/Entities/DiscordEmbedBuilder.cs
+++ b/DSharpPlus/Entities/DiscordEmbedBuilder.cs
@@ -110,7 +110,7 @@ namespace DSharpPlus.Entities
             this.Title = original.Title;
             this.Description = original.Description;
             this.Url = original.Url?.ToString();
-            this.ImageUrl = original.ImageUrl;
+            this.ImageUrl = original.Image.Url?.ToString();
             this.Color = original.Color;
             this.Timestamp = original.Timestamp;
 

--- a/DSharpPlus/Entities/DiscordEmbedBuilder.cs
+++ b/DSharpPlus/Entities/DiscordEmbedBuilder.cs
@@ -110,6 +110,7 @@ namespace DSharpPlus.Entities
             this.Title = original.Title;
             this.Description = original.Description;
             this.Url = original.Url?.ToString();
+            this.ImageUrl = original.ImageUrl;
             this.Color = original.Color;
             this.Timestamp = original.Timestamp;
 

--- a/DSharpPlus/Entities/DiscordEmbedBuilder.cs
+++ b/DSharpPlus/Entities/DiscordEmbedBuilder.cs
@@ -110,7 +110,7 @@ namespace DSharpPlus.Entities
             this.Title = original.Title;
             this.Description = original.Description;
             this.Url = original.Url?.ToString();
-            this.ImageUrl = original.Image.Url?.ToString();
+            this.ImageUrl = original.Image?.Url?.ToString();
             this.Color = original.Color;
             this.Timestamp = original.Timestamp;
 


### PR DESCRIPTION
We're not recopying this property when reconstructing an EmbedBuilder from an embed