### PR TITLE
Interactivity: Single Line Pages

### DIFF
--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -324,7 +324,7 @@ namespace DSharpPlus.Interactivity
                     for(int i = 0; i < subsplit.Length; i++)
                     {
                         s += subsplit[i];
-                        if(i % 15 == 0)
+                        if(i >= 15 && i % 15 == 0)
                         {
                             split.Add(s);
                             s = "";


### PR DESCRIPTION
# Summary
This change updates `GeneratePagesInContent`'s `SplitType.Line` so it no longer adds the first line as a page.

# Details
The first line will always be split as a separate page. Its unclear if this is intentional and causes confusion while trying to use this function. 

# Changes proposed
* Added a check that ensures the current line is after the cut off point before splitting it.

# Notes
What is the intended behaviour here? Is it suppose to create a new page for the first line? Maybe this should be documented if so.