### PR TITLE
fix(apiclient): Handle reply when message is deleted.

### DIFF
--- a/DSharpPlus/Net/DiscordApiClient.cs
+++ b/DSharpPlus/Net/DiscordApiClient.cs
@@ -55,9 +55,10 @@ namespace DSharpPlus.Net
 
             PopulateMessage(author, ret);
 
-            if (ret.MessageType == MessageType.Reply)
+            var referencedMsg = msg_raw["referenced_message"];
+            if (ret.MessageType == MessageType.Reply && !string.IsNullOrWhiteSpace(referencedMsg?.ToString()))
             {
-                author = msg_raw["referenced_message"]["author"].ToObject<TransportUser>();
+                author = referencedMsg["author"].ToObject<TransportUser>();
                 ret.ReferencedMessage.Discord = this.Discord;
                 PopulateMessage(author, ret.ReferencedMessage);
             }


### PR DESCRIPTION
# Summary
Fixes #799

# Details
Ensures that a message reply is properly handled if deleted. Previously it would throw a json exception stating that it can't access the child indexer (author) because the outer referenced_message is null.
