### PR TITLE
Fix member in interactions

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1813,7 +1813,7 @@ namespace DSharpPlus
             this.UserCache.AddOrUpdate(usr.Id, usr, (old, @new) => @new);
 
             if (member != null)
-                usr = new DiscordMember(usr) { _guild_id = guildId.Value, Discord = this };
+                usr = new DiscordMember(member) { _guild_id = guildId.Value, Discord = this };
 
             interaction.User = usr;
             interaction.ChannelId = channelId;


### PR DESCRIPTION
# Summary
Fixes an issue with interaction member being constructed with the wrong object

# Details
When the User object was created from a `DiscordMember` in the interaction, the `usr` object was passed in the constructor instead of the `TransportMember`.