### PR TITLE
Fix permissions in audit logs

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -1474,8 +1474,8 @@ namespace DSharpPlus.Entities
                                 case "permissions":
                                     entryrol.PermissionChange = new PropertyChange<Permissions?>
                                     {
-                                        Before = xc.OldValue != null ? (Permissions?)(long)xc.OldValue : null,
-                                        After = xc.NewValue != null ? (Permissions?)(long)xc.NewValue : null
+                                        Before = xc.OldValue != null ? (Permissions?)long.Parse((string)xc.OldValue) : null,
+                                        After = xc.NewValue != null ? (Permissions?)long.Parse((string)xc.NewValue) : null
                                     };
                                     break;
 


### PR DESCRIPTION
# Summary
Fixes an issue where a casting error would be thrown for role edit/create audit log entries.

# Details
In api v6 permissions were sent as `long`s, but it was changed to be sent as a string in api v8. This was probably missed out when updating the library to v8.

# Changes proposed
cast to `string` and do `long.Parse` instead of casting directly to `long`