### PR TITLE
Implement slash command endpoints

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1310,6 +1310,183 @@ namespace DSharpPlus
             => this.ApiClient.DeleteAllReactionsAsync(channel_id, message_id, reason);
         #endregion
 
+        #region Slash Commands
+        /// <summary>
+        /// Gets all the global slash commands for this application.
+        /// </summary>
+        /// <returns>A list of global slash commands.</returns>
+        public Task<IReadOnlyList<DiscordApplicationCommand>> GetGlobalApplicationCommandsAsync() =>
+            this.ApiClient.GetGlobalApplicationCommandsAsync(this.CurrentApplication.Id);
+
+        /// <summary>
+        /// Overwrites the existing global slash commands. New commands are automatically created and missing commands are automatically deleted.
+        /// </summary>
+        /// <param name="commands">The list of commands to overwrite with.</param>
+        /// <returns>The list of global commands.</returns>
+        public Task<IReadOnlyList<DiscordApplicationCommand>> BulkOverwriteGlobalApplicationCommandsAsync(IEnumerable<DiscordApplicationCommand> commands) =>
+            this.ApiClient.BulkOverwriteGlobalApplicationCommandsAsync(this.CurrentApplication.Id, commands);
+
+        /// <summary>
+        /// Creates or overwrites a global slash command.
+        /// </summary>
+        /// <param name="command">The command to create.</param>
+        /// <returns>The created command.</returns>
+        public Task<DiscordApplicationCommand> CreateGlobalApplicationCommandAsync(DiscordApplicationCommand command) =>
+            this.ApiClient.CreateGlobalApplicationCommandAsync(this.CurrentApplication.Id, command);
+
+        /// <summary>
+        /// Gets a global slash command by its id.
+        /// </summary>
+        /// <param name="commandId">The id of the command to get.</param>
+        /// <returns>The command with the id.</returns>
+        public Task<DiscordApplicationCommand> GetGlobalApplicationCommandAsync(ulong commandId) =>
+            this.ApiClient.GetGlobalApplicationCommandAsync(this.CurrentApplication.Id, commandId);
+
+        /// <summary>
+        /// Edits a global slash command.
+        /// </summary>
+        /// <param name="commandId">The id of the command to edit.</param>
+        /// <param name="action">Action to perform.</param>
+        /// <returns>The edited command.</returns>
+        public async Task<DiscordApplicationCommand> EditGlobalApplicationCommandAsync(ulong commandId, Action<ApplicationCommandEditModel> action)
+        {
+            var mdl = new ApplicationCommandEditModel();
+            action(mdl);
+            var applicationId = this.CurrentApplication?.Id ?? (await this.GetCurrentApplicationAsync()).Id;
+            return await this.ApiClient.EditGlobalApplicationCommandAsync(applicationId, commandId, mdl.Name, mdl.Description, mdl.Options);
+        }
+
+        /// <summary>
+        /// Deletes a global slash command.
+        /// </summary>
+        /// <param name="commandId">The id of the command to delete.</param>
+        public Task DeleteGlobalApplicationCommandAsync(ulong commandId) =>
+            this.ApiClient.DeleteGlobalApplicationCommandAsync(this.CurrentApplication.Id, commandId);
+
+        /// <summary>
+        /// Gets all the slash commands for a guild.
+        /// </summary>
+        /// <param name="guildId">The id of the guild to get slash commands for.</param>
+        /// <returns>A list of slash commands in the guild.</returns>
+        public Task<IReadOnlyList<DiscordApplicationCommand>> GetGuildApplicationCommandsAsync(ulong guildId) =>
+            this.ApiClient.GetGuildApplicationCommandsAsync(this.CurrentApplication.Id, guildId);
+
+        /// <summary>
+        /// Overwrites the existing slash commands in a guild. New commands are automatically created and missing commands are automatically deleted.
+        /// </summary>
+        /// <param name="guildId">The id of the guild.</param>
+        /// <param name="commands">The list of commands to overwrite with.</param>
+        /// <returns>The list of guild commands.</returns>
+        public Task<IReadOnlyList<DiscordApplicationCommand>> BulkOverwriteGuildApplicationCommandsAsync(ulong guildId, IEnumerable<DiscordApplicationCommand> commands) =>
+            this.ApiClient.BulkOverwriteGuildApplicationCommandsAsync(this.CurrentApplication.Id, guildId, commands);
+
+        /// <summary>
+        /// Creates or overwrites a guild slash command.
+        /// </summary>
+        /// <param name="guildId">The id of the guild to create the slash command in.</param>
+        /// <param name="command">The command to create.</param>
+        /// <returns>The created command.</returns>
+        public Task<DiscordApplicationCommand> CreateGuildApplicationCommandAsync(ulong guildId, DiscordApplicationCommand command) =>
+            this.ApiClient.CreateGuildApplicationCommandAsync(this.CurrentApplication.Id, guildId, command);
+
+        /// <summary>
+        /// Gets a slash command in a guild by its id.
+        /// </summary>
+        /// <param name="guildId">The id of the guild the slash command is in.</param>
+        /// <param name="commandId">The id of the command to get.</param>
+        /// <returns>The command with the id.</returns>
+        public Task<DiscordApplicationCommand> GetGuildApplicationCommandAsync(ulong guildId, ulong commandId) =>
+             this.ApiClient.GetGuildApplicationCommandAsync(this.CurrentApplication.Id, guildId, commandId);
+
+        /// <summary>
+        /// Edits a slash command in a guild.
+        /// </summary>
+        /// <param name="guildId">The id of the guild the slash command is in.</param>
+        /// <param name="commandId">The id of the command to edit.</param>
+        /// <param name="action">Action to perform.</param>
+        /// <returns>The edited command.</returns>
+        public async Task<DiscordApplicationCommand> EditGuildApplicationCommandAsync(ulong guildId, ulong commandId, Action<ApplicationCommandEditModel> action)
+        {
+            var mdl = new ApplicationCommandEditModel();
+            action(mdl);
+            var applicationId = this.CurrentApplication?.Id ?? (await this.GetCurrentApplicationAsync()).Id;
+            return await this.ApiClient.EditGuildApplicationCommandAsync(applicationId, guildId, commandId, mdl.Name, mdl.Description, mdl.Options);
+        }
+
+        /// <summary>
+        /// Deletes a slash command in a guild.
+        /// </summary>
+        /// <param name="guildId">The id of the guild to delete the slash command in.</param>
+        /// <param name="commandId">The id of the command.</param>
+        public Task DeleteGuildApplicationCommandAsync(ulong guildId, ulong commandId) =>
+            this.ApiClient.DeleteGuildApplicationCommandAsync(this.CurrentApplication.Id, guildId, commandId);
+
+        /// <summary>
+        /// Creates a response to an interaction.
+        /// </summary>
+        /// <param name="interactionId">The id of the interaction.</param>
+        /// <param name="interactionToken">The token of the interaction</param>
+        /// <param name="type">The type of the response.</param>
+        /// <param name="builder">The data, if any, to send.</param>
+        public Task CreateInteractionResponseAsync(ulong interactionId, string interactionToken, InteractionResponseType type, DiscordInteractionResponseBuilder builder = null) =>
+            this.ApiClient.CreateInteractionResponseAsync(interactionId, interactionToken, type, builder);
+
+        /// <summary>
+        /// Edits the original interaction response.
+        /// </summary>
+        /// <param name="interactionToken">The token of the interaction.</param>
+        /// <param name="builder">The webhook builder.</param>
+        /// <returns>The <see cref="DiscordMessage"/> edited.</returns>
+        public async Task<DiscordMessage> EditOriginalInteractionResponseAsync(string interactionToken, DiscordWebhookBuilder builder)
+        {
+            builder.Validate(isInteractionResponse: true);
+
+            return await this.ApiClient.EditOriginalInteractionResponseAsync(this.CurrentApplication.Id, interactionToken, builder);
+        }
+
+        /// <summary>
+        /// Deletes the original interaction response.
+        /// <param name="interactionToken">The token of the interaction.</param>
+        /// </summary>>
+        public Task DeleteOriginalInteractionResponseAsync(string interactionToken) =>
+            this.ApiClient.DeleteOriginalInteractionResponseAsync(this.CurrentApplication.Id, interactionToken);
+
+        /// <summary>
+        /// Creates a follow up message to an interaction.
+        /// </summary>
+        /// <param name="interactionToken">The token of the interaction.</param>
+        /// <param name="builder">The webhook builder.</param>
+        /// <returns>The <see cref="DiscordMessage"/> created.</returns>
+        public async Task<DiscordMessage> CreateFollowupMessageAsync(string interactionToken, DiscordWebhookBuilder builder)
+        {
+            builder.Validate(isFollowup: true);
+
+            return await this.ApiClient.CreateFollowupMessageAsync(this.CurrentApplication.Id, interactionToken, builder);
+        }
+
+        /// <summary>
+        /// Edits a follow up message.
+        /// </summary>
+        /// <param name="interactionToken">The token of the interaction.</param>
+        /// <param name="messageId">The id of the follow up message.</param>
+        /// <param name="builder">The webhook builder.</param>
+        /// <returns>The <see cref="DiscordMessage"/> edited.</returns>
+        public async Task<DiscordMessage> EditFollowupMessageAsync(string interactionToken, ulong messageId, DiscordWebhookBuilder builder)
+        {
+            builder.Validate(isFollowup: true);
+
+            return await this.ApiClient.EditFollowupMessageAsync(this.CurrentApplication.Id, interactionToken, messageId, builder);
+        }
+
+        /// <summary>
+        /// Deletes a follow up message.
+        /// </summary>
+        /// <param name="interactionToken">The token of the interaction.</param>
+        /// <param name="messageId">The id of the follow up message.</param>
+        public Task DeleteFollowupMessageAsync(string interactionToken, ulong messageId) =>
+            this.ApiClient.DeleteFollowupMessageAsync(this.CurrentApplication.Id, interactionToken, messageId);
+        #endregion
+
         #region Misc
         /// <summary>
         /// Gets assets from an application

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -15,6 +15,7 @@ using DSharpPlus.EventArgs;
 using DSharpPlus.Exceptions;
 using DSharpPlus.Net.Abstractions;
 using Emzi0767.Utilities;
+using DSharpPlus.Net.Models;
 
 namespace DSharpPlus
 {
@@ -580,6 +581,116 @@ namespace DSharpPlus
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordGuildTemplate> GetTemplateAsync(string code)
             => this.ApiClient.GetTemplateAsync(code);
+
+        /// <summary>
+        /// Gets all the global slash commands for this application.
+        /// </summary>
+        /// <returns>A list of global slash commands.</returns>
+        public Task<IReadOnlyList<DiscordApplicationCommand>> GetGlobalApplicationCommandsAsync() =>
+            this.ApiClient.GetGlobalApplicationCommandsAsync(this.CurrentApplication.Id);
+
+        /// <summary>
+        /// Overwrites the existing global slash commands. New commands are automatically created and missing commands are automatically deleted.
+        /// </summary>
+        /// <param name="commands">The list of commands to overwrite with.</param>
+        /// <returns>The list of global commands.</returns>
+        public Task<IReadOnlyList<DiscordApplicationCommand>> BulkOverwriteGlobalApplicationCommandsAsync(IEnumerable<DiscordApplicationCommand> commands) =>
+            this.ApiClient.BulkOverwriteGlobalApplicationCommandsAsync(this.CurrentApplication.Id, commands);
+
+        /// <summary>
+        /// Creates or overwrites a global slash command.
+        /// </summary>
+        /// <param name="command">The command to create.</param>
+        /// <returns>The created command.</returns>
+        public Task<DiscordApplicationCommand> CreateGlobalApplicationCommandAsync(DiscordApplicationCommand command) =>
+            this.ApiClient.CreateGlobalApplicationCommandAsync(this.CurrentApplication.Id, command);
+
+        /// <summary>
+        /// Gets a global slash command by its id.
+        /// </summary>
+        /// <param name="commandId">The id of the command to get.</param>
+        /// <returns>The command with the id.</returns>
+        public Task<DiscordApplicationCommand> GetGlobalApplicationCommandAsync(ulong commandId) =>
+            this.ApiClient.GetGlobalApplicationCommandAsync(this.CurrentApplication.Id, commandId);
+
+        /// <summary>
+        /// Edits a global slash command.
+        /// </summary>
+        /// <param name="commandId">The id of the command to edit.</param>
+        /// <param name="action">Action to perform.</param>
+        /// <returns>The edited command.</returns>
+        public async Task<DiscordApplicationCommand> EditGlobalApplicationCommandAsync(ulong commandId, Action<ApplicationCommandEditModel> action)
+        {
+            var mdl = new ApplicationCommandEditModel();
+            action(mdl);
+            var applicationId = this.CurrentApplication?.Id ?? (await this.GetCurrentApplicationAsync()).Id;
+            return await this.ApiClient.EditGlobalApplicationCommandAsync(applicationId, commandId, mdl.Name, mdl.Description, mdl.Options);
+        }
+
+        /// <summary>
+        /// Deletes a global slash command.
+        /// </summary>
+        /// <param name="commandId">The id of the command to delete.</param>
+        public Task DeleteGlobalApplicationCommandAsync(ulong commandId) =>
+            this.ApiClient.DeleteGlobalApplicationCommandAsync(this.CurrentApplication.Id, commandId);
+
+        /// <summary>
+        /// Gets all the slash commands for a guild.
+        /// </summary>
+        /// <param name="guildId">The id of the guild to get slash commands for.</param>
+        /// <returns>A list of slash commands in the guild.</returns>
+        public Task<IReadOnlyList<DiscordApplicationCommand>> GetGuildApplicationCommandsAsync(ulong guildId) =>
+            this.ApiClient.GetGuildApplicationCommandsAsync(this.CurrentApplication.Id, guildId);
+
+        /// <summary>
+        /// Overwrites the existing slash commands in a guild. New commands are automatically created and missing commands are automatically deleted.
+        /// </summary>
+        /// <param name="guildId">The id of the guild.</param>
+        /// <param name="commands">The list of commands to overwrite with.</param>
+        /// <returns>The list of guild commands.</returns>
+        public Task<IReadOnlyList<DiscordApplicationCommand>> BulkOverwriteGuildApplicationCommandsAsync(ulong guildId, IEnumerable<DiscordApplicationCommand> commands) =>
+            this.ApiClient.BulkOverwriteGuildApplicationCommandsAsync(this.CurrentApplication.Id, guildId, commands);
+
+        /// <summary>
+        /// Creates or overwrites a guild slash command.
+        /// </summary>
+        /// <param name="guildId">The id of the guild to create the slash command in.</param>
+        /// <param name="command">The command to create.</param>
+        /// <returns>The created command.</returns>
+        public Task<DiscordApplicationCommand> CreateGuildApplicationCommandAsync(ulong guildId, DiscordApplicationCommand command) =>
+            this.ApiClient.CreateGuildApplicationCommandAsync(this.CurrentApplication.Id, guildId, command);
+
+        /// <summary>
+        /// Gets a slash command in a guild by its id.
+        /// </summary>
+        /// <param name="guildId">The id of the guild the slash command is in.</param>
+        /// <param name="commandId">The id of the command to get.</param>
+        /// <returns>The command with the id.</returns>
+        public Task<DiscordApplicationCommand> GetGuildApplicationCommandAsync(ulong guildId, ulong commandId) =>
+             this.ApiClient.GetGuildApplicationCommandAsync(this.CurrentApplication.Id, guildId, commandId);
+
+        /// <summary>
+        /// Edits a slash command in a guild.
+        /// </summary>
+        /// <param name="guildId">The id of the guild the slash command is in.</param>
+        /// <param name="commandId">The id of the command to edit.</param>
+        /// <param name="action">Action to perform.</param>
+        /// <returns>The edited command.</returns>
+        public async Task<DiscordApplicationCommand> EditGuildApplicationCommandAsync(ulong guildId, ulong commandId, Action<ApplicationCommandEditModel> action)
+        {
+            var mdl = new ApplicationCommandEditModel();
+            action(mdl);
+            var applicationId = this.CurrentApplication?.Id ?? (await this.GetCurrentApplicationAsync()).Id;
+            return await this.ApiClient.EditGuildApplicationCommandAsync(applicationId, guildId, commandId, mdl.Name, mdl.Description, mdl.Options);
+        }
+
+        /// <summary>
+        /// Deletes a slash command in a guild.
+        /// </summary>
+        /// <param name="guildId">The id of the guild to delete the slash command in.</param>
+        /// <param name="commandId">The id of the command.</param>
+        public Task DeleteGuildApplicationCommandAsync(ulong guildId, ulong commandId) =>
+            this.ApiClient.DeleteGuildApplicationCommandAsync(this.CurrentApplication.Id, guildId, commandId);
         #endregion
 
         #region Internal Caching Methods

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -2116,6 +2116,42 @@ namespace DSharpPlus.Entities
             action(mdl);
             return await this.Discord.ApiClient.ModifyGuildMembershipScreeningFormAsync(this.Id, mdl.Enabled, mdl.Fields, mdl.Description);
         }
+
+        /// <summary>
+        /// Gets all the slash commands in this guild.
+        /// </summary>
+        /// <returns>A list of slash commands in this guild.</returns>
+        public Task<IReadOnlyList<DiscordApplicationCommand>> GetApplicationCommandsAsync() =>
+            this.Discord.ApiClient.GetGuildApplicationCommandsAsync(this.Discord.CurrentApplication.Id, this.Id);
+
+        /// <summary>
+        /// Overwrites the existing slash commands in this guild. New commands are automatically created and missing commands are automatically delete
+        /// </summary>
+        /// <param name="commands">The list of commands to overwrite with.</param>
+        /// <returns>The list of guild commands</returns>
+        public Task<IReadOnlyList<DiscordApplicationCommand>> BulkOverwriteApplicationCommandsAsync(IEnumerable<DiscordApplicationCommand> commands) =>
+            this.Discord.ApiClient.BulkOverwriteGuildApplicationCommandsAsync(this.Discord.CurrentApplication.Id, this.Id, commands);
+
+        /// <summary>
+        /// Creates or overwrites a slash command in this guild.
+        /// </summary>
+        /// <param name="command">The command to create.</param>
+        /// <returns>The created command.</returns>
+        public Task<DiscordApplicationCommand> CreateApplicationCommandAsync(DiscordApplicationCommand command) =>
+            this.Discord.ApiClient.CreateGuildApplicationCommandAsync(this.Discord.CurrentApplication.Id, this.Id, command);
+
+        /// <summary>
+        /// Edits a slash command in this guild.
+        /// </summary>
+        /// <param name="commandId">The id of the command to edit.</param>
+        /// <param name="action">Action to perform.</param>
+        /// <returns>The edit command.</returns>
+        public async Task<DiscordApplicationCommand> EditApplicationCommandAsync(ulong commandId, Action<ApplicationCommandEditModel> action)
+        {
+            var mdl = new ApplicationCommandEditModel();
+            action(mdl);
+            return await this.Discord.ApiClient.EditGuildApplicationCommandAsync(this.Discord.CurrentApplication.Id, this.Id, commandId, mdl.Name, mdl.Description, mdl.Options);
+        }
         #endregion
 
         /// <summary>

--- a/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace DSharpPlus.Entities
 {
@@ -69,5 +70,63 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("application_id")]
         public ulong ApplicationId { get; internal set; }
+
+        /// <summary>
+        /// Creates a response to this interaction.
+        /// </summary>
+        /// <param name="type">The type of the response.</param>
+        /// <param name="builder">The data, if any, to send.</param>
+        public Task CreateResponseAsync(InteractionResponseType type, DiscordInteractionResponseBuilder builder = null) =>
+            this.Discord.ApiClient.CreateInteractionResponseAsync(this.Id, this.Token, type, builder);
+
+        /// <summary>
+        /// Edits the original interaction response.
+        /// </summary>
+        /// <param name="builder">The webhook builder.</param>
+        /// <returns>The <see cref="DiscordMessage"/> edited.</returns>
+        public async Task<DiscordMessage> EditOriginalResponseAsync(DiscordWebhookBuilder builder)
+        {
+            builder.Validate(isInteractionResponse: true);
+
+            return await this.Discord.ApiClient.EditOriginalInteractionResponseAsync(this.Discord.CurrentApplication.Id, this.Token, builder);
+        }
+
+        /// <summary>
+        /// Deletes the original interaction response.
+        /// </summary>>
+        public Task DeleteOriginalResponseAsync() =>
+            this.Discord.ApiClient.DeleteOriginalInteractionResponseAsync(this.Discord.CurrentApplication.Id, this.Token);
+
+        /// <summary>
+        /// Creates a follow up message to this interaction.
+        /// </summary>
+        /// <param name="builder">The webhook builder.</param>
+        /// <returns>The <see cref="DiscordMessage"/> created.</returns>
+        public async Task<DiscordMessage> CreateFollowupMessageAsync(DiscordWebhookBuilder builder)
+        {
+            builder.Validate(isFollowup: true);
+
+            return await this.Discord.ApiClient.CreateFollowupMessageAsync(this.Discord.CurrentApplication.Id, this.Token, builder);
+        }
+
+        /// <summary>
+        /// Edits a follow up message.
+        /// </summary>
+        /// <param name="messageId">The id of the follow up message.</param>
+        /// <param name="builder">The webhook builder.</param>
+        /// <returns>The <see cref="DiscordMessage"/> edited.</returns>
+        public async Task<DiscordMessage> EditFollowupMessageAsync(ulong messageId, DiscordWebhookBuilder builder)
+        {
+            builder.Validate(isFollowup: true);
+
+            return await this.Discord.ApiClient.EditFollowupMessageAsync(this.Discord.CurrentApplication.Id, this.Token, messageId, builder);
+        }
+
+        /// <summary>
+        /// Deletes a follow up message.
+        /// </summary>
+        /// <param name="messageId">The id of the follow up message.</param>
+        public Task DeleteFollowupMessageAsync(ulong messageId) =>
+            this.Discord.ApiClient.DeleteFollowupMessageAsync(this.Discord.CurrentApplication.Id, this.Token, messageId);
     }
 }

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace DSharpPlus.Entities
+{
+    internal class DiscordInteractionApplicationCommandCallbackData
+    {
+        [JsonProperty("tts", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsTTS { get; internal set; }
+
+        [JsonProperty("content", NullValueHandling = NullValueHandling.Ignore)]
+        public string Content { get; internal set; }
+
+        [JsonProperty("embeds", NullValueHandling = NullValueHandling.Ignore)]
+        public IEnumerable<DiscordEmbed> Embeds { get; internal set; }
+
+        [JsonProperty("allowed_mentions", NullValueHandling = NullValueHandling.Ignore)]
+        public IEnumerable<IMention> Mentions { get; internal set; }
+
+        [JsonProperty("flags", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Flags { get; internal set; }
+    }
+}

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace DSharpPlus.Entities
+{
+    /// <summary>
+    /// Constructs an interaction response.
+    /// </summary>
+    public sealed class DiscordInteractionResponseBuilder
+    {
+        /// <summary>
+        /// Whether this interaction response is text-to-speech.
+        /// </summary>
+        public bool IsTTS { get; set; }
+
+        /// <summary>
+        /// Whether this interaction response should be ephemeral.
+        /// </summary>
+        public bool IsEphemeral { get; set; }
+
+        /// <summary>
+        /// Content of the message to send.
+        /// </summary>
+        public string Content
+        {
+            get => this._content;
+            set
+            {
+                if (value != null && value.Length > 2000)
+                    throw new ArgumentException("Content length cannot exceed 2000 characters.", nameof(value));
+                this._content = value;
+            }
+        }
+        private string _content;
+
+        /// <summary>
+        /// Embeds to send on this interaction response.
+        /// </summary>
+        public IReadOnlyList<DiscordEmbed> Embeds { get; }
+        private readonly List<DiscordEmbed> _embeds = new List<DiscordEmbed>();
+
+        /// <summary>
+        /// Mentions to send on this interaction response.
+        /// </summary>
+        public IEnumerable<IMention> Mentions { get; }
+        private readonly List<IMention> _mentions = new List<IMention>();
+
+        /// <summary>
+        /// Constructs a new empty interaction response builder.
+        /// </summary>
+        public DiscordInteractionResponseBuilder()
+        {
+            this.Embeds = new ReadOnlyCollection<DiscordEmbed>(this._embeds);
+            this.Mentions = new ReadOnlyCollection<IMention>(this._mentions);
+        }
+
+        /// <summary>
+        /// Indicates if the interaction response will be text-to-speech.
+        /// </summary>
+        /// <param name="tts">Text-to-speech</param>
+        public DiscordInteractionResponseBuilder WithTTS(bool tts)
+        {
+            this.IsTTS = tts;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the interaction response to be ephemeral
+        /// </summary>
+        /// <param name="ephemeral">Ephemeral</param>
+        public DiscordInteractionResponseBuilder AsEphemeral(bool ephemeral)
+        {
+            this.IsEphemeral = ephemeral;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the content of the message to send.
+        /// </summary>
+        /// <param name="content">Content to send.</param>
+        public DiscordInteractionResponseBuilder WithContent(string content)
+        {
+            this.Content = content;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an embed to send with the interaction response.
+        /// </summary>
+        /// <param name="embed">Embed to add.</param>
+        public DiscordInteractionResponseBuilder AddEmbed(DiscordEmbed embed)
+        {
+            this._embeds.Add(embed);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the given embeds to send with the interaction response.
+        /// </summary>
+        /// <param name="embeds">Embeds to add.</param>
+        public DiscordInteractionResponseBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
+        {
+            this._embeds.AddRange(embeds);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the mention to the mentions to parse, etc. with the interaction response.
+        /// </summary>
+        /// <param name="mention">Mention to add.</param>
+        public DiscordInteractionResponseBuilder AddMention(IMention mention)
+        {
+            this._mentions.Add(mention);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the mentions to the mentions to parse, etc. with the interaction response.
+        /// </summary>
+        /// <param name="mentions">Mentions to add.</param>
+        public DiscordInteractionResponseBuilder AddMentions(IEnumerable<IMention> mentions)
+        {
+            this._mentions.AddRange(mentions);
+            return this;
+        }
+
+        /// <summary>
+        /// Allows for clearing the Interaction Response Builder so that it can be used again to send a new response.
+        /// </summary>
+        public void Clear()
+        {
+            this.Content = "";
+            this._embeds.Clear();
+            this.IsTTS = false;
+            this.IsEphemeral = false;
+            this._mentions.Clear();
+        }
+    }
+}

--- a/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
@@ -266,18 +266,33 @@ namespace DSharpPlus.Entities
         /// Does the validation before we send a the Create/Modify request.
         /// </summary>
         /// <param name="isModify">Tells the method to perform the Modify Validation or Create Validation.</param>
-        internal void Validate(bool isModify = false)
+        /// <param name="isFollowup">Tells the method to perform the follow up message validation.</param>
+        /// <param name="isInteractionResponse">Tells the method to perform the interaction response validation.</param>
+        internal void Validate(bool isModify = false, bool isFollowup = false, bool isInteractionResponse = false)
         {
             if (isModify)
             {
-                if (this.Files.Any())
-                    throw new ArgumentException("You cannot add files when modifying a message.");
-
                 if (this.Username.HasValue)
                     throw new ArgumentException("You cannot change the username of a message.");
 
                 if (this.AvatarUrl.HasValue)
                     throw new ArgumentException("You cannot change the avatar of a message.");
+            }
+            else if (isFollowup)
+            {
+                if (this.Username.HasValue)
+                    throw new ArgumentException("You cannot change the username of a follow up message.");
+
+                if (this.AvatarUrl.HasValue)
+                    throw new ArgumentException("You cannot change the avatar of a follow up message.");
+            }
+            else if (isInteractionResponse)
+            {
+                if (this.Username.HasValue)
+                    throw new ArgumentException("You cannot change the username of an interaction response.");
+
+                if (this.AvatarUrl.HasValue)
+                    throw new ArgumentException("You cannot change the avatar of an interaction response.");
             }
             else
             {

--- a/DSharpPlus/Enums/InteractionResponseType.cs
+++ b/DSharpPlus/Enums/InteractionResponseType.cs
@@ -1,0 +1,23 @@
+﻿namespace DSharpPlus
+{
+    /// <summary>
+    /// Represents the type of interaction response
+    /// </summary>
+    public enum InteractionResponseType
+    {
+        /// <summary>
+        /// Acknowledges a Ping.
+        /// </summary>
+        Pong = 1,
+        
+        /// <summary>
+        /// Responds to the interaction with a message.
+        /// </summary>
+        ChannelMessageWithSource = 4,
+
+        /// <summary>
+        /// Acknowledges an interaction to edit to a response later. The user sees a "thinking" state.
+        /// </summary>
+        DeferredChannelMessageWithSource = 5
+    }
+}

--- a/DSharpPlus/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
@@ -1,0 +1,39 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.Net.Abstractions
+{
+    internal class RestApplicationCommandCreatePayload
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("options")]
+        public IEnumerable<DiscordApplicationCommandOption> Options { get; set; }
+    }
+
+    internal class RestApplicationCommandEditPayload
+    {
+        [JsonProperty("name")]
+        public Optional<string> Name { get; set; }
+
+        [JsonProperty("description")]
+        public Optional<string> Description { get; set; }
+
+        [JsonProperty("options")]
+        public Optional<IReadOnlyCollection<DiscordApplicationCommandOption>> Options { get; set; }
+    }
+
+    internal class RestInteractionResponsePayload
+    {
+        [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]
+        public InteractionResponseType Type { get; set; }
+
+        [JsonProperty("data", NullValueHandling = NullValueHandling.Ignore)]
+        public DiscordInteractionApplicationCommandCallbackData Data { get; set; }
+    }
+}

--- a/DSharpPlus/Net/Models/ApplicationCommandEditModel.cs
+++ b/DSharpPlus/Net/Models/ApplicationCommandEditModel.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.Net.Models
+{
+    public class ApplicationCommandEditModel
+    {
+        /// <summary>
+        /// Sets the command's new name.
+        /// </summary>
+        public Optional<string> Name { internal get; set; }
+
+        /// <summary>
+        /// Sets the command's new description
+        /// </summary>
+        public Optional<string> Description { internal get; set; }
+
+        /// <summary>
+        /// Sets the command's new options.
+        /// </summary>
+        public Optional<IReadOnlyCollection<DiscordApplicationCommandOption>> Options { internal get; set; }
+    }
+}

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -278,7 +278,7 @@ namespace DSharpPlus.Net
             };
             if (reason != null)
                 urlparams["reason"] = reason;
-            
+
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.BANS}/:user_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { guild_id, user_id }, out var path);
 
@@ -761,7 +761,7 @@ namespace DSharpPlus.Net
                 HasEmbed = embed != null,
                 Embed = embed
             };
-            
+
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
@@ -873,7 +873,7 @@ namespace DSharpPlus.Net
 
             return new ReadOnlyCollection<DiscordMessage>(new List<DiscordMessage>(msgs));
         }
-        
+
         internal async Task<DiscordMessage> GetChannelMessageAsync(ulong channel_id, ulong message_id)
         {
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id";
@@ -893,7 +893,7 @@ namespace DSharpPlus.Net
             {
                 Suppress = suppress
             };
-            
+
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.SUPPRESS_EMBEDS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id, message_id }, out var path);
 
@@ -1143,26 +1143,26 @@ namespace DSharpPlus.Net
             {
                 WebhookChannelId = webhook_channel_id
             };
-            
+
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.FOLLOWERS}";
-            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new {channel_id}, out var path);
+            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
             var url = Utilities.GetApiUriFor(path);
             var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
-            
+
             return JsonConvert.DeserializeObject<DiscordFollowedChannel>(response.Response);
         }
 
         internal async Task<DiscordMessage> CrosspostMessageAsync(ulong channel_id, ulong message_id)
         {
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.CROSSPOST}";
-            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new {channel_id, message_id}, out var path);
+            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id, message_id }, out var path);
 
             var url = Utilities.GetApiUriFor(path);
             var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route).ConfigureAwait(false);
             return JsonConvert.DeserializeObject<DiscordMessage>(response.Response);
         }
-        
+
         #endregion
 
         #region Member
@@ -1253,7 +1253,7 @@ namespace DSharpPlus.Net
 
             var url = Utilities.GetApiUriBuilderFor(path)
                 .AddParameter($"limit", limit.ToString(CultureInfo.InvariantCulture));
-            
+
             if (before != null)
                 url.AddParameter("before", before.Value.ToString(CultureInfo.InvariantCulture));
             if (after != null)
@@ -1443,7 +1443,7 @@ namespace DSharpPlus.Net
 
             var sb = new StringBuilder();
 
-            if(include_roles != null)
+            if (include_roles != null)
             {
                 var roleArray = include_roles.ToArray();
                 var roleArrayCount = roleArray.Count();
@@ -1943,7 +1943,7 @@ namespace DSharpPlus.Net
             return ret;
         }
 
-        internal async Task<DiscordMessage> EditWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong message_id, DiscordWebhookBuilder builder)
+        internal async Task<DiscordMessage> EditWebhookMessageAsync(ulong webhook_id, string webhook_token, string message_id, DiscordWebhookBuilder builder)
         {
             var pld = new RestWebhookMessageEditPayload
             {
@@ -1962,8 +1962,10 @@ namespace DSharpPlus.Net
             ret.Discord = this.Discord;
             return ret;
         }
+        internal Task<DiscordMessage> EditWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong message_id, DiscordWebhookBuilder builder) =>
+            this.EditWebhookMessageAsync(webhook_id, webhook_token, message_id.ToString(), builder);
 
-        internal async Task DeleteWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong message_id)
+        internal async Task DeleteWebhookMessageAsync(ulong webhook_id, string webhook_token, string message_id)
         {
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.MESSAGES}/:message_id";
             var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { webhook_id, webhook_token, message_id }, out var path);
@@ -1971,6 +1973,8 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route);
         }
+        internal Task DeleteWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong message_id) =>
+            this.DeleteWebhookMessageAsync(webhook_id, webhook_token, message_id.ToString());
         #endregion
 
         #region Reactions
@@ -2196,6 +2200,255 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
+        #endregion
+
+        #region Slash Commands
+        internal async Task<IReadOnlyList<DiscordApplicationCommand>> GetGlobalApplicationCommandsAsync(ulong application_id)
+        {
+            var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { application_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route);
+
+            var ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response);
+            foreach (var app in ret)
+                app.Discord = this.Discord;
+            return ret.ToList();
+        }
+
+        internal async Task<IReadOnlyList<DiscordApplicationCommand>> BulkOverwriteGlobalApplicationCommandsAsync(ulong application_id, IEnumerable<DiscordApplicationCommand> commands)
+        {
+            var pld = new List<RestApplicationCommandCreatePayload>();
+            foreach(var command in commands)
+            {
+                pld.Add(new RestApplicationCommandCreatePayload
+                {
+                    Name = command.Name,
+                    Description = command.Description,
+                    Options = command.Options
+                });
+            }
+
+            var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { application_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, route, payload: DiscordJson.SerializeObject(pld));
+
+            var ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response);
+            foreach (var app in ret)
+                app.Discord = this.Discord;
+            return ret.ToList();
+        }
+
+        internal async Task<DiscordApplicationCommand> CreateGlobalApplicationCommandAsync(ulong application_id, DiscordApplicationCommand command)
+        {
+            var pld = new RestApplicationCommandCreatePayload
+            {
+                Name = command.Name,
+                Description = command.Description,
+                Options = command.Options
+            };
+
+            var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { application_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld));
+
+            var ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response);
+            ret.Discord = this.Discord;
+
+            return ret;
+        }
+
+        internal async Task<DiscordApplicationCommand> GetGlobalApplicationCommandAsync(ulong application_id, ulong command_id)
+        {
+            var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}/:command_id";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { application_id, command_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route);
+
+            var ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response);
+            ret.Discord = this.Discord;
+
+            return ret;
+        }
+
+        internal async Task<DiscordApplicationCommand> EditGlobalApplicationCommandAsync(ulong application_id, ulong command_id, Optional<string> name, Optional<string> description, Optional<IReadOnlyCollection<DiscordApplicationCommandOption>> options)
+        {
+            var pld = new RestApplicationCommandEditPayload
+            {
+                Name = name,
+                Description = description,
+                Options = options
+            };
+
+            var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}/:command_id";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { application_id, command_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld));
+
+            var ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response);
+            ret.Discord = this.Discord;
+
+            return ret;
+        }
+
+        internal async Task DeleteGlobalApplicationCommandAsync(ulong application_id, ulong command_id)
+        {
+            var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}/:command_id";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { application_id, command_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route);
+        }
+
+        internal async Task<IReadOnlyList<DiscordApplicationCommand>> GetGuildApplicationCommandsAsync(ulong application_id, ulong guild_id)
+        {
+            var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { application_id, guild_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route);
+
+            var ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response);
+            foreach (var app in ret)
+                app.Discord = this.Discord;
+            return ret.ToList();
+        }
+
+        internal async Task<IReadOnlyList<DiscordApplicationCommand>> BulkOverwriteGuildApplicationCommandsAsync(ulong application_id, ulong guild_id, IEnumerable<DiscordApplicationCommand> commands)
+        {
+            var pld = new List<RestApplicationCommandCreatePayload>();
+            foreach (var command in commands)
+            {
+                pld.Add(new RestApplicationCommandCreatePayload
+                {
+                    Name = command.Name,
+                    Description = command.Description,
+                    Options = command.Options
+                });
+            }
+
+            var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.PUT, route, new { application_id, guild_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, route, payload: DiscordJson.SerializeObject(pld));
+
+            var ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response);
+            foreach (var app in ret)
+                app.Discord = this.Discord;
+            return ret.ToList();
+        }
+
+        internal async Task<DiscordApplicationCommand> CreateGuildApplicationCommandAsync(ulong application_id, ulong guild_id, DiscordApplicationCommand command)
+        {
+            var pld = new RestApplicationCommandCreatePayload
+            {
+                Name = command.Name,
+                Description = command.Description,
+                Options = command.Options
+            };
+
+            var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { application_id, guild_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld));
+
+            var ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response);
+            ret.Discord = this.Discord;
+
+            return ret;
+        }
+
+        internal async Task<DiscordApplicationCommand> GetGuildApplicationCommandAsync(ulong application_id, ulong guild_id, ulong command_id)
+        {
+            var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}/:command_id";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { application_id, guild_id, command_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route);
+
+            var ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response);
+            ret.Discord = this.Discord;
+
+            return ret;
+        }
+
+        internal async Task<DiscordApplicationCommand> EditGuildApplicationCommandAsync(ulong application_id, ulong guild_id, ulong command_id, Optional<string> name, Optional<string> description, Optional<IReadOnlyCollection<DiscordApplicationCommandOption>> options)
+        {
+            var pld = new RestApplicationCommandEditPayload
+            {
+                Name = name,
+                Description = description,
+                Options = options
+            };
+
+            var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}/:command_id";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { application_id, guild_id, command_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld));
+
+            var ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response);
+            ret.Discord = this.Discord;
+
+            return ret;
+        }
+
+        internal async Task DeleteGuildApplicationCommandAsync(ulong application_id, ulong guild_id, ulong command_id)
+        {
+            var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}/:command_id";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { application_id, guild_id, command_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route);
+        }
+
+        internal async Task CreateInteractionResponseAsync(ulong interaction_id, string interaction_token, InteractionResponseType type, DiscordInteractionResponseBuilder builder)
+        {
+            var pld = new RestInteractionResponsePayload
+            {
+                Type = type,
+                Data = builder != null ? new DiscordInteractionApplicationCommandCallbackData
+                {
+                    Content = builder.Content,
+                    Embeds = builder.Embeds,
+                    IsTTS = builder.IsTTS,
+                    Mentions = builder.Mentions,
+                    Flags = builder.IsEphemeral ? 64 : null
+                } : null
+            };
+
+            var route = $"{Endpoints.INTERACTIONS}/:interaction_id/:interaction_token{Endpoints.CALLBACK}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { interaction_id, interaction_token }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld));
+        }
+
+        internal Task<DiscordMessage> EditOriginalInteractionResponseAsync(ulong application_id, string interaction_token, DiscordWebhookBuilder builder) =>
+            this.EditWebhookMessageAsync(application_id, interaction_token, "@original", builder);
+
+        internal Task DeleteOriginalInteractionResponseAsync(ulong application_id, string interaction_token) =>
+            this.DeleteWebhookMessageAsync(application_id, interaction_token, "@original");
+
+        internal Task<DiscordMessage> CreateFollowupMessageAsync(ulong application_id, string interaction_token, DiscordWebhookBuilder builder) =>
+            this.ExecuteWebhookAsync(application_id, interaction_token, builder);
+
+        internal Task<DiscordMessage> EditFollowupMessageAsync(ulong application_id, string interaction_token, ulong message_id, DiscordWebhookBuilder builder) =>
+            this.EditWebhookMessageAsync(application_id, interaction_token, message_id, builder);
+
+        internal Task DeleteFollowupMessageAsync(ulong application_id, string interaction_token, ulong message_id) =>
+            this.DeleteWebhookMessageAsync(application_id, interaction_token, message_id);
+
+        //TODO: edit, delete, follow up
         #endregion
 
         #region Misc

--- a/DSharpPlus/Net/Rest/Endpoints.cs
+++ b/DSharpPlus/Net/Rest/Endpoints.cs
@@ -51,5 +51,8 @@
         public const string WIDGET_JSON = "/widget.json";
         public const string TEMPLATES = "/templates";
         public const string MEMBER_VERIFICATION = "/member-verification";
+        public const string COMMANDS = "/commands";
+        public const string INTERACTIONS = "/interactions";
+        public const string CALLBACK = "/callback";
     }
 }


### PR DESCRIPTION
# Summary
Adds all the slash command API endpoints

# Details
Added all the documented endpoints, ~~as well as the bulk overwrite endpoint, which hasn't been documented yet (for some reason, blame discord)~~(now documented). This will effectively mean that slash commands have been added to the library, but people will have to make their own handlers until we get around to making our own. I chose to add the guild endpoints to `DiscordClient` as well as `DiscordGuild`, since a lot of times you might not have the guild object and just the id, but this is up for discussion. I additionally also removed the restriction for editing files with webhooks.