### PR TITLE
[ci skip] Remove file name example from message builder article

### DIFF
--- a/docs/articles/beyond_basics/messagebuilder.md
+++ b/docs/articles/beyond_basics/messagebuilder.md
@@ -24,14 +24,6 @@ For sending files, you'll have to use the MessageBuilder to construct your messa
         .SendAsync(ctx.Channel);           
 }
 ```
-OR
-
-```cs
-var msg = await new DiscordMessageBuilder()
-    .WithContent("Here is a really dumb file that I am testing with.")
-    .WithFile("./ADumbFile.txt")
-    .SendAsync(ctx.Channel);
-```
 
 ### Adding Mentions
 For sending mentions, you'll have to use the MessageBuilder to construct your message, see example below:

--- a/docs/articles/beyond_basics/messagebuilder.md
+++ b/docs/articles/beyond_basics/messagebuilder.md
@@ -5,8 +5,8 @@ title: Message Builder
 
 ## Background
 Before the message builder was put into place, we had one large method for sending messages along with 3 additional methods for sending files. This
-was becoming a major code smell and it was hard to maintain and add more params onto it. Now we support just sending a simple message, an embed, a simple
-message with an embed, or a full fledged message builder.
+was becoming a major code smell and it was hard to maintain and add more parameters onto it. Now we support just sending a simple message, an embed, a simple
+message with an embed, or a message builder.
 
 ## Using the Message Builder
 The API Documentation for the message builder can be found at @DSharpPlus.Entities.DiscordMessageBuilder but here we'll go over some of the concepts of using the


### PR DESCRIPTION
# Summary
Removed the example for giving the file name in the message builder article