### PR TITLE
Add ability to make followup message ephemeral

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1475,9 +1475,9 @@ namespace DSharpPlus
         /// <param name="interactionToken">The token of the interaction.</param>
         /// <param name="builder">The webhook builder.</param>
         /// <returns>The <see cref="DiscordMessage"/> created.</returns>
-        public async Task<DiscordMessage> CreateFollowupMessageAsync(string interactionToken, DiscordWebhookBuilder builder)
+        public async Task<DiscordMessage> CreateFollowupMessageAsync(string interactionToken, DiscordFollowupMessageBuilder builder)
         {
-            builder.Validate(isFollowup: true);
+            builder.Validate();
 
             return await this.ApiClient.CreateFollowupMessageAsync(this.CurrentApplication.Id, interactionToken, builder);
         }

--- a/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
@@ -209,7 +209,7 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Allows for clearing the Webhook Builder so that it can be used again to send a new message.
+        /// Allows for clearing the Followup Message builder so that it can be used again to send a new message.
         /// </summary>
         public void Clear()
         {

--- a/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DSharpPlus.Entities
+{
+    /// <summary>
+    /// Constructs a followup message to an interaction.
+    /// </summary>
+    public sealed class DiscordFollowupMessageBuilder
+    {
+        /// <summary>
+        /// Whether this followup message is text-to-speech.
+        /// </summary>
+        public bool IsTTS { get; set; }
+
+        /// <summary>
+        /// Whether this followup message should be ephemeral.
+        /// </summary>
+        public bool IsEphemeral { get; set; }
+
+        internal int? Flags
+            => this.IsEphemeral ? 64 : null;
+
+        /// <summary>
+        /// Message to send on followup message.
+        /// </summary>
+        public string Content
+        {
+            get => this._content;
+            set
+            {
+                if (value != null && value.Length > 2000)
+                    throw new ArgumentException("Content length cannot exceed 2000 characters.", nameof(value));
+                this._content = value;
+            }
+        }
+        private string _content;
+
+        /// <summary>
+        /// Embeds to send on followup message.
+        /// </summary>
+        public IReadOnlyList<DiscordEmbed> Embeds { get; }
+        private readonly List<DiscordEmbed> _embeds = new List<DiscordEmbed>();
+
+        /// <summary>
+        /// Files to send on this followup message.
+        /// </summary>
+        public IReadOnlyCollection<DiscordMessageFile> Files => this._files;
+
+        internal readonly List<DiscordMessageFile> _files = new List<DiscordMessageFile>();
+
+        /// <summary>
+        /// Mentions to send on this followup message.
+        /// </summary>
+        public IEnumerable<IMention> Mentions { get; }
+        private readonly List<IMention> _mentions = new List<IMention>();
+
+        /// <summary>
+        /// Constructs a new empty followup message builder.
+        /// </summary>
+        public DiscordFollowupMessageBuilder()
+        {
+            this.Embeds = new ReadOnlyCollection<DiscordEmbed>(this._embeds);
+            this.Mentions = new ReadOnlyCollection<IMention>(this._mentions);
+        }
+
+        /// <summary>
+        /// Indicates if the followup message must use text-to-speech.
+        /// </summary>
+        /// <param name="tts">Text-to-speech</param>
+        public DiscordFollowupMessageBuilder WithTTS(bool tts)
+        {
+            this.IsTTS = tts;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the message to send with the followup message..
+        /// </summary>
+        /// <param name="content">Message to send.</param>
+        public DiscordFollowupMessageBuilder WithContent(string content)
+        {
+            this.Content = content;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds an embed to the followup message.
+        /// </summary>
+        /// <param name="embed">Embed to add.</param>
+        public DiscordFollowupMessageBuilder AddEmbed(DiscordEmbed embed)
+        {
+            this._embeds.Add(embed);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the given embeds to the followup message.
+        /// </summary>
+        /// <param name="embeds">Embeds to add.</param>
+        public DiscordFollowupMessageBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
+        {
+            this._embeds.AddRange(embeds);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a file to the followup message.
+        /// </summary>
+        /// <param name="filename">Name of the file.</param>
+        /// <param name="data">File data.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
+        public DiscordFollowupMessageBuilder AddFile(string filename, Stream data, bool resetStreamPosition = false)
+        {
+            if (this.Files.Count() >= 10)
+                throw new ArgumentException("Cannot send more than 10 files with a single message.");
+
+            if (this._files.Any(x => x.FileName == filename))
+                throw new ArgumentException("A File with that filename already exists");
+
+            if (resetStreamPosition)
+                this._files.Add(new DiscordMessageFile(filename, data, data.Position));
+            else
+                this._files.Add(new DiscordMessageFile(filename, data, null));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets if the message has files to be sent.
+        /// </summary>
+        /// <param name="stream">The Stream to the file.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
+        /// <returns></returns>
+        public DiscordFollowupMessageBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
+        {
+            if (this.Files.Count() >= 10)
+                throw new ArgumentException("Cannot send more than 10 files with a single message.");
+
+            if (this._files.Any(x => x.FileName == stream.Name))
+                throw new ArgumentException("A File with that filename already exists");
+
+            if (resetStreamPosition)
+                this._files.Add(new DiscordMessageFile(stream.Name, stream, stream.Position));
+            else
+                this._files.Add(new DiscordMessageFile(stream.Name, stream, null));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the given files to the followup message.
+        /// </summary>
+        /// <param name="files">Dictionary of file name and file data.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
+        public DiscordFollowupMessageBuilder AddFiles(Dictionary<string, Stream> files, bool resetStreamPosition = false)
+        {
+            if (this.Files.Count() + files.Count() >= 10)
+                throw new ArgumentException("Cannot send more than 10 files with a single message.");
+
+            foreach (var file in files)
+            {
+                if (this._files.Any(x => x.FileName == file.Key))
+                    throw new ArgumentException("A File with that filename already exists");
+
+                if (resetStreamPosition)
+                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, file.Value.Position));
+                else
+                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, null));
+            }
+
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the mention to the mentions to parse, etc. with the followup message.
+        /// </summary>
+        /// <param name="mention">Mention to add.</param>
+        public DiscordFollowupMessageBuilder AddMention(IMention mention)
+        {
+            this._mentions.Add(mention);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the mentions to the mentions to parse, etc. with the followup message.
+        /// </summary>
+        /// <param name="mentions">Mentions to add.</param>
+        public DiscordFollowupMessageBuilder AddMentions(IEnumerable<IMention> mentions)
+        {
+            this._mentions.AddRange(mentions);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the followup message to be ephemeral.
+        /// </summary>
+        /// <param name="ephemeral">Ephemeral.</param>
+        public DiscordFollowupMessageBuilder AsEphemeral(bool ephemeral)
+        {
+            this.IsEphemeral = ephemeral;
+            return this;
+        }
+
+        /// <summary>
+        /// Allows for clearing the Webhook Builder so that it can be used again to send a new message.
+        /// </summary>
+        public void Clear()
+        {
+            this.Content = "";
+            this._embeds.Clear();
+            this.IsTTS = false;
+            this._mentions.Clear();
+            this._files.Clear();
+            this.IsEphemeral = false;
+        }
+
+        internal void Validate()
+        {
+            if (this.Files?.Count == 0 && string.IsNullOrEmpty(this.Content) && !this.Embeds.Any())
+                throw new ArgumentException("You must specify content, an embed, or at least one file.");
+        }
+    }
+}

--- a/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
@@ -102,9 +102,9 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="builder">The webhook builder.</param>
         /// <returns>The <see cref="DiscordMessage"/> created.</returns>
-        public async Task<DiscordMessage> CreateFollowupMessageAsync(DiscordWebhookBuilder builder)
+        public async Task<DiscordMessage> CreateFollowupMessageAsync(DiscordFollowupMessageBuilder builder)
         {
-            builder.Validate(isFollowup: true);
+            builder.Validate();
 
             return await this.Discord.ApiClient.CreateFollowupMessageAsync(this.Discord.CurrentApplication.Id, this.Token, builder);
         }

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -66,9 +66,9 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Sets the interaction response to be ephemeral
+        /// Sets the interaction response to be ephemeral.
         /// </summary>
-        /// <param name="ephemeral">Ephemeral</param>
+        /// <param name="ephemeral">Ephemeral.</param>
         public DiscordInteractionResponseBuilder AsEphemeral(bool ephemeral)
         {
             this.IsEphemeral = ephemeral;

--- a/DSharpPlus/Enums/Message/MessageFlags.cs
+++ b/DSharpPlus/Enums/Message/MessageFlags.cs
@@ -42,6 +42,16 @@ namespace DSharpPlus
         /// <summary>
         /// The message came from the urgent message system.
         /// </summary>
-        Urgent = 1 << 4
+        Urgent = 1 << 4,
+
+        /// <summary>
+        /// The message is only visible to the user who invoked the interaction.
+        /// </summary>
+        Ephemeral = 1 << 6,
+
+        /// <summary>
+        /// The message is an interaction response and the bot is "thinking".
+        /// </summary>
+        Loading = 1 << 7
     }
 }

--- a/DSharpPlus/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
@@ -36,4 +36,22 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("data", NullValueHandling = NullValueHandling.Ignore)]
         public DiscordInteractionApplicationCommandCallbackData Data { get; set; }
     }
+
+    internal class RestFollowupMessageCreatePayload
+    {
+        [JsonProperty("content", NullValueHandling = NullValueHandling.Ignore)]
+        public string Content { get; set; }
+
+        [JsonProperty("tts", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsTTS { get; set; }
+
+        [JsonProperty("embeds", NullValueHandling = NullValueHandling.Ignore)]
+        public IEnumerable<DiscordEmbed> Embeds { get; set; }
+
+        [JsonProperty("allowed_mentions", NullValueHandling = NullValueHandling.Ignore)]
+        public DiscordMentions Mentions { get; set; }
+
+        [JsonProperty("flags", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Flags { get; set; }
+    }
 }


### PR DESCRIPTION
# Summary
Created a `DiscordFollowupMessageBuilder` to be able to make followup message ephemeral.

# Details
Also added the message flags for ephemeral and loading states.