### PR TITLE
fix: Try to cache DM channels during REST.

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -544,7 +544,7 @@ namespace DSharpPlus
                 xo._channel_id = channel.Id;
             }
 
-            this._guilds[channel.GuildId]._channels[channel.Id] = channel;
+            this._guilds[channel.GuildId.Value]._channels[channel.Id] = channel;
 
             await this._channelCreated.InvokeAsync(this, new ChannelCreateEventArgs { Channel = channel, Guild = channel.Guild }).ConfigureAwait(false);
         }
@@ -622,7 +622,7 @@ namespace DSharpPlus
             {
                 var dmChannel = channel as DiscordDmChannel;
 
-                if (this._privateChannels.TryRemove(dmChannel.Id, out var cachedDmChannel)) dmChannel = cachedDmChannel;
+                _ = this._privateChannels.TryRemove(dmChannel.Id, out _);
 
                 await this._dmChannelDeleted.InvokeAsync(this, new DmChannelDeleteEventArgs { Channel = dmChannel }).ConfigureAwait(false);
             }
@@ -1447,7 +1447,7 @@ namespace DSharpPlus
             if (channel?.Guild != null)
                 usr = channel.Guild.Members.TryGetValue(userId, out var member)
                     ? member
-                    : new DiscordMember(usr) { Discord = this, _guild_id = channel.GuildId };
+                    : new DiscordMember(usr) { Discord = this, _guild_id = channel.GuildId.Value };
 
             if (channel == null 
                 || this.Configuration.MessageCacheSize == 0 

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -21,7 +21,7 @@ namespace DSharpPlus.Entities
         /// Gets ID of the guild to which this channel belongs.
         /// </summary>
         [JsonProperty("guild_id", NullValueHandling = NullValueHandling.Ignore)]
-        public ulong GuildId { get; internal set; }
+        public ulong? GuildId { get; internal set; }
 
         /// <summary>
         /// Gets ID of the category that contains this channel.
@@ -73,7 +73,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public DiscordGuild Guild 
-            => this.Discord.Guilds.TryGetValue(this.GuildId, out var guild) ? guild : null;
+            => this.GuildId.HasValue && this.Discord.Guilds.TryGetValue(this.GuildId.Value, out var guild) ? guild : null;
 
         /// <summary>
         /// Gets a collection of permission overwrites for this channel.

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -34,7 +34,7 @@ namespace DSharpPlus.Entities
             this._stickersLazy = new Lazy<IReadOnlyList<DiscordMessageSticker>>(() => new ReadOnlyCollection<DiscordMessageSticker>(this._stickers));
             this._jumpLink = new Lazy<Uri>(() =>
             {
-                var gid = this.Channel is DiscordDmChannel ? "@me" : this.Channel.GuildId.ToString(CultureInfo.InvariantCulture);
+                var gid = this.Channel is DiscordDmChannel ? "@me" : this.Channel.GuildId.Value.ToString(CultureInfo.InvariantCulture);
                 var cid = this.ChannelId.ToString(CultureInfo.InvariantCulture);
                 var mid = this.Id.ToString(CultureInfo.InvariantCulture);
 

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -258,8 +258,15 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordDmChannel> CreateDmChannelAsync() 
-            => this.Discord.ApiClient.CreateDmAsync(this.Id);
+        public Task<DiscordDmChannel> CreateDmChannelAsync()
+        {
+            DiscordDmChannel dm = default;
+
+            if (this.Discord is DiscordClient dc)
+                dm = dc._privateChannels.Values.FirstOrDefault(x => x.Recipients[0].Id == this.Id);
+            
+            return dm != null ? Task.FromResult(dm) : this.Discord.ApiClient.CreateDmAsync(this.Id);
+        }
 
         /// <summary>
         /// Sends a direct message to this member. Creates a direct message channel if one does not exist already.

--- a/DSharpPlus/Entities/Voice/DiscordVoiceState.cs
+++ b/DSharpPlus/Entities/Voice/DiscordVoiceState.cs
@@ -150,7 +150,7 @@ namespace DSharpPlus.Entities
 
 		public override string ToString()
 		{
-			return $"{this.UserId.ToString(CultureInfo.InvariantCulture)} in {(this.GuildId ?? this.Channel.GuildId).ToString(CultureInfo.InvariantCulture)}";
+			return $"{this.UserId.ToString(CultureInfo.InvariantCulture)} in {(this.GuildId ?? this.Channel.GuildId.Value).ToString(CultureInfo.InvariantCulture)}";
 		}
 	}
 }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1165,6 +1165,9 @@ namespace DSharpPlus.Net
             var ret = JsonConvert.DeserializeObject<DiscordDmChannel>(res.Response);
             ret.Discord = this.Discord;
 
+            if (this.Discord is DiscordClient dc)
+                _ = dc._privateChannels.TryAdd(ret.Id, ret);
+
             return ret;
         }
 


### PR DESCRIPTION
# Summary
This PR attempts to fix DM channel caching by trying to cache it from rest, since a channel create event is no longer sent for DMs. This also allows us to fetch a cached DM channel rather than having to make a request every time, and we can ensure the state of the cache since it will be removed upon a DM channel delete. 

I also made guildId nullable on the `DiscordChannel` object since the `DiscordDMChannel` inherits from it.