### PR TITLE
Fix race condition: reaction removal (interactivity)

### DIFF
--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -35,7 +35,6 @@ namespace DSharpPlus.Interactivity.EventHandling
             {
                 var tcs = await request.GetTaskCompletionSourceAsync().ConfigureAwait(false);
                 await tcs.Task.ConfigureAwait(false);
-                await request.DoCleanupAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -44,6 +43,14 @@ namespace DSharpPlus.Interactivity.EventHandling
             finally
             {
                 this._requests.TryRemove(request);
+                try
+                {
+                    await request.DoCleanupAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    this._client.Logger.LogError(InteractivityEvents.InteractivityPaginationError, ex, "Exception occurred while paginating");
+                }
             }
         }
 


### PR DESCRIPTION
# Summary
This fixes an issue where interactivity reactions would get re-added due to the interactivityrequest class not getting removed before reactions would get removed. (This causes a race condition, re-adding reactions when really it shouldn't)

Ideally, we'd want to get this change in before the official 4.x release.

# Details
Made sure `TryRemove` from the `requests` list is executed before `DoCleanupAsync`.

# Notes
- Point of discussion, suggested by emzi: we could look into bubbling up exceptions from interactivity (from what I remember, a lot of it is just getting silently ignored. Might be favorable to have users handle these themselves.)
- The try/catch/finally now has a try/catch in it's finally block to ensure `DoCleanupAsync` does not throw again after removing the request. I am not entirely sure whether that would be the best solution. Also up for discussion?