### PR TITLE
Fix replies erroring out for invalid Ids

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -196,8 +196,7 @@ namespace DSharpPlus.Entities
                 else
                     this._files.Add(new DiscordMessageFile(file.Key, file.Value, null));
             }
-                
-
+            
             return this;
         }
 
@@ -206,6 +205,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="messageId">The ID of the message to reply to.</param>
         /// <param name="mention">If we should mention the user in the reply.</param>
+        /// <param name="failOnInvalidReply">Whether sending a reply that references an invalid message should be </param>
         /// <returns></returns>
         public DiscordMessageBuilder WithReply(ulong messageId, bool mention = false, bool failOnInvalidReply = false)
         {

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -57,6 +57,13 @@ namespace DSharpPlus.Entities
         /// Gets if the Reply should mention the user.
         /// </summary>
         public bool MentionOnReply { get; private set; } = false;
+        
+        /// <summary>
+        /// Gets if the Reply will error if the Reply Message Id does not reference a valid message.
+        /// <para>If set to false, invalid replies are send as a regular message.</para>
+        /// <para>Defaults to false.</para>
+        /// </summary>
+        public bool FailOnInvalidReply { get; set; }
 
         /// <summary>
         /// Sets the Content of the Message.
@@ -90,6 +97,8 @@ namespace DSharpPlus.Entities
             this.Embed = embed;
             return this;
         }
+        
+        
 
         /// <summary>
         /// Sets if the message has allowed mentions.
@@ -198,13 +207,14 @@ namespace DSharpPlus.Entities
         /// <param name="messageId">The ID of the message to reply to.</param>
         /// <param name="mention">If we should mention the user in the reply.</param>
         /// <returns></returns>
-        public DiscordMessageBuilder WithReply(ulong messageId, bool mention = false)
+        public DiscordMessageBuilder WithReply(ulong messageId, bool mention = false, bool failOnInvalidReply = false)
         {
             this.ReplyId = messageId;
             this.MentionOnReply = mention;
-
+            this.FailOnInvalidReply = failOnInvalidReply;
             return this;
         }
+        
 
         /// <summary>
         /// Sends the Message to a specific channel

--- a/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using DSharpPlus.Entities;
 using Newtonsoft.Json;
 
@@ -89,8 +89,12 @@ namespace DSharpPlus.Net.Abstractions
     {
         [JsonProperty("tts", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsTTS { get; set; }
+        
         [JsonProperty("message_reference", NullValueHandling = NullValueHandling.Ignore)]
         public InternalDiscordMessageReference? MessageReference { get; set; }
+
+        [JsonProperty("fail_if_not_exists", NullValueHandling = NullValueHandling.Ignore)]
+        public bool FailIfNotExists { get; set; }
     }
 
     internal sealed class RestChannelMessageCreateMultipartPayload


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
As noted [here](https://discord.com/developers/docs/resources/channel#message-object-message-reference-structure), Discord added a new field to messages which indicates whether replies should be sent as a normal message or error out. 

# Details
Yes

# Changes proposed
- Add a boolean property (which has a default value of false) to prevent Discord from erroring out if a reply does not exist. 
# Notes
This could actually happen for a number of reasons, for example, a message getting deleted during command execution. 