### PR TITLE
Make RespondAsync produce a non-mentioning reply.

### DIFF
--- a/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
@@ -47,7 +47,7 @@ namespace DSharpPlus.CommandsNext
         public DiscordMember Member 
             => this._lazyAssMember.Value;
 
-        private Lazy<DiscordMember> _lazyAssMember;
+        private readonly Lazy<DiscordMember> _lazyAssMember;
 
         /// <summary>
         /// Gets the CommandsNext service instance that handled this command.

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -19,7 +19,7 @@ namespace DSharpPlus
         public override IReadOnlyDictionary<ulong, DiscordGuild> Guilds
             => _guilds_lazy.Value;
 
-        internal Dictionary<ulong, DiscordGuild> _guilds = new Dictionary<ulong, DiscordGuild>();
+        internal Dictionary<ulong, DiscordGuild> _guilds = new();
         private Lazy<IReadOnlyDictionary<ulong, DiscordGuild>> _guilds_lazy;
 
         public DiscordRestClient(DiscordConfiguration config) : base(config)
@@ -183,7 +183,7 @@ namespace DSharpPlus
         /// <param name="deafened">Whether this user should be deafened on join</param>
         /// <returns></returns>
         public Task<DiscordMember> AddGuildMemberAsync(ulong guild_id, ulong user_id, string access_token, string nick, IEnumerable<DiscordRole> roles, bool muted, bool deafened)
-            => this.ApiClient.AddGuildMemberAsync(guild_id, user_id, this.Configuration.Token, nick, roles, muted, deafened);
+            => this.ApiClient.AddGuildMemberAsync(guild_id, user_id, access_token, nick, roles, muted, deafened);
 
         /// <summary>
         /// Gets all guild members
@@ -423,7 +423,7 @@ namespace DSharpPlus
         /// <param name="content">Message (text) content</param>
         /// <returns></returns>
         public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, string content)
-            => this.ApiClient.CreateMessageAsync(channel_id, content, null);
+            => this.ApiClient.CreateMessageAsync(channel_id, content, null, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
 
         /// <summary>
         /// Sends a message
@@ -432,7 +432,7 @@ namespace DSharpPlus
         /// <param name="embed">Embed to attach</param>
         /// <returns></returns>
         public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, DiscordEmbed embed)
-            => this.ApiClient.CreateMessageAsync(channel_id, null, embed);
+            => this.ApiClient.CreateMessageAsync(channel_id, null, embed, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
 
         /// <summary>
         /// Sends a message
@@ -442,7 +442,7 @@ namespace DSharpPlus
         /// <param name="embed">Embed to attach</param>
         /// <returns></returns>
         public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, string content, DiscordEmbed embed)
-            => this.ApiClient.CreateMessageAsync(channel_id, content, embed);
+            => this.ApiClient.CreateMessageAsync(channel_id, content, embed, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
 
         /// <summary>
         /// Sends a message

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -1,5 +1,4 @@
-﻿#pragma warning disable CS0618
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -29,7 +28,7 @@ namespace DSharpPlus
         internal bool _isShard = false;
         internal RingBuffer<DiscordMessage> MessageCache { get; }
 
-        private List<BaseExtension> _extensions = new List<BaseExtension>();
+        private List<BaseExtension> _extensions = new();
         private StatusUpdate _status = null;
 
         private ManualResetEventSlim ConnectionLock { get; } = new ManualResetEventSlim(true);
@@ -76,7 +75,7 @@ namespace DSharpPlus
         /// ID.
         /// </summary>
         public IReadOnlyDictionary<ulong, DiscordDmChannel> PrivateChannels { get; }
-        internal ConcurrentDictionary<ulong, DiscordDmChannel> _privateChannels = new ConcurrentDictionary<ulong, DiscordDmChannel>();
+        internal ConcurrentDictionary<ulong, DiscordDmChannel> _privateChannels = new();
 
         /// <summary>
         /// Gets a dictionary of guilds that this client is in. The dictionary's key is the guild ID. Note that the
@@ -84,7 +83,7 @@ namespace DSharpPlus
         /// <see cref="GuildAvailable"/> or <see cref="GuildDownloadCompleted"/> events haven't been fired yet)
         /// </summary>
         public override IReadOnlyDictionary<ulong, DiscordGuild> Guilds { get; }
-        internal ConcurrentDictionary<ulong, DiscordGuild> _guilds = new ConcurrentDictionary<ulong, DiscordGuild>();
+        internal ConcurrentDictionary<ulong, DiscordGuild> _guilds = new();
 
         /// <summary>
         /// Gets the WS latency for this client.
@@ -100,8 +99,7 @@ namespace DSharpPlus
         public IReadOnlyDictionary<ulong, DiscordPresence> Presences
             => this._presencesLazy.Value;
 
-        internal Dictionary<ulong, DiscordPresence> _presences = new 
-            Dictionary<ulong, DiscordPresence>();
+        internal Dictionary<ulong, DiscordPresence> _presences = new();
         private Lazy<IReadOnlyDictionary<ulong, DiscordPresence>> _presencesLazy;
         #endregion
 
@@ -301,7 +299,7 @@ namespace DSharpPlus
             }
 
             // non-closure, hence args
-            void FailConnection(ManualResetEventSlim cl)
+            static void FailConnection(ManualResetEventSlim cl)
             {
                 // unlock this (if applicable) so we can let others attempt to connect
                 cl?.Set();
@@ -371,7 +369,7 @@ namespace DSharpPlus
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, string content = null)
-            => this.ApiClient.CreateMessageAsync(channel.Id, content, null);
+            => this.ApiClient.CreateMessageAsync(channel.Id, content, embed: null, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
 
         /// <summary>
         /// Sends a message
@@ -384,7 +382,7 @@ namespace DSharpPlus
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, DiscordEmbed embed = null)
-            => this.ApiClient.CreateMessageAsync(channel.Id, null, embed);
+            => this.ApiClient.CreateMessageAsync(channel.Id, null, embed, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
 
         /// <summary>
         /// Sends a message
@@ -398,7 +396,7 @@ namespace DSharpPlus
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(DiscordChannel channel, string content = null, DiscordEmbed embed = null)
-            => this.ApiClient.CreateMessageAsync(channel.Id, content, embed);
+            => this.ApiClient.CreateMessageAsync(channel.Id, content, embed, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
 
         /// <summary>
         /// Sends a message

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -83,9 +83,9 @@ namespace DSharpPlus.Entities
             => this._permissionOverwritesLazy.Value;
 
         [JsonProperty("permission_overwrites", NullValueHandling = NullValueHandling.Ignore)]
-        internal List<DiscordOverwrite> _permissionOverwrites = new List<DiscordOverwrite>();
+        internal List<DiscordOverwrite> _permissionOverwrites = new();
         [JsonIgnore]
-        private Lazy<IReadOnlyList<DiscordOverwrite>> _permissionOverwritesLazy;
+        private readonly Lazy<IReadOnlyList<DiscordOverwrite>> _permissionOverwritesLazy;
 
         /// <summary>
         /// Gets the channel's topic. This is applicable to text channels only.
@@ -196,7 +196,7 @@ namespace DSharpPlus.Entities
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
                 throw new ArgumentException("Cannot send a text message to a non-text channel.");
 
-            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, null);
+            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, null, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
         }
 
         /// <summary>
@@ -213,7 +213,7 @@ namespace DSharpPlus.Entities
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
                 throw new ArgumentException("Cannot send a text message to a non-text channel.");
 
-            return this.Discord.ApiClient.CreateMessageAsync(this.Id, null, embed);
+            return this.Discord.ApiClient.CreateMessageAsync(this.Id, null, embed, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
         }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace DSharpPlus.Entities
             if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
                 throw new ArgumentException("Cannot send a text message to a non-text channel.");
 
-            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, embed);
+            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, embed, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
         }
 
         /// <summary>
@@ -442,7 +442,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot get a negative number of messages.");
 
             if (limit == 0)
-                return new DiscordMessage[0];
+                return Array.Empty<DiscordMessage>();
 
             //return this.Discord.ApiClient.GetChannelMessagesAsync(this.Id, limit, before, after, around);
             if (limit > 100 && around != null)
@@ -450,10 +450,10 @@ namespace DSharpPlus.Entities
 
             var msgs = new List<DiscordMessage>(limit);
             var remaining = limit;
-            var lastCount = 0;
             ulong? last = null;
             var isAfter = after != null;
 
+            int lastCount;
             do
             {
                 var fetchSize = remaining > 100 ? 100 : remaining;
@@ -796,7 +796,7 @@ namespace DSharpPlus.Entities
         /// <returns>Whether the <see cref="DiscordChannel"/> is equal to this <see cref="DiscordChannel"/>.</returns>
         public bool Equals(DiscordChannel e)
         {
-            if (ReferenceEquals(e, null))
+            if (e is null)
                 return false;
 
             if (ReferenceEquals(this, e))

--- a/DSharpPlus/Entities/Channel/Message/DiscordMentions.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMentions.cs
@@ -34,6 +34,7 @@ namespace DSharpPlus.Entities
         [JsonProperty("parse", NullValueHandling = NullValueHandling.Ignore)]
         public IEnumerable<string> Parse { get; }
         
+        // WHY IS THERE NO DOCSTRING HERE
         [JsonProperty("replied_user", NullValueHandling = NullValueHandling.Ignore)]
         public bool? RepliedUser { get; }
 
@@ -47,7 +48,7 @@ namespace DSharpPlus.Entities
             // Doing this allows for "no parsing"
             if (!mentions.Any())
             {
-                Parse = new string[0];
+                Parse = Array.Empty<string>();
                 this.RepliedUser = mention;
                 return;
             }

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -1,12 +1,10 @@
-#pragma warning disable CS0618
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {
@@ -22,12 +20,12 @@ namespace DSharpPlus.Entities
             this._mentionedChannelsLazy = new Lazy<IReadOnlyList<DiscordChannel>>(() => {
                 if (this._mentionedChannels != null)
                     return new ReadOnlyCollection<DiscordChannel>(this._mentionedChannels);
-                return new DiscordChannel[0];
+                return Array.Empty<DiscordChannel>();
             });
             this._mentionedRolesLazy = new Lazy<IReadOnlyList<DiscordRole>>(() => {
                 if (this._mentionedRoles != null)
                     return new ReadOnlyCollection<DiscordRole>(this._mentionedRoles);
-                return new DiscordRole[0];
+                return Array.Empty<DiscordRole>();
             });
             this._mentionedUsersLazy = new Lazy<IReadOnlyList<DiscordUser>>(() => new ReadOnlyCollection<DiscordUser>(this._mentionedUsers));
             this._reactionsLazy = new Lazy<IReadOnlyList<DiscordReaction>>(() => new ReadOnlyCollection<DiscordReaction>(this._reactions));
@@ -151,7 +149,7 @@ namespace DSharpPlus.Entities
         [JsonProperty("mentions", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordUser> _mentionedUsers;
         [JsonIgnore]
-        Lazy<IReadOnlyList<DiscordUser>> _mentionedUsersLazy;
+        readonly Lazy<IReadOnlyList<DiscordUser>> _mentionedUsersLazy;
 
         // TODO this will probably throw an exception in DMs since it tries to wrap around a null List...
         // this is probably low priority but need to find out a clean way to solve it...
@@ -165,7 +163,7 @@ namespace DSharpPlus.Entities
         [JsonIgnore]
         internal List<DiscordRole> _mentionedRoles;
         [JsonIgnore]
-        private Lazy<IReadOnlyList<DiscordRole>> _mentionedRolesLazy;
+        private readonly Lazy<IReadOnlyList<DiscordRole>> _mentionedRolesLazy;
 
         /// <summary>
         /// Gets channels mentioned by this message.
@@ -177,7 +175,7 @@ namespace DSharpPlus.Entities
         [JsonIgnore]
         internal List<DiscordChannel> _mentionedChannels;
         [JsonIgnore]
-        private Lazy<IReadOnlyList<DiscordChannel>> _mentionedChannelsLazy;
+        private readonly Lazy<IReadOnlyList<DiscordChannel>> _mentionedChannelsLazy;
 
         /// <summary>
         /// Gets files attached to this message.
@@ -187,9 +185,9 @@ namespace DSharpPlus.Entities
             => this._attachmentsLazy.Value;
 
         [JsonProperty("attachments", NullValueHandling = NullValueHandling.Ignore)]
-        internal List<DiscordAttachment> _attachments = new List<DiscordAttachment>();
+        internal List<DiscordAttachment> _attachments = new();
         [JsonIgnore]
-        private Lazy<IReadOnlyList<DiscordAttachment>> _attachmentsLazy;
+        private readonly Lazy<IReadOnlyList<DiscordAttachment>> _attachmentsLazy;
 
         /// <summary>
         /// Gets embeds attached to this message.
@@ -199,9 +197,9 @@ namespace DSharpPlus.Entities
             => this._embedsLazy.Value;
 
         [JsonProperty("embeds", NullValueHandling = NullValueHandling.Ignore)]
-        internal List<DiscordEmbed> _embeds = new List<DiscordEmbed>();
+        internal List<DiscordEmbed> _embeds = new();
         [JsonIgnore]
-        private Lazy<IReadOnlyList<DiscordEmbed>> _embedsLazy;
+        private readonly Lazy<IReadOnlyList<DiscordEmbed>> _embedsLazy;
 
         /// <summary>
         /// Gets reactions used on this message.
@@ -211,9 +209,9 @@ namespace DSharpPlus.Entities
             => this._reactionsLazy.Value;
 
         [JsonProperty("reactions", NullValueHandling = NullValueHandling.Ignore)]
-        internal List<DiscordReaction> _reactions = new List<DiscordReaction>();
+        internal List<DiscordReaction> _reactions = new();
         [JsonIgnore]
-        private Lazy<IReadOnlyList<DiscordReaction>> _reactionsLazy;
+        private readonly Lazy<IReadOnlyList<DiscordReaction>> _reactionsLazy;
 
         /*
         /// <summary>
@@ -254,14 +252,14 @@ namespace DSharpPlus.Entities
         public DiscordMessageApplication Application { get; internal set; }
 
         [JsonProperty("message_reference", NullValueHandling = NullValueHandling.Ignore)]
-        internal InternalDiscordMessageReference? _reference { get; set; }
+        internal InternalDiscordMessageReference? InternalReference { get; set; }
 
         /// <summary>
         /// Gets the original message reference from the crossposted message.
         /// </summary>
         [JsonIgnore]
         public DiscordMessageReference Reference
-            => (this._reference.HasValue) ? this?.InternalBuildMessageReference() : null;
+            => (this.InternalReference.HasValue) ? this?.InternalBuildMessageReference() : null;
 
         /// <summary>
         /// Gets the bitwise flags for this message.
@@ -281,7 +279,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public Uri JumpLink => this._jumpLink.Value;
-        private Lazy<Uri> _jumpLink;
+        private readonly Lazy<Uri> _jumpLink;
 
         /// <summary>
         /// Gets stickers for this message.
@@ -291,9 +289,9 @@ namespace DSharpPlus.Entities
             => this._stickersLazy.Value;
 
         [JsonProperty("stickers", NullValueHandling = NullValueHandling.Ignore)]
-        internal List<DiscordMessageSticker> _stickers = new List<DiscordMessageSticker>();
+        internal List<DiscordMessageSticker> _stickers = new();
         [JsonIgnore]
-        private Lazy<IReadOnlyList<DiscordMessageSticker>> _stickersLazy;
+        private readonly Lazy<IReadOnlyList<DiscordMessageSticker>> _stickersLazy;
 
         [JsonProperty("guild_id", NullValueHandling = NullValueHandling.Ignore)]
         internal ulong? GuildId { get; set; }
@@ -313,9 +311,9 @@ namespace DSharpPlus.Entities
         internal DiscordMessageReference InternalBuildMessageReference()
         {
             var client = this.Discord as DiscordClient;
-            var guildId = this._reference.Value.guildId;
-            var channelId = this._reference.Value.channelId;
-            var messageId = this._reference.Value.messageId;
+            var guildId = this.InternalReference.Value.GuildId;
+            var channelId = this.InternalReference.Value.ChannelId;
+            var messageId = this.InternalReference.Value.MessageId;
 
             var reference = new DiscordMessageReference();
 
@@ -517,7 +515,7 @@ namespace DSharpPlus.Entities
             => this.Discord.ApiClient.UnpinMessageAsync(this.ChannelId, this.Id);
 
         /// <summary>
-        /// Responds to the message.
+        /// Responds to the message. This produces a reply.
         /// </summary>
         /// <param name="content">Message content to respond with.</param>
         /// <returns>The sent message.</returns>
@@ -526,10 +524,10 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> RespondAsync(string content) 
-            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, content, null);
+            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, content, null, replyMessageId: this.Id, mentionReply: false, failOnInvalidReply: false);
 
         /// <summary>
-        /// Responds to the message.
+        /// Responds to the message. This produces a reply.
         /// </summary>
         /// <param name="embed">Embed to attach to the message.</param>
         /// <returns>The sent message.</returns>
@@ -538,10 +536,10 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> RespondAsync(DiscordEmbed embed)
-            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, null, embed);
+            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, null, embed, replyMessageId: this.Id, mentionReply: false, failOnInvalidReply: false);
 
         /// <summary>
-        /// Responds to the message.
+        /// Responds to the message. This produces a reply.
         /// </summary>
         /// <param name="content">Message content to respond with.</param>
         /// <param name="embed">Embed to attach to the message.</param>
@@ -551,10 +549,10 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> RespondAsync(string content, DiscordEmbed embed)
-            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, content, embed);
+            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, content, embed, replyMessageId: this.Id, mentionReply: false, failOnInvalidReply: false);
 
         /// <summary>
-        /// Responds to the message.
+        /// Responds to the message. This produces a reply.
         /// </summary>
         /// <param name="builder">The Discord message builder.</param>
         /// <returns>The sent message.</returns>
@@ -563,10 +561,10 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> RespondAsync(DiscordMessageBuilder builder)
-            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, builder);
+            => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, builder.WithReply(this.Id, mention: false, failOnInvalidReply: false));
 
         /// <summary>
-        /// Responds to the message.
+        /// Responds to the message. This produces a reply.
         /// </summary>
         /// <param name="action">The Discord message builder.</param>
         /// <returns>The sent message.</returns>
@@ -578,11 +576,11 @@ namespace DSharpPlus.Entities
         {
             var builder = new DiscordMessageBuilder();
             action(builder);
-            return this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, builder);
+            return this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, builder.WithReply(this.Id, mention: false, failOnInvalidReply: false));
         }
 
         /// <summary>
-        /// Creates a reaction to this message
+        /// Creates a reaction to this message.
         /// </summary>
         /// <param name="emoji">The emoji you want to react with, either an emoji or name:id</param>
         /// <returns></returns>
@@ -661,7 +659,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot get a negative number of reactions' users.");
 
             if (limit == 0)
-                return new DiscordUser[0];
+                return Array.Empty<DiscordUser>();
 
             var users = new List<DiscordUser>(limit);
             var remaining = limit;
@@ -709,7 +707,7 @@ namespace DSharpPlus.Entities
         /// <returns>Whether the <see cref="DiscordMessage"/> is equal to this <see cref="DiscordMessage"/>.</returns>
         public bool Equals(DiscordMessage e)
         {
-            if (ReferenceEquals(e, null))
+            if (e is null)
                 return false;
 
             if (ReferenceEquals(this, e))

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -46,7 +46,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         public IReadOnlyCollection<DiscordMessageFile> Files => this._files;
 
-        internal List<DiscordMessageFile> _files = new List<DiscordMessageFile>();
+        internal List<DiscordMessageFile> _files = new();
 
         /// <summary>
         /// Gets the Reply Message ID.

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageReference.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageReference.cs
@@ -31,12 +31,12 @@ namespace DSharpPlus.Entities
     internal struct InternalDiscordMessageReference
     {
         [JsonProperty("message_id", NullValueHandling = NullValueHandling.Ignore)]
-        internal ulong? messageId { get; set; }
+        internal ulong? MessageId { get; set; }
 
         [JsonProperty("channel_id", NullValueHandling = NullValueHandling.Ignore)]
-        internal ulong? channelId { get; set; }
+        internal ulong? ChannelId { get; set; }
 
         [JsonProperty("guild_id", NullValueHandling = NullValueHandling.Ignore)]
-        internal ulong? guildId { get; set; }
+        internal ulong? GuildId { get; set; }
     }
 }

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -176,9 +176,7 @@ namespace DSharpPlus.Net
                     await bucket.TryResetLimitAsync(now).ConfigureAwait(false);
 
                     // Decrement the remaining number of requests as there can be other concurrent requests before this one finishes and has a chance to update the bucket
-#pragma warning disable 420 // interlocked access is always volatile
                     if (Interlocked.Decrement(ref bucket._remaining) < 0)
-#pragma warning restore 420 // blaze it
                     {
                         this.Logger.LogDebug(LoggerEvents.RatelimitDiag, "Request for {0} is blocked", bucket.ToString());
                         var delay = bucket.Reset - now;
@@ -372,9 +370,7 @@ namespace DSharpPlus.Net
             {
                 if (bucket._limitTesting == 0)
                 {
-#pragma warning disable 420 // interlocked access is always volatile
                     if (Interlocked.CompareExchange(ref bucket._limitTesting, 1, 0) == 0)
-#pragma warning restore 420
                     {
                         // if we got here when the first request was just finishing, we must not create the waiter task as it would signel ExecureRequestAsync to bypass rate limiting
                         if (bucket._limitValid)


### PR DESCRIPTION
# Summary
Alters the behaviour of `.RespondAsync` methods as promised.

# Details
They will now produce a non-mentioning response by default.

# Notes
Editing replies causes them to lose their non-mentioning status. This appears to be a bug in the implementation itself, rather than something I introduced.