### PR TITLE
Fix inline replies inconsistently throwing Bad Request: 400

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageReference.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageReference.cs
@@ -38,5 +38,8 @@ namespace DSharpPlus.Entities
 
         [JsonProperty("guild_id", NullValueHandling = NullValueHandling.Ignore)]
         internal ulong? GuildId { get; set; }
+        
+        [JsonProperty("fail_if_not_exists", NullValueHandling = NullValueHandling.Ignore)]
+        public bool FailIfNotExists { get; set; }
     }
 }

--- a/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
@@ -92,9 +92,6 @@ namespace DSharpPlus.Net.Abstractions
         
         [JsonProperty("message_reference", NullValueHandling = NullValueHandling.Ignore)]
         public InternalDiscordMessageReference? MessageReference { get; set; }
-
-        [JsonProperty("fail_if_not_exists", NullValueHandling = NullValueHandling.Ignore)]
-        public bool FailIfNotExists { get; set; }
     }
 
     internal sealed class RestChannelMessageCreateMultipartPayload

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -794,12 +794,9 @@ namespace DSharpPlus.Net
             };
 
             if (replyMessageId != null)
-            {
-                pld.MessageReference = new InternalDiscordMessageReference { MessageId = replyMessageId };
-                pld.FailIfNotExists = failOnInvalidReply;
-            }
+                pld.MessageReference = new InternalDiscordMessageReference { MessageId = replyMessageId, FailIfNotExists = failOnInvalidReply };
 
-            if (replyMessageId != null)
+                if (replyMessageId != null)
                 pld.Mentions = new DiscordMentions(Mentions.None, mentionReply);
 
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
@@ -830,10 +827,8 @@ namespace DSharpPlus.Net
             };
 
             if (builder.ReplyId != null)
-            {
-                pld.MessageReference = new InternalDiscordMessageReference { MessageId = builder.ReplyId };
-                pld.FailIfNotExists = builder.FailOnInvalidReply;
-            }
+                pld.MessageReference = new InternalDiscordMessageReference { MessageId = builder.ReplyId, FailIfNotExists = builder.FailOnInvalidReply};
+
 
             if (builder.Mentions != null || builder.ReplyId != null)
                 pld.Mentions = new DiscordMentions(builder.Mentions ?? Mentions.None, builder.MentionOnReply);


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
In summary, I was a dumbass and didn't pay attention to where I added `if_not_exists`. It's supposed to be on the message_reference, not the message create payload

# Details
c:

# Changes proposed

# Notes
Please don't grill me (again), Emzi.