### PR TITLE
Fix Lavalink URLs

### DIFF
--- a/docs/articles/audio/lavalink/setup.md
+++ b/docs/articles/audio/lavalink/setup.md
@@ -4,21 +4,21 @@ title: Lavalink Setup
 ---
 
 # Lavalink - the newer, better way to do music
-[Lavalink](https://github.com/Frederikam/Lavalink) is a standalone program, written in Java, using JDA. It's a 
+[Lavalink](https://github.com/freyacodes/Lavalink) is a standalone program, written in Java. It's a 
 lightweight solution for playing music from sources such as YouTube or 
 Soundcloud. Unlike raw voice solutions, such as VoiceNext, Lavalink can handle 
 hundreds of concurrent streams, and supports sharding.
 
 ## Configuring Java
-In order to run Lavalink, you must have Java 13 or greater installed. Certain Java versions may not be functional with Lavalink, so it is best to check the [requirements](https://github.com/Frederikam/Lavalink#requirements) before downloading.
+In order to run Lavalink, you must have Java 13 or greater installed. Certain Java versions may not be functional with Lavalink, so it is best to check the [requirements](https://github.com/freyacodes/Lavalink#requirements) before downloading.
 The latest releases can be found [here](https://www.oracle.com/technetwork/java/javase/downloads/index.html).
 
 Make sure the location of the newest JRE's bin folder is added to your system variable's path. This will make the `java` command run from the latest runtime. You can verify that you have the right version by entering `java -version` in your command prompt or terminal.
 
 ## Downloading Lavalink  
-Next, head over to the [releases](https://github.com/Frederikam/Lavalink/releases) tab on the Lavalink GitHub page and download the Jar file from the latest version. Alternatively, stable builds with the latest changes can be found on their [CI Server](https://ci.fredboat.com/viewLog.html?buildId=lastSuccessful&buildTypeId=Lavalink_Build&tab=artifacts&guest=1).
+Next, head over to the [releases](https://github.com/freyacodes/Lavalink/releases) tab on the Lavalink GitHub page and download the Jar file from the latest version. Alternatively, stable builds with the latest changes can be found on their [CI Server](https://ci.fredboat.com/viewLog.html?buildId=lastSuccessful&buildTypeId=Lavalink_Build&tab=artifacts&guest=1).
 
-The program will not be ready to run yet, as you will need to create a configuration file first. To do so, create a new YAML file called `application.yml`, and use the [example file](https://github.com/Frederikam/Lavalink/blob/master/LavalinkServer/application.yml.example), or copy this text:
+The program will not be ready to run yet, as you will need to create a configuration file first. To do so, create a new YAML file called `application.yml`, and use the [example file](https://github.com/freyacodes/Lavalink/blob/master/LavalinkServer/application.yml.example), or copy this text:
 
 ```yaml
 server: # REST and WS server


### PR DESCRIPTION
# Summary
Fixes GitHub urls pointing at my repository. 

# Details
I have changed my name, and someone else has taken over my old username.

# Changes proposed
* Fixes URLs
* Removed mention of JDA. Lavalink does not use JDA
