### PR TITLE
Fixed typo in TryFromName method in DiscordEmoji.cs

### DIFF
--- a/DSharpPlus/Entities/Emoji/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/Emoji/DiscordEmoji.cs
@@ -327,7 +327,7 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Attempts to create an emoji obejct from emote name that includes colons (eg. :thinking:). This method also 
+        /// Attempts to create an emoji object from emote name that includes colons (eg. :thinking:). This method also 
         /// supports skin tone variations (eg. :ok_hand::skin-tone-2:), standard emoticons (eg. :D), as well as guild 
         /// emoji (still specified by :name:).
         /// </summary>

--- a/DSharpPlus/Entities/Emoji/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/Emoji/DiscordEmoji.cs
@@ -339,7 +339,7 @@ namespace DSharpPlus.Entities
             => TryFromName(client, name, true, out emoji);
 
         /// <summary>
-        /// Attempts to create an emoji obejct from emote name that includes colons (eg. :thinking:). This method also 
+        /// Attempts to create an emoji object from emote name that includes colons (eg. :thinking:). This method also 
         /// supports skin tone variations (eg. :ok_hand::skin-tone-2:), standard emoticons (eg. :D), as well as guild 
         /// emoji (still specified by :name:).
         /// </summary>


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Fixes typo in https://github.com/DSharpPlus/DSharpPlus/blob/1437dbcb598720b3c97244c8997dd0f36654482e/DSharpPlus/Entities/Emoji/DiscordEmoji.cs#L330

# Details
N/A

# Changes proposed
* Just a typo fix in docs.