### PR TITLE
Updates permissions to include Use Slash Commands

### DIFF
--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -4,7 +4,7 @@ namespace DSharpPlus
 {
     public static class PermissionMethods
     {
-        internal static Permissions FULL_PERMS { get; } = (Permissions)2147483647L;
+        internal static Permissions FULL_PERMS { get; } = (Permissions)4294967295L;
 
         /// <summary>
         /// Calculates whether this permission set contains the given permission.
@@ -68,7 +68,7 @@ namespace DSharpPlus
         /// Indicates all permissions are granted
         /// </summary>
         [PermissionString("All permissions")]
-        All = 2147483647,
+        All = 4294967295,
 
         /// <summary>
         /// Allows creation of instant channel invites.
@@ -248,7 +248,13 @@ namespace DSharpPlus
         /// Allows the user to go live.
         /// </summary>
         [PermissionString("Allow stream")]
-        Stream	= 0x0000000000000200
+        Stream	= 0x0000000000000200,
+
+        /// <summary>
+        /// Allows the user to use slash commands.
+        /// </summary>
+        [PermissionString("Use slash commands")]
+        UseSlashCommands = 0x0000000080000000
     }
 
     /// <summary>


### PR DESCRIPTION
# Summary
Implements the Use Slash Commands permission to `DSharpPlus.Permissions`

# Details
Adds the permission `UseSlashCommands` to the `Permissions` enum.

# Changes proposed
* Add `Permissions.UseSlashCommands` with a value of `0x0000000080000000`
* Modify the `FULL_PERMS` and `All` values to the result of the old `All` value and the value of `UseSlashCommands`