### PR TITLE
Fix interaction data option value conversion

### DIFF
--- a/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
@@ -21,40 +21,42 @@ namespace DSharpPlus.Entities
         [JsonProperty("type")]
         public ApplicationCommandOptionType Type { get; internal set; }
 
+        [JsonProperty("value")]
+        internal string _value { get; set; }
+
         /// <summary>
         /// Gets the value of this interaction parameter. 
-        /// <para>This can be cast to an <see langword="int"></see> / <see langword="long"/>, <see langword="bool"></see>, <see langword="string"></see> or <see langword="ulong"/> depending on the <see cref="Name"/></para>
+        /// <para>This can be cast to a <see langword="long"/>, <see langword="bool"></see>, <see langword="string"></see> or <see langword="ulong"/> depending on the <see cref="Type"/></para>
         /// </summary>
-        [JsonProperty("value")]
-        [JsonConverter(typeof(DiscordInteractionOptionTypeConverter))]
-        public object Value { get; internal set; }
+        [JsonIgnore]
+        public object Value
+        {
+            get
+            {
+                switch (this.Type)
+                {
+                    case ApplicationCommandOptionType.Boolean:
+                        return bool.Parse(this._value);
+                    case ApplicationCommandOptionType.Integer:
+                        return long.Parse(this._value);
+                    case ApplicationCommandOptionType.String:
+                        return this._value;
+                    case ApplicationCommandOptionType.Channel:
+                        return ulong.Parse(this._value);
+                    case ApplicationCommandOptionType.User:
+                        return ulong.Parse(this._value);
+                    case ApplicationCommandOptionType.Role:
+                        return ulong.Parse(this._value);
+                    default:
+                        return this._value;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets the additional parameters if this parameter is a subcommand.
         /// </summary>
         [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
         public IEnumerable<DiscordInteractionDataOption> Options { get; internal set; }
-    }
-
-    internal sealed class DiscordInteractionOptionTypeConverter : JsonConverter
-    {
-        public override bool CanConvert(Type objectType)
-            => objectType == typeof(string) || objectType == typeof(long) || objectType == typeof(bool) || objectType == typeof(int);
-
-
-        public override object ReadJson(JsonReader reader, Type objectType, object value, JsonSerializer serializer)
-        {
-            if (reader.Value is string str)
-            {
-                // For snowflakes
-                if (ulong.TryParse(str, out var ul))
-                    return ul;
-            }
-
-            return reader.Value;
-        }
-
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-            => serializer.Serialize(writer, value);
     }
 }


### PR DESCRIPTION
# Summary
Changes the interaction data option value to convert using the `Type` value.

# Details
The previous implementation would bug out if a ulong was passed into a string parameter. This uses the type value given by discord to avoid that kind of confusion.

# Changes proposed
* Remove the `JsonConverter` and use a switch instead.