### PR TITLE
fix(HasPermission): Always return true if permission contains admin.

### DIFF
--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -12,7 +12,8 @@ namespace DSharpPlus
         /// <param name="p">The permissions to calculate from</param>
         /// <param name="permission">permission you want to check</param>
         /// <returns></returns>
-        public static bool HasPermission(this Permissions p, Permissions permission) => (p & permission) == permission;
+        public static bool HasPermission(this Permissions p, Permissions permission) 
+            => p.HasFlag(Permissions.Administrator) || (p & permission) == permission;
 
         /// <summary>
         /// Grants permissions.


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Fixes #846 

# Details
Changes the `HasPermission` method to always return true if the permission set contains admin.