### PR TITLE
Fix overwrite builder nullrefs

### DIFF
--- a/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwriteBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwriteBuilder.cs
@@ -29,12 +29,23 @@ namespace DSharpPlus.Entities
         public SnowflakeObject Target { get; private set; }
 
         /// <summary>
-        /// Creates a new Discord permission overwrite builder. This class can be used to construct permission overwrites for guild channels, used when creating channels.
+        /// Creates a new Discord permission overwrite builder for a member. This class can be used to construct permission overwrites for guild channels, used when creating channels.
         /// </summary>
-        public DiscordOverwriteBuilder()
+        public DiscordOverwriteBuilder(DiscordMember member)
         {
-
+            this.Target = member;
+            this.Type = OverwriteType.Member;
         }
+        /// <summary>
+        /// Creates a new Discord permission overwrite builder for a role. This class can be used to construct permission overwrites for guild channels, used when creating channels.
+        /// </summary>
+        public DiscordOverwriteBuilder(DiscordRole role)
+        {
+            this.Target = role;
+            this.Type = OverwriteType.Role;
+        }
+
+        internal DiscordOverwriteBuilder() { }
 
         /// <summary>
         /// Allows a permission for this overwrite.

--- a/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwriteBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwriteBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Newtonsoft.Json;
+using System;
 
 namespace DSharpPlus.Entities
 {
@@ -45,7 +46,14 @@ namespace DSharpPlus.Entities
             this.Type = OverwriteType.Role;
         }
 
-        internal DiscordOverwriteBuilder() { }
+        /// <summary>
+        /// Creates a new Discord permission overwrite builder. This class can be used to construct permission overwrites for guild channels, used when creating channels.
+        /// </summary>
+        [Obsolete("Will be removed in 5.0. Use specialized constructors instead", false)]
+        public DiscordOverwriteBuilder()
+        {
+            
+        }
 
         /// <summary>
         /// Allows a permission for this overwrite.

--- a/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwriteBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwriteBuilder.cs
@@ -1,6 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
-using System;
 
 namespace DSharpPlus.Entities
 {


### PR DESCRIPTION
# Summary
Makes the overwrite builder constructor take a role or member.

# Details
Previously you could make an overwrite builder without setting a target which would cause a null reference exception. Since it's required to set one, I added constructors for role and member.