### PR TITLE
Match animated emojis

### DIFF
--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -125,7 +125,7 @@ namespace DSharpPlus
 
         internal static bool ContainsEmojis(string message)
         {
-            string pattern = @"<:(.*):(\d+)>";
+            string pattern = @"<a?:(.*):(\d+)>";
             Regex regex = new Regex(pattern, RegexOptions.ECMAScript);
             return regex.IsMatch(message);
         }
@@ -156,7 +156,7 @@ namespace DSharpPlus
 
         internal static IEnumerable<ulong> GetEmojis(DiscordMessage message)
         {
-            var regex = new Regex(@"<:([a-zA-Z0-9_]+):(\d+)>", RegexOptions.ECMAScript);
+            var regex = new Regex(@"<a?:([a-zA-Z0-9_]+):(\d+)>", RegexOptions.ECMAScript);
             var matches = regex.Matches(message.Content);
             foreach (Match match in matches)
                 yield return ulong.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Your regex was :b:orked

# Details
I don't know what they're used for, but I noticed regexes that matched emojis don't match animated emojis which have the structure of `<a:name:id>` where regular emojis do not have the `a` there.

# Changes proposed
Added `a?` to appropriate regexes in Utilities.cs

# Notes
I totally understand if this gets shot down for being a micro-pr; I was browsing through code while looking for something else and noticed this. Kinda bugged me.