### PR TITLE
Changed CommandGroup ExecuteAsync to throw CommandNotFoundException

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -62,7 +62,7 @@ Building this way outputs NuGet packages, and a documentation package. Ensure yo
 ### GNU/Linux
 When all necessary prerequisites are installed, you can proceed to building. There are technically 2 ways to build the library, though both of them perform the same steps, they are just invoked slightly differently.
 
-#### Through Visual Studio COde
+#### Through Visual Studio Code
 1. Open Visual Studio Code and open the folder to which you cloned DSharpPlus as your workspace.
 2. Select Build > Run Task...
 3. Select `buildRelease` task and wait for it to finish.

--- a/DSharpPlus.CommandsNext/Entities/CommandGroup.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandGroup.cs
@@ -70,12 +70,20 @@ namespace DSharpPlus.CommandsNext
             }
 
             if (!this.IsExecutableWithoutSubcommands)
+            {
+                string exMsg;
+                if (cn == null)
+                    exMsg = base.Name;
+                else
+                    exMsg = base.Name + " " + cn;
                 return new CommandResult
                 {
                     IsSuccessful = false,
-                    Exception = new InvalidOperationException("No matching subcommands were found, and this group is not executable."),
+                    Exception = new CommandNotFoundException(exMsg),
                     Context = ctx
                 };
+            }
+                
 
             return await base.ExecuteAsync(ctx).ConfigureAwait(false);
         }

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -152,11 +152,11 @@ namespace DSharpPlus.Test
             return Task.CompletedTask;
         }
 
-        //private Task Discord_ClientErrored(DiscordClient client, ClientErrorEventArgs e)
-        //{
-        //    e.Client.Logger.LogError(TestBotEventId, e.Exception, "Client threw an exception");
-        //    return Task.CompletedTask;
-        //}
+        /*private Task Discord_ClientErrored(DiscordClient client, ClientErrorEventArgs e)
+        {
+            client.Logger.LogError(TestBotEventId, e.Exception, "Client threw an exception");
+            return Task.CompletedTask;
+        }*/
 
         private Task Discord_SocketError(DiscordClient client, SocketErrorEventArgs e)
         {
@@ -180,7 +180,18 @@ namespace DSharpPlus.Test
         private async Task CommandsNextService_CommandErrored(CommandsNextExtension cnext, CommandErrorEventArgs e)
         {
             if (e.Exception is CommandNotFoundException && (e.Command == null || e.Command.QualifiedName != "help"))
+            {
+                // Not logged as error to console because it's an user caused error
+                var embed = new DiscordEmbedBuilder
+                {
+                    Color = new DiscordColor("#FF0000"),
+                    Title = "Command Not Found Exception",
+                    Description = $"`{((CommandNotFoundException)e.Exception).CommandName}`, no such command or subcommand was found.",
+                    Timestamp = DateTime.UtcNow
+                };
+                await e.Context.RespondAsync("", embed: embed);
                 return;
+            }
 
             e.Context.Client.Logger.LogError(TestBotEventId, e.Exception, "Exception occurred during {0}'s invocation of '{1}'", e.Context.User.Username, e.Context.Command.QualifiedName);
 


### PR DESCRIPTION
# Summary
Changed it to where D#+ throws a CommandNotFoundException when a user tries to execute an invalid command with a command group.

# Changes proposed
- CommandGroup ExecuteAsync now throws a CommandNotFoundException instead of an InvalidOperationException if no matching subcommands were found and the group is not executable
- Modified TestBot's CommandErrored handler to inform user no command was found (and to allow testing of the change)

# Notes
- CommandNotFoundException only has a single property for the command name. Rather than adding an other property for the group name, the command name will contain both the group and invalid command if applicable
- TestBot does not log an error the console as it's a user created error
- This is my first PR and contribution to the library so if there any errors or mistakes let me know