### PR TITLE
Update Permissions to include newly documented thread permissions

### DIFF
--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -261,7 +261,7 @@ namespace DSharpPlus
         /// Allows the user to request to speak in stage channels.
         /// </summary>
         [PermissionString("Request to speak")]
-        RequestToSpeak = 0x0000000100000000
+        RequestToSpeak = 0x0000000100000000,
         
         /// <summary>
         /// Allows the user to manage guild events.

--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -262,6 +262,8 @@ namespace DSharpPlus
         /// </summary>
         [PermissionString("Request to speak")]
         RequestToSpeak = 0x0000000100000000
+        
+        // To change "Stage ticket permission
     }
 
     /// <summary>

--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -4,7 +4,7 @@ namespace DSharpPlus
 {
     public static class PermissionMethods
     {
-        internal static Permissions FULL_PERMS { get; } = (Permissions)17179869183;
+        internal static Permissions FULL_PERMS { get; } = (Permissions)128849018879L;
 
         /// <summary>
         /// Calculates whether this permission set contains the given permission.
@@ -69,7 +69,7 @@ namespace DSharpPlus
         /// Indicates all permissions are granted
         /// </summary>
         [PermissionString("All permissions")]
-        All = 17179869183,
+        All = 128849018879,
 
         /// <summary>
         /// Allows creation of instant channel invites.
@@ -266,8 +266,20 @@ namespace DSharpPlus
         /// <summary>
         /// Allows the user to manage guild events.
         /// </summary>
-        [PermissionString("Manage Events")]
-        ManageEvents = 0x0000000200000000
+        [PermissionString("Manage Threads")]
+        ManageEvents = 0x0000000400000000,
+        
+        /// <summary>
+        /// Allows the user to manage guild events.
+        /// </summary>
+        [PermissionString("Use Public Threads")]
+        ManageEvents = 0x0000000800000000,
+        
+        /// <summary>
+        /// Allows the user to manage guild events.
+        /// </summary>
+        [PermissionString("Use Private Threads")]
+        ManageEvents = 0x0000001000000000
     }
 
     /// <summary>

--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -258,25 +258,25 @@ namespace DSharpPlus
         UseSlashCommands = 0x0000000080000000,
 
         /// <summary>
-        /// Allows the user to request to speak in stage channels.
+        /// Allows for requesting to speak in stage channels.
         /// </summary>
         [PermissionString("Request to speak")]
         RequestToSpeak = 0x0000000100000000,
         
         /// <summary>
-        /// Allows the user to manage guild events.
+        /// Allows for deleting and archiving threads, and viewing all private threads.
         /// </summary>
         [PermissionString("Manage Threads")]
         ManageEvents = 0x0000000400000000,
         
         /// <summary>
-        /// Allows the user to manage guild events.
+        /// Allows for creating and participating in threads.
         /// </summary>
         [PermissionString("Use Public Threads")]
         ManageEvents = 0x0000000800000000,
         
         /// <summary>
-        /// Allows the user to manage guild events.
+        /// Allows for creating and participating in private threads.
         /// </summary>
         [PermissionString("Use Private Threads")]
         ManageEvents = 0x0000001000000000

--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -4,7 +4,7 @@ namespace DSharpPlus
 {
     public static class PermissionMethods
     {
-        internal static Permissions FULL_PERMS { get; } = (Permissions)8589934591;
+        internal static Permissions FULL_PERMS { get; } = (Permissions)17179869183;
 
         /// <summary>
         /// Calculates whether this permission set contains the given permission.
@@ -69,7 +69,7 @@ namespace DSharpPlus
         /// Indicates all permissions are granted
         /// </summary>
         [PermissionString("All permissions")]
-        All = 8589934591,
+        All = 17179869183,
 
         /// <summary>
         /// Allows creation of instant channel invites.
@@ -263,7 +263,11 @@ namespace DSharpPlus
         [PermissionString("Request to speak")]
         RequestToSpeak = 0x0000000100000000
         
-        // To change "Stage ticket permission
+        /// <summary>
+        /// Allows the user to manage guild events.
+        /// </summary>
+        [PermissionString("Manage Events")]
+        ManageEvents = 0x0000000200000000
     }
 
     /// <summary>

--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -267,19 +267,19 @@ namespace DSharpPlus
         /// Allows for deleting and archiving threads, and viewing all private threads.
         /// </summary>
         [PermissionString("Manage Threads")]
-        ManageEvents = 0x0000000400000000,
+        ManageThreads = 0x0000000400000000,
         
         /// <summary>
         /// Allows for creating and participating in threads.
         /// </summary>
         [PermissionString("Use Public Threads")]
-        ManageEvents = 0x0000000800000000,
+        UsePublicThreads = 0x0000000800000000,
         
         /// <summary>
         /// Allows for creating and participating in private threads.
         /// </summary>
         [PermissionString("Use Private Threads")]
-        ManageEvents = 0x0000001000000000
+        UsePrivateThreads = 0x0000001000000000
     }
 
     /// <summary>


### PR DESCRIPTION
# Summary

Implements the following permissions to `DSharpPlus.Permissions`:

- `MANAGE_THREADS `
- `USE_PUBLIC_THREADS`
- `USE_PRIVATE_THREADS`

# Details

Adds the following permissions to the `Permissions` enum.
- `ManageThreads`
- `UsePublicThreads`
- `UsePrivateThreads`

# Changes proposed

  - Add `Permissions.ManageThreads` with a value of `0x0000000400000000`
  - Add `Permissions.UsePublicThreads` with a value of `0x0000000800000000`
  - Add `Permissions.UsePrivateThreads` with a value of `0x0000001000000000`

  - Modify the `FULL_PERMS` and `All` values to the result of the old `All` value and all new values resulting to a new value of `128849018879`
