### PR TITLE
Implement Video Quality Mode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,260 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+#### Core EditorConfig Options ####
+
+# All files 
+[*] 
+
+# General
+charset = utf-8
+trim_trailing_whitespace = true
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = true
+
+# Project files
+[*.{csproj,targets,yml}]
+indent_size = 2
+
+[NuGet.config]
+indent_size = 2
+
+# Solution files
+[*.sln]
+indent_style = tab
+tab_width = 4
+
+#### .NET Coding Conventions ####
+
+# C# files
+[*.cs]
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+file_header_template = This file is part of the DSharpPlus project.\n\nCopyright (c) 2015 Mike Santiago\nCopyright (c) 2016-2021 DSharpPlus Contributors\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the "Software"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = true:error
+dotnet_style_qualification_for_field = true
+dotnet_style_qualification_for_method = true:error
+dotnet_style_qualification_for_property = true:error
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:error
+dotnet_style_predefined_type_for_member_access = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:suggestion
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_compound_assignment = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment = true:warning
+dotnet_style_prefer_conditional_expression_over_return = true:warning
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
+dotnet_style_prefer_inferred_tuple_names = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:error
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = non_public
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:warning
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = when_on_single_line:warning
+csharp_style_expression_bodied_constructors = false:warning
+csharp_style_expression_bodied_indexers = when_on_single_line:warning
+csharp_style_expression_bodied_lambdas = true:warning
+csharp_style_expression_bodied_local_functions = when_on_single_line:warning
+csharp_style_expression_bodied_methods = when_on_single_line:warning
+csharp_style_expression_bodied_operators = when_on_single_line:warning
+csharp_style_expression_bodied_properties = when_on_single_line:warning
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_prefer_not_pattern = true:warning
+csharp_style_prefer_pattern_matching = false
+csharp_style_prefer_switch_expression = true
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = false
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Code-block preferences
+csharp_prefer_braces = false:suggestion
+csharp_prefer_simple_using_statement = true
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true:warning
+csharp_style_deconstructed_variable_declaration = true
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+csharp_style_inlined_variable_declaration = true:warning
+csharp_style_pattern_local_over_anonymous_function = true:warning
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_range_operator = true
+csharp_style_throw_expression = false:warning
+csharp_style_unused_value_assignment_preference = discard_variable:silent
+csharp_style_unused_value_expression_statement_preference = discard_variable
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:error
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = error
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = error
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.async_methods_should_be_async_suffix.severity = error
+dotnet_naming_rule.async_methods_should_be_async_suffix.symbols = async_methods
+dotnet_naming_rule.async_methods_should_be_async_suffix.style = async_suffix
+
+dotnet_naming_rule.const_fields_should_be_pascal_case.severity = warning
+dotnet_naming_rule.const_fields_should_be_pascal_case.symbols = const_fields
+dotnet_naming_rule.const_fields_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.private_or_internal_field_should_be_underscore_prefixed_camel_case.severity = warning
+dotnet_naming_rule.private_or_internal_field_should_be_underscore_prefixed_camel_case.symbols = private_or_internal_field
+dotnet_naming_rule.private_or_internal_field_should_be_underscore_prefixed_camel_case.style = underscore_prefixed_camel_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = warning
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
+dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = internal, private, private_protected
+dotnet_naming_symbols.private_or_internal_field.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+dotnet_naming_symbols.async_methods.applicable_kinds = method
+dotnet_naming_symbols.async_methods.applicable_accessibilities = public, internal, protected_internal, protected, private_protected
+dotnet_naming_symbols.async_methods.required_modifiers = async
+
+dotnet_naming_symbols.const_fields.applicable_kinds = field, property
+dotnet_naming_symbols.const_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.const_fields.required_modifiers = const
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.underscore_prefixed_camel_case.required_prefix = _
+dotnet_naming_style.underscore_prefixed_camel_case.required_suffix = 
+dotnet_naming_style.underscore_prefixed_camel_case.word_separator = 
+dotnet_naming_style.underscore_prefixed_camel_case.capitalization = camel_case
+
+dotnet_naming_style.async_suffix.required_prefix = 
+dotnet_naming_style.async_suffix.required_suffix = Async
+dotnet_naming_style.async_suffix.word_separator = 
+dotnet_naming_style.async_suffix.capitalization = pascal_case

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -16,5 +16,4 @@ custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
  - https://ko-fi.com/naamloos
  - https://ko-fi.com/emzi0767
  - https://paypal.me/Emzi0767/5USD
- - https://patreon.com/emzi0767
 # insert Neuheit here

--- a/.nuget/NuGet.config
+++ b/.nuget/NuGet.config
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <packageSources>
-        <!-- Feed no longer used -->
-        <!-- <add key=".NET Core (MyGet)" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" /> -->
-      
-        <!-- Feed now defunct -->
-        <!-- <add key="Roslyn (MyGet)" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" /> -->
-    </packageSources>
+  <packageSources>
+    <!-- Feed no longer used -->
+    <!-- <add key=".NET Core (MyGet)" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" /> -->
+
+    <!-- Feed now defunct -->
+    <!-- <add key="Roslyn (MyGet)" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" /> -->
+  </packageSources>
 </configuration>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,8 @@ throughout the repository, with several exceptions:
   blocks, pass the task through instead of awaiting it. For example:
   
   ```cs
-  public Task DoSomethingAsync() =>
-      this.DoAnotherThingAsync();
+  public Task DoSomethingAsync()
+    => this.DoAnotherThingAsync();
       
   public Task DoAnotherThingAsync()
   {

--- a/DSharpPlus.CommandsNext/Attributes/AliasesAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/AliasesAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/DSharpPlus.CommandsNext/Attributes/CheckBaseAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/CheckBaseAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading.Tasks;
 
 namespace DSharpPlus.CommandsNext.Attributes

--- a/DSharpPlus.CommandsNext/Attributes/CommandAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/CommandAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Linq;
 
 namespace DSharpPlus.CommandsNext.Attributes

--- a/DSharpPlus.CommandsNext/Attributes/CooldownAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/CooldownAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Threading;
@@ -69,10 +92,7 @@ namespace DSharpPlus.CommandsNext.Attributes
             if (bucket == null)
                 return TimeSpan.Zero;
 
-            if (bucket.RemainingUses > 0)
-                return TimeSpan.Zero;
-
-            return bucket.ResetsAt - DateTimeOffset.UtcNow;
+            return bucket.RemainingUses > 0 ? TimeSpan.Zero : bucket.ResetsAt - DateTimeOffset.UtcNow;
         }
 
         /// <summary>
@@ -173,7 +193,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <summary>
         /// Gets the remaining number of uses before the cooldown is triggered.
         /// </summary>
-        public int RemainingUses 
+        public int RemainingUses
             => Volatile.Read(ref this._remaining_uses);
 
         private int _remaining_uses;
@@ -254,20 +274,14 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// Returns a string representation of this command cooldown bucket.
         /// </summary>
         /// <returns>String representation of this command cooldown bucket.</returns>
-        public override string ToString()
-        {
-            return $"Command bucket {this.BucketId}";
-        }
+        public override string ToString() => $"Command bucket {this.BucketId}";
 
         /// <summary>
         /// Checks whether this <see cref="CommandCooldownBucket"/> is equal to another object.
         /// </summary>
         /// <param name="obj">Object to compare to.</param>
         /// <returns>Whether the object is equal to this <see cref="CommandCooldownBucket"/>.</returns>
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as CommandCooldownBucket);
-        }
+        public override bool Equals(object obj) => this.Equals(obj as CommandCooldownBucket);
 
         /// <summary>
         /// Checks whether this <see cref="CommandCooldownBucket"/> is equal to another <see cref="CommandCooldownBucket"/>.
@@ -276,13 +290,12 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <returns>Whether the <see cref="CommandCooldownBucket"/> is equal to this <see cref="CommandCooldownBucket"/>.</returns>
         public bool Equals(CommandCooldownBucket other)
         {
-            if (ReferenceEquals(other, null))
+            if (other is null)
                 return false;
 
-            if (ReferenceEquals(this, other))
-                return true;
-
-            return this.UserId == other.UserId && this.ChannelId == other.ChannelId && this.GuildId == other.GuildId;
+            return ReferenceEquals(this, other)
+                ? true
+                : this.UserId == other.UserId && this.ChannelId == other.ChannelId && this.GuildId == other.GuildId;
         }
 
         /// <summary>
@@ -291,7 +304,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <returns>The hash code for this <see cref="CommandCooldownBucket"/>.</returns>
         public override int GetHashCode()
         {
-            int hash = 13;
+            var hash = 13;
 
             hash = (hash * 7) + this.UserId.GetHashCode();
             hash = (hash * 7) + this.ChannelId.GetHashCode();
@@ -308,16 +321,13 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <returns>Whether the two buckets are equal.</returns>
         public static bool operator ==(CommandCooldownBucket bucket1, CommandCooldownBucket bucket2)
         {
-            var null1 = ReferenceEquals(bucket1, null);
-            var null2 = ReferenceEquals(bucket2, null);
+            var null1 = bucket1 is null;
+            var null2 = bucket2 is null;
 
             if (null1 && null2)
                 return true;
 
-            if (null1 != null2)
-                return false;
-
-            return null1.Equals(null2);
+            return null1 != null2 ? false : null1.Equals(null2);
         }
 
         /// <summary>
@@ -326,7 +336,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <param name="bucket1">First bucket to compare.</param>
         /// <param name="bucket2">Second bucket to compare.</param>
         /// <returns>Whether the two buckets are not equal.</returns>
-        public static bool operator !=(CommandCooldownBucket bucket1, CommandCooldownBucket bucket2) 
+        public static bool operator !=(CommandCooldownBucket bucket1, CommandCooldownBucket bucket2)
             => !(bucket1 == bucket2);
 
         /// <summary>
@@ -336,7 +346,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <param name="channelId">ID of the channel with which this cooldown is associated.</param>
         /// <param name="guildId">ID of the guild with which this cooldown is associated.</param>
         /// <returns>Generated bucket ID.</returns>
-        public static string MakeId(ulong userId = 0, ulong channelId = 0, ulong guildId = 0) 
+        public static string MakeId(ulong userId = 0, ulong channelId = 0, ulong guildId = 0)
             => $"{userId.ToString(CultureInfo.InvariantCulture)}:{channelId.ToString(CultureInfo.InvariantCulture)}:{guildId.ToString(CultureInfo.InvariantCulture)}";
     }
 }

--- a/DSharpPlus.CommandsNext/Attributes/DescriptionAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/DescriptionAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.CommandsNext.Attributes
 {

--- a/DSharpPlus.CommandsNext/Attributes/DontInjectAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/DontInjectAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.CommandsNext.Attributes
 {

--- a/DSharpPlus.CommandsNext/Attributes/GroupAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/GroupAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Linq;
 
 namespace DSharpPlus.CommandsNext.Attributes

--- a/DSharpPlus.CommandsNext/Attributes/HiddenAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/HiddenAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.CommandsNext.Attributes
 {

--- a/DSharpPlus.CommandsNext/Attributes/ModuleLifespanAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/ModuleLifespanAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.CommandsNext.Attributes
 {

--- a/DSharpPlus.CommandsNext/Attributes/PriorityAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/PriorityAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.CommandsNext.Attributes
 {

--- a/DSharpPlus.CommandsNext/Attributes/RemainingTextAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RemainingTextAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.CommandsNext.Attributes
 {

--- a/DSharpPlus.CommandsNext/Attributes/RequireBotPermissionsAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireBotPermissionsAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading.Tasks;
 
 namespace DSharpPlus.CommandsNext.Attributes
@@ -45,10 +68,7 @@ namespace DSharpPlus.CommandsNext.Attributes
             if ((pbot & Permissions.Administrator) != 0)
                 return true;
 
-            if ((pbot & this.Permissions) == this.Permissions)
-                return true;
-
-            return false;
+            return (pbot & this.Permissions) == this.Permissions;
         }
     }
 }

--- a/DSharpPlus.CommandsNext/Attributes/RequireDirectMessageAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireDirectMessageAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System.Threading.Tasks;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Threading.Tasks;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.CommandsNext.Attributes

--- a/DSharpPlus.CommandsNext/Attributes/RequireGuildAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireGuildAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System.Threading.Tasks;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Threading.Tasks;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.CommandsNext.Attributes

--- a/DSharpPlus.CommandsNext/Attributes/RequireNsfwAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireNsfwAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading.Tasks;
 
 namespace DSharpPlus.CommandsNext.Attributes

--- a/DSharpPlus.CommandsNext/Attributes/RequireOwnerAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireOwnerAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -15,10 +38,7 @@ namespace DSharpPlus.CommandsNext.Attributes
             var app = ctx.Client.CurrentApplication;
             var me = ctx.Client.CurrentUser;
 
-            if (app != null)
-                return Task.FromResult(app.Owners.Any(x => x.Id == ctx.User.Id));
-
-            return Task.FromResult(ctx.User.Id == me.Id);
+            return app != null ? Task.FromResult(app.Owners.Any(x => x.Id == ctx.User.Id)) : Task.FromResult(ctx.User.Id == me.Id);
         }
     }
 }

--- a/DSharpPlus.CommandsNext/Attributes/RequirePermissionsAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequirePermissionsAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading.Tasks;
 
 namespace DSharpPlus.CommandsNext.Attributes
@@ -48,7 +71,7 @@ namespace DSharpPlus.CommandsNext.Attributes
 
             if (!usrok)
                 usrok = (pusr & Permissions.Administrator) != 0 || (pusr & this.Permissions) == this.Permissions;
-            
+
             if (!botok)
                 botok = (pbot & Permissions.Administrator) != 0 || (pbot & this.Permissions) == this.Permissions;
 

--- a/DSharpPlus.CommandsNext/Attributes/RequirePrefixesAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequirePrefixesAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -43,21 +66,13 @@ namespace DSharpPlus.CommandsNext.Attributes
             var ins = rns.Intersect(this.RoleNames, ctx.CommandsNext.GetStringComparer());
             var inc = ins.Count();
 
-            switch (this.CheckMode)
+            return this.CheckMode switch
             {
-                case RoleCheckMode.All:
-                    return Task.FromResult(this.RoleNames.Count == inc);
-                    
-                case RoleCheckMode.SpecifiedOnly:
-                    return Task.FromResult(rnc == inc);
-
-                case RoleCheckMode.None:
-                    return Task.FromResult(inc == 0);
-                    
-                case RoleCheckMode.Any:
-                default:
-                    return Task.FromResult(inc > 0);
-            }
+                RoleCheckMode.All => Task.FromResult(this.RoleNames.Count == inc),
+                RoleCheckMode.SpecifiedOnly => Task.FromResult(rnc == inc),
+                RoleCheckMode.None => Task.FromResult(inc == 0),
+                _ => Task.FromResult(inc > 0),
+            };
         }
     }
 

--- a/DSharpPlus.CommandsNext/Attributes/RequireUserPermissionsAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireUserPermissionsAttribute.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading.Tasks;
 
 namespace DSharpPlus.CommandsNext.Attributes
@@ -45,10 +68,7 @@ namespace DSharpPlus.CommandsNext.Attributes
             if ((pusr & Permissions.Administrator) != 0)
                 return Task.FromResult(true);
 
-            if ((pusr & this.Permissions) == this.Permissions)
-                return Task.FromResult(true);
-
-            return Task.FromResult(false);
+            return (pusr & this.Permissions) == this.Permissions ? Task.FromResult(true) : Task.FromResult(false);
         }
     }
 }

--- a/DSharpPlus.CommandsNext/BaseCommandModule.cs
+++ b/DSharpPlus.CommandsNext/BaseCommandModule.cs
@@ -1,4 +1,27 @@
-﻿using System.Threading.Tasks;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Threading.Tasks;
 
 namespace DSharpPlus.CommandsNext
 {

--- a/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/DSharpPlus.CommandsNext/CommandsNextEvents.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextEvents.cs
@@ -1,4 +1,27 @@
-﻿using Microsoft.Extensions.Logging;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus.CommandsNext
 {

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -112,7 +135,7 @@ namespace DSharpPlus.CommandsNext
 
                 var xcvt = ncvt.MakeGenericType(xt);
                 var xnt = nt.MakeGenericType(xt);
-                if (ArgumentConverters.ContainsKey(xcvt))
+                if (this.ArgumentConverters.ContainsKey(xcvt))
                     continue;
 
                 var xcv = Activator.CreateInstance(xcvt) as IArgumentConverter;
@@ -130,10 +153,7 @@ namespace DSharpPlus.CommandsNext
         /// Sets the help formatter to use with the default help command.
         /// </summary>
         /// <typeparam name="T">Type of the formatter to use.</typeparam>
-        public void SetHelpFormatter<T>() where T : BaseHelpFormatter
-        {
-            this.HelpFormatter.SetFormatterType<T>();
-        }
+        public void SetHelpFormatter<T>() where T : BaseHelpFormatter => this.HelpFormatter.SetFormatterType<T>();
 
         #region DiscordClient Registration
         /// <summary>
@@ -164,7 +184,7 @@ namespace DSharpPlus.CommandsNext
                 {
                     var checks = this.Config.DefaultHelpChecks.ToArray();
 
-                    for (int i = 0; i < tcmds.Count; i++)
+                    for (var i = 0; i < tcmds.Count; i++)
                         tcmds[i].WithExecutionChecks(checks);
                 }
 
@@ -251,7 +271,7 @@ namespace DSharpPlus.CommandsNext
                 rawArguments = commandString.Substring(pos).Trim();
                 return cmd;
             }
-            
+
             while (cmd is CommandGroup)
             {
                 var cm2 = cmd as CommandGroup;
@@ -459,7 +479,7 @@ namespace DSharpPlus.CommandsNext
                         if (inheritedChecks != null)
                             foreach (var chk in inheritedChecks)
                                 groupBuilder.WithExecutionCheck(chk);
-                        
+
                         foreach (var mi in ti.DeclaredMethods.Where(x => x.IsCommandCandidate(out _) && x.GetCustomAttribute<GroupCommandAttribute>() != null))
                             groupBuilder.WithOverload(new CommandOverloadBuilder(mi));
                         break;
@@ -506,7 +526,7 @@ namespace DSharpPlus.CommandsNext
                     continue;
 
                 var attrs = m.GetCustomAttributes();
-                if (!(attrs.FirstOrDefault(xa => xa is CommandAttribute) is CommandAttribute cattr))
+                if (attrs.FirstOrDefault(xa => xa is CommandAttribute) is not CommandAttribute cattr)
                     continue;
 
                 var commandName = cattr.Name;
@@ -575,8 +595,8 @@ namespace DSharpPlus.CommandsNext
                 .Where(xt => xt.IsModuleCandidateType() && xt.DeclaredConstructors.Any(xc => xc.IsPublic));
             foreach (var type in types)
             {
-                this.RegisterCommands(type.AsType(), 
-                    groupBuilder, 
+                this.RegisterCommands(type.AsType(),
+                    groupBuilder,
                     !isModule ? moduleChecks : null,
                     out var tempCommands);
 
@@ -585,8 +605,8 @@ namespace DSharpPlus.CommandsNext
                         groupBuilder.WithExecutionCheck(chk);
 
                 if (isModule && tempCommands != null)
-                        foreach (var xtcmd in tempCommands)
-                            groupBuilder.WithChild(xtcmd);
+                    foreach (var xtcmd in tempCommands)
+                        groupBuilder.WithChild(xtcmd);
                 else if (tempCommands != null)
                     commands.AddRange(tempCommands);
             }
@@ -659,10 +679,9 @@ namespace DSharpPlus.CommandsNext
                             break;
                         }
 
-                        if (ctx.Config.CaseSensitive)
-                            cmd = searchIn.FirstOrDefault(xc => xc.Name == c || (xc.Aliases != null && xc.Aliases.Contains(c)));
-                        else
-                            cmd = searchIn.FirstOrDefault(xc => xc.Name.ToLowerInvariant() == c.ToLowerInvariant() || (xc.Aliases != null && xc.Aliases.Select(xs => xs.ToLowerInvariant()).Contains(c.ToLowerInvariant())));
+                        cmd = ctx.Config.CaseSensitive
+                            ? searchIn.FirstOrDefault(xc => xc.Name == c || (xc.Aliases != null && xc.Aliases.Contains(c)))
+                            : searchIn.FirstOrDefault(xc => xc.Name.ToLowerInvariant() == c.ToLowerInvariant() || (xc.Aliases != null && xc.Aliases.Select(xs => xs.ToLowerInvariant()).Contains(c.ToLowerInvariant())));
 
                         if (cmd == null)
                             break;
@@ -671,10 +690,7 @@ namespace DSharpPlus.CommandsNext
                         if (failedChecks.Any())
                             throw new ChecksFailedException(cmd, ctx, failedChecks);
 
-                        if (cmd is CommandGroup)
-                            searchIn = (cmd as CommandGroup).Children;
-                        else
-                            searchIn = null;
+                        searchIn = cmd is CommandGroup ? (cmd as CommandGroup).Children : null;
                     }
 
                     if (cmd == null)
@@ -728,7 +744,7 @@ namespace DSharpPlus.CommandsNext
 
                 var builder = new DiscordMessageBuilder().WithContent(helpMessage.Content).WithEmbed(helpMessage.Embed);
 
-                if (!ctx.Config.DmHelp || ctx.Channel is DiscordDmChannel || ctx.Guild == null) 
+                if (!ctx.Config.DmHelp || ctx.Channel is DiscordDmChannel || ctx.Guild == null)
                     await ctx.RespondAsync(builder).ConfigureAwait(false);
                 else
                     await ctx.Member.SendMessageAsync(builder).ConfigureAwait(false);
@@ -830,14 +846,11 @@ namespace DSharpPlus.CommandsNext
             if (!this.ArgumentConverters.ContainsKey(t))
                 throw new ArgumentException("There is no converter specified for given type.", nameof(T));
 
-            if (!(this.ArgumentConverters[t] is IArgumentConverter<T> cv))
+            if (this.ArgumentConverters[t] is not IArgumentConverter<T> cv)
                 throw new ArgumentException("Invalid converter registered for this type.", nameof(T));
 
             var cvr = await cv.ConvertAsync(value, ctx).ConfigureAwait(false);
-            if (!cvr.HasValue)
-                throw new ArgumentException("Could not convert specified value to given type.", nameof(value));
-
-            return cvr.Value;
+            return !cvr.HasValue ? throw new ArgumentException("Could not convert specified value to given type.", nameof(value)) : cvr.Value;
         }
 
         /// <summary>
@@ -931,7 +944,6 @@ namespace DSharpPlus.CommandsNext
             if (!ti.IsValueType)
                 return;
 
-            var nullableConverterType = typeof(NullableConverter<>).MakeGenericType(t);
             var nullableType = typeof(Nullable<>).MakeGenericType(t);
             this.UserFriendlyTypeNames[nullableType] = value;
         }
@@ -950,10 +962,7 @@ namespace DSharpPlus.CommandsNext
             if (ti.IsGenericTypeDefinition && t.GetGenericTypeDefinition() == typeof(Nullable<>))
             {
                 var tn = ti.GenericTypeArguments[0];
-                if (this.UserFriendlyTypeNames.ContainsKey(tn))
-                    return this.UserFriendlyTypeNames[tn];
-
-                return tn.Name;
+                return this.UserFriendlyTypeNames.ContainsKey(tn) ? this.UserFriendlyTypeNames[tn] : tn.Name;
             }
 
             return t.Name;

--- a/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -33,10 +56,7 @@ namespace DSharpPlus.CommandsNext
             if (str.Length >= content.Length)
                 return -1;
 
-            if (!content.StartsWith(str, comparisonType))
-                return -1;
-
-            return str.Length;
+            return !content.StartsWith(str, comparisonType) ? -1 : str.Length;
         }
 
         /// <summary>
@@ -61,10 +81,7 @@ namespace DSharpPlus.CommandsNext
                 return -1;
 
             var userId = ulong.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture);
-            if (user.Id != userId)
-                return -1;
-
-            return m.Value.Length;
+            return user.Id != userId ? -1 : m.Value.Length;
         }
 
         //internal static string ExtractNextArgument(string str, out string remainder)
@@ -133,10 +150,7 @@ namespace DSharpPlus.CommandsNext
                 {
                     removeIndices.Add(i - startPosition);
 
-                    if (!inQuote)
-                        inQuote = true;
-                    else
-                        inQuote = false;
+                    inQuote = !inQuote;
                 }
 
                 if (inEscape)
@@ -145,16 +159,12 @@ namespace DSharpPlus.CommandsNext
                 if (endPosition != -1)
                 {
                     startPos = endPosition;
-                    if (startPosition != endPosition)
-                        return str.Substring(startPosition, endPosition - startPosition).CleanupString(removeIndices);
-                    return null;
+                    return startPosition != endPosition ? str.Substring(startPosition, endPosition - startPosition).CleanupString(removeIndices) : null;
                 }
             }
 
             startPos = str.Length;
-            if (startPos != startPosition)
-                return str.Substring(startPosition).CleanupString(removeIndices);
-            return null;
+            return startPos != startPosition ? str.Substring(startPosition).CleanupString(removeIndices) : null;
         }
 
         internal static string CleanupString(this string s, IList<int> indices)
@@ -204,7 +214,7 @@ namespace DSharpPlus.CommandsNext
                             argValue = ExtractNextArgument(argString, ref foundAt);
                             if (argValue == null)
                                 break;
-                            
+
                             rawArgumentList.Add(argValue);
                         }
 
@@ -264,7 +274,7 @@ namespace DSharpPlus.CommandsNext
                 else
                 {
                     try
-                    { 
+                    {
                         args[i + 2] = rawArgumentList[i] != null ? await ctx.CommandsNext.ConvertArgument(rawArgumentList[i], ctx, arg.Type).ConfigureAwait(false) : arg.DefaultValue;
                     }
                     catch (Exception ex)

--- a/DSharpPlus.CommandsNext/Converters/ArgumentBindingResult.cs
+++ b/DSharpPlus.CommandsNext/Converters/ArgumentBindingResult.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 
 namespace DSharpPlus.CommandsNext.Converters

--- a/DSharpPlus.CommandsNext/Converters/BaseHelpFormatter.cs
+++ b/DSharpPlus.CommandsNext/Converters/BaseHelpFormatter.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using DSharpPlus.CommandsNext.Entities;
 
 namespace DSharpPlus.CommandsNext.Converters

--- a/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
+++ b/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using DSharpPlus.CommandsNext.Entities;

--- a/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -49,7 +72,7 @@ namespace DSharpPlus.CommandsNext.Converters
             var us = ctx.Client.Guilds.Values
                 .SelectMany(xkvp => xkvp.Members.Values)
                 .Where(xm => (cs ? xm.Username : xm.Username.ToLowerInvariant()) == un && ((dv != null && xm.Discriminator == dv) || dv == null));
-            
+
             var usr = us.FirstOrDefault();
             return usr != null ? Optional.FromValue<DiscordUser>(usr) : Optional.FromNoValue<DiscordUser>();
         }
@@ -97,7 +120,7 @@ namespace DSharpPlus.CommandsNext.Converters
             var dv = di != -1 ? value.Substring(di + 1) : null;
 
             var us = ctx.Guild.Members.Values
-                .Where(xm => ((cs ? xm.Username : xm.Username.ToLowerInvariant()) == un && ((dv != null && xm.Discriminator == dv) || dv == null)) 
+                .Where(xm => ((cs ? xm.Username : xm.Username.ToLowerInvariant()) == un && ((dv != null && xm.Discriminator == dv) || dv == null))
                           || (cs ? xm.Nickname : xm.Nickname?.ToLowerInvariant()) == value);
 
             var mbr = us.FirstOrDefault();
@@ -192,10 +215,9 @@ namespace DSharpPlus.CommandsNext.Converters
         {
             if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var gid))
             {
-                if (ctx.Client.Guilds.TryGetValue(gid, out var result))
-                    return Task.FromResult(Optional.FromValue(result));
-                else
-                    return Task.FromResult(Optional.FromNoValue<DiscordGuild>());
+                return ctx.Client.Guilds.TryGetValue(gid, out var result)
+                    ? Task.FromResult(Optional.FromValue(result))
+                    : Task.FromResult(Optional.FromNoValue<DiscordGuild>());
             }
 
             var cs = ctx.Config.CaseSensitive;
@@ -233,7 +255,7 @@ namespace DSharpPlus.CommandsNext.Converters
                     return Optional.FromNoValue<DiscordMessage>();
 
                 var uripath = MessagePathRegex.Match(uri.AbsolutePath);
-                if (!uripath.Success 
+                if (!uripath.Success
                     || !ulong.TryParse(uripath.Groups["channel"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var cid)
                     || !ulong.TryParse(uripath.Groups["message"].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out mid))
                     return Optional.FromNoValue<DiscordMessage>();
@@ -288,10 +310,9 @@ namespace DSharpPlus.CommandsNext.Converters
                 if (!ulong.TryParse(sid, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id))
                     return Task.FromResult(Optional.FromNoValue<DiscordEmoji>());
 
-                if (DiscordEmoji.TryFromGuildEmote(ctx.Client, id, out emoji))
-                    return Task.FromResult(Optional.FromValue(emoji));
-
-                return Task.FromResult(Optional.FromValue(new DiscordEmoji
+                return DiscordEmoji.TryFromGuildEmote(ctx.Client, id, out emoji)
+                    ? Task.FromResult(Optional.FromValue(emoji))
+                    : Task.FromResult(Optional.FromValue(new DiscordEmoji
                 {
                     Discord = ctx.Client,
                     Id = id,
@@ -335,10 +356,9 @@ namespace DSharpPlus.CommandsNext.Converters
                 var p2 = byte.TryParse(m.Groups[2].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var g);
                 var p3 = byte.TryParse(m.Groups[3].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var b);
 
-                if (!(p1 && p2 && p3))
-                    return Task.FromResult(Optional.FromNoValue<DiscordColor>());
-                
-                return Task.FromResult(Optional.FromValue(new DiscordColor(r, g, b)));
+                return !(p1 && p2 && p3)
+                    ? Task.FromResult(Optional.FromNoValue<DiscordColor>())
+                    : Task.FromResult(Optional.FromValue(new DiscordColor(r, g, b)));
             }
 
             return Task.FromResult(Optional.FromNoValue<DiscordColor>());

--- a/DSharpPlus.CommandsNext/Converters/EnumConverter.cs
+++ b/DSharpPlus.CommandsNext/Converters/EnumConverter.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Reflection;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
@@ -14,10 +37,9 @@ namespace DSharpPlus.CommandsNext.Converters
             if (!ti.IsEnum)
                 throw new InvalidOperationException("Cannot convert non-enum value to an enum.");
 
-            if (Enum.TryParse(value, !ctx.Config.CaseSensitive, out T ev))
-                return Task.FromResult(Optional.FromValue(ev));
-
-            return Task.FromResult(Optional.FromNoValue<T>());
+            return Enum.TryParse(value, !ctx.Config.CaseSensitive, out T ev)
+                ? Task.FromResult(Optional.FromValue(ev))
+                : Task.FromResult(Optional.FromNoValue<T>());
         }
     }
 }

--- a/DSharpPlus.CommandsNext/Converters/HelpFormatterFactory.cs
+++ b/DSharpPlus.CommandsNext/Converters/HelpFormatterFactory.cs
@@ -1,4 +1,27 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DSharpPlus.CommandsNext.Converters
 {
@@ -8,14 +31,8 @@ namespace DSharpPlus.CommandsNext.Converters
 
         public HelpFormatterFactory() { }
 
-        public void SetFormatterType<T>() where T : BaseHelpFormatter
-        {
-            this.Factory = ActivatorUtilities.CreateFactory(typeof(T), new[] { typeof(CommandContext) });
-        }
+        public void SetFormatterType<T>() where T : BaseHelpFormatter => this.Factory = ActivatorUtilities.CreateFactory(typeof(T), new[] { typeof(CommandContext) });
 
-        public BaseHelpFormatter Create(CommandContext ctx)
-        {
-            return this.Factory(ctx.Services, new object[] { ctx }) as BaseHelpFormatter;
-        }
+        public BaseHelpFormatter Create(CommandContext ctx) => this.Factory(ctx.Services, new object[] { ctx }) as BaseHelpFormatter;
     }
 }

--- a/DSharpPlus.CommandsNext/Converters/IArgumentConverter.cs
+++ b/DSharpPlus.CommandsNext/Converters/IArgumentConverter.cs
@@ -1,4 +1,27 @@
-﻿using System.Threading.Tasks;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Threading.Tasks;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.CommandsNext.Converters

--- a/DSharpPlus.CommandsNext/Converters/NullableConverter.cs
+++ b/DSharpPlus.CommandsNext/Converters/NullableConverter.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
 

--- a/DSharpPlus.CommandsNext/Converters/NumericConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/NumericConverters.cs
@@ -1,4 +1,27 @@
-﻿using System.Globalization;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Globalization;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
 
@@ -8,10 +31,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<bool>> IArgumentConverter<bool>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (bool.TryParse(value, out var result))
-                return Task.FromResult(Optional.FromValue(result));
-
-            return Task.FromResult(Optional.FromNoValue<bool>());
+            return bool.TryParse(value, out var result)
+                ? Task.FromResult(Optional.FromValue(result))
+                : Task.FromResult(Optional.FromNoValue<bool>());
         }
     }
 
@@ -19,10 +41,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<sbyte>> IArgumentConverter<sbyte>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (sbyte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional.FromValue(result));
-
-            return Task.FromResult(Optional.FromNoValue<sbyte>());
+            return sbyte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+                ? Task.FromResult(Optional.FromValue(result))
+                : Task.FromResult(Optional.FromNoValue<sbyte>());
         }
     }
 
@@ -30,10 +51,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<byte>> IArgumentConverter<byte>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (byte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional.FromValue(result));
-
-            return Task.FromResult(Optional.FromNoValue<byte>());
+            return byte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+                ? Task.FromResult(Optional.FromValue(result))
+                : Task.FromResult(Optional.FromNoValue<byte>());
         }
     }
 
@@ -41,10 +61,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<short>> IArgumentConverter<short>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (short.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional.FromValue(result));
-
-            return Task.FromResult(Optional.FromNoValue<short>());
+            return short.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+                ? Task.FromResult(Optional.FromValue(result))
+                : Task.FromResult(Optional.FromNoValue<short>());
         }
     }
 
@@ -52,10 +71,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<ushort>> IArgumentConverter<ushort>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (ushort.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional.FromValue(result));
-
-            return Task.FromResult(Optional.FromNoValue<ushort>());
+            return ushort.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+                ? Task.FromResult(Optional.FromValue(result))
+                : Task.FromResult(Optional.FromNoValue<ushort>());
         }
     }
 
@@ -63,10 +81,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<int>> IArgumentConverter<int>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional.FromValue(result));
-
-            return Task.FromResult(Optional.FromNoValue<int>());
+            return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+                ? Task.FromResult(Optional.FromValue(result))
+                : Task.FromResult(Optional.FromNoValue<int>());
         }
     }
 
@@ -74,10 +91,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<uint>> IArgumentConverter<uint>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (uint.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional.FromValue(result));
-
-            return Task.FromResult(Optional.FromNoValue<uint>());
+            return uint.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+                ? Task.FromResult(Optional.FromValue(result))
+                : Task.FromResult(Optional.FromNoValue<uint>());
         }
     }
 
@@ -85,10 +101,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<long>> IArgumentConverter<long>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional.FromValue(result));
-
-            return Task.FromResult(Optional.FromNoValue<long>());
+            return long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+                ? Task.FromResult(Optional.FromValue(result))
+                : Task.FromResult(Optional.FromNoValue<long>());
         }
     }
 
@@ -96,10 +111,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<ulong>> IArgumentConverter<ulong>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional.FromValue(result));
-
-            return Task.FromResult(Optional.FromNoValue<ulong>());
+            return ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+                ? Task.FromResult(Optional.FromValue(result))
+                : Task.FromResult(Optional.FromNoValue<ulong>());
         }
     }
 
@@ -107,10 +121,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<float>> IArgumentConverter<float>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (float.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional.FromValue(result));
-
-            return Task.FromResult(Optional.FromNoValue<float>());
+            return float.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var result)
+                ? Task.FromResult(Optional.FromValue(result))
+                : Task.FromResult(Optional.FromNoValue<float>());
         }
     }
 
@@ -118,10 +131,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<double>> IArgumentConverter<double>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional.FromValue(result));
-
-            return Task.FromResult(Optional.FromNoValue<double>());
+            return double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var result)
+                ? Task.FromResult(Optional.FromValue(result))
+                : Task.FromResult(Optional.FromNoValue<double>());
         }
     }
 
@@ -129,10 +141,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<decimal>> IArgumentConverter<decimal>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var result))
-                return Task.FromResult(Optional.FromValue(result));
-
-            return Task.FromResult(Optional.FromNoValue<decimal>());
+            return decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var result)
+                ? Task.FromResult(Optional.FromValue(result))
+                : Task.FromResult(Optional.FromNoValue<decimal>());
         }
     }
 }

--- a/DSharpPlus.CommandsNext/Converters/StringConverter.cs
+++ b/DSharpPlus.CommandsNext/Converters/StringConverter.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
 

--- a/DSharpPlus.CommandsNext/Converters/TimeConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/TimeConverters.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -10,10 +33,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<DateTime>> IArgumentConverter<DateTime>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result))
-                return Task.FromResult(new Optional<DateTime>(result));
-
-            return Task.FromResult(Optional.FromNoValue<DateTime>());
+            return DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result)
+                ? Task.FromResult(new Optional<DateTime>(result))
+                : Task.FromResult(Optional.FromNoValue<DateTime>());
         }
     }
 
@@ -21,10 +43,9 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<DateTimeOffset>> IArgumentConverter<DateTimeOffset>.ConvertAsync(string value, CommandContext ctx)
         {
-            if (DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result))
-                return Task.FromResult(Optional.FromValue(result));
-
-            return Task.FromResult(Optional.FromNoValue<DateTimeOffset>());
+            return DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result)
+                ? Task.FromResult(Optional.FromValue(result))
+                : Task.FromResult(Optional.FromNoValue<DateTimeOffset>());
         }
     }
 

--- a/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
+++ b/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../DSharpPlus.targets" />

--- a/DSharpPlus.CommandsNext/Entities/Builders/CommandBuilder.cs
+++ b/DSharpPlus.CommandsNext/Entities/Builders/CommandBuilder.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/DSharpPlus.CommandsNext/Entities/Builders/CommandGroupBuilder.cs
+++ b/DSharpPlus.CommandsNext/Entities/Builders/CommandGroupBuilder.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using DSharpPlus.CommandsNext.Entities;
@@ -27,7 +50,7 @@ namespace DSharpPlus.CommandsNext.Builders
         /// Creates a new command group builder.
         /// </summary>
         /// <param name="module">Module on which this group is to be defined.</param>
-        public CommandGroupBuilder(ICommandModule module) 
+        public CommandGroupBuilder(ICommandModule module)
             : base(module)
         {
             this.ChildrenList = new List<CommandBuilder>();

--- a/DSharpPlus.CommandsNext/Entities/Builders/CommandModuleBuilder.cs
+++ b/DSharpPlus.CommandsNext/Entities/Builders/CommandModuleBuilder.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.CommandsNext.Entities;
 
@@ -52,16 +75,12 @@ namespace DSharpPlus.CommandsNext.Builders
 
         internal ICommandModule Build(IServiceProvider services)
         {
-            switch (this.Lifespan)
+            return this.Lifespan switch
             {
-                case ModuleLifespan.Singleton:
-                    return new SingletonCommandModule(this.Type, services);
-
-                case ModuleLifespan.Transient:
-                    return new TransientCommandModule(this.Type);
-            }
-
-            throw new NotSupportedException("Module lifespans other than transient and singleton are not supported.");
+                ModuleLifespan.Singleton => new SingletonCommandModule(this.Type, services),
+                ModuleLifespan.Transient => new TransientCommandModule(this.Type),
+                _ => throw new NotSupportedException("Module lifespans other than transient and singleton are not supported."),
+            };
         }
     }
 }

--- a/DSharpPlus.CommandsNext/Entities/Builders/CommandOverloadBuilder.cs
+++ b/DSharpPlus.CommandsNext/Entities/Builders/CommandOverloadBuilder.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -54,7 +77,7 @@ namespace DSharpPlus.CommandsNext.Builders
         { }
 
         private CommandOverloadBuilder(MethodInfo method, object target)
-        { 
+        {
             if (!method.IsCommandCandidate(out var prms))
                 throw new ArgumentException("Specified method is not suitable for a command.", nameof(method));
 
@@ -111,7 +134,7 @@ namespace DSharpPlus.CommandsNext.Builders
                             break;
                     }
                 }
-                
+
                 if (i > 2 && !ca.IsOptional && !ca.IsCatchAll && args[i - 3].IsOptional)
                     throw new InvalidOverloadException("Non-optional argument cannot appear after an optional one", method, arg);
 

--- a/DSharpPlus.CommandsNext/Entities/Command.cs
+++ b/DSharpPlus.CommandsNext/Entities/Command.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -85,7 +108,7 @@ namespace DSharpPlus.CommandsNext
                         continue;
 
                     ctx.RawArguments = args.Raw;
-                    
+
                     var mdl = ovl.InvocationTarget ?? this.Module?.GetInstance(ctx.Services);
                     if (mdl is BaseCommandModule bcmBefore)
                         await bcmBefore.BeforeExecutionAsync(ctx).ConfigureAwait(false);
@@ -132,7 +155,7 @@ namespace DSharpPlus.CommandsNext
             var fchecks = new List<CheckBaseAttribute>();
             if (this.ExecutionChecks != null && this.ExecutionChecks.Any())
                 foreach (var ec in this.ExecutionChecks)
-                    if (!(await ec.ExecuteCheckAsync(ctx, help).ConfigureAwait(false)))
+                    if (!await ec.ExecuteCheckAsync(ctx, help).ConfigureAwait(false))
                         fchecks.Add(ec);
 
             return fchecks;
@@ -185,21 +208,15 @@ namespace DSharpPlus.CommandsNext
             else if (o1 == null && o2 == null)
                 return true;
 
-            var cmd = obj as Command;
-            if ((object)cmd == null)
-                return false;
-
-            return cmd.QualifiedName == this.QualifiedName;
+            return obj is Command cmd
+&& cmd.QualifiedName == this.QualifiedName;
         }
 
         /// <summary>
         /// Gets this command's hash code.
         /// </summary>
         /// <returns>This command's hash code.</returns>
-        public override int GetHashCode()
-        {
-            return this.QualifiedName.GetHashCode();
-        }
+        public override int GetHashCode() => this.QualifiedName.GetHashCode();
 
         /// <summary>
         /// Returns a string representation of this command.
@@ -207,9 +224,9 @@ namespace DSharpPlus.CommandsNext
         /// <returns>String representation of this command.</returns>
         public override string ToString()
         {
-            if (this is CommandGroup g)
-                return $"Command Group: {this.QualifiedName}, {g.Children.Count} top-level children";
-            return $"Command: {this.QualifiedName}";
+            return this is CommandGroup g
+                ? $"Command Group: {this.QualifiedName}, {g.Children.Count} top-level children"
+                : $"Command: {this.QualifiedName}";
         }
     }
 }

--- a/DSharpPlus.CommandsNext/Entities/CommandArgument.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandArgument.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 
 namespace DSharpPlus.CommandsNext
@@ -9,7 +32,7 @@ namespace DSharpPlus.CommandsNext
         /// Gets this argument's name.
         /// </summary>
         public string Name { get; internal set; }
-        
+
         /// <summary>
         /// Gets this argument's type.
         /// </summary>

--- a/DSharpPlus.CommandsNext/Entities/CommandGroup.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandGroup.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -35,12 +58,9 @@ namespace DSharpPlus.CommandsNext
 
             if (cn != null)
             {
-                Command cmd = null;
-                if (ctx.Config.CaseSensitive)
-                    cmd = this.Children.FirstOrDefault(xc => xc.Name == cn || (xc.Aliases != null && xc.Aliases.Contains(cn)));
-                else
-                    cmd = this.Children.FirstOrDefault(xc => xc.Name.ToLowerInvariant() == cn.ToLowerInvariant() || (xc.Aliases != null && xc.Aliases.Select(xs => xs.ToLowerInvariant()).Contains(cn.ToLowerInvariant())));
-
+                var cmd = ctx.Config.CaseSensitive
+                    ? this.Children.FirstOrDefault(xc => xc.Name == cn || (xc.Aliases != null && xc.Aliases.Contains(cn)))
+                    : this.Children.FirstOrDefault(xc => xc.Name.ToLowerInvariant() == cn.ToLowerInvariant() || (xc.Aliases != null && xc.Aliases.Select(xs => xs.ToLowerInvariant()).Contains(cn.ToLowerInvariant())));
                 if (cmd != null)
                 {
                     // pass the execution on
@@ -57,27 +77,25 @@ namespace DSharpPlus.CommandsNext
                     };
 
                     var fchecks = await cmd.RunChecksAsync(xctx, false).ConfigureAwait(false);
-                    if (fchecks.Any())
-                        return new CommandResult
+                    return fchecks.Any()
+                        ? new CommandResult
                         {
                             IsSuccessful = false,
                             Exception = new ChecksFailedException(cmd, xctx, fchecks),
                             Context = xctx
-                        };
-                    
-                    return await cmd.ExecuteAsync(xctx).ConfigureAwait(false);
+                        }
+                        : await cmd.ExecuteAsync(xctx).ConfigureAwait(false);
                 }
             }
 
-            if (!this.IsExecutableWithoutSubcommands)
-                return new CommandResult
+            return !this.IsExecutableWithoutSubcommands
+                ? new CommandResult
                 {
                     IsSuccessful = false,
                     Exception = new InvalidOperationException("No matching subcommands were found, and this group is not executable."),
                     Context = ctx
-                };
-
-            return await base.ExecuteAsync(ctx).ConfigureAwait(false);
+                }
+                : await base.ExecuteAsync(ctx).ConfigureAwait(false);
         }
     }
 }

--- a/DSharpPlus.CommandsNext/Entities/CommandHelpMessage.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandHelpMessage.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.CommandsNext.Entities
 {

--- a/DSharpPlus.CommandsNext/Entities/CommandModule.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandModule.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.CommandsNext.Entities
 {

--- a/DSharpPlus.CommandsNext/Entities/CommandOverload.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandOverload.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 
 namespace DSharpPlus.CommandsNext
@@ -22,7 +45,7 @@ namespace DSharpPlus.CommandsNext
         /// Gets this command overload's delegate.
         /// </summary>
         internal Delegate Callable { get; set; }
-        
+
         internal object InvocationTarget { get; set; }
 
         internal CommandOverload() { }

--- a/DSharpPlus.CommandsNext/Entities/CommandResult.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandResult.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.CommandsNext
 {
@@ -11,7 +34,7 @@ namespace DSharpPlus.CommandsNext
         /// Gets whether the command execution succeeded.
         /// </summary>
         public bool IsSuccessful { get; internal set; }
-        
+
         /// <summary>
         /// Gets the exception (if any) that occurred when executing the command.
         /// </summary>

--- a/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,34 +40,34 @@ namespace DSharpPlus.CommandsNext
         /// Gets the client which received the message.
         /// </summary>
         public DiscordClient Client { get; internal set; }
-        
+
         /// <summary>
         /// Gets the message that triggered the execution.
         /// </summary>
         public DiscordMessage Message { get; internal set; }
-        
+
         /// <summary>
         /// Gets the channel in which the execution was triggered,
         /// </summary>
-        public DiscordChannel Channel 
+        public DiscordChannel Channel
             => this.Message.Channel;
 
         /// <summary>
         /// Gets the guild in which the execution was triggered. This property is null for commands sent over direct messages.
         /// </summary>
-        public DiscordGuild Guild 
+        public DiscordGuild Guild
             => this.Channel.Guild;
 
         /// <summary>
         /// Gets the user who triggered the execution.
         /// </summary>
-        public DiscordUser User 
+        public DiscordUser User
             => this.Message.Author;
 
         /// <summary>
         /// Gets the member who triggered the execution. This property is null for commands sent over direct messages.
         /// </summary>
-        public DiscordMember Member 
+        public DiscordMember Member
             => this._lazyAssMember.Value;
 
         private readonly Lazy<DiscordMember> _lazyAssMember;
@@ -123,7 +146,7 @@ namespace DSharpPlus.CommandsNext
         /// </summary>
         /// <param name="builder">The Discord Message builder.</param>
         /// <returns></returns>
-        public Task<DiscordMessage> RespondAsync(DiscordMessageBuilder builder) 
+        public Task<DiscordMessage> RespondAsync(DiscordMessageBuilder builder)
             => this.Message.RespondAsync(builder);
 
         /// <summary>
@@ -138,7 +161,7 @@ namespace DSharpPlus.CommandsNext
         /// Triggers typing in the channel containing the message that triggered the command.
         /// </summary>
         /// <returns></returns>
-        public Task TriggerTypingAsync() 
+        public Task TriggerTypingAsync()
             => this.Channel.TriggerTypingAsync();
 
         internal struct ServiceContext : IDisposable
@@ -154,10 +177,7 @@ namespace DSharpPlus.CommandsNext
                 this.IsInitialized = true;
             }
 
-            public void Dispose()
-            {
-                this.Scope?.Dispose();
-            }
+            public void Dispose() => this.Scope?.Dispose();
         }
     }
 }

--- a/DSharpPlus.CommandsNext/EventArgs/CommandErrorEventArgs.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandErrorEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.CommandsNext
 {

--- a/DSharpPlus.CommandsNext/EventArgs/CommandEventArgs.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using Emzi0767.Utilities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Emzi0767.Utilities;
 
 namespace DSharpPlus.CommandsNext
 {
@@ -15,7 +38,7 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Gets the command that was executed.
         /// </summary>
-        public Command Command 
+        public Command Command
             => this.Context.Command;
     }
 }

--- a/DSharpPlus.CommandsNext/EventArgs/CommandExecutionEventArgs.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandExecutionEventArgs.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.CommandsNext
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.CommandsNext
 {
     /// <summary>
     /// Represents arguments for <see cref="CommandsNextExtension.CommandExecuted"/> event.

--- a/DSharpPlus.CommandsNext/Exceptions/ChecksFailedException.cs
+++ b/DSharpPlus.CommandsNext/Exceptions/ChecksFailedException.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using DSharpPlus.CommandsNext.Attributes;

--- a/DSharpPlus.CommandsNext/Exceptions/CommandNotFoundException.cs
+++ b/DSharpPlus.CommandsNext/Exceptions/CommandNotFoundException.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.CommandsNext.Exceptions
 {
@@ -26,9 +49,6 @@ namespace DSharpPlus.CommandsNext.Exceptions
         /// Returns a string representation of this <see cref="CommandNotFoundException"/>.
         /// </summary>
         /// <returns>A string representation.</returns>
-        public override string ToString()
-        {
-            return $"{this.GetType()}: {this.Message}\nCommand name: {this.CommandName}"; // much like System.ArgumentNullException works
-        }
+        public override string ToString() => $"{this.GetType()}: {this.Message}\nCommand name: {this.CommandName}"; // much like System.ArgumentNullException works
     }
 }

--- a/DSharpPlus.CommandsNext/Exceptions/DuplicateCommandException.cs
+++ b/DSharpPlus.CommandsNext/Exceptions/DuplicateCommandException.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.CommandsNext.Exceptions
 {
@@ -26,9 +49,6 @@ namespace DSharpPlus.CommandsNext.Exceptions
         /// Returns a string representation of this <see cref="DuplicateCommandException"/>.
         /// </summary>
         /// <returns>A string representation.</returns>
-        public override string ToString()
-        {
-            return $"{this.GetType()}: {this.Message}\nCommand name: {this.CommandName}"; // much like System.ArgumentException works
-        }
+        public override string ToString() => $"{this.GetType()}: {this.Message}\nCommand name: {this.CommandName}"; // much like System.ArgumentException works
     }
 }

--- a/DSharpPlus.CommandsNext/Exceptions/DuplicateOverloadException.cs
+++ b/DSharpPlus.CommandsNext/Exceptions/DuplicateOverloadException.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -39,9 +62,6 @@ namespace DSharpPlus.CommandsNext.Exceptions
         /// Returns a string representation of this <see cref="DuplicateOverloadException"/>.
         /// </summary>
         /// <returns>A string representation.</returns>
-        public override string ToString()
-        {
-            return $"{this.GetType()}: {this.Message}\nCommand name: {this.CommandName}\nArgument types: {this.ArgumentSetKey}"; // much like System.ArgumentException works
-        }
+        public override string ToString() => $"{this.GetType()}: {this.Message}\nCommand name: {this.CommandName}\nArgument types: {this.ArgumentSetKey}"; // much like System.ArgumentException works
     }
 }

--- a/DSharpPlus.CommandsNext/Exceptions/InvalidOverloadException.cs
+++ b/DSharpPlus.CommandsNext/Exceptions/InvalidOverloadException.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Reflection;
 
 namespace DSharpPlus.CommandsNext.Exceptions
@@ -30,7 +53,7 @@ namespace DSharpPlus.CommandsNext.Exceptions
             this.Method = method;
             this.Parameter = parameter;
         }
-        
+
         /// <summary>
         /// Creates a new <see cref="InvalidOverloadException"/>.
         /// </summary>
@@ -47,10 +70,9 @@ namespace DSharpPlus.CommandsNext.Exceptions
         public override string ToString()
         {
             // much like System.ArgumentNullException works
-            if (this.Parameter == null)
-                return $"{this.GetType()}: {this.Message}\nMethod: {this.Method} (declared in {this.Method.DeclaringType})";
-            else
-                return $"{this.GetType()}: {this.Message}\nMethod: {this.Method} (declared in {this.Method.DeclaringType})\nArgument: {this.Parameter.ParameterType} {this.Parameter.Name}";
+            return this.Parameter == null
+                ? $"{this.GetType()}: {this.Message}\nMethod: {this.Method} (declared in {this.Method.DeclaringType})"
+                : $"{this.GetType()}: {this.Message}\nMethod: {this.Method} (declared in {this.Method.DeclaringType})\nArgument: {this.Parameter.ParameterType} {this.Parameter.Name}";
         }
     }
 }

--- a/DSharpPlus.CommandsNext/ExtensionMethods.cs
+++ b/DSharpPlus.CommandsNext/ExtensionMethods.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -64,7 +87,7 @@ namespace DSharpPlus.CommandsNext
         /// <returns>The module, or null if not activated.</returns>
         public static CommandsNextExtension GetCommandsNext(this DiscordClient client)
             => client.GetExtension<CommandsNextExtension>();
-        
+
 
         /// <summary>
         /// Gets the active CommandsNext modules for all shards in this client.
@@ -74,7 +97,7 @@ namespace DSharpPlus.CommandsNext
         public static async Task<IReadOnlyDictionary<int, CommandsNextExtension>> GetCommandsNextAsync(this DiscordShardedClient client)
         {
             await client.InitializeShardsAsync().ConfigureAwait(false);
-            var extensions = new Dictionary<int, CommandsNextExtension>();            
+            var extensions = new Dictionary<int, CommandsNextExtension>();
 
             foreach (var shard in client.ShardClients.Select(xkvp => xkvp.Value))
             {

--- a/DSharpPlus.Interactivity/DSharpPlus.Interactivity.csproj
+++ b/DSharpPlus.Interactivity/DSharpPlus.Interactivity.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../DSharpPlus.targets" />

--- a/DSharpPlus.Interactivity/Enums/PaginationBehaviour.cs
+++ b/DSharpPlus.Interactivity/Enums/PaginationBehaviour.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Interactivity.Enums
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Interactivity.Enums
 {
     /// <summary>
     /// Specifies how pagination will handle advancing past the first and last pages.

--- a/DSharpPlus.Interactivity/Enums/PaginationDeletion.cs
+++ b/DSharpPlus.Interactivity/Enums/PaginationDeletion.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Interactivity.Enums
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Interactivity.Enums
 {
     /// <summary>
     /// Specifies what should be done once pagination times out.

--- a/DSharpPlus.Interactivity/Enums/PollBehaviour.cs
+++ b/DSharpPlus.Interactivity/Enums/PollBehaviour.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Interactivity.Enums
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Interactivity.Enums
 {
     /// <summary>
     /// Specifies what should be done when a poll times out.

--- a/DSharpPlus.Interactivity/Enums/SplitType.cs
+++ b/DSharpPlus.Interactivity/Enums/SplitType.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Interactivity.Enums
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Interactivity.Enums
 {
     /// <summary>
     /// Specifies how to split a string.

--- a/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -36,7 +59,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             this._matchrequests = new ConcurrentHashSet<MatchRequest<T>>();
             this._collectrequests = new ConcurrentHashSet<CollectRequest<T>>();
             this._event = (AsyncEvent<DiscordClient, T>)handler.GetValue(_client);
-            this._handler = new AsyncEventHandler<DiscordClient, T>(HandleEvent);
+            this._handler = new AsyncEventHandler<DiscordClient, T>(this.HandleEvent);
             this._event.Register(_handler);
         }
 
@@ -121,16 +144,16 @@ namespace DSharpPlus.Interactivity.EventHandling
         public void Dispose()
         {
             this.disposed = true;
-            if(this._event != null)
+            if (this._event != null)
                 this._event.Unregister(_handler);
 
             this._event = null;
             this._handler = null;
             this._client = null;
 
-            if(this._matchrequests != null)
+            if (this._matchrequests != null)
                 this._matchrequests.Clear();
-            if(this._collectrequests != null)
+            if (this._collectrequests != null)
                 this._collectrequests.Clear();
 
             this._matchrequests = null;

--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading.Tasks;
 using ConcurrentCollections;
 using DSharpPlus.Entities;
@@ -29,7 +52,7 @@ namespace DSharpPlus.Interactivity.EventHandling
 
         public async Task DoPaginationAsync(IPaginationRequest request)
         {
-            await ResetReactionsAsync(request).ConfigureAwait(false);
+            await this.ResetReactionsAsync(request).ConfigureAwait(false);
             this._requests.Add(request);
             try
             {
@@ -78,13 +101,13 @@ namespace DSharpPlus.Interactivity.EventHandling
                                  eventargs.Emoji == emojis.SkipRight ||
                                  eventargs.Emoji == emojis.Stop))
                             {
-                                await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                                await this.PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
                             }
                             else if (eventargs.Emoji == emojis.Stop &&
                                      req is PaginationRequest paginationRequest &&
                                      paginationRequest.PaginationDeletion == PaginationDeletion.DeleteMessage)
                             {
-                                await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                                await this.PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
                             }
                             else
                             {
@@ -132,13 +155,13 @@ namespace DSharpPlus.Interactivity.EventHandling
                                  eventargs.Emoji == emojis.SkipRight ||
                                  eventargs.Emoji == emojis.Stop))
                             {
-                                await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                                await this.PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
                             }
                             else if (eventargs.Emoji == emojis.Stop &&
                                      req is PaginationRequest paginationRequest &&
                                      paginationRequest.PaginationDeletion == PaginationDeletion.DeleteMessage)
                             {
-                                await PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
+                                await this.PaginateAsync(req, eventargs.Emoji).ConfigureAwait(false);
                             }
                         }
                     }
@@ -161,7 +184,7 @@ namespace DSharpPlus.Interactivity.EventHandling
 
                     if (msg.Id == eventargs.Message.Id)
                     {
-                        await ResetReactionsAsync(req).ConfigureAwait(false);
+                        await this.ResetReactionsAsync(req).ConfigureAwait(false);
                     }
                 }
             });

--- a/DSharpPlus.Interactivity/EventHandling/Poller.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Poller.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -85,7 +108,7 @@ namespace DSharpPlus.Interactivity.EventHandling
                 // match message
                 if (req._message.Id == eventargs.Message.Id && req._message.ChannelId == eventargs.Channel.Id)
                 {
-                    if(eventargs.User.Id != _client.CurrentUser.Id)
+                    if (eventargs.User.Id != _client.CurrentUser.Id)
                         req.RemoveReaction(eventargs.Emoji, eventargs.User);
                 }
             }
@@ -97,7 +120,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             foreach (var req in _requests)
             {
                 // match message
-                if(req._message.Id == eventargs.Message.Id && req._message.ChannelId == eventargs.Channel.Id)
+                if (req._message.Id == eventargs.Message.Id && req._message.ChannelId == eventargs.Channel.Id)
                 {
                     req.ClearCollected();
                 }

--- a/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -47,19 +70,19 @@ namespace DSharpPlus.Interactivity.EventHandling
             var handler = tinfo.DeclaredFields.First(x => x.FieldType == typeof(AsyncEvent<DiscordClient, MessageReactionAddEventArgs>));
 
             this._reactionAddEvent = (AsyncEvent<DiscordClient, MessageReactionAddEventArgs>)handler.GetValue(_client);
-            this._reactionAddHandler = new AsyncEventHandler<DiscordClient, MessageReactionAddEventArgs>(HandleReactionAdd);
+            this._reactionAddHandler = new AsyncEventHandler<DiscordClient, MessageReactionAddEventArgs>(this.HandleReactionAdd);
             this._reactionAddEvent.Register(_reactionAddHandler);
 
             handler = tinfo.DeclaredFields.First(x => x.FieldType == typeof(AsyncEvent<DiscordClient, MessageReactionRemoveEventArgs>));
 
             this._reactionRemoveEvent = (AsyncEvent<DiscordClient, MessageReactionRemoveEventArgs>)handler.GetValue(_client);
-            this._reactionRemoveHandler = new AsyncEventHandler<DiscordClient, MessageReactionRemoveEventArgs>(HandleReactionRemove);
+            this._reactionRemoveHandler = new AsyncEventHandler<DiscordClient, MessageReactionRemoveEventArgs>(this.HandleReactionRemove);
             this._reactionRemoveEvent.Register(_reactionRemoveHandler);
 
             handler = tinfo.DeclaredFields.First(x => x.FieldType == typeof(AsyncEvent<DiscordClient, MessageReactionsClearEventArgs>));
 
             this._reactionClearEvent = (AsyncEvent<DiscordClient, MessageReactionsClearEventArgs>)handler.GetValue(_client);
-            this._reactionClearHandler = new AsyncEventHandler<DiscordClient, MessageReactionsClearEventArgs>(HandleReactionClear);
+            this._reactionClearHandler = new AsyncEventHandler<DiscordClient, MessageReactionsClearEventArgs>(this.HandleReactionClear);
             this._reactionClearEvent.Register(_reactionClearHandler);
         }
 
@@ -88,7 +111,7 @@ namespace DSharpPlus.Interactivity.EventHandling
         private Task HandleReactionAdd(DiscordClient client, MessageReactionAddEventArgs eventargs)
         {
             // foreach request add
-            foreach(var req in _requests)
+            foreach (var req in _requests)
             {
                 if (req.message.Id == eventargs.Message.Id)
                 {
@@ -119,7 +142,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             {
                 if (req.message.Id == eventargs.Message.Id)
                 {
-                    if(req._collected.Any(x => x.Emoji == eventargs.Emoji && x.Users.Any(y => y.Id == eventargs.User.Id)))
+                    if (req._collected.Any(x => x.Emoji == eventargs.Emoji && x.Users.Any(y => y.Id == eventargs.User.Id)))
                     {
                         var reaction = req._collected.First(x => x.Emoji == eventargs.Emoji && x.Users.Any(y => y.Id == eventargs.User.Id));
                         req._collected.TryRemove(reaction);
@@ -211,6 +234,6 @@ namespace DSharpPlus.Interactivity.EventHandling
     {
         public DiscordEmoji Emoji { get; internal set; }
         public ConcurrentHashSet<DiscordUser> Users { get; internal set; }
-        public int Total { get { return Users.Count; } }
+        public int Total => this.Users.Count;
     }
 }

--- a/DSharpPlus.Interactivity/EventHandling/Requests/CollectRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/CollectRequest.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using ConcurrentCollections;

--- a/DSharpPlus.Interactivity/EventHandling/Requests/IPaginationRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/IPaginationRequest.cs
@@ -1,4 +1,27 @@
-﻿using System.Threading.Tasks;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Threading.Tasks;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.Interactivity.EventHandling
@@ -10,7 +33,7 @@ namespace DSharpPlus.Interactivity.EventHandling
         /// </summary>
         /// <returns></returns>
         int PageCount { get; }
-        
+
         /// <summary>
         /// Returns the current page.
         /// </summary>

--- a/DSharpPlus.Interactivity/EventHandling/Requests/MatchRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/MatchRequest.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Emzi0767.Utilities;

--- a/DSharpPlus.Interactivity/EventHandling/Requests/PaginationRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/PaginationRequest.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,14 +33,13 @@ namespace DSharpPlus.Interactivity.EventHandling
     internal class PaginationRequest : IPaginationRequest
     {
         private TaskCompletionSource<bool> _tcs;
-        private CancellationTokenSource _ct;
+        private readonly CancellationTokenSource _ct;
         private TimeSpan _timeout;
-        private List<Page> _pages;
-        private PaginationBehaviour _behaviour;
-        private PaginationDeletion _deletion;
-        private DiscordMessage _message;
-        private PaginationEmojis _emojis;
-        private DiscordUser _user;
+        private readonly List<Page> _pages;
+        private readonly PaginationBehaviour _behaviour;
+        private readonly DiscordMessage _message;
+        private readonly PaginationEmojis _emojis;
+        private readonly DiscordUser _user;
         private int index = 0;
 
         /// <summary>
@@ -41,7 +63,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             this._message = message;
             this._user = user;
 
-            this._deletion = deletion;
+            this.PaginationDeletion = deletion;
             this._behaviour = behaviour;
             this._emojis = emojis;
 
@@ -51,10 +73,10 @@ namespace DSharpPlus.Interactivity.EventHandling
                 this._pages.Add(p);
             }
         }
-        
+
         public int PageCount => _pages.Count;
 
-        public PaginationDeletion PaginationDeletion => _deletion;
+        public PaginationDeletion PaginationDeletion { get; }
 
         public async Task<Page> GetPageAsync()
         {
@@ -148,7 +170,7 @@ namespace DSharpPlus.Interactivity.EventHandling
 
         public async Task DoCleanupAsync()
         {
-            switch (_deletion)
+            switch (PaginationDeletion)
             {
                 case PaginationDeletion.DeleteEmojis:
                     await _message.DeleteAllReactionsAsync().ConfigureAwait(false);
@@ -210,7 +232,7 @@ namespace DSharpPlus.Interactivity
     {
         public string Content { get; set; }
         public DiscordEmbed Embed { get; set; }
-        
+
         public Page(string content = "", DiscordEmbedBuilder embed = null)
         {
             this.Content = content;

--- a/DSharpPlus.Interactivity/EventHandling/Requests/PollRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/PollRequest.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -33,7 +56,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             this._collected = new ConcurrentHashSet<PollEmoji>();
             this._message = message;
 
-            foreach (DiscordEmoji e in emojis)
+            foreach (var e in emojis)
             {
                 _collected.Add(new PollEmoji(e));
             }
@@ -42,7 +65,7 @@ namespace DSharpPlus.Interactivity.EventHandling
         internal void ClearCollected()
         {
             _collected.Clear();
-            foreach (DiscordEmoji e in _emojis)
+            foreach (var e in _emojis)
             {
                 _collected.Add(new PollEmoji(e));
             }

--- a/DSharpPlus.Interactivity/Extensions/ChannelExtensions.cs
+++ b/DSharpPlus.Interactivity/Extensions/ChannelExtensions.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
@@ -19,7 +42,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="predicate">A predicate that should return <see langword="true"/> if a message matches.</param>
         /// <param name="timeoutOverride">Overrides the timeout set in <see cref="InteractivityConfiguration.Timeout"/></param>
         /// <exception cref="InvalidOperationException">Thrown if interactivity is not enabled for the client associated with the channel.</exception>
-        public static Task<InteractivityResult<DiscordMessage>> GetNextMessageAsync(this DiscordChannel channel, Func<DiscordMessage, bool> predicate, TimeSpan? timeoutOverride = null) 
+        public static Task<InteractivityResult<DiscordMessage>> GetNextMessageAsync(this DiscordChannel channel, Func<DiscordMessage, bool> predicate, TimeSpan? timeoutOverride = null)
             => GetInteractivity(channel).WaitForMessageAsync(msg => msg.ChannelId == channel.Id && predicate(msg), timeoutOverride);
 
         /// <summary>
@@ -48,7 +71,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="user">The target user.</param>
         /// <param name="timeoutOverride">Overrides the timeout set in <see cref="InteractivityConfiguration.Timeout"/></param>
         /// <exception cref="InvalidOperationException">Thrown if interactivity is not enabled for the client associated with the channel.</exception>
-        public static Task<InteractivityResult<TypingStartEventArgs>> WaitForUserTypingAsync(this DiscordChannel channel, DiscordUser user, TimeSpan? timeoutOverride = null) 
+        public static Task<InteractivityResult<TypingStartEventArgs>> WaitForUserTypingAsync(this DiscordChannel channel, DiscordUser user, TimeSpan? timeoutOverride = null)
             => GetInteractivity(channel).WaitForUserTypingAsync(user, channel, timeoutOverride);
 
         /// <summary>
@@ -62,7 +85,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="deletion"></param>
         /// <param name="timeoutoverride"></param>
         /// <exception cref="InvalidOperationException">Thrown if interactivity is not enabled for the client associated with the channel.</exception>
-        public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationEmojis emojis = null, PaginationBehaviour? behaviour = default, PaginationDeletion? deletion = default, TimeSpan? timeoutoverride = null) 
+        public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationEmojis emojis = null, PaginationBehaviour? behaviour = default, PaginationDeletion? deletion = default, TimeSpan? timeoutoverride = null)
             => GetInteractivity(channel).SendPaginatedMessageAsync(channel, user, pages, emojis, behaviour, deletion, timeoutoverride);
 
         /// <summary>
@@ -73,9 +96,9 @@ namespace DSharpPlus.Interactivity.Extensions
             var client = (DiscordClient)channel.Discord;
             var interactivity = client.GetInteractivity();
 
-            if (interactivity == null) throw new InvalidOperationException($"Interactivity is not enabled for this {(client._isShard ? "shard" : "client")}.");
-
-            return interactivity;
+            return interactivity == null
+                ? throw new InvalidOperationException($"Interactivity is not enabled for this {(client._isShard ? "shard" : "client")}.")
+                : interactivity;
         }
     }
 }

--- a/DSharpPlus.Interactivity/Extensions/ClientExtensions.cs
+++ b/DSharpPlus.Interactivity/Extensions/ClientExtensions.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -65,7 +88,7 @@ namespace DSharpPlus.Interactivity.Extensions
         public static async Task<ReadOnlyDictionary<int, InteractivityExtension>> GetInteractivityAsync(this DiscordShardedClient client)
         {
             await client.InitializeShardsAsync().ConfigureAwait(false);
-            var extensions = new Dictionary<int, InteractivityExtension>();            
+            var extensions = new Dictionary<int, InteractivityExtension>();
 
             foreach (var shard in client.ShardClients.Select(xkvp => xkvp.Value))
             {

--- a/DSharpPlus.Interactivity/Extensions/MessageExtensions.cs
+++ b/DSharpPlus.Interactivity/Extensions/MessageExtensions.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
@@ -82,9 +105,9 @@ namespace DSharpPlus.Interactivity.Extensions
             var client = (DiscordClient)message.Discord;
             var interactivity = client.GetInteractivity();
 
-            if (interactivity == null) throw new InvalidOperationException($"Interactivity is not enabled for this {(client._isShard ? "shard" : "client")}.");
-
-            return interactivity;
+            return interactivity == null
+                ? throw new InvalidOperationException($"Interactivity is not enabled for this {(client._isShard ? "shard" : "client")}.")
+                : interactivity;
         }
     }
 }

--- a/DSharpPlus.Interactivity/InteractivityConfiguration.cs
+++ b/DSharpPlus.Interactivity/InteractivityConfiguration.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using DSharpPlus.Interactivity.Enums;
 
 namespace DSharpPlus.Interactivity
@@ -37,7 +60,8 @@ namespace DSharpPlus.Interactivity
         /// <summary>
         /// Creates a new instance of <see cref="InteractivityConfiguration"/>.
         /// </summary>
-        public InteractivityConfiguration() {
+        public InteractivityConfiguration()
+        {
         }
 
         /// <summary>

--- a/DSharpPlus.Interactivity/InteractivityEvents.cs
+++ b/DSharpPlus.Interactivity/InteractivityEvents.cs
@@ -1,4 +1,27 @@
-﻿using Microsoft.Extensions.Logging;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus.Interactivity
 {

--- a/DSharpPlus.Interactivity/InteractivityResult.cs
+++ b/DSharpPlus.Interactivity/InteractivityResult.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Interactivity
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Interactivity
 {
     /// <summary>
     /// Interactivity result

--- a/DSharpPlus.Lavalink/DSharpPlus.Lavalink.csproj
+++ b/DSharpPlus.Lavalink/DSharpPlus.Lavalink.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../DSharpPlus.targets" />
@@ -16,9 +16,9 @@
     <Description>Lavalink implementation for DSharpPlus. Lavalink is an easy and lightweight method of streaming audio to Discord.</Description>
     <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, audio, voice, radio, music, lavalink, lavaplayer</PackageTags>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/DSharpPlus.Lavalink/DiscordClientExtensions.cs
+++ b/DSharpPlus.Lavalink/DiscordClientExtensions.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -93,14 +116,13 @@ namespace DSharpPlus.Lavalink
             if (channel.Type != ChannelType.Voice && channel.Type != ChannelType.Stage)
                 throw new InvalidOperationException("You can only connect to voice and stage channels.");
 
-            if (!(channel.Discord is DiscordClient discord) || discord == null)
+            if (channel.Discord is not DiscordClient discord || discord == null)
                 throw new NullReferenceException();
 
             var lava = discord.GetLavalink();
-            if (lava == null)
-                throw new InvalidOperationException("Lavalink is not initialized for this Discord client.");
-
-            return node.ConnectAsync(channel);
+            return lava == null
+                ? throw new InvalidOperationException("Lavalink is not initialized for this Discord client.")
+                : node.ConnectAsync(channel);
         }
     }
 }

--- a/DSharpPlus.Lavalink/Entities/LavalinkCommands.cs
+++ b/DSharpPlus.Lavalink/Entities/LavalinkCommands.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -31,7 +54,7 @@ namespace DSharpPlus.Lavalink.Entities
     {
         [JsonProperty("track")]
         public string Track { get; }
-        
+
         public LavalinkPlay(LavalinkGuildConnection lvl, LavalinkTrack track)
             : base("play", lvl.GuildIdString)
         {

--- a/DSharpPlus.Lavalink/Entities/LavalinkDispatch.cs
+++ b/DSharpPlus.Lavalink/Entities/LavalinkDispatch.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Lavalink.Entities
 {

--- a/DSharpPlus.Lavalink/Entities/LavalinkEqualizerTypes.cs
+++ b/DSharpPlus.Lavalink/Entities/LavalinkEqualizerTypes.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/DSharpPlus.Lavalink/Entities/LavalinkPayload.cs
+++ b/DSharpPlus.Lavalink/Entities/LavalinkPayload.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Lavalink.Entities
 {
@@ -11,7 +34,9 @@ namespace DSharpPlus.Lavalink.Entities
         public string GuildId { get; }
 
         internal LavalinkPayload(string opcode)
-            => this.Operation = opcode;
+        {
+            this.Operation = opcode;
+        }
 
         internal LavalinkPayload(string opcode, string guildId)
         {

--- a/DSharpPlus.Lavalink/Entities/LavalinkRouteStatus.cs
+++ b/DSharpPlus.Lavalink/Entities/LavalinkRouteStatus.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Lavalink.Entities
@@ -10,7 +33,7 @@ namespace DSharpPlus.Lavalink.Entities
         /// </summary>
         [JsonIgnore]
         public LavalinkRoutePlannerType? Class
-            => this.GetLavalinkRoutePlannerType(_class);
+            => this.GetLavalinkRoutePlannerType(this._class);
 
         /// <summary>
         /// Gets the details of the route planner.
@@ -23,23 +46,14 @@ namespace DSharpPlus.Lavalink.Entities
 
         private LavalinkRoutePlannerType? GetLavalinkRoutePlannerType(string type)
         {
-            switch(type)
+            return type switch
             {
-                case "RotatingIpRoutePlanner":
-                    return LavalinkRoutePlannerType.RotatingIpRoutePlanner;
-
-                case "BalancingIpRoutePlanner":
-                    return LavalinkRoutePlannerType.BalancingIpRoutePlanner;
-
-                case "NanoIpRoutePlanner":
-                    return LavalinkRoutePlannerType.NanoIpRoutePlanner;
-
-                case "RotatingNanoIpRoutePlanner":
-                    return LavalinkRoutePlannerType.RotatingNanoIpRoutePlanner;
-
-                default:
-                    return null;
-            }
+                "RotatingIpRoutePlanner" => LavalinkRoutePlannerType.RotatingIpRoutePlanner,
+                "BalancingIpRoutePlanner" => LavalinkRoutePlannerType.BalancingIpRoutePlanner,
+                "NanoIpRoutePlanner" => LavalinkRoutePlannerType.NanoIpRoutePlanner,
+                "RotatingNanoIpRoutePlanner" => LavalinkRoutePlannerType.RotatingNanoIpRoutePlanner,
+                _ => null,
+            };
         }
     }
 

--- a/DSharpPlus.Lavalink/Entities/LavalinkUpdates.cs
+++ b/DSharpPlus.Lavalink/Entities/LavalinkUpdates.cs
@@ -1,4 +1,27 @@
-﻿#pragma warning disable 0649
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma warning disable 0649
 
 using System;
 using Newtonsoft.Json;
@@ -10,12 +33,12 @@ namespace DSharpPlus.Lavalink.Entities
         [JsonIgnore]
         public DateTimeOffset Time => Utilities.GetDateTimeOffsetFromMilliseconds(this._time);
         [JsonProperty("time")]
-        private long _time;
+        private readonly long _time;
 
         [JsonIgnore]
         public TimeSpan Position => TimeSpan.FromMilliseconds(this._position);
         [JsonProperty("position")]
-        private long _position;
+        private readonly long _position;
     }
 
     /// <summary>
@@ -43,21 +66,21 @@ namespace DSharpPlus.Lavalink.Entities
     {
         [JsonProperty("playingPlayers")]
         public int ActivePlayers { get; set; }
-        
+
         [JsonProperty("players")]
         public int TotalPlayers { get; set; }
 
         [JsonIgnore]
         public TimeSpan Uptime => TimeSpan.FromMilliseconds(this._uptime);
         [JsonProperty("uptime")]
-        private long _uptime;
+        private readonly long _uptime;
 
         [JsonProperty("cpu")]
         public CpuStats Cpu { get; set; }
 
         [JsonProperty("memory")]
         public MemoryStats Memory { get; set; }
-        
+
         [JsonProperty("frameStats")]
         public FrameStats Frames { get; set; }
 

--- a/DSharpPlus.Lavalink/Entities/LavalinkVoiceServerUpdate.cs
+++ b/DSharpPlus.Lavalink/Entities/LavalinkVoiceServerUpdate.cs
@@ -1,4 +1,27 @@
-﻿using System.Globalization;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Globalization;
 using DSharpPlus.EventArgs;
 using Newtonsoft.Json;
 

--- a/DSharpPlus.Lavalink/Entities/LavalinkVoiceStateUpdatePayload.cs
+++ b/DSharpPlus.Lavalink/Entities/LavalinkVoiceStateUpdatePayload.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Lavalink.Entities
 {

--- a/DSharpPlus.Lavalink/Enums/LavalinkRoutePlannerType.cs
+++ b/DSharpPlus.Lavalink/Enums/LavalinkRoutePlannerType.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Lavalink
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Lavalink
 {
     public enum LavalinkRoutePlannerType
     {

--- a/DSharpPlus.Lavalink/Enums/LavalinkSearchType.cs
+++ b/DSharpPlus.Lavalink/Enums/LavalinkSearchType.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Lavalink
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Lavalink
 {
     public enum LavalinkSearchType
     {

--- a/DSharpPlus.Lavalink/EventArgs/NodeDisconnectedEventArgs.cs
+++ b/DSharpPlus.Lavalink/EventArgs/NodeDisconnectedEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using Emzi0767.Utilities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Emzi0767.Utilities;
 
 namespace DSharpPlus.Lavalink.EventArgs
 {

--- a/DSharpPlus.Lavalink/EventArgs/PlayerUpdateEventArgs.cs
+++ b/DSharpPlus.Lavalink/EventArgs/PlayerUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using Emzi0767.Utilities;
 
 namespace DSharpPlus.Lavalink.EventArgs

--- a/DSharpPlus.Lavalink/EventArgs/StatisticsReceivedEventArgs.cs
+++ b/DSharpPlus.Lavalink/EventArgs/StatisticsReceivedEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Lavalink.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Lavalink.Entities;
 using Emzi0767.Utilities;
 
 namespace DSharpPlus.Lavalink.EventArgs

--- a/DSharpPlus.Lavalink/EventArgs/TrackEventArgs.cs
+++ b/DSharpPlus.Lavalink/EventArgs/TrackEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using Emzi0767.Utilities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Emzi0767.Utilities;
 
 namespace DSharpPlus.Lavalink.EventArgs
 {
@@ -103,7 +126,7 @@ namespace DSharpPlus.Lavalink.EventArgs
         public long Threshold { get; set; }
         public string Track { get; set; }
     }
-    
+
     /// <summary>
     /// Represents event arguments for a track stuck event.
     /// </summary>

--- a/DSharpPlus.Lavalink/EventArgs/WebSocketCloseEventArgs.cs
+++ b/DSharpPlus.Lavalink/EventArgs/WebSocketCloseEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using Emzi0767.Utilities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Emzi0767.Utilities;
 
 namespace DSharpPlus.Lavalink.EventArgs
 {
@@ -21,7 +44,7 @@ namespace DSharpPlus.Lavalink.EventArgs
         /// Gets whether the termination was initiated by the remote party (i.e. Discord).
         /// </summary>
         public bool Remote { get; }
-        
+
         internal WebSocketCloseEventArgs(int code, string reason, bool remote)
         {
             this.Code = code;

--- a/DSharpPlus.Lavalink/LavalinkConfiguration.cs
+++ b/DSharpPlus.Lavalink/LavalinkConfiguration.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 using DSharpPlus.Net;
 
 namespace DSharpPlus.Lavalink

--- a/DSharpPlus.Lavalink/LavalinkEvents.cs
+++ b/DSharpPlus.Lavalink/LavalinkEvents.cs
@@ -1,4 +1,27 @@
-﻿using Microsoft.Extensions.Logging;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus.Lavalink
 {

--- a/DSharpPlus.Lavalink/LavalinkExtension.cs
+++ b/DSharpPlus.Lavalink/LavalinkExtension.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,7 +49,7 @@ namespace DSharpPlus.Lavalink
         /// Gets a dictionary of connected Lavalink nodes for the extension.
         /// </summary>
         public IReadOnlyDictionary<ConnectionEndpoint, LavalinkNodeConnection> ConnectedNodes { get; }
-        private ConcurrentDictionary<ConnectionEndpoint, LavalinkNodeConnection> _connectedNodes = new ConcurrentDictionary<ConnectionEndpoint, LavalinkNodeConnection>();
+        private readonly ConcurrentDictionary<ConnectionEndpoint, LavalinkNodeConnection> _connectedNodes = new();
 
         /// <summary>
         /// Creates a new instance of this Lavalink extension.
@@ -139,27 +162,27 @@ namespace DSharpPlus.Lavalink
                 var bPenaltyCount = b.Statistics.ActivePlayers;
 
                 //cpu load
-                aPenaltyCount += (int)Math.Pow(1.05d, 100 * (a.Statistics.CpuSystemLoad / a.Statistics.CpuCoreCount) * 10 - 10);
-                bPenaltyCount += (int)Math.Pow(1.05d, 100 * (b.Statistics.CpuSystemLoad / a.Statistics.CpuCoreCount) * 10 - 10);
+                aPenaltyCount += (int)Math.Pow(1.05d, (100 * (a.Statistics.CpuSystemLoad / a.Statistics.CpuCoreCount) * 10) - 10);
+                bPenaltyCount += (int)Math.Pow(1.05d, (100 * (b.Statistics.CpuSystemLoad / a.Statistics.CpuCoreCount) * 10) - 10);
 
                 //frame load
                 if (a.Statistics.AverageDeficitFramesPerMinute > 0)
                 {
                     //deficit frame load
-                    aPenaltyCount += (int)(Math.Pow(1.03d, 500f * (a.Statistics.AverageDeficitFramesPerMinute / 3000f)) * 600 - 600);
+                    aPenaltyCount += (int)((Math.Pow(1.03d, 500f * (a.Statistics.AverageDeficitFramesPerMinute / 3000f)) * 600) - 600);
 
                     //null frame load
-                    aPenaltyCount += (int)(Math.Pow(1.03d, 500f * (a.Statistics.AverageNulledFramesPerMinute / 3000f)) * 300 - 300);
+                    aPenaltyCount += (int)((Math.Pow(1.03d, 500f * (a.Statistics.AverageNulledFramesPerMinute / 3000f)) * 300) - 300);
                 }
 
                 //frame load
                 if (b.Statistics.AverageDeficitFramesPerMinute > 0)
                 {
                     //deficit frame load
-                    bPenaltyCount += (int)(Math.Pow(1.03d, 500f * (b.Statistics.AverageDeficitFramesPerMinute / 3000f)) * 600 - 600);
+                    bPenaltyCount += (int)((Math.Pow(1.03d, 500f * (b.Statistics.AverageDeficitFramesPerMinute / 3000f)) * 600) - 600);
 
                     //null frame load
-                    bPenaltyCount += (int)(Math.Pow(1.03d, 500f * (b.Statistics.AverageNulledFramesPerMinute / 3000f)) * 300 - 300);
+                    bPenaltyCount += (int)((Math.Pow(1.03d, 500f * (b.Statistics.AverageNulledFramesPerMinute / 3000f)) * 300) - 300);
                 }
 
                 return aPenaltyCount - bPenaltyCount;

--- a/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -28,7 +51,7 @@ namespace DSharpPlus.Lavalink
             add { this._playerUpdated.Register(value); }
             remove { this._playerUpdated.Unregister(value); }
         }
-        private AsyncEvent<LavalinkGuildConnection, PlayerUpdateEventArgs> _playerUpdated;
+        private readonly AsyncEvent<LavalinkGuildConnection, PlayerUpdateEventArgs> _playerUpdated;
 
         /// <summary>
         /// Triggered whenever playback of a track starts.
@@ -39,7 +62,7 @@ namespace DSharpPlus.Lavalink
             add { this._playbackStarted.Register(value); }
             remove { this._playbackStarted.Unregister(value); }
         }
-        private AsyncEvent<LavalinkGuildConnection, TrackStartEventArgs> _playbackStarted;
+        private readonly AsyncEvent<LavalinkGuildConnection, TrackStartEventArgs> _playbackStarted;
 
         /// <summary>
         /// Triggered whenever playback of a track finishes.
@@ -49,7 +72,7 @@ namespace DSharpPlus.Lavalink
             add { this._playbackFinished.Register(value); }
             remove { this._playbackFinished.Unregister(value); }
         }
-        private AsyncEvent<LavalinkGuildConnection, TrackFinishEventArgs> _playbackFinished;
+        private readonly AsyncEvent<LavalinkGuildConnection, TrackFinishEventArgs> _playbackFinished;
 
         /// <summary>
         /// Triggered whenever playback of a track gets stuck.
@@ -59,7 +82,7 @@ namespace DSharpPlus.Lavalink
             add { this._trackStuck.Register(value); }
             remove { this._trackStuck.Unregister(value); }
         }
-        private AsyncEvent<LavalinkGuildConnection, TrackStuckEventArgs> _trackStuck;
+        private readonly AsyncEvent<LavalinkGuildConnection, TrackStuckEventArgs> _trackStuck;
 
         /// <summary>
         /// Triggered whenever playback of a track encounters an error.
@@ -69,7 +92,7 @@ namespace DSharpPlus.Lavalink
             add { this._trackException.Register(value); }
             remove { this._trackException.Unregister(value); }
         }
-        private AsyncEvent<LavalinkGuildConnection, TrackExceptionEventArgs> _trackException;
+        private readonly AsyncEvent<LavalinkGuildConnection, TrackExceptionEventArgs> _trackException;
 
         /// <summary>
         /// Triggered whenever Discord Voice WebSocket connection is terminated.
@@ -79,7 +102,7 @@ namespace DSharpPlus.Lavalink
             add { this._webSocketClosed.Register(value); }
             remove { this._webSocketClosed.Unregister(value); }
         }
-        private AsyncEvent<LavalinkGuildConnection, WebSocketCloseEventArgs> _webSocketClosed;
+        private readonly AsyncEvent<LavalinkGuildConnection, WebSocketCloseEventArgs> _webSocketClosed;
 
         /// <summary>
         /// Gets whether this channel is still connected.

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
@@ -34,7 +57,7 @@ namespace DSharpPlus.Lavalink
             add { this._lavalinkSocketError.Register(value); }
             remove { this._lavalinkSocketError.Unregister(value); }
         }
-        private AsyncEvent<LavalinkNodeConnection, SocketErrorEventArgs> _lavalinkSocketError;
+        private readonly AsyncEvent<LavalinkNodeConnection, SocketErrorEventArgs> _lavalinkSocketError;
 
         /// <summary>
         /// Triggered when this node disconnects.
@@ -44,7 +67,7 @@ namespace DSharpPlus.Lavalink
             add { this._disconnected.Register(value); }
             remove { this._disconnected.Unregister(value); }
         }
-        private AsyncEvent<LavalinkNodeConnection, NodeDisconnectedEventArgs> _disconnected;
+        private readonly AsyncEvent<LavalinkNodeConnection, NodeDisconnectedEventArgs> _disconnected;
 
         /// <summary>
         /// Triggered when this node receives a statistics update.
@@ -54,7 +77,7 @@ namespace DSharpPlus.Lavalink
             add { this._statsReceived.Register(value); }
             remove { this._statsReceived.Unregister(value); }
         }
-        private AsyncEvent<LavalinkNodeConnection, StatisticsReceivedEventArgs> _statsReceived;
+        private readonly AsyncEvent<LavalinkNodeConnection, StatisticsReceivedEventArgs> _statsReceived;
 
         /// <summary>
         /// Triggered whenever any of the players on this node is updated.
@@ -64,7 +87,7 @@ namespace DSharpPlus.Lavalink
             add { this._playerUpdated.Register(value); }
             remove { this._playerUpdated.Unregister(value); }
         }
-        private AsyncEvent<LavalinkGuildConnection, PlayerUpdateEventArgs> _playerUpdated;
+        private readonly AsyncEvent<LavalinkGuildConnection, PlayerUpdateEventArgs> _playerUpdated;
 
         /// <summary>
         /// Triggered whenever playback of a track starts.
@@ -75,7 +98,7 @@ namespace DSharpPlus.Lavalink
             add { this._playbackStarted.Register(value); }
             remove { this._playbackStarted.Unregister(value); }
         }
-        private AsyncEvent<LavalinkGuildConnection, TrackStartEventArgs> _playbackStarted;
+        private readonly AsyncEvent<LavalinkGuildConnection, TrackStartEventArgs> _playbackStarted;
 
         /// <summary>
         /// Triggered whenever playback of a track finishes.
@@ -85,7 +108,7 @@ namespace DSharpPlus.Lavalink
             add { this._playbackFinished.Register(value); }
             remove { this._playbackFinished.Unregister(value); }
         }
-        private AsyncEvent<LavalinkGuildConnection, TrackFinishEventArgs> _playbackFinished;
+        private readonly AsyncEvent<LavalinkGuildConnection, TrackFinishEventArgs> _playbackFinished;
 
         /// <summary>
         /// Triggered whenever playback of a track gets stuck.
@@ -95,7 +118,7 @@ namespace DSharpPlus.Lavalink
             add { this._trackStuck.Register(value); }
             remove { this._trackStuck.Unregister(value); }
         }
-        private AsyncEvent<LavalinkGuildConnection, TrackStuckEventArgs> _trackStuck;
+        private readonly AsyncEvent<LavalinkGuildConnection, TrackStuckEventArgs> _trackStuck;
 
         /// <summary>
         /// Triggered whenever playback of a track encounters an error.
@@ -105,7 +128,7 @@ namespace DSharpPlus.Lavalink
             add { this._trackException.Register(value); }
             remove { this._trackException.Unregister(value); }
         }
-        private AsyncEvent<LavalinkGuildConnection, TrackExceptionEventArgs> _trackException;
+        private readonly AsyncEvent<LavalinkGuildConnection, TrackExceptionEventArgs> _trackException;
 
         /// <summary>
         /// Gets the remote endpoint of this Lavalink node connection.
@@ -130,7 +153,7 @@ namespace DSharpPlus.Lavalink
         /// Gets a dictionary of Lavalink guild connections for this node.
         /// </summary>
         public IReadOnlyDictionary<ulong, LavalinkGuildConnection> ConnectedGuilds { get; }
-        internal ConcurrentDictionary<ulong, LavalinkGuildConnection> _connectedGuilds = new ConcurrentDictionary<ulong, LavalinkGuildConnection>();
+        internal ConcurrentDictionary<ulong, LavalinkGuildConnection> _connectedGuilds = new();
 
         /// <summary>
         /// Gets the REST client for this Lavalink connection.
@@ -316,14 +339,14 @@ namespace DSharpPlus.Lavalink
         /// <param name="guild">Guild to get connection for.</param>
         /// <returns>Channel connection, which allows for playback control.</returns>
         public LavalinkGuildConnection GetGuildConnection(DiscordGuild guild)
-            => this._connectedGuilds.TryGetValue(guild.Id, out LavalinkGuildConnection lgc) && lgc.IsConnected ? lgc : null;
+            => this._connectedGuilds.TryGetValue(guild.Id, out var lgc) && lgc.IsConnected ? lgc : null;
 
         internal async Task SendPayloadAsync(LavalinkPayload payload)
             => await this.WsSendAsync(JsonConvert.SerializeObject(payload, Formatting.None)).ConfigureAwait(false);
 
         private async Task WebSocket_OnMessage(IWebSocketClient client, SocketMessageEventArgs e)
         {
-            if (!(e is SocketTextMessageEventArgs et))
+            if (e is not SocketTextMessageEventArgs et)
             {
                 this.Discord.Logger.LogCritical(LavalinkEvents.LavalinkConnectionError, "Lavalink sent binary data - unable to process");
                 return;
@@ -359,7 +382,7 @@ namespace DSharpPlus.Lavalink
                             break;
 
                         case EventType.TrackEndEvent:
-                            TrackEndReason reason = TrackEndReason.Cleanup;
+                            var reason = TrackEndReason.Cleanup;
                             switch (jsonData["reason"].ToString())
                             {
                                 case "FINISHED":

--- a/DSharpPlus.Lavalink/LavalinkRestEndpoints.cs
+++ b/DSharpPlus.Lavalink/LavalinkRestEndpoints.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Lavalink
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Lavalink
 {
     internal static class Endpoints
     {

--- a/DSharpPlus.Lavalink/LavalinkTrack.cs
+++ b/DSharpPlus.Lavalink/LavalinkTrack.cs
@@ -1,4 +1,27 @@
-﻿#pragma warning disable 0649
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma warning disable 0649
 
 using System;
 using System.Collections.Generic;
@@ -141,7 +164,7 @@ namespace DSharpPlus.Lavalink
         /// </summary>
         [JsonProperty("playlistInfo")]
         public LavalinkPlaylistInfo PlaylistInfo { get; internal set; }
-        
+
         /// <summary>
         /// Gets the exception details if a track loading failed.
         /// </summary>

--- a/DSharpPlus.Lavalink/LavalinkUtil.cs
+++ b/DSharpPlus.Lavalink/LavalinkUtil.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.IO;
 using System.Text;
 using DSharpPlus.Lavalink.EventArgs;
@@ -16,7 +39,7 @@ namespace DSharpPlus.Lavalink
         /// </summary>
         public static bool MayStartNext(this TrackEndReason reason)
             => reason == TrackEndReason.Finished || reason == TrackEndReason.LoadFailed;
-        
+
         /// <summary>
         /// Decodes a Lavalink track string.
         /// </summary>
@@ -34,7 +57,7 @@ namespace DSharpPlus.Lavalink
             {
                 TrackString = track
             };
-            
+
             using (var ms = new MemoryStream(raw))
             using (var br = new JavaBinaryReader(ms))
             {
@@ -44,7 +67,7 @@ namespace DSharpPlus.Lavalink
                 var messageSize = messageHeader & 0x3FFFFFFF;
                 //if (messageSize != raw.Length)
                 //    Warn($"Size conflict: {messageSize} but was {raw.Length}");
-                
+
                 // https://github.com/sedmelluq/lavaplayer/blob/804cd1038229230052d9b1dee5e6d1741e30e284/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayerManager.java#L268
 
                 // java bytes are signed
@@ -64,31 +87,10 @@ namespace DSharpPlus.Lavalink
                 decoded.IsStream = br.ReadBoolean();
 
                 var uri = br.ReadNullableString();
-                if (uri != null && version >= 2)
-                    decoded.Uri = new Uri(uri);
-                else
-                    decoded.Uri = null;
+                decoded.Uri = uri != null && version >= 2 ? new Uri(uri) : null;
             }
 
             return decoded;
-        }
-
-        private static uint SwapEndianness(uint v)
-        {
-            v = (v << 16) | (v >> 16);
-            return ((v & 0xFF00FF00) >> 8 | ((v & 0x00FF00FF) << 8));
-        }
-
-        private static short SwapEndianness(short v)
-        {
-            return (short)((v << 8) | (v >> 8));
-        }
-
-        private static ulong SwapEndianness(ulong v)
-        {
-            v = (v >> 32) | (v << 32);
-            v = ((v & 0xFFFF0000FFFF0000) >> 16) | ((v & 0x0000FFFF0000FFFF) << 16);
-            return ((v & 0xFF00FF00FF00FF00) >> 8) | ((v & 0x00FF00FF00FF00FF) << 8);
         }
     }
 
@@ -109,9 +111,9 @@ namespace DSharpPlus.Lavalink
         // https://docs.oracle.com/javase/7/docs/api/java/io/DataInput.html#readUTF()
         public string ReadJavaUtf8()
         {
-            var length = ReadUInt16(); // string size in bytes
+            var length = this.ReadUInt16(); // string size in bytes
             var bytes = new byte[length];
-            var amountRead = Read(bytes, 0, length);
+            var amountRead = this.Read(bytes, 0, length);
             if (amountRead < length)
                 throw new InvalidDataException("EOS unexpected");
 
@@ -125,7 +127,7 @@ namespace DSharpPlus.Lavalink
                 var value1 = bytes[i];
                 if ((value1 & 0b10000000) == 0) // highest bit 1 is false
                 {
-                    output[strlen++] = (char) value1;
+                    output[strlen++] = (char)value1;
                     continue;
                 }
 
@@ -137,11 +139,11 @@ namespace DSharpPlus.Lavalink
                     (value2 & 0b10000000) != 0) //   highest bit 1 is true
                 {
                     var value1Chop = (value1 & 0b00011111) << 6;
-                    var value2Chop = (value2 & 0b00111111);
-                    output[strlen++] = (char) (value1Chop | value2Chop);
+                    var value2Chop = value2 & 0b00111111;
+                    output[strlen++] = (char)(value1Chop | value2Chop);
                     continue;
                 }
-                
+
                 var value3 = bytes[++i];
                 if ((value1 & 0b00010000) == 0 && // highest bit 4 is false
                     (value1 & 0b11100000) != 0 && // highest bit 1,2,3 are true
@@ -152,50 +154,44 @@ namespace DSharpPlus.Lavalink
                 {
                     var value1Chop = (value1 & 0b00001111) << 12;
                     var value2Chop = (value2 & 0b00111111) << 6;
-                    var value3Chop = (value3 & 0b00111111);
-                    output[strlen++] = (char) (value1Chop | value2Chop | value3Chop);
+                    var value3Chop = value3 & 0b00111111;
+                    output[strlen++] = (char)(value1Chop | value2Chop | value3Chop);
                     continue;
                 }
             }
-            
+
             return new string(output, 0, strlen);
         }
 
         // https://github.com/sedmelluq/lavaplayer/blob/b0c536098c4f92e6d03b00f19221021f8f50b19b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/DataFormatTools.java#L114-L125
-        public string ReadNullableString()
-        {
-            return ReadBoolean() ? ReadJavaUtf8() : null;
-        }
+        public string ReadNullableString() => this.ReadBoolean() ? this.ReadJavaUtf8() : null;
 
         // swap endianness
-        public override decimal ReadDecimal()
-        {
-            throw new MissingMethodException("This method does not have a Java equivalent");
-        }
+        public override decimal ReadDecimal() => throw new MissingMethodException("This method does not have a Java equivalent");
 
         // from https://github.com/Zoltu/Zoltu.EndianAwareBinaryReaderWriter under CC0
-        public override float ReadSingle() => Read(4, BitConverter.ToSingle);
+        public override float ReadSingle() => this.Read(4, BitConverter.ToSingle);
 
-        public override double ReadDouble() => Read(8, BitConverter.ToDouble);
+        public override double ReadDouble() => this.Read(8, BitConverter.ToDouble);
 
-        public override short ReadInt16() => Read(2, BitConverter.ToInt16);
+        public override short ReadInt16() => this.Read(2, BitConverter.ToInt16);
 
-        public override int ReadInt32() => Read(4, BitConverter.ToInt32);
+        public override int ReadInt32() => this.Read(4, BitConverter.ToInt32);
 
-        public override long ReadInt64() => Read(8, BitConverter.ToInt64);
+        public override long ReadInt64() => this.Read(8, BitConverter.ToInt64);
 
-        public override ushort ReadUInt16() => Read(2, BitConverter.ToUInt16);
+        public override ushort ReadUInt16() => this.Read(2, BitConverter.ToUInt16);
 
-        public override uint ReadUInt32() => Read(4, BitConverter.ToUInt32);
+        public override uint ReadUInt32() => this.Read(4, BitConverter.ToUInt32);
 
-        public override ulong ReadUInt64() => Read(8, BitConverter.ToUInt64);
+        public override ulong ReadUInt64() => this.Read(8, BitConverter.ToUInt64);
 
         private T Read<T>(int size, Func<byte[], int, T> converter) where T : struct
         {
             //Contract.Requires(size >= 0);
             //Contract.Requires(converter != null);
 
-            var bytes = GetNextBytesNativeEndian(size);
+            var bytes = this.GetNextBytesNativeEndian(size);
             return converter(bytes, 0);
         }
 
@@ -205,7 +201,7 @@ namespace DSharpPlus.Lavalink
             //Contract.Ensures(Contract.Result<Byte[]>() != null);
             //Contract.Ensures(Contract.Result<Byte[]>().Length == count);
 
-            var bytes = GetNextBytes(count);
+            var bytes = this.GetNextBytes(count);
             if (BitConverter.IsLittleEndian)
                 Array.Reverse(bytes);
             return bytes;
@@ -218,12 +214,9 @@ namespace DSharpPlus.Lavalink
             //Contract.Ensures(Contract.Result<Byte[]>().Length == count);
 
             var buffer = new byte[count];
-            var bytesRead = BaseStream.Read(buffer, 0, count);
+            var bytesRead = this.BaseStream.Read(buffer, 0, count);
 
-            if (bytesRead != count)
-                throw new EndOfStreamException();
-
-            return buffer;
+            return bytesRead != count ? throw new EndOfStreamException() : buffer;
         }
     }
 }

--- a/DSharpPlus.Rest/DSharpPlus.Rest.csproj
+++ b/DSharpPlus.Rest/DSharpPlus.Rest.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../DSharpPlus.targets" />

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1,12 +1,35 @@
-﻿using System.Collections.Generic;
-using DSharpPlus.Entities;
-using System.Threading.Tasks;
-using DSharpPlus.Net.Abstractions;
-using System.IO;
-using System.Collections.ObjectModel;
-using System.Linq;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DSharpPlus.Entities;
 using DSharpPlus.Exceptions;
+using DSharpPlus.Net.Abstractions;
 using DSharpPlus.Net.Models;
 
 namespace DSharpPlus
@@ -36,7 +59,7 @@ namespace DSharpPlus
             await base.InitializeAsync().ConfigureAwait(false);
             _guilds_lazy = new Lazy<IReadOnlyDictionary<ulong, DiscordGuild>>(() => new ReadOnlyDictionary<ulong, DiscordGuild>(_guilds));
             var gs = await this.ApiClient.GetCurrentUserGuildsAsync(100, null, null).ConfigureAwait(false);
-            foreach (DiscordGuild g in gs)
+            foreach (var g in gs)
             {
                 _guilds[g.Id] = g;
             }
@@ -351,10 +374,9 @@ namespace DSharpPlus
         /// <returns></returns>
         public Task<DiscordChannel> CreateGuildChannelAsync(ulong id, string name, ChannelType type, ulong? parent, Optional<string> topic, int? bitrate, int? userLimit, IEnumerable<DiscordOverwriteBuilder> overwrites, bool? nsfw, Optional<int?> perUserRateLimit, string reason)
         {
-            if (type != ChannelType.Category && type != ChannelType.Text && type != ChannelType.Voice && type != ChannelType.News && type != ChannelType.Store && type != ChannelType.Stage)
-                throw new ArgumentException("Channel type must be text, voice, stage, or category.", nameof(type));
-
-            return this.ApiClient.CreateGuildChannelAsync(id, name, type, parent, topic, bitrate, userLimit, overwrites, nsfw, perUserRateLimit, reason);
+            return type != ChannelType.Category && type != ChannelType.Text && type != ChannelType.Voice && type != ChannelType.News && type != ChannelType.Store && type != ChannelType.Stage
+                ? throw new ArgumentException("Channel type must be text, voice, stage, or category.", nameof(type))
+                : this.ApiClient.CreateGuildChannelAsync(id, name, type, parent, topic, bitrate, userLimit, overwrites, nsfw, perUserRateLimit, reason);
         }
 
         /// <summary>
@@ -626,7 +648,7 @@ namespace DSharpPlus
         /// <param name="nickname">Dm nickname</param>
         /// <returns></returns>
         public Task JoinGroupDmAsync(ulong channel_id, string nickname)
-            => this.ApiClient.AddGroupDmRecipientAsync(channel_id, CurrentUser.Id, Configuration.Token, nickname);
+            => this.ApiClient.AddGroupDmRecipientAsync(channel_id, this.CurrentUser.Id, this.Configuration.Token, nickname);
 
         /// <summary>
         /// Adds a member to a group DM
@@ -645,7 +667,7 @@ namespace DSharpPlus
         /// <param name="channel_id">Channel id</param>
         /// <returns></returns>
         public Task LeaveGroupDmAsync(ulong channel_id)
-            => this.ApiClient.RemoveGroupDmRecipientAsync(channel_id, CurrentUser.Id);
+            => this.ApiClient.RemoveGroupDmRecipientAsync(channel_id, this.CurrentUser.Id);
 
         /// <summary>
         /// Removes a member from a group DM
@@ -867,7 +889,7 @@ namespace DSharpPlus
         /// <param name="reason">Why this role was modified</param>
         /// <returns></returns>
         public Task<DiscordRole> ModifyGuildRoleAsync(ulong guild_id, ulong role_id, string name, Permissions? permissions, DiscordColor? color, bool? hoist, bool? mentionable, string reason)
-            => this.ApiClient.ModifyGuildRoleAsync(guild_id, role_id, name, permissions, (color.HasValue? (int?)color.Value.Value : null), hoist, mentionable, reason);
+            => this.ApiClient.ModifyGuildRoleAsync(guild_id, role_id, name, permissions, color.HasValue ? (int?)color.Value.Value : null, hoist, mentionable, reason);
 
         /// <summary>
         /// Modifies a role
@@ -881,7 +903,7 @@ namespace DSharpPlus
             var mdl = new RoleEditModel();
             action(mdl);
 
-            return ModifyGuildRoleAsync(guild_id, role_id, mdl.Name, mdl.Permissions, mdl.Color, mdl.Hoist, mdl.Mentionable, mdl.AuditLogReason);
+            return this.ModifyGuildRoleAsync(guild_id, role_id, mdl.Name, mdl.Permissions, mdl.Color, mdl.Hoist, mdl.Mentionable, mdl.AuditLogReason);
         }
 
         /// <summary>

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -369,14 +369,15 @@ namespace DSharpPlus
         /// <param name="userLimit">Voice channel user limit</param>
         /// <param name="overwrites">Channel overwrites</param>
         /// <param name="nsfw">Whether this channel should be marked as NSFW</param>
-        /// <param name="perUserRateLimit">Slow mode timeout for users.</param>
+        /// <param name="perUserRateLimit">Slow mode timeout for users</param>
+        /// <param name="channelQualityMode">Voice channel quality mode</param>
         /// <param name="reason">Reason this channel was created</param>
         /// <returns></returns>
-        public Task<DiscordChannel> CreateGuildChannelAsync(ulong id, string name, ChannelType type, ulong? parent, Optional<string> topic, int? bitrate, int? userLimit, IEnumerable<DiscordOverwriteBuilder> overwrites, bool? nsfw, Optional<int?> perUserRateLimit, string reason)
+        public Task<DiscordChannel> CreateGuildChannelAsync(ulong id, string name, ChannelType type, ulong? parent, Optional<string> topic, int? bitrate, int? userLimit, IEnumerable<DiscordOverwriteBuilder> overwrites, bool? nsfw, Optional<int?> perUserRateLimit, ChannelQualityMode? channelQualityMode, string reason)
         {
             return type != ChannelType.Category && type != ChannelType.Text && type != ChannelType.Voice && type != ChannelType.News && type != ChannelType.Store && type != ChannelType.Stage
                 ? throw new ArgumentException("Channel type must be text, voice, stage, or category.", nameof(type))
-                : this.ApiClient.CreateGuildChannelAsync(id, name, type, parent, topic, bitrate, userLimit, overwrites, nsfw, perUserRateLimit, reason);
+                : this.ApiClient.CreateGuildChannelAsync(id, name, type, parent, topic, bitrate, userLimit, overwrites, nsfw, perUserRateLimit, channelQualityMode, reason);
         }
 
         /// <summary>
@@ -392,10 +393,11 @@ namespace DSharpPlus
         /// <param name="userLimit">New voice channel user limit</param>
         /// <param name="perUserRateLimit">Slow mode timeout for users.</param>
         /// <param name="rtcRegion">New region override.</param>
+        /// <param name="channelQualityMode">New video quality mode.</param>
         /// <param name="reason">Reason why this channel was modified</param>
         /// <returns></returns>
-        public Task ModifyChannelAsync(ulong id, string name, int? position, Optional<string> topic, bool? nsfw, Optional<ulong?> parent, int? bitrate, int? userLimit, Optional<int?> perUserRateLimit, Optional<DiscordVoiceRegion> rtcRegion, string reason)
-            => this.ApiClient.ModifyChannelAsync(id, name, position, topic, nsfw, parent, bitrate, userLimit, perUserRateLimit, rtcRegion.IfPresent(e => e?.Id), reason);
+        public Task ModifyChannelAsync(ulong id, string name, int? position, Optional<string> topic, bool? nsfw, Optional<ulong?> parent, int? bitrate, int? userLimit, Optional<int?> perUserRateLimit, Optional<DiscordVoiceRegion> rtcRegion, ChannelQualityMode? channelQualityMode, string reason)
+            => this.ApiClient.ModifyChannelAsync(id, name, position, topic, nsfw, parent, bitrate, userLimit, perUserRateLimit, rtcRegion.IfPresent(e => e?.Id), channelQualityMode, reason);
 
         /// <summary>
         /// Modifies a channel
@@ -410,7 +412,7 @@ namespace DSharpPlus
 
             return this.ApiClient.ModifyChannelAsync(channelId, mdl.Name, mdl.Position, mdl.Topic, mdl.Nsfw,
                 mdl.Parent.HasValue ? mdl.Parent.Value?.Id : default(Optional<ulong?>), mdl.Bitrate, mdl.Userlimit, mdl.PerUserRateLimit, mdl.RtcRegion.IfPresent(e => e?.Id),
-                mdl.AuditLogReason);
+                mdl.ChannelQualityMode, mdl.AuditLogReason);
         }
 
         /// <summary>

--- a/DSharpPlus.Test/BeeMovie.cs
+++ b/DSharpPlus.Test/BeeMovie.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 namespace DSharpPlus.Test

--- a/DSharpPlus.Test/DSharpPlus.Test.csproj
+++ b/DSharpPlus.Test/DSharpPlus.Test.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
@@ -44,7 +44,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.9.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="5.0.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\DSharpPlus.Lavalink\DSharpPlus.Lavalink.csproj" />
     <ProjectReference Include="..\DSharpPlus.Rest\DSharpPlus.Rest.csproj" />
@@ -53,7 +53,7 @@
     <ProjectReference Include="..\DSharpPlus.Interactivity\DSharpPlus.Interactivity.csproj" />
     <ProjectReference Include="..\DSharpPlus.VoiceNext\DSharpPlus.VoiceNext.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Update="config.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -65,5 +65,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  
+
 </Project>

--- a/DSharpPlus.Test/PermissionInheritanceCommands.cs
+++ b/DSharpPlus.Test/PermissionInheritanceCommands.cs
@@ -1,4 +1,27 @@
-﻿using System.Threading.Tasks;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Threading.Tasks;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 

--- a/DSharpPlus.Test/Program.cs
+++ b/DSharpPlus.Test/Program.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -43,7 +66,7 @@ namespace DSharpPlus.Test
                 tskl.Add(bot.RunAsync());
                 await Task.Delay(7500).ConfigureAwait(false);
             }
-            
+
             await Task.WhenAll(tskl).ConfigureAwait(false);
 
             try

--- a/DSharpPlus.Test/Reply.cs
+++ b/DSharpPlus.Test/Reply.cs
@@ -1,4 +1,27 @@
-﻿using System.Threading.Tasks;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Threading.Tasks;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
@@ -8,13 +31,13 @@ namespace DSharpPlus.Test
     public class Reply : BaseCommandModule
     {
         [Command, Priority(0)]
-        public async Task ReplyAsync(CommandContext ctx, [RemainingText]string response = "")
+        public async Task ReplyAsync(CommandContext ctx, [RemainingText] string response = "")
         {
             var builder = new DiscordMessageBuilder();
 
             if (string.IsNullOrEmpty(response))
-            {                
-                builder.WithContent("This is a reply! :)");   
+            {
+                builder.WithContent("This is a reply! :)");
             }
             else
             {
@@ -28,7 +51,7 @@ namespace DSharpPlus.Test
         }
 
         [Command, Priority(2)]
-        public async Task ReplyAsync(CommandContext ctx, DiscordUser user, [RemainingText]string response = "")
+        public async Task ReplyAsync(CommandContext ctx, DiscordUser user, [RemainingText] string response = "")
         {
             if (ctx.Message.Reference?.Message is null)
                 await ctx.RespondAsync("You need to reply to a message for this :(");
@@ -40,9 +63,9 @@ namespace DSharpPlus.Test
                     .SendAsync(ctx.Channel);
             }
         }
-        
+
         [Command, Priority(1)]
-        public async Task ReplyAsync(CommandContext ctx, bool mention, [RemainingText]string response = "")
+        public async Task ReplyAsync(CommandContext ctx, bool mention, [RemainingText] string response = "")
         {
             var builder = new DiscordMessageBuilder();
 

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 #pragma warning disable CS0618
 using System;
 using System.Collections.Generic;
@@ -25,12 +48,10 @@ namespace DSharpPlus.Test
 
         private TestBotConfig Config { get; }
         public DiscordClient Discord { get; }
-        private TestBotCommands Commands { get; }
         private VoiceNextExtension VoiceService { get; }
         private CommandsNextExtension CommandsNextService { get; }
         private InteractivityExtension InteractivityService { get; }
         private LavalinkExtension LavalinkService { get; }
-        private Timer GameGuard { get; set; }
 
         public TestBot(TestBotConfig cfg, int shardid)
         {
@@ -51,19 +72,19 @@ namespace DSharpPlus.Test
                 LogTimestampFormat = "dd-MM-yyyy HH:mm:ss zzz",
                 Intents = DiscordIntents.All // if 4013 is received, change to DiscordIntents.AllUnprivileged
             };
-            Discord = new DiscordClient(dcfg);
+            this.Discord = new DiscordClient(dcfg);
 
             // events
-            Discord.Ready += this.Discord_Ready;
-            Discord.GuildAvailable += this.Discord_GuildAvailable;
+            this.Discord.Ready += this.Discord_Ready;
+            this.Discord.GuildAvailable += this.Discord_GuildAvailable;
             //Discord.PresenceUpdated += this.Discord_PresenceUpdated;
             //Discord.ClientErrored += this.Discord_ClientErrored;
-            Discord.SocketErrored += this.Discord_SocketError;
-            Discord.GuildCreated += this.Discord_GuildCreated;
-            Discord.VoiceStateUpdated += this.Discord_VoiceStateUpdated;
-            Discord.GuildDownloadCompleted += this.Discord_GuildDownloadCompleted;
-            Discord.GuildUpdated += this.Discord_GuildUpdated;
-            Discord.ChannelDeleted += this.Discord_ChannelDeleted;
+            this.Discord.SocketErrored += this.Discord_SocketError;
+            this.Discord.GuildCreated += this.Discord_GuildCreated;
+            this.Discord.VoiceStateUpdated += this.Discord_VoiceStateUpdated;
+            this.Discord.GuildDownloadCompleted += this.Discord_GuildDownloadCompleted;
+            this.Discord.GuildUpdated += this.Discord_GuildUpdated;
+            this.Discord.ChannelDeleted += this.Discord_ChannelDeleted;
 
             // For event timeout testing
             //Discord.GuildDownloadCompleted += async (s, e) =>
@@ -94,7 +115,7 @@ namespace DSharpPlus.Test
                 IgnoreExtraArguments = false,
                 UseDefaultCommandHandler = true,
             };
-            this.CommandsNextService = Discord.UseCommandsNext(cncfg);
+            this.CommandsNextService = this.Discord.UseCommandsNext(cncfg);
             this.CommandsNextService.CommandErrored += this.CommandsNextService_CommandErrored;
             this.CommandsNextService.CommandExecuted += this.CommandsNextService_CommandExecuted;
             this.CommandsNextService.RegisterCommands(typeof(TestBot).GetTypeInfo().Assembly);
@@ -106,8 +127,8 @@ namespace DSharpPlus.Test
                 Timeout = TimeSpan.FromSeconds(3)
             };
 
-            this.InteractivityService = Discord.UseInteractivity(icfg);
-            this.LavalinkService = Discord.UseLavalink();
+            this.InteractivityService = this.Discord.UseInteractivity(icfg);
+            this.LavalinkService = this.Discord.UseLavalink();
 
             //this.Discord.MessageCreated += async e =>
             //{
@@ -118,27 +139,15 @@ namespace DSharpPlus.Test
             //};
         }
 
-        private Task Discord_PresenceUpdated(DiscordClient client, PresenceUpdateEventArgs e)
-        {
-            client.Logger.LogInformation(TestBotEventId, "Presence updated: '{0}'", e.Activity.Name);
-            return Task.CompletedTask;
-        }
-
         public async Task RunAsync()
         {
-			var act = new DiscordActivity("the screams of your ancestors", ActivityType.ListeningTo);
-            await Discord.ConnectAsync(act, UserStatus.DoNotDisturb).ConfigureAwait(false);
+            var act = new DiscordActivity("the screams of your ancestors", ActivityType.ListeningTo);
+            await this.Discord.ConnectAsync(act, UserStatus.DoNotDisturb).ConfigureAwait(false);
         }
 
-        public async Task StopAsync()
-        {
-            await Discord.DisconnectAsync().ConfigureAwait(false);
-        }
+        public async Task StopAsync() => await this.Discord.DisconnectAsync().ConfigureAwait(false);
 
-        private Task Discord_Ready(DiscordClient client, ReadyEventArgs e)
-        {
-            return Task.CompletedTask;
-        }
+        private Task Discord_Ready(DiscordClient client, ReadyEventArgs e) => Task.CompletedTask;
 
         private Task Discord_GuildAvailable(DiscordClient client, GuildCreateEventArgs e)
         {
@@ -202,7 +211,7 @@ namespace DSharpPlus.Test
                     Description = $"`{e.Exception.GetType()}` occurred when executing `{e.Command.QualifiedName}`.",
                     Timestamp = DateTime.UtcNow
                 };
-                embed.WithFooter(Discord.CurrentUser.Username, Discord.CurrentUser.AvatarUrl)
+                embed.WithFooter(this.Discord.CurrentUser.Username, this.Discord.CurrentUser.AvatarUrl)
                     .AddField("Message", ex.Message);
                 await e.Context.RespondAsync(embed: embed.Build()).ConfigureAwait(false);
             }

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Concurrent;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,45 +34,45 @@ using DSharpPlus.Entities;
 namespace DSharpPlus.Test
 {
     public class TestBotCommands : BaseCommandModule
-	{
-		public static ConcurrentDictionary<ulong, string> PrefixSettings { get; } = new ConcurrentDictionary<ulong, string>();
+    {
+        public static ConcurrentDictionary<ulong, string> PrefixSettings { get; } = new ConcurrentDictionary<ulong, string>();
 
-		[Command("crosspost")]
-		public async Task CrosspostAsync(CommandContext ctx, DiscordChannel chn, DiscordMessage msg)
-		{
-			var message = await chn.CrosspostMessageAsync(msg).ConfigureAwait(false);
-			await ctx.RespondAsync($":ok_hand: Message published: {message.Id}").ConfigureAwait(false);
-		}
+        [Command("crosspost")]
+        public async Task CrosspostAsync(CommandContext ctx, DiscordChannel chn, DiscordMessage msg)
+        {
+            var message = await chn.CrosspostMessageAsync(msg).ConfigureAwait(false);
+            await ctx.RespondAsync($":ok_hand: Message published: {message.Id}").ConfigureAwait(false);
+        }
 
-		[Command("follow")]
-		public async Task FollowAsync(CommandContext ctx, DiscordChannel channelToFollow, DiscordChannel targetChannel)
-		{
-			await channelToFollow.FollowAsync(targetChannel).ConfigureAwait(false);
-			await ctx.RespondAsync($":ok_hand: Following channel {channelToFollow.Mention} into {targetChannel.Mention} (Guild: {targetChannel.Guild.Id})").ConfigureAwait(false);
-		}
+        [Command("follow")]
+        public async Task FollowAsync(CommandContext ctx, DiscordChannel channelToFollow, DiscordChannel targetChannel)
+        {
+            await channelToFollow.FollowAsync(targetChannel).ConfigureAwait(false);
+            await ctx.RespondAsync($":ok_hand: Following channel {channelToFollow.Mention} into {targetChannel.Mention} (Guild: {targetChannel.Guild.Id})").ConfigureAwait(false);
+        }
 
-		[Command("setprefix"), Aliases("channelprefix"), Description("Sets custom command prefix for current channel. The bot will still respond to the default one."), RequireOwner]
-		public async Task SetPrefixAsync(CommandContext ctx, [Description("The prefix to use for current channel.")] string prefix = null)
-		{
-			if (string.IsNullOrWhiteSpace(prefix))
-				if (PrefixSettings.TryRemove(ctx.Channel.Id, out _))
-					await ctx.RespondAsync("👍").ConfigureAwait(false);
-				else
-					await ctx.RespondAsync("👎").ConfigureAwait(false);
-			else
-			{
-				PrefixSettings.AddOrUpdate(ctx.Channel.Id, prefix, (k, vold) => prefix);
-				await ctx.RespondAsync("👍").ConfigureAwait(false);
-			}
-		}
+        [Command("setprefix"), Aliases("channelprefix"), Description("Sets custom command prefix for current channel. The bot will still respond to the default one."), RequireOwner]
+        public async Task SetPrefixAsync(CommandContext ctx, [Description("The prefix to use for current channel.")] string prefix = null)
+        {
+            if (string.IsNullOrWhiteSpace(prefix))
+                if (PrefixSettings.TryRemove(ctx.Channel.Id, out _))
+                    await ctx.RespondAsync("👍").ConfigureAwait(false);
+                else
+                    await ctx.RespondAsync("👎").ConfigureAwait(false);
+            else
+            {
+                PrefixSettings.AddOrUpdate(ctx.Channel.Id, prefix, (k, vold) => prefix);
+                await ctx.RespondAsync("👍").ConfigureAwait(false);
+            }
+        }
 
-		[Command("sudo"), Description("Run a command as another user."), Hidden, RequireOwner]
-		public async Task SudoAsync(CommandContext ctx, DiscordUser user, [RemainingText] string content)
-		{
+        [Command("sudo"), Description("Run a command as another user."), Hidden, RequireOwner]
+        public async Task SudoAsync(CommandContext ctx, DiscordUser user, [RemainingText] string content)
+        {
             var cmd = ctx.CommandsNext.FindCommand(content, out var args);
             var fctx = ctx.CommandsNext.CreateFakeContext(user, ctx.Channel, content, ctx.Prefix, cmd, args);
             await ctx.CommandsNext.ExecuteCommandAsync(fctx).ConfigureAwait(false);
-		}
+        }
 
         [Group("bind"), Description("Various argument binder testing commands.")]
         public class Binding : BaseCommandModule
@@ -60,14 +83,14 @@ namespace DSharpPlus.Test
                     .WithTimestamp(msg.CreationTimestamp)
                     .WithAuthor($"{msg.Author.Username}#{msg.Author.Discriminator}", msg.Author.AvatarUrl)
                     .WithDescription(msg.Content));
-		}
+        }
 
 
         [Command("mention"), Description("Attempts to mention a user")]
         public async Task MentionablesAsync(CommandContext ctx, DiscordUser user)
         {
-            string content = $"Hey, {user.Mention}! Listen!";
-            await ctx.Channel.SendMessageAsync("✔ should ping, ❌ should not ping.").ConfigureAwait(false);                                                                                           
+            var content = $"Hey, {user.Mention}! Listen!";
+            await ctx.Channel.SendMessageAsync("✔ should ping, ❌ should not ping.").ConfigureAwait(false);
 
             await ctx.Channel.SendMessageAsync("✔ Default Behaviour: " + content).ConfigureAwait(false);                                                                                            //Should ping User
 
@@ -118,8 +141,8 @@ namespace DSharpPlus.Test
         [Command("editMention"), Description("Attempts to mention a user via edit message")]
         public async Task EditMentionablesAsync(CommandContext ctx, DiscordUser user)
         {
-            string origcontent = $"Hey, silly! Listen!";
-            string newContent = $"Hey, {user.Mention}! Listen!";
+            var origcontent = $"Hey, silly! Listen!";
+            var newContent = $"Hey, {user.Mention}! Listen!";
 
             await ctx.Channel.SendMessageAsync("✔ should ping, ❌ should not ping.").ConfigureAwait(false);
 
@@ -129,7 +152,7 @@ namespace DSharpPlus.Test
                .ModifyAsync(test1Msg)
                .ConfigureAwait(false);                                                                                                                               //Should ping User
 
-            var test2Msg = await ctx.Channel.SendMessageAsync("✔ UserMention(user): " + origcontent).ConfigureAwait(false);      
+            var test2Msg = await ctx.Channel.SendMessageAsync("✔ UserMention(user): " + origcontent).ConfigureAwait(false);
             await new DiscordMessageBuilder()
                .WithContent("✔ UserMention(user): " + newContent)
                .WithAllowedMentions(new IMention[] { new UserMention(user) })
@@ -245,7 +268,7 @@ namespace DSharpPlus.Test
         }
 
         [Command("CreateSomeFile")]
-        public async Task CreateSomeFile(CommandContext ctx, string fileName, [RemainingText]string fileBody)
+        public async Task CreateSomeFile(CommandContext ctx, string fileName, [RemainingText] string fileBody)
         {
             using (var fs = new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite))
             using (var sw = new StreamWriter(fs))
@@ -350,12 +373,12 @@ namespace DSharpPlus.Test
         [Command("chainreply")]
         public async Task ChainReplyAsync(CommandContext ctx)
         {
-            DiscordMessageBuilder builder = new DiscordMessageBuilder();
+            var builder = new DiscordMessageBuilder();
 
-            StringBuilder contentBuilder = new StringBuilder();
+            var contentBuilder = new StringBuilder();
 
-            ulong reply = ctx.Message.Id;
-            bool ping = false;
+            var reply = ctx.Message.Id;
+            var ping = false;
 
             if (ctx.Message.MessageType == MessageType.Reply)
             {
@@ -438,7 +461,7 @@ namespace DSharpPlus.Test
             var contentBuilder = new StringBuilder("Message has no attachment.");
 
 
-            if(message.Attachments.Any())
+            if (message.Attachments.Any())
             {
                 contentBuilder.Clear();
                 foreach (var attachment in message.Attachments)

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -488,5 +488,65 @@ namespace DSharpPlus.Test
 
             await ctx.RespondAsync(response.ToString());
         }
+        [Command("invertquality")]
+        public async Task InvertVideoQualityMode(CommandContext ctx, DiscordChannel channel)
+        {
+            if (channel.Type != ChannelType.Voice)
+            {
+                await ctx.RespondAsync("Channel is not a voice channel.");
+                return;
+            }
+
+            var response = new StringBuilder($"{channel.Mention}\n" + $"Previous QualityMode: {channel.ChannelQualityMode}\n");
+
+            ChannelQualityMode mode;
+            if (channel.ChannelQualityMode == ChannelQualityMode.Auto)
+                mode = ChannelQualityMode.Full;
+            else
+                mode = ChannelQualityMode.Auto;
+
+            await channel.ModifyAsync(edit =>
+            {
+                edit.AuditLogReason = "Test Method";
+                edit.ChannelQualityMode = mode;
+            });
+
+            response.AppendLine($"New QualityMode: {channel.ChannelQualityMode}");
+
+            await ctx.RespondAsync(response.ToString());
+        }
+        [Command("clonevoice")] // Testing Channel.CloneChannel() with quality mode changes
+        public async Task CloneVoiceChannel(CommandContext ctx, DiscordChannel channel)
+        {
+            if (channel.Type != ChannelType.Voice)
+            {
+                await ctx.RespondAsync("Channel is not a voice channel.");
+                return;
+            }
+            
+
+            var clonedChannel = await channel.CloneAsync();
+            await clonedChannel.ModifyAsync(edit =>
+            {
+                edit.AuditLogReason = "Test Method";
+                edit.Name = clonedChannel.Name + " Cloned";
+            });
+            await ctx.RespondAsync($"{clonedChannel.Mention} cloned.");
+
+        }
+        [Command("createvoices")] // Testing Guild.CreateChannel() and Guild.CreateVoiceChannelAsync() with quality mode changes
+        public async Task CreateVoiceChannels(CommandContext ctx, DiscordChannel channel)
+        {
+            if (channel.Type != ChannelType.Voice)
+            {
+                await ctx.RespondAsync("Channel is not a voice channel.");
+                return;
+            }
+
+            var cGenericChannel = await ctx.Guild.CreateChannelAsync(channel.Name + " [Generic]", ChannelType.Voice, channel.Parent, null, null, null, null, null, null, ChannelQualityMode.Auto, null);
+            var cVoiceChannel = await ctx.Guild.CreateVoiceChannelAsync(channel.Name + " [Voice]", channel.Parent, null, null, null, ChannelQualityMode.Full, null);
+
+            await ctx.RespondAsync($"{cGenericChannel.Mention} and {cVoiceChannel.Mention} created.");
+        }
     }
 }

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -471,5 +471,22 @@ namespace DSharpPlus.Test
             }
             await ctx.RespondAsync(contentBuilder.ToString());
         }
+        [Command("voiceproperties")]
+        public async Task GetVideoQualityMode(CommandContext ctx, DiscordChannel channel)
+        {
+            if(channel.Type != ChannelType.Voice)
+            {
+                await ctx.RespondAsync("Channel is not a voice channel.");
+                return; //you can remove to test values for non voice channels
+            }
+
+            var response = new StringBuilder($"{channel.Mention} Properties\n");
+            response.AppendLine($"Bitrate: {channel.Bitrate}");
+            response.AppendLine($"UserLimit: " + (channel.UserLimit != 0 ? channel.UserLimit.ToString() : "No Limit"));
+            response.AppendLine($"RtcRegion: {channel.RtcRegion}");
+            response.AppendLine($"VideoQualityMode: {channel.ChannelQualityMode}");
+
+            await ctx.RespondAsync(response.ToString());
+        }
     }
 }

--- a/DSharpPlus.Test/TestBotConfig.cs
+++ b/DSharpPlus.Test/TestBotConfig.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Test
 {
@@ -8,7 +31,7 @@ namespace DSharpPlus.Test
         public string Token { get; private set; } = string.Empty;
 
         [JsonProperty("command_prefixes")]
-        public string[] CommandPrefixes { get; private set; } = new[] { "d#", "d#+"  };
+        public string[] CommandPrefixes { get; private set; } = new[] { "d#", "d#+" };
 
         [JsonProperty("shards")]
         public int ShardCount { get; private set; } = 1;

--- a/DSharpPlus.Test/TestBotDynamicCommands.cs
+++ b/DSharpPlus.Test/TestBotDynamicCommands.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/DSharpPlus.Test/TestBotEvalCommands.cs
+++ b/DSharpPlus.Test/TestBotEvalCommands.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using DSharpPlus.CommandsNext;

--- a/DSharpPlus.Test/TestBotHelpFormatter.cs
+++ b/DSharpPlus.Test/TestBotHelpFormatter.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using DSharpPlus.CommandsNext;

--- a/DSharpPlus.Test/TestBotLavaCommands.cs
+++ b/DSharpPlus.Test/TestBotLavaCommands.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -266,11 +289,11 @@ namespace DSharpPlus.Test
             await ctx.RespondAsync(sb.ToString()).ConfigureAwait(false);
         }
 
-        private static string[] Units = new[] { "", "ki", "Mi", "Gi" };
+        private static readonly string[] Units = new[] { "", "ki", "Mi", "Gi" };
         private static string SizeToString(long l)
         {
             double d = l;
-            int u = 0;
+            var u = 0;
             while (d >= 900 && u < Units.Length - 2)
             {
                 u++;

--- a/DSharpPlus.Test/TestBotPaginator.cs
+++ b/DSharpPlus.Test/TestBotPaginator.cs
@@ -1,11 +1,34 @@
-﻿using DSharpPlus.Entities;
-using DSharpPlus.Interactivity;
-using DSharpPlus.Interactivity.EventHandling;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using DSharpPlus.Entities;
+using DSharpPlus.Interactivity;
+using DSharpPlus.Interactivity.EventHandling;
 
 namespace DSharpPlus.Test
 {
@@ -15,13 +38,13 @@ namespace DSharpPlus.Test
     /// </summary>
     public class TestBotPaginator : IPaginationRequest
     {
-        private List<Page> pages;
-        private TaskCompletionSource<bool> _tcs;
-        private CancellationTokenSource _cts;
-        private DiscordMessage _msg;
+        private readonly List<Page> pages;
+        private readonly TaskCompletionSource<bool> _tcs;
+        private readonly CancellationTokenSource _cts;
+        private readonly DiscordMessage _msg;
         private int index = 0;
-        private PaginationEmojis _emojis;
-        private DiscordUser _usr;
+        private readonly PaginationEmojis _emojis;
+        private readonly DiscordUser _usr;
 
         public int PageCount
             => this.pages.Count;
@@ -37,10 +60,7 @@ namespace DSharpPlus.Test
             this._usr = usr;
         }
 
-        public async Task DoCleanupAsync()
-        {
-            await this._msg.DeleteAsync().ConfigureAwait(false);
-        }
+        public async Task DoCleanupAsync() => await this._msg.DeleteAsync().ConfigureAwait(false);
 
         public async Task<PaginationEmojis> GetEmojisAsync()
         {

--- a/DSharpPlus.Test/TestBotVoiceCommands.cs
+++ b/DSharpPlus.Test/TestBotVoiceCommands.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO;
@@ -81,7 +104,7 @@ namespace DSharpPlus.Test
             var transmitStream = vnc.GetTransmitSink();
             transmitStream.VolumeModifier = vol;
 
-            await ctx.RespondAsync($"Volume set to {(vol * 100).ToString("0.00")}%").ConfigureAwait(false);
+            await ctx.RespondAsync($"Volume set to {vol * 100:0.00}%").ConfigureAwait(false);
         }
 
         [Command("join")]
@@ -253,7 +276,7 @@ namespace DSharpPlus.Test
                     };
                     var ffmpeg = Process.Start(ffmpeg_inf);
                     var ffout = ffmpeg.StandardOutput.BaseStream;
-                    
+
                     var transmitStream = vnc.GetTransmitSink();
                     await ffout.CopyToAsync(transmitStream).ConfigureAwait(false);
                     await transmitStream.FlushAsync().ConfigureAwait(false);
@@ -336,7 +359,7 @@ namespace DSharpPlus.Test
                 };
                 var ffmpeg = Process.Start(ffmpeg_inf);
                 var ffout = ffmpeg.StandardOutput.BaseStream;
-                
+
                 var transmitStream = vnc.GetTransmitSink();
                 await ffout.CopyToAsync(transmitStream).ConfigureAwait(false);
                 await transmitStream.FlushAsync().ConfigureAwait(false);

--- a/DSharpPlus.VoiceNext/AudioFormat.cs
+++ b/DSharpPlus.VoiceNext/AudioFormat.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;

--- a/DSharpPlus.VoiceNext/Codec/Helpers.cs
+++ b/DSharpPlus.VoiceNext/Codec/Helpers.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/DSharpPlus.VoiceNext/Codec/Interop.cs
+++ b/DSharpPlus.VoiceNext/Codec/Interop.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Runtime.InteropServices;
 
 namespace DSharpPlus.VoiceNext.Codec
@@ -124,10 +147,7 @@ namespace DSharpPlus.VoiceNext.Codec
         public static IntPtr OpusCreateEncoder(AudioFormat audioFormat)
         {
             var encoder = _OpusCreateEncoder(audioFormat.SampleRate, audioFormat.ChannelCount, (int)audioFormat.VoiceApplication, out var error);
-            if (error != OpusError.Ok)
-                throw new Exception($"Could not instantiate Opus encoder: {error} ({(int)error}).");
-
-            return encoder;
+            return error != OpusError.Ok ? throw new Exception($"Could not instantiate Opus encoder: {error} ({(int)error}).") : encoder;
         }
 
         public static void OpusSetEncoderOption(IntPtr encoder, OpusControl option, int value)
@@ -157,10 +177,7 @@ namespace DSharpPlus.VoiceNext.Codec
         public static IntPtr OpusCreateDecoder(AudioFormat audioFormat)
         {
             var decoder = _OpusCreateDecoder(audioFormat.SampleRate, audioFormat.ChannelCount, out var error);
-            if (error != OpusError.Ok)
-                throw new Exception($"Could not instantiate Opus decoder: {error} ({(int)error}).");
-
-            return decoder;
+            return error != OpusError.Ok ? throw new Exception($"Could not instantiate Opus decoder: {error} ({(int)error}).") : decoder;
         }
 
         public static unsafe int OpusDecode(IntPtr decoder, ReadOnlySpan<byte> opus, int frameSize, Span<byte> pcm, bool useFec)
@@ -183,7 +200,7 @@ namespace DSharpPlus.VoiceNext.Codec
         public static unsafe int OpusDecode(IntPtr decoder, int frameSize, Span<byte> pcm)
         {
             var len = 0;
-            
+
             fixed (byte* pcmPtr = &pcm.GetPinnableReference())
                 len = _OpusDecode(decoder, null, 0, pcmPtr, frameSize, 1);
 
@@ -208,10 +225,7 @@ namespace DSharpPlus.VoiceNext.Codec
             frameSize = frames * samplesPerFrame;
         }
 
-        public static void OpusGetLastPacketDuration(IntPtr decoder, out int sampleCount)
-        {
-            _OpusDecoderControl(decoder, OpusControl.GetLastPacketDuration, out sampleCount);
-        }
-#endregion
+        public static void OpusGetLastPacketDuration(IntPtr decoder, out int sampleCount) => _OpusDecoderControl(decoder, OpusControl.GetLastPacketDuration, out sampleCount);
+        #endregion
     }
 }

--- a/DSharpPlus.VoiceNext/Codec/Opus.cs
+++ b/DSharpPlus.VoiceNext/Codec/Opus.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 
 namespace DSharpPlus.VoiceNext.Codec
@@ -71,10 +94,7 @@ namespace DSharpPlus.VoiceNext.Codec
             target = target.Slice(0, sampleSize);
         }
 
-        public void ProcessPacketLoss(OpusDecoder decoder, int frameSize, ref Span<byte> target)
-        {
-            Interop.OpusDecode(decoder.Decoder, frameSize, target);
-        }
+        public void ProcessPacketLoss(OpusDecoder decoder, int frameSize, ref Span<byte> target) => Interop.OpusDecode(decoder.Decoder, frameSize, target);
 
         public int GetLastPacketSampleCount(OpusDecoder decoder)
         {
@@ -144,12 +164,12 @@ namespace DSharpPlus.VoiceNext.Codec
         /// <param name="outputFormat"></param>
         internal void Initialize(AudioFormat outputFormat)
         {
-            if (Decoder != IntPtr.Zero)
-                Interop.OpusDestroyDecoder(Decoder);
+            if (this.Decoder != IntPtr.Zero)
+                Interop.OpusDestroyDecoder(this.Decoder);
 
-            AudioFormat = outputFormat;
+            this.AudioFormat = outputFormat;
 
-            Decoder = Interop.OpusCreateDecoder(outputFormat);
+            this.Decoder = Interop.OpusCreateDecoder(outputFormat);
         }
 
         /// <summary>

--- a/DSharpPlus.VoiceNext/Codec/Sodium.cs
+++ b/DSharpPlus.VoiceNext/Codec/Sodium.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -145,10 +168,7 @@ namespace DSharpPlus.VoiceNext.Codec
                 throw new CryptographicException($"Could not decrypt the buffer. Sodium returned code {result}.");
         }
 
-        public void Dispose()
-        {
-            this.CSPRNG.Dispose();
-        }
+        public void Dispose() => this.CSPRNG.Dispose();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static KeyValuePair<string, EncryptionMode> SelectMode(IEnumerable<string> availableModes)

--- a/DSharpPlus.VoiceNext/DSharpPlus.VoiceNext.csproj
+++ b/DSharpPlus.VoiceNext/DSharpPlus.VoiceNext.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../DSharpPlus.targets" />
@@ -21,9 +21,9 @@
     <PackageReference Include="DSharpPlus.VoiceNext.Natives" Version="1.0.0" />
     <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/DSharpPlus.VoiceNext/DiscordClientExtensions.cs
+++ b/DSharpPlus.VoiceNext/DiscordClientExtensions.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -14,7 +37,7 @@ namespace DSharpPlus.VoiceNext
         /// </summary>
         /// <param name="client">Discord client to create VoiceNext instance for.</param>
         /// <returns>VoiceNext client instance.</returns>
-        public static VoiceNextExtension UseVoiceNext(this DiscordClient client) 
+        public static VoiceNextExtension UseVoiceNext(this DiscordClient client)
             => UseVoiceNext(client, new VoiceNextConfiguration());
 
         /// <summary>
@@ -61,7 +84,7 @@ namespace DSharpPlus.VoiceNext
         /// </summary>
         /// <param name="client">Discord client to get VoiceNext instance for.</param>
         /// <returns>VoiceNext client instance.</returns>
-        public static VoiceNextExtension GetVoiceNext(this DiscordClient client) 
+        public static VoiceNextExtension GetVoiceNext(this DiscordClient client)
             => client.GetExtension<VoiceNextExtension>();
 
         /// <summary>
@@ -98,7 +121,7 @@ namespace DSharpPlus.VoiceNext
             if (channel.Type != ChannelType.Voice && channel.Type != ChannelType.Stage)
                 throw new InvalidOperationException("You can only connect to voice or stage channels.");
 
-            if (!(channel.Discord is DiscordClient discord) || discord == null)
+            if (channel.Discord is not DiscordClient discord || discord == null)
                 throw new NullReferenceException();
 
             var vnext = discord.GetVoiceNext();
@@ -106,10 +129,9 @@ namespace DSharpPlus.VoiceNext
                 throw new InvalidOperationException("VoiceNext is not initialized for this Discord client.");
 
             var vnc = vnext.GetConnection(channel.Guild);
-            if (vnc != null)
-                throw new InvalidOperationException("VoiceNext is already connected in this guild.");
-
-            return vnext.ConnectAsync(channel);
+            return vnc != null
+                ? throw new InvalidOperationException("VoiceNext is already connected in this guild.")
+                : vnext.ConnectAsync(channel);
         }
     }
 }

--- a/DSharpPlus.VoiceNext/Entities/AudioSender.cs
+++ b/DSharpPlus.VoiceNext/Entities/AudioSender.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using DSharpPlus.Entities;
 using DSharpPlus.VoiceNext.Codec;
 
@@ -18,9 +41,6 @@ namespace DSharpPlus.VoiceNext.Entities
             this.Decoder = decoder;
         }
 
-        public void Dispose()
-        {
-            this.Decoder?.Dispose();
-        }
+        public void Dispose() => this.Decoder?.Dispose();
     }
 }

--- a/DSharpPlus.VoiceNext/Entities/VoiceDispatch.cs
+++ b/DSharpPlus.VoiceNext/Entities/VoiceDispatch.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.VoiceNext.Entities
 {

--- a/DSharpPlus.VoiceNext/Entities/VoiceIdentifyPayload.cs
+++ b/DSharpPlus.VoiceNext/Entities/VoiceIdentifyPayload.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.VoiceNext.Entities
 {

--- a/DSharpPlus.VoiceNext/Entities/VoicePacket.cs
+++ b/DSharpPlus.VoiceNext/Entities/VoicePacket.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.VoiceNext.Entities
 {

--- a/DSharpPlus.VoiceNext/Entities/VoiceReadyPayload.cs
+++ b/DSharpPlus.VoiceNext/Entities/VoiceReadyPayload.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.VoiceNext.Entities

--- a/DSharpPlus.VoiceNext/Entities/VoiceSelectProtocolPayload.cs
+++ b/DSharpPlus.VoiceNext/Entities/VoiceSelectProtocolPayload.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.VoiceNext.Entities
 {

--- a/DSharpPlus.VoiceNext/Entities/VoiceSelectProtocolPayloadData.cs
+++ b/DSharpPlus.VoiceNext/Entities/VoiceSelectProtocolPayloadData.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.VoiceNext.Entities
 {

--- a/DSharpPlus.VoiceNext/Entities/VoiceServerUpdatePayload.cs
+++ b/DSharpPlus.VoiceNext/Entities/VoiceServerUpdatePayload.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.VoiceNext.Entities
 {

--- a/DSharpPlus.VoiceNext/Entities/VoiceSessionDescriptionPayload.cs
+++ b/DSharpPlus.VoiceNext/Entities/VoiceSessionDescriptionPayload.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.VoiceNext.Entities
 {

--- a/DSharpPlus.VoiceNext/Entities/VoiceSpeakingPayload.cs
+++ b/DSharpPlus.VoiceNext/Entities/VoiceSpeakingPayload.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.VoiceNext.Entities
 {

--- a/DSharpPlus.VoiceNext/Entities/VoiceStateUpdatePayload.cs
+++ b/DSharpPlus.VoiceNext/Entities/VoiceStateUpdatePayload.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.VoiceNext.Entities
 {

--- a/DSharpPlus.VoiceNext/Entities/VoiceUserJoinPayload.cs
+++ b/DSharpPlus.VoiceNext/Entities/VoiceUserJoinPayload.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.VoiceNext.Entities
 {

--- a/DSharpPlus.VoiceNext/Entities/VoiceUserLeavePayload.cs
+++ b/DSharpPlus.VoiceNext/Entities/VoiceUserLeavePayload.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.VoiceNext.Entities
 {

--- a/DSharpPlus.VoiceNext/EventArgs/VoiceReceiveEventArgs.cs
+++ b/DSharpPlus.VoiceNext/EventArgs/VoiceReceiveEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 

--- a/DSharpPlus.VoiceNext/EventArgs/VoiceUserJoinEventArgs.cs
+++ b/DSharpPlus.VoiceNext/EventArgs/VoiceUserJoinEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 
 namespace DSharpPlus.VoiceNext.EventArgs

--- a/DSharpPlus.VoiceNext/EventArgs/VoiceUserLeaveEventArgs.cs
+++ b/DSharpPlus.VoiceNext/EventArgs/VoiceUserLeaveEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 
 namespace DSharpPlus.VoiceNext.EventArgs

--- a/DSharpPlus.VoiceNext/IVoiceFilter.cs
+++ b/DSharpPlus.VoiceNext/IVoiceFilter.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.VoiceNext
 {

--- a/DSharpPlus.VoiceNext/RawVoicePacket.cs
+++ b/DSharpPlus.VoiceNext/RawVoicePacket.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 

--- a/DSharpPlus.VoiceNext/StreamExtensions.cs
+++ b/DSharpPlus.VoiceNext/StreamExtensions.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
@@ -31,7 +54,7 @@ namespace DSharpPlus.VoiceNext
                 throw new ArgumentOutOfRangeException(nameof(bufferSize), bufferSize, "bufferSize cannot be less than or equal to zero");
 
             var bufferLength = bufferSize ?? destination.SampleLength;
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferLength);
+            var buffer = ArrayPool<byte>.Shared.Rent(bufferLength);
             try
             {
                 int bytesRead;

--- a/DSharpPlus.VoiceNext/VoiceApplication.cs
+++ b/DSharpPlus.VoiceNext/VoiceApplication.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.VoiceNext
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.VoiceNext
 {
     /// <summary>
     /// Represents encoder settings preset for Opus.

--- a/DSharpPlus.VoiceNext/VoiceNextConfiguration.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConfiguration.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.VoiceNext
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.VoiceNext
 {
     /// <summary>
     /// VoiceNext client configuration.

--- a/DSharpPlus.VoiceNext/VoiceNextEvents.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextEvents.cs
@@ -1,4 +1,27 @@
-﻿using Microsoft.Extensions.Logging;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus.VoiceNext
 {

--- a/DSharpPlus.sln
+++ b/DSharpPlus.sln
@@ -11,6 +11,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DSharpPlus.VoiceNext", "DSh
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4255B64D-92EC-46B3-BC3B-ED2C3A8073EE}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		CONTRIBUTING.md = CONTRIBUTING.md
 		LICENSE = LICENSE
 		README.md = README.md
@@ -40,6 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build Items", "Build Items"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{430C28D8-5F85-4D6E-AA68-211549435245}"
 	ProjectSection(SolutionItems) = preProject
+		.github\FUNDING.yml = .github\FUNDING.yml
 		.github\ISSUE_TEMPLATE.md = .github\ISSUE_TEMPLATE.md
 		.github\PULL_REQUEST_TEMPLATE.md = .github\PULL_REQUEST_TEMPLATE.md
 	EndProjectSection

--- a/DSharpPlus.targets
+++ b/DSharpPlus.targets
@@ -1,46 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	
-	<PropertyGroup>
+
+  <PropertyGroup>
     <VersionPrefix>4.1.0</VersionPrefix>
     <NoWarn>1591</NoWarn>
     <LangVersion>9.0</LangVersion>
     <Optimize>True</Optimize>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <DebugType>Portable</DebugType>
-	</PropertyGroup>
-	
-	<PropertyGroup>
-		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-		<Authors>Naamloos, afroraydude, DrCreo, Death, TiaqoY0, Axiom, Emzi0767, DSharpPlus contributors</Authors>
-		<Company>DSharpPlus developers</Company>
-		<PackageLicenseUrl>https://github.com/DSharpPlus/DSharpPlus/blob/master/LICENSE</PackageLicenseUrl>
-		<PackageProjectUrl>https://github.com/DSharpPlus/DSharpPlus</PackageProjectUrl>
-		<PackageIconUrl>https://raw.githubusercontent.com/DSharpPlus/DSharpPlus/master/logo/dsharpplus.png</PackageIconUrl>
-		<RepositoryUrl>https://github.com/DSharpPlus/DSharpPlus</RepositoryUrl>
-		<RepositoryType>Git</RepositoryType>
-	</PropertyGroup>
-  
-	<PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-		<Optimize>False</Optimize>
-	</PropertyGroup>
+  </PropertyGroup>
 
-	<PropertyGroup Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">
-		<Version>$(VersionPrefix)-$(VersionSuffix)-$(BuildNumber)</Version>
-		<AssemblyVersion>$(VersionPrefix).$(BuildNumber)</AssemblyVersion>
-		<FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
-	</PropertyGroup>
+  <PropertyGroup>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Authors>Naamloos, afroraydude, DrCreo, Death, TiaqoY0, Axiom, Emzi0767, DSharpPlus contributors</Authors>
+    <Company>DSharpPlus developers</Company>
+    <PackageLicenseUrl>https://github.com/DSharpPlus/DSharpPlus/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/DSharpPlus/DSharpPlus</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/DSharpPlus/DSharpPlus/master/logo/dsharpplus.png</PackageIconUrl>
+    <RepositoryUrl>https://github.com/DSharpPlus/DSharpPlus</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
+  </PropertyGroup>
 
-	<PropertyGroup Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' == ''">
-		<Version>$(VersionPrefix)-$(VersionSuffix)</Version>
-		<AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
-		<FileVersion>$(VersionPrefix).0</FileVersion>
-	</PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <Optimize>False</Optimize>
+  </PropertyGroup>
 
-	<PropertyGroup Condition="'$(VersionSuffix)' == ''">
-		<Version>$(VersionPrefix)</Version>
-		<AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
-		<FileVersion>$(VersionPrefix).0</FileVersion>
-	</PropertyGroup>
-	
+  <PropertyGroup Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">
+    <Version>$(VersionPrefix)-$(VersionSuffix)-$(BuildNumber)</Version>
+    <AssemblyVersion>$(VersionPrefix).$(BuildNumber)</AssemblyVersion>
+    <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' == ''">
+    <Version>$(VersionPrefix)-$(VersionSuffix)</Version>
+    <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
+    <FileVersion>$(VersionPrefix).0</FileVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(VersionSuffix)' == ''">
+    <Version>$(VersionPrefix)</Version>
+    <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
+    <FileVersion>$(VersionPrefix).0</FileVersion>
+  </PropertyGroup>
+
 </Project>

--- a/DSharpPlus/AsyncManualResetEvent.cs
+++ b/DSharpPlus/AsyncManualResetEvent.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,7 +37,7 @@ namespace DSharpPlus
 
         private TaskCompletionSource<bool> _tsc;
 
-        public AsyncManualResetEvent() 
+        public AsyncManualResetEvent()
             : this(false)
         { }
 
@@ -26,9 +49,9 @@ namespace DSharpPlus
                 _tsc.TrySetResult(true);
         }
 
-        public Task WaitAsync() { return _tsc.Task; }
+        public Task WaitAsync() => _tsc.Task;
 
-        public Task SetAsync() { return Task.Run(() => _tsc.TrySetResult(true)); }
+        public Task SetAsync() => Task.Run(() => _tsc.TrySetResult(true));
 
         public void Reset()
         {

--- a/DSharpPlus/BaseExtension.cs
+++ b/DSharpPlus/BaseExtension.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
 {
     /// <summary>
     /// Represents base for all DSharpPlus extensions. To implement your own extension, extend this class, and implement its abstract members.

--- a/DSharpPlus/Clients/BaseDiscordClient.cs
+++ b/DSharpPlus/Clients/BaseDiscordClient.cs
@@ -1,4 +1,27 @@
-﻿#pragma warning disable CS0618
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma warning disable CS0618
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -53,7 +76,7 @@ namespace DSharpPlus
         /// <summary>
         /// Gets the list of available voice regions. Note that this property will not contain VIP voice regions.
         /// </summary>
-        public IReadOnlyDictionary<string, DiscordVoiceRegion> VoiceRegions 
+        public IReadOnlyDictionary<string, DiscordVoiceRegion> VoiceRegions
             => this._voice_regions_lazy.Value;
 
         /// <summary>
@@ -158,7 +181,7 @@ namespace DSharpPlus
         /// </summary>
         /// <returns></returns>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<IReadOnlyList<DiscordVoiceRegion>> ListVoiceRegionsAsync() 
+        public Task<IReadOnlyList<DiscordVoiceRegion>> ListVoiceRegionsAsync()
             => this.ApiClient.ListVoiceRegionsAsync();
 
         /// <summary>
@@ -211,7 +234,7 @@ namespace DSharpPlus
 
         internal DiscordUser GetCachedOrEmptyUserInternal(ulong user_id)
         {
-            TryGetCachedUserInternal(user_id, out var user);
+            this.TryGetCachedUserInternal(user_id, out var user);
             return user;
         }
 

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -603,7 +603,8 @@ namespace DSharpPlus
                     ParentId = channel_new.ParentId,
                     IsNSFW = channel_new.IsNSFW,
                     PerUserRateLimit = channel_new.PerUserRateLimit,
-                    RtcRegionId = channel_new.RtcRegionId
+                    RtcRegionId = channel_new.RtcRegionId,
+                    ChannelQualityMode = channel_new.ChannelQualityMode
                 };
 
                 channel_new.Bitrate = channel.Bitrate;
@@ -616,6 +617,7 @@ namespace DSharpPlus
                 channel_new.PerUserRateLimit = channel.PerUserRateLimit;
                 channel_new.Type = channel.Type;
                 channel_new.RtcRegionId = channel.RtcRegionId;
+                channel_new.ChannelQualityMode = channel.ChannelQualityMode;
 
                 channel_new._permissionOverwrites.Clear();
 

--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using DSharpPlus.EventArgs;
 using Emzi0767.Utilities;
 using Microsoft.Extensions.Logging;
@@ -629,7 +652,7 @@ namespace DSharpPlus
         internal void EventErrorHandler<TSender, TArgs>(AsyncEvent<TSender, TArgs> asyncEvent, Exception ex, AsyncEventHandler<TSender, TArgs> handler, TSender sender, TArgs eventArgs)
             where TArgs : AsyncEventArgs
         {
-            if(ex is AsyncEventTimeoutException)
+            if (ex is AsyncEventTimeoutException)
             {
                 this.Logger.LogWarning(LoggerEvents.EventHandlerException, $"An event handler for {asyncEvent.Name} took too long to execute. Defined as \"{handler.Method.ToString().Replace(handler.Method.ReturnType.ToString(), "").TrimStart()}\" located in \"{handler.Method.DeclaringType}\".");
                 return;
@@ -640,10 +663,7 @@ namespace DSharpPlus
         }
 
         private void Goof<TSender, TArgs>(AsyncEvent<TSender, TArgs> asyncEvent, Exception ex, AsyncEventHandler<TSender, TArgs> handler, TSender sender, TArgs eventArgs)
-            where TArgs : AsyncEventArgs
-        {
-            this.Logger.LogCritical(LoggerEvents.EventHandlerException, ex, "Exception event handler {0} (defined in {1}) threw an exception", handler.Method, handler.Method.DeclaringType);
-        }
+            where TArgs : AsyncEventArgs => this.Logger.LogCritical(LoggerEvents.EventHandlerException, ex, "Exception event handler {0} (defined in {1}) threw an exception", handler.Method, handler.Method.DeclaringType);
 
         #endregion
     }

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -1,15 +1,38 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Concurrent;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using DSharpPlus.Net.Abstractions;
 using DSharpPlus.Net.WebSocket;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus
 {
@@ -21,7 +44,7 @@ namespace DSharpPlus
         private DateTimeOffset _lastHeartbeat;
         private Task _heartbeatTask;
 
-        internal static DateTimeOffset DiscordEpoch = new DateTimeOffset(2015, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        internal static DateTimeOffset DiscordEpoch = new(2015, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
         private int _skippedHeartbeats = 0;
         private long _lastSequence;
@@ -38,7 +61,7 @@ namespace DSharpPlus
 
         private static ConcurrentDictionary<ulong, SocketLock> SocketLocks { get; } = new ConcurrentDictionary<ulong, SocketLock>();
         private ManualResetEventSlim SessionLock { get; } = new ManualResetEventSlim(true);
-        
+
         #endregion
 
         #region Internal Connection Methods
@@ -131,18 +154,16 @@ namespace DSharpPlus
                 }
                 else if (e is SocketBinaryMessageEventArgs ebin) // :DDDD
                 {
-                    using (var ms = new MemoryStream())
+                    using var ms = new MemoryStream();
+                    if (!this._payloadDecompressor.TryDecompress(new ArraySegment<byte>(ebin.Message), ms))
                     {
-                        if (!this._payloadDecompressor.TryDecompress(new ArraySegment<byte>(ebin.Message), ms))
-                        {
-                            this.Logger.LogError(LoggerEvents.WebSocketReceiveFailure, "Payload decompression failed");
-                            return;
-                        }
-
-                        ms.Position = 0;
-                        using (var sr = new StreamReader(ms, Utilities.UTF8))
-                            msg = await sr.ReadToEndAsync().ConfigureAwait(false);
+                        this.Logger.LogError(LoggerEvents.WebSocketReceiveFailure, "Payload decompression failed");
+                        return;
                     }
+
+                    ms.Position = 0;
+                    using var sr = new StreamReader(ms, Utilities.UTF8);
+                    msg = await sr.ReadToEndAsync().ConfigureAwait(false);
                 }
 
                 try
@@ -165,14 +186,14 @@ namespace DSharpPlus
                 this.ConnectionLock.Set();
                 this.SessionLock.Set();
 
-                if(!this._disposed)
+                if (!this._disposed)
                     this._cancelTokenSource.Cancel();
 
                 this.Logger.LogDebug(LoggerEvents.ConnectionClose, "Connection closed ({0}, '{1}')", e.CloseCode, e.CloseMessage);
                 await this._socketClosed.InvokeAsync(this, e).ConfigureAwait(false);
 
 
-                
+
                 if (this.Configuration.AutoReconnect && (e.CloseCode < 4001 || e.CloseCode >= 5000))
                 {
                     this.Logger.LogCritical(LoggerEvents.ConnectionClose, "Connection terminated ({0}, '{1}'), reconnecting", e.CloseCode, e.CloseMessage);
@@ -234,7 +255,7 @@ namespace DSharpPlus
         internal async Task OnHeartbeatAsync(long seq)
         {
             this.Logger.LogTrace(LoggerEvents.WebSocketReceive, "Received HEARTBEAT (OP1)");
-            await SendHeartbeatAsync(seq).ConfigureAwait(false);
+            await this.SendHeartbeatAsync(seq).ConfigureAwait(false);
         }
 
         internal async Task OnReconnectAsync()
@@ -258,13 +279,13 @@ namespace DSharpPlus
             {
                 this.Logger.LogTrace(LoggerEvents.WebSocketReceive, "Received INVALID_SESSION (OP9, true)");
                 await Task.Delay(6000).ConfigureAwait(false);
-                await SendResumeAsync().ConfigureAwait(false);
+                await this.SendResumeAsync().ConfigureAwait(false);
             }
             else
             {
                 this.Logger.LogTrace(LoggerEvents.WebSocketReceive, "Received INVALID_SESSION (OP9, false)");
                 this._sessionId = null;
-                await SendIdentifyAsync(this._status).ConfigureAwait(false);
+                await this.SendIdentifyAsync(this._status).ConfigureAwait(false);
             }
         }
 
@@ -288,9 +309,9 @@ namespace DSharpPlus
             this._heartbeatTask = Task.Run(this.HeartbeatLoopAsync, this._cancelToken);
 
             if (string.IsNullOrEmpty(this._sessionId))
-                await SendIdentifyAsync(this._status).ConfigureAwait(false);
+                await this.SendIdentifyAsync(this._status).ConfigureAwait(false);
             else
-                await SendResumeAsync().ConfigureAwait(false);
+                await this.SendResumeAsync().ConfigureAwait(false);
         }
 
         internal async Task OnHeartbeatAckAsync()

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -1,20 +1,43 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Collections.ObjectModel;
-using Newtonsoft.Json.Linq;
-using Microsoft.Extensions.Logging;
-using DSharpPlus.Net;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using DSharpPlus.Exceptions;
+using DSharpPlus.Net;
 using DSharpPlus.Net.Abstractions;
-using Emzi0767.Utilities;
 using DSharpPlus.Net.Models;
+using Emzi0767.Utilities;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus
 {
@@ -34,7 +57,7 @@ namespace DSharpPlus
         private ManualResetEventSlim ConnectionLock { get; } = new ManualResetEventSlim(true);
 
         #endregion
-        
+
         #region Public Fields/Properties
         /// <summary>
         /// Gets the gateway protocol version.
@@ -299,11 +322,9 @@ namespace DSharpPlus
             }
 
             // non-closure, hence args
-            static void FailConnection(ManualResetEventSlim cl)
-            {
+            static void FailConnection(ManualResetEventSlim cl) =>
                 // unlock this (if applicable) so we can let others attempt to connect
                 cl?.Set();
-            }
         }
 
         public Task ReconnectAsync(bool startNewSession = false)
@@ -489,7 +510,7 @@ namespace DSharpPlus
         {
             if (this._guilds.TryGetValue(id, out var guild) && (!withCounts.HasValue || !withCounts.Value))
                 return guild;
-            
+
             guild = await this.ApiClient.GetGuildAsync(id, withCounts).ConfigureAwait(false);
             var channels = await this.ApiClient.GetGuildChannelsAsync(guild.Id).ConfigureAwait(false);
             foreach (var channel in channels) guild._channels[channel.Id] = channel;
@@ -505,7 +526,7 @@ namespace DSharpPlus
         /// <exception cref="Exceptions.NotFoundException">Thrown when the guild does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordGuildPreview> GetGuildPreviewAsync(ulong id) 
+        public Task<DiscordGuildPreview> GetGuildPreviewAsync(ulong id)
             => this.ApiClient.GetGuildPreviewAsync(id);
 
         /// <summary>
@@ -727,7 +748,7 @@ namespace DSharpPlus
 
         internal DiscordGuild InternalGetCachedGuild(ulong? guildId)
         {
-            if(this._guilds != null && guildId.HasValue)
+            if (this._guilds != null && guildId.HasValue)
             {
                 if (this._guilds.TryGetValue(guildId.Value, out var guild))
                     return guild;
@@ -751,25 +772,20 @@ namespace DSharpPlus
             var channel = this.InternalGetCachedChannel(message.ChannelId);
 
             if (channel != null) return;
-            
-            if (!message.GuildId.HasValue)
-            {
-                channel = new DiscordDmChannel
+
+            channel = !message.GuildId.HasValue
+                ? new DiscordDmChannel
                 {
                     Id = message.ChannelId,
                     Discord = this,
                     Type = ChannelType.Private
-                };
-            }
-            else 
-            {
-                channel = new DiscordChannel
+                }
+                : new DiscordChannel
                 {
                     Id = message.ChannelId,
                     Discord = this
                 };
-            }
-            
+
             message.Channel = channel;
         }
 
@@ -814,7 +830,7 @@ namespace DSharpPlus
                     }
                 }
             }
-            else if(usr.Username != null) // check if not a skeleton user
+            else if (usr.Username != null) // check if not a skeleton user
             {
                 _ = this.UserCache.AddOrUpdate(usr.Id, usr, (id, old) =>
                 {
@@ -971,7 +987,7 @@ namespace DSharpPlus
             var extensions = this._extensions; // prevent _extensions being modified during dispose
             this._extensions = null;
             foreach (var extension in extensions)
-                if (extension is IDisposable disposable) 
+                if (extension is IDisposable disposable)
                     disposable.Dispose();
 
             try

--- a/DSharpPlus/Clients/DiscordShardedClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.Events.cs
@@ -1,8 +1,31 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using DSharpPlus.EventArgs;
 using Emzi0767.Utilities;
+using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus
 {
@@ -623,10 +646,7 @@ namespace DSharpPlus
         }
 
         private void Goof<TArgs>(AsyncEvent<DiscordClient, TArgs> asyncEvent, Exception ex, AsyncEventHandler<DiscordClient, TArgs> handler, DiscordClient sender, TArgs eventArgs)
-            where TArgs : AsyncEventArgs
-        {
-            this.Logger.LogCritical(LoggerEvents.EventHandlerException, ex, "Exception event handler {0} (defined in {1}) threw an exception", handler.Method, handler.Method.DeclaringType);
-        }
+            where TArgs : AsyncEventArgs => this.Logger.LogCritical(LoggerEvents.EventHandlerException, ex, "Exception event handler {0} (defined in {1}) threw an exception", handler.Method, handler.Method.DeclaringType);
 
         #endregion
 

--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -1,20 +1,43 @@
-﻿#pragma warning disable CS0618
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma warning disable CS0618
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
-using System.Diagnostics;
-using System.Globalization;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Collections.ObjectModel;
-using Microsoft.Extensions.Logging;
-using Newtonsoft.Json.Linq;
-using DSharpPlus.Net;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
+using DSharpPlus.Net;
 using Emzi0767.Utilities;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus
 {
@@ -53,7 +76,7 @@ namespace DSharpPlus
         /// <summary>
         /// Gets the list of available voice regions. Note that this property will not contain VIP voice regions.
         /// </summary>
-        public IReadOnlyDictionary<string, DiscordVoiceRegion> VoiceRegions 
+        public IReadOnlyDictionary<string, DiscordVoiceRegion> VoiceRegions
             => this._voiceRegionsLazy?.Value;
 
         #endregion
@@ -67,10 +90,10 @@ namespace DSharpPlus
         /// </summary>
         private ConcurrentDictionary<string, DiscordVoiceRegion> _internalVoiceRegions;
 
-        private ConcurrentDictionary<int, DiscordClient> _shards = new ConcurrentDictionary<int, DiscordClient>();
+        private readonly ConcurrentDictionary<int, DiscordClient> _shards = new();
         private Lazy<IReadOnlyDictionary<string, DiscordVoiceRegion>> _voiceRegionsLazy;
         private bool _isStarted;
-        private bool _manuallySharding;
+        private readonly bool _manuallySharding;
 
         #endregion
 
@@ -251,7 +274,7 @@ namespace DSharpPlus
 
             this.Logger.LogDebug(LoggerEvents.ShardRest, $"Obtaining gateway information from GET {Endpoints.GATEWAY}{Endpoints.BOT}...");
             var resp = await http.GetAsync(url).ConfigureAwait(false);
-            
+
             http.Dispose();
 
             if (!resp.IsSuccessStatusCode)
@@ -271,7 +294,7 @@ namespace DSharpPlus
             //There is a delay from parsing here.
             timer.Stop();
 
-            info.SessionBucket.resetAfter -= (int)timer.ElapsedMilliseconds; 
+            info.SessionBucket.resetAfter -= (int)timer.ElapsedMilliseconds;
             info.SessionBucket.ResetAfter = DateTimeOffset.UtcNow + TimeSpan.FromMilliseconds(info.SessionBucket.resetAfter);
 
             return info;
@@ -309,7 +332,7 @@ namespace DSharpPlus
         }
 
 
-        private readonly Lazy<string> _versionString = new Lazy<string>(() =>
+        private readonly Lazy<string> _versionString = new(() =>
         {
             var a = typeof(DiscordShardedClient).GetTypeInfo().Assembly;
 
@@ -387,7 +410,7 @@ namespace DSharpPlus
             this.CurrentUser = null;
             this.CurrentApplication = null;
 
-            for (int i = 0; i < this._shards.Count; i++)
+            for (var i = 0; i < this._shards.Count; i++)
             {
                 if (this._shards.TryGetValue(i, out var client))
                 {
@@ -576,9 +599,9 @@ namespace DSharpPlus
 
         private int getShardIdFromGuilds(ulong id)
         {
-            foreach(var s in this._shards.Values)
+            foreach (var s in this._shards.Values)
             {
-                if(s._guilds.TryGetValue(id, out _))
+                if (s._guilds.TryGetValue(id, out _))
                 {
                     return s.ShardId;
                 }

--- a/DSharpPlus/Clients/DiscordWebhookClient.cs
+++ b/DSharpPlus/Clients/DiscordWebhookClient.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -58,7 +81,7 @@ namespace DSharpPlus
         /// <param name="loggerFactory">The optional logging factory to use for this client.</param>
         /// <param name="minimumLogLevel">The minimum logging level for messages.</param>
         /// <param name="logTimestampFormat">The timestamp format to use for the logger.</param>
-        public DiscordWebhookClient(IWebProxy proxy = null, TimeSpan? timeout = null, bool useRelativeRateLimit = true, 
+        public DiscordWebhookClient(IWebProxy proxy = null, TimeSpan? timeout = null, bool useRelativeRateLimit = true,
             ILoggerFactory loggerFactory = null, LogLevel minimumLogLevel = LogLevel.Information, string logTimestampFormat = "yyyy-MM-dd HH:mm:ss zzz")
         {
             this._minimumLogLevel = minimumLogLevel;
@@ -120,7 +143,7 @@ namespace DSharpPlus
                 throw new ArgumentException("Invalid webhook URL supplied.", nameof(url));
 
             var token = tokenraw.Value;
-            return AddWebhookAsync(id, token);
+            return this.AddWebhookAsync(id, token);
         }
 
         /// <summary>

--- a/DSharpPlus/DSharpPlus.csproj
+++ b/DSharpPlus/DSharpPlus.csproj
@@ -14,7 +14,7 @@
     <Description>A C# API for Discord based off DiscordSharp, but rewritten to fit the API standards.</Description>
     <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, webhooks</PackageTags>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />

--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Net;
 using DSharpPlus.Net.Udp;
 using DSharpPlus.Net.WebSocket;
@@ -153,10 +176,7 @@ namespace DSharpPlus
         public UdpClientFactoryDelegate UdpClientFactory
         {
             internal get => this._udpClientFactory;
-            set
-            {
-                this._udpClientFactory = value ?? throw new InvalidOperationException("You need to supply a valid UDP client factory method.");
-            }
+            set => this._udpClientFactory = value ?? throw new InvalidOperationException("You need to supply a valid UDP client factory method.");
         }
         private UdpClientFactoryDelegate _udpClientFactory = DspUdpClient.CreateNew;
 
@@ -170,7 +190,7 @@ namespace DSharpPlus
         /// <summary>
         /// Creates a new configuration with default values.
         /// </summary>
-        public DiscordConfiguration() 
+        public DiscordConfiguration()
         { }
 
         /// <summary>

--- a/DSharpPlus/DiscordIntents.cs
+++ b/DSharpPlus/DiscordIntents.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus
 {

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -33,7 +56,7 @@ namespace DSharpPlus.Entities
         /// Gets the category that contains this channel.
         /// </summary>
         [JsonIgnore]
-        public DiscordChannel Parent 
+        public DiscordChannel Parent
             => this.ParentId.HasValue ? this.Guild.GetChannel(this.ParentId.Value) : null;
 
         /// <summary>
@@ -58,28 +81,28 @@ namespace DSharpPlus.Entities
         /// Gets whether this channel is a DM channel.
         /// </summary>
         [JsonIgnore]
-        public bool IsPrivate 
+        public bool IsPrivate
             => this.Type == ChannelType.Private || this.Type == ChannelType.Group;
 
         /// <summary>
         /// Gets whether this channel is a channel category.
         /// </summary>
         [JsonIgnore]
-        public bool IsCategory 
+        public bool IsCategory
             => this.Type == ChannelType.Category;
 
         /// <summary>
         /// Gets the guild to which this channel belongs.
         /// </summary>
         [JsonIgnore]
-        public DiscordGuild Guild 
+        public DiscordGuild Guild
             => this.GuildId.HasValue && this.Discord.Guilds.TryGetValue(this.GuildId.Value, out var guild) ? guild : null;
 
         /// <summary>
         /// Gets a collection of permission overwrites for this channel.
         /// </summary>
         [JsonIgnore]
-        public IReadOnlyList<DiscordOverwrite> PermissionOverwrites 
+        public IReadOnlyList<DiscordOverwrite> PermissionOverwrites
             => this._permissionOverwritesLazy.Value;
 
         [JsonProperty("permission_overwrites", NullValueHandling = NullValueHandling.Ignore)]
@@ -133,9 +156,9 @@ namespace DSharpPlus.Entities
         /// Gets this channel's mention string.
         /// </summary>
         [JsonIgnore]
-        public string Mention 
+        public string Mention
             => Formatter.Mention(this);
-        
+
         /// <summary>
         /// Gets this channel's children. This applies only to channel categories.
         /// </summary>
@@ -144,10 +167,9 @@ namespace DSharpPlus.Entities
         {
             get
             {
-                if (!IsCategory)
-                    throw new ArgumentException("Only channel categories contain children.");
-
-                return Guild._channels.Values.Where(e => e.ParentId == Id);
+                return !this.IsCategory
+                    ? throw new ArgumentException("Only channel categories contain children.")
+                    : this.Guild._channels.Values.Where(e => e.ParentId == this.Id);
             }
         }
 
@@ -162,10 +184,9 @@ namespace DSharpPlus.Entities
                 if (this.Guild == null)
                     throw new InvalidOperationException("Cannot query users outside of guild channels.");
 
-                if (this.Type == ChannelType.Voice || this.Type == ChannelType.Stage)
-                    return Guild.Members.Values.Where(x => x.VoiceState?.ChannelId == this.Id);
-
-                return Guild.Members.Values.Where(x => (this.PermissionsFor(x) & Permissions.AccessChannels) == Permissions.AccessChannels);
+                return this.Type == ChannelType.Voice || this.Type == ChannelType.Stage
+                    ? this.Guild.Members.Values.Where(x => x.VoiceState?.ChannelId == this.Id)
+                    : this.Guild.Members.Values.Where(x => (this.PermissionsFor(x) & Permissions.AccessChannels) == Permissions.AccessChannels);
             }
         }
 
@@ -203,10 +224,9 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(string content)
         {
-            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a text message to a non-text channel.");
-
-            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, null, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
+            return this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News
+                ? throw new ArgumentException("Cannot send a text message to a non-text channel.")
+                : this.Discord.ApiClient.CreateMessageAsync(this.Id, content, null, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
         }
 
         /// <summary>
@@ -220,10 +240,9 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(DiscordEmbed embed)
         {
-            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a text message to a non-text channel.");
-
-            return this.Discord.ApiClient.CreateMessageAsync(this.Id, null, embed, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
+            return this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News
+                ? throw new ArgumentException("Cannot send a text message to a non-text channel.")
+                : this.Discord.ApiClient.CreateMessageAsync(this.Id, null, embed, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
         }
 
         /// <summary>
@@ -238,10 +257,9 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> SendMessageAsync(string content, DiscordEmbed embed)
         {
-            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot send a text message to a non-text channel.");
-
-            return this.Discord.ApiClient.CreateMessageAsync(this.Id, content, embed, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
+            return this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News
+                ? throw new ArgumentException("Cannot send a text message to a non-text channel.")
+                : this.Discord.ApiClient.CreateMessageAsync(this.Id, content, embed, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
         }
 
         /// <summary>
@@ -285,8 +303,8 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task DeleteAsync(string reason = null) 
-            => this.Discord.ApiClient.DeleteChannelAsync(Id, reason);
+        public Task DeleteAsync(string reason = null)
+            => this.Discord.ApiClient.DeleteChannelAsync(this.Id, reason);
 
         /// <summary>
         /// Clones this channel. This operation will create a channel with identical settings to this one. Note that this will not copy messages.
@@ -334,15 +352,12 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public async Task<DiscordMessage> GetMessageAsync(ulong id)
         {
-            if (this.Discord.Configuration.MessageCacheSize > 0 
-                && this.Discord is DiscordClient dc 
-                && dc.MessageCache != null 
-                && dc.MessageCache.TryGet(xm => xm.Id == id && xm.ChannelId == this.Id, out var msg))
-            {
-                return msg;
-            }
-
-            return await this.Discord.ApiClient.GetMessageAsync(Id, id).ConfigureAwait(false);
+            return this.Discord.Configuration.MessageCacheSize > 0
+                && this.Discord is DiscordClient dc
+                && dc.MessageCache != null
+                && dc.MessageCache.TryGet(xm => xm.Id == id && xm.ChannelId == this.Id, out var msg)
+                ? msg
+                : await this.Discord.ApiClient.GetMessageAsync(this.Id, id).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -387,10 +402,7 @@ namespace DSharpPlus.Entities
                     ChannelId = chns[i].Id
                 };
 
-                if (chns[i].Id == this.Id)
-                    pmds[i].Position = position;
-                else
-                    pmds[i].Position = chns[i].Position >= position ? chns[i].Position + 1 : chns[i].Position;
+                pmds[i].Position = chns[i].Id == this.Id ? position : chns[i].Position >= position ? chns[i].Position + 1 : chns[i].Position;
             }
 
             return this.Discord.ApiClient.ModifyGuildChannelPositionAsync(this.Guild.Id, pmds, reason);
@@ -510,7 +522,7 @@ namespace DSharpPlus.Entities
                 await this.Discord.ApiClient.DeleteMessageAsync(this.Id, msgs.Single(), reason).ConfigureAwait(false);
                 return;
             }
-            
+
             for (var i = 0; i < msgs.Count(); i += 100)
                 await this.Discord.ApiClient.DeleteMessagesAsync(this.Id, msgs.Skip(i).Take(100), reason).ConfigureAwait(false);
         }
@@ -538,10 +550,9 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<IReadOnlyList<DiscordInvite>> GetInvitesAsync()
         {
-            if (this.Guild == null)
-                throw new ArgumentException("Cannot get the invites of a channel that does not belong to a guild.");
-
-            return this.Discord.ApiClient.GetChannelInvitesAsync(Id);
+            return this.Guild == null
+                ? throw new ArgumentException("Cannot get the invites of a channel that does not belong to a guild.")
+                : this.Discord.ApiClient.GetChannelInvitesAsync(this.Id);
         }
 
         /// <summary>
@@ -558,7 +569,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordInvite> CreateInviteAsync(int max_age = 86400, int max_uses = 0, bool temporary = false, bool unique = false, string reason = null)
-            => this.Discord.ApiClient.CreateChannelInviteAsync(Id, max_age, max_uses, temporary, unique, reason);
+            => this.Discord.ApiClient.CreateChannelInviteAsync(this.Id, max_age, max_uses, temporary, unique, reason);
 
         /// <summary>
         /// Adds a channel permission overwrite for specified member.
@@ -572,7 +583,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task AddOverwriteAsync(DiscordMember member, Permissions allow = Permissions.None, Permissions deny = Permissions.None, string reason = null) 
+        public Task AddOverwriteAsync(DiscordMember member, Permissions allow = Permissions.None, Permissions deny = Permissions.None, string reason = null)
             => this.Discord.ApiClient.EditChannelPermissionsAsync(this.Id, member.Id, allow, deny, "member", reason);
 
         /// <summary>
@@ -587,7 +598,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task AddOverwriteAsync(DiscordRole role, Permissions allow = Permissions.None, Permissions deny = Permissions.None, string reason = null) 
+        public Task AddOverwriteAsync(DiscordRole role, Permissions allow = Permissions.None, Permissions deny = Permissions.None, string reason = null)
             => this.Discord.ApiClient.EditChannelPermissionsAsync(this.Id, role.Id, allow, deny, "role", reason);
 
         /// <summary>
@@ -599,10 +610,9 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task TriggerTypingAsync()
         {
-            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot start typing in a non-text channel.");
-
-            return this.Discord.ApiClient.TriggerTypingAsync(Id);
+            return this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News
+                ? throw new ArgumentException("Cannot start typing in a non-text channel.")
+                : this.Discord.ApiClient.TriggerTypingAsync(this.Id);
         }
 
         /// <summary>
@@ -615,10 +625,9 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<IReadOnlyList<DiscordMessage>> GetPinnedMessagesAsync()
         {
-            if (this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News)
-                throw new ArgumentException("A non-text channel does not have pinned messages.");
-
-            return this.Discord.ApiClient.GetPinnedMessagesAsync(this.Id);
+            return this.Type != ChannelType.Text && this.Type != ChannelType.Private && this.Type != ChannelType.Group && this.Type != ChannelType.News
+                ? throw new ArgumentException("A non-text channel does not have pinned messages.")
+                : this.Discord.ApiClient.GetPinnedMessagesAsync(this.Id);
         }
 
         /// <summary>
@@ -651,7 +660,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.ManageWebhooks"/> permission.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<IReadOnlyList<DiscordWebhook>> GetWebhooksAsync() 
+        public Task<IReadOnlyList<DiscordWebhook>> GetWebhooksAsync()
             => this.Discord.ApiClient.GetChannelWebhooksAsync(this.Id);
 
         /// <summary>
@@ -667,7 +676,7 @@ namespace DSharpPlus.Entities
         {
             if (this.Type != ChannelType.Voice && this.Type != ChannelType.Stage)
                 throw new ArgumentException("Cannot place a member in a non-voice channel!"); // be a little more angery, let em learn!!1
-            
+
             await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, member.Id, default, default, default,
                 default, this.Id, null).ConfigureAwait(false);
         }
@@ -680,10 +689,9 @@ namespace DSharpPlus.Entities
         /// <exception cref="UnauthorizedException">Thrown when the current user doesn't have <see cref="Permissions.ManageWebhooks"/> on the target channel</exception>
         public Task<DiscordFollowedChannel> FollowAsync(DiscordChannel targetChannel)
         {
-            if (this.Type != ChannelType.News)
-                throw new ArgumentException("Cannot follow a non-news channel.");
-
-            return this.Discord.ApiClient.FollowChannelAsync(this.Id, targetChannel.Id);
+            return this.Type != ChannelType.News
+                ? throw new ArgumentException("Cannot follow a non-news channel.")
+                : this.Discord.ApiClient.FollowChannelAsync(this.Id, targetChannel.Id);
         }
 
         /// <summary>
@@ -696,10 +704,9 @@ namespace DSharpPlus.Entities
         /// </exception>
         public Task<DiscordMessage> CrosspostMessageAsync(DiscordMessage message)
         {
-            if ((message.Flags & MessageFlags.Crossposted) == MessageFlags.Crossposted)
-                throw new ArgumentException("Message is already crossposted.");
-            
-            return this.Discord.ApiClient.CrosspostMessageAsync(this.Id, message.Id);
+            return (message.Flags & MessageFlags.Crossposted) == MessageFlags.Crossposted
+                ? throw new ArgumentException("Message is already crossposted.")
+                : this.Discord.ApiClient.CrosspostMessageAsync(this.Id, message.Id);
         }
 
         /// <summary>
@@ -728,7 +735,7 @@ namespace DSharpPlus.Entities
             //
             // you should use a single tilde
             // ~emzi
-            
+
             // user > role > everyone
             // allow > deny > undefined
             // =>
@@ -762,7 +769,7 @@ namespace DSharpPlus.Entities
                 .Select(xr => this._permissionOverwrites.FirstOrDefault(xo => xo.Id == xr.Id))
                 .Where(xo => xo != null)
                 .ToList();
-            
+
             // assign channel permission overwrites for @everyone pseudo-role
             var everyoneOverwrites = this._permissionOverwrites.FirstOrDefault(xo => xo.Id == everyoneRole.Id);
             if (everyoneOverwrites != null)
@@ -779,7 +786,7 @@ namespace DSharpPlus.Entities
             // channel overrides for just this member
             var mbOverrides = this._permissionOverwrites.FirstOrDefault(xo => xo.Id == mbr.Id);
             if (mbOverrides == null) return perms;
-            
+
             // assign channel permission overwrites for just this member
             perms &= ~mbOverrides.Denied;
             perms |= mbOverrides.Allowed;
@@ -797,9 +804,7 @@ namespace DSharpPlus.Entities
                 return $"Channel Category {this.Name} ({this.Id})";
             if (this.Type == ChannelType.Text || this.Type == ChannelType.News)
                 return $"Channel #{this.Name} ({this.Id})";
-            if (!string.IsNullOrWhiteSpace(this.Name))
-                return $"Channel {this.Name} ({this.Id})";
-            return $"Channel {this.Id}";
+            return !string.IsNullOrWhiteSpace(this.Name) ? $"Channel {this.Name} ({this.Id})" : $"Channel {this.Id}";
         }
         #endregion
 
@@ -808,10 +813,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="obj">Object to compare to.</param>
         /// <returns>Whether the object is equal to this <see cref="DiscordChannel"/>.</returns>
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as DiscordChannel);
-        }
+        public override bool Equals(object obj) => this.Equals(obj as DiscordChannel);
 
         /// <summary>
         /// Checks whether this <see cref="DiscordChannel"/> is equal to another <see cref="DiscordChannel"/>.
@@ -823,20 +825,14 @@ namespace DSharpPlus.Entities
             if (e is null)
                 return false;
 
-            if (ReferenceEquals(this, e))
-                return true;
-
-            return this.Id == e.Id;
+            return ReferenceEquals(this, e) ? true : this.Id == e.Id;
         }
 
         /// <summary>
         /// Gets the hash code for this <see cref="DiscordChannel"/>.
         /// </summary>
         /// <returns>The hash code for this <see cref="DiscordChannel"/>.</returns>
-        public override int GetHashCode()
-        {
-            return this.Id.GetHashCode();
-        }
+        public override int GetHashCode() => this.Id.GetHashCode();
 
         /// <summary>
         /// Gets whether the two <see cref="DiscordChannel"/> objects are equal.
@@ -852,10 +848,7 @@ namespace DSharpPlus.Entities
             if ((o1 == null && o2 != null) || (o1 != null && o2 == null))
                 return false;
 
-            if (o1 == null && o2 == null)
-                return true;
-
-            return e1.Id == e2.Id;
+            return o1 == null && o2 == null ? true : e1.Id == e2.Id;
         }
 
         /// <summary>
@@ -864,7 +857,7 @@ namespace DSharpPlus.Entities
         /// <param name="e1">First channel to compare.</param>
         /// <param name="e2">Second channel to compare.</param>
         /// <returns>Whether the two channels are not equal.</returns>
-        public static bool operator !=(DiscordChannel e1, DiscordChannel e2) 
+        public static bool operator !=(DiscordChannel e1, DiscordChannel e2)
             => !(e1 == e2);
     }
 }

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -142,6 +142,12 @@ namespace DSharpPlus.Entities
         public int? PerUserRateLimit { get; internal set; }
 
         /// <summary>
+        /// Gets this channel's video quality mode. This is applicable to voice channels only.
+        /// </summary>
+        [JsonProperty("video_quality_mode", NullValueHandling = NullValueHandling.Ignore)]
+        public ChannelQualityMode ChannelQualityMode { get; internal set; }
+
+        /// <summary>
         /// Gets when the last pinned message was pinned.
         /// </summary>
         [JsonIgnore]

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -344,7 +344,7 @@ namespace DSharpPlus.Entities
                 perUserRateLimit = Optional.FromNoValue<int?>();
             }
 
-            return await this.Guild.CreateChannelAsync(this.Name, this.Type, this.Parent, this.Topic, bitrate, userLimit, ovrs, this.IsNSFW, perUserRateLimit, reason).ConfigureAwait(false);
+            return await this.Guild.CreateChannelAsync(this.Name, this.Type, this.Parent, this.Topic, bitrate, userLimit, ovrs, this.IsNSFW, perUserRateLimit, this.ChannelQualityMode, reason).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -381,7 +381,7 @@ namespace DSharpPlus.Entities
             action(mdl);
             return this.Discord.ApiClient.ModifyChannelAsync(this.Id, mdl.Name, mdl.Position, mdl.Topic, mdl.Nsfw,
                 mdl.Parent.HasValue ? mdl.Parent.Value?.Id : default(Optional<ulong?>), mdl.Bitrate, mdl.Userlimit, mdl.PerUserRateLimit, mdl.RtcRegion.IfPresent(r => r?.Id),
-                mdl.AuditLogReason);
+                mdl.ChannelQualityMode, mdl.AuditLogReason);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -114,25 +114,25 @@ namespace DSharpPlus.Entities
         /// Gets the channel's topic. This is applicable to text channels only.
         /// </summary>
         [JsonProperty("topic", NullValueHandling = NullValueHandling.Ignore)]
-        public string Topic { get; internal set; } = "";
+        public string Topic { get; internal set; }
 
         /// <summary>
         /// Gets the ID of the last message sent in this channel. This is applicable to text channels only.
         /// </summary>
         [JsonProperty("last_message_id", NullValueHandling = NullValueHandling.Ignore)]
-        public ulong LastMessageId { get; internal set; } = 0;
+        public ulong? LastMessageId { get; internal set; }
 
         /// <summary>
         /// Gets this channel's bitrate. This is applicable to voice channels only.
         /// </summary>
         [JsonProperty("bitrate", NullValueHandling = NullValueHandling.Ignore)]
-        public int Bitrate { get; internal set; }
+        public int? Bitrate { get; internal set; }
 
         /// <summary>
         /// Gets this channel's user limit. This is applicable to voice channels only.
         /// </summary>
         [JsonProperty("user_limit", NullValueHandling = NullValueHandling.Ignore)]
-        public int UserLimit { get; internal set; }
+        public int? UserLimit { get; internal set; }
 
         /// <summary>
         /// <para>Gets the slow mode delay configured for this channel.</para>

--- a/DSharpPlus/Entities/Channel/DiscordDmChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordDmChannel.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -41,7 +64,7 @@ namespace DSharpPlus.Entities
         /// Gets the URL of this channel's icon.
         /// </summary>
         [JsonIgnore]
-        public string IconUrl 
+        public string IconUrl
             => !string.IsNullOrWhiteSpace(this.IconHash) ? $"https://cdn.discordapp.com/channel-icons/{this.Id.ToString(CultureInfo.InvariantCulture)}/{this.IconHash}.png" : null;
 
         /// <summary>
@@ -53,7 +76,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task AddDmRecipientAsync(ulong user_id, string accesstoken, string nickname) 
+        public Task AddDmRecipientAsync(ulong user_id, string accesstoken, string nickname)
             => this.Discord.ApiClient.AddGroupDmRecipientAsync(this.Id, user_id, accesstoken, nickname);
 
         /// <summary>
@@ -64,7 +87,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task RemoveDmRecipientAsync(ulong user_id, string accesstoken) 
+        public Task RemoveDmRecipientAsync(ulong user_id, string accesstoken)
             => this.Discord.ApiClient.RemoveGroupDmRecipientAsync(this.Id, user_id);
     }
 }

--- a/DSharpPlus/Entities/Channel/DiscordFollowedChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordFollowedChannel.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
@@ -12,7 +35,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("channel_id", NullValueHandling = NullValueHandling.Ignore)]
         public ulong ChannelId { get; internal set; }
-        
+
         /// <summary>
         /// Gets the id of the webhook that posts crossposted messages to the channel.
         /// </summary>

--- a/DSharpPlus/Entities/Channel/Message/DiscordAttachment.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordAttachment.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Channel/Message/DiscordMentions.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMentions.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
@@ -33,7 +56,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("parse", NullValueHandling = NullValueHandling.Ignore)]
         public IEnumerable<string> Parse { get; }
-        
+
         // WHY IS THERE NO DOCSTRING HERE
         [JsonProperty("replied_user", NullValueHandling = NullValueHandling.Ignore)]
         public bool? RepliedUser { get; }
@@ -42,13 +65,13 @@ namespace DSharpPlus.Entities
         {
             //Null check just to be safe
             if (mentions == null) return;
-            
+
             //If we have no item in our mentions, its likely to be a empty array. 
             // This is a special case were we want parse to be a empty array
             // Doing this allows for "no parsing"
             if (!mentions.Any())
             {
-                Parse = Array.Empty<string>();
+                this.Parse = Array.Empty<string>();
                 this.RepliedUser = mention;
                 return;
             }
@@ -57,12 +80,12 @@ namespace DSharpPlus.Entities
             {
                 this.RepliedUser = mention;
             }
-            
-            
+
+
             //Prepare a list of allowed IDs. We will be adding to these IDs.
-            HashSet<ulong> roles = new HashSet<ulong>();
-            HashSet<ulong> users = new HashSet<ulong>();
-            HashSet<string> parse = new HashSet<string>();
+            var roles = new HashSet<ulong>();
+            var users = new HashSet<ulong>();
+            var parse = new HashSet<string>();
 
             foreach (var m in mentions)
             {
@@ -87,7 +110,7 @@ namespace DSharpPlus.Entities
                     case EveryoneMention e:
                         parse.Add(ParseEveryone);
                         break;
-                    
+
                     case RepliedUserMention _:
                         this.RepliedUser = mention;
                         break;
@@ -96,14 +119,14 @@ namespace DSharpPlus.Entities
 
             //Check the validity of each item. If it isn't in the explicit allow list and they have items, then add them.
             if (!parse.Contains(ParseUsers) && users.Count > 0)
-                Users = users;
+                this.Users = users;
 
             if (!parse.Contains(ParseRoles) && roles.Count > 0)
-                Roles = roles;
+                this.Roles = roles;
 
             //If we have a empty parse aray, we don't want to add it.
             if (parse.Count > 0)
-                Parse = parse;
+                this.Parse = parse;
         }
     }
 }

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -17,16 +40,10 @@ namespace DSharpPlus.Entities
         {
             this._attachmentsLazy = new Lazy<IReadOnlyList<DiscordAttachment>>(() => new ReadOnlyCollection<DiscordAttachment>(this._attachments));
             this._embedsLazy = new Lazy<IReadOnlyList<DiscordEmbed>>(() => new ReadOnlyCollection<DiscordEmbed>(this._embeds));
-            this._mentionedChannelsLazy = new Lazy<IReadOnlyList<DiscordChannel>>(() => {
-                if (this._mentionedChannels != null)
-                    return new ReadOnlyCollection<DiscordChannel>(this._mentionedChannels);
-                return Array.Empty<DiscordChannel>();
-            });
-            this._mentionedRolesLazy = new Lazy<IReadOnlyList<DiscordRole>>(() => {
-                if (this._mentionedRoles != null)
-                    return new ReadOnlyCollection<DiscordRole>(this._mentionedRoles);
-                return Array.Empty<DiscordRole>();
-            });
+            this._mentionedChannelsLazy = new Lazy<IReadOnlyList<DiscordChannel>>(() => this._mentionedChannels != null
+                    ? new ReadOnlyCollection<DiscordChannel>(this._mentionedChannels)
+                    : Array.Empty<DiscordChannel>());
+            this._mentionedRolesLazy = new Lazy<IReadOnlyList<DiscordRole>>(() => this._mentionedRoles != null ? new ReadOnlyCollection<DiscordRole>(this._mentionedRoles) : Array.Empty<DiscordRole>());
             this._mentionedUsersLazy = new Lazy<IReadOnlyList<DiscordUser>>(() => new ReadOnlyCollection<DiscordUser>(this._mentionedUsers));
             this._reactionsLazy = new Lazy<IReadOnlyList<DiscordReaction>>(() => new ReadOnlyCollection<DiscordReaction>(this._reactions));
             this._stickersLazy = new Lazy<IReadOnlyList<DiscordMessageSticker>>(() => new ReadOnlyCollection<DiscordMessageSticker>(this._stickers));
@@ -39,7 +56,7 @@ namespace DSharpPlus.Entities
                 return new Uri($"https://discord.com/channels/{gid}/{cid}/{mid}");
             });
         }
-        
+
         internal DiscordMessage(DiscordMessage other)
             : this()
         {
@@ -47,8 +64,8 @@ namespace DSharpPlus.Entities
 
             this._attachments = other._attachments; // the attachments cannot change, thus no need to copy and reallocate.
             this._embeds = new List<DiscordEmbed>(other._embeds);
-            
-            if (other._mentionedChannels != null) 
+
+            if (other._mentionedChannels != null)
                 this._mentionedChannels = new List<DiscordChannel>(other._mentionedChannels);
             if (other._mentionedRoles != null)
                 this._mentionedRoles = new List<DiscordRole>(other._mentionedRoles);
@@ -73,12 +90,12 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public DiscordChannel Channel
-        { 
+        {
             get => (this.Discord as DiscordClient)?.InternalGetCachedChannel(this.ChannelId) ?? this._channel;
             internal set => this._channel = value;
         }
 
-        private DiscordChannel _channel; 
+        private DiscordChannel _channel;
 
         /// <summary>
         /// Gets the ID of the channel in which the message was sent.
@@ -113,8 +130,8 @@ namespace DSharpPlus.Entities
         /// Gets the message's edit timestamp. Will be null if the message was not edited.
         /// </summary>
         [JsonIgnore]
-        public DateTimeOffset? EditedTimestamp 
-            => !string.IsNullOrWhiteSpace(this.EditedTimestampRaw) && DateTimeOffset.TryParse(this.EditedTimestampRaw, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dto) ? 
+        public DateTimeOffset? EditedTimestamp
+            => !string.IsNullOrWhiteSpace(this.EditedTimestampRaw) && DateTimeOffset.TryParse(this.EditedTimestampRaw, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dto) ?
                 (DateTimeOffset?)dto : null;
 
         [JsonProperty("edited_timestamp", NullValueHandling = NullValueHandling.Ignore)]
@@ -124,7 +141,7 @@ namespace DSharpPlus.Entities
         /// Gets whether this message was edited.
         /// </summary>
         [JsonIgnore]
-        public bool IsEdited 
+        public bool IsEdited
             => !string.IsNullOrWhiteSpace(this.EditedTimestampRaw);
 
         /// <summary>
@@ -139,11 +156,11 @@ namespace DSharpPlus.Entities
         [JsonProperty("mention_everyone", NullValueHandling = NullValueHandling.Ignore)]
         public bool MentionEveryone { get; internal set; }
 
-		/// <summary>
-		/// Gets users or members mentioned by this message.
-		/// </summary>
-		[JsonIgnore]
-        public IReadOnlyList<DiscordUser> MentionedUsers 
+        /// <summary>
+        /// Gets users or members mentioned by this message.
+        /// </summary>
+        [JsonIgnore]
+        public IReadOnlyList<DiscordUser> MentionedUsers
             => this._mentionedUsersLazy.Value;
 
         [JsonProperty("mentions", NullValueHandling = NullValueHandling.Ignore)]
@@ -157,7 +174,7 @@ namespace DSharpPlus.Entities
         /// Gets roles mentioned by this message.
         /// </summary>
         [JsonIgnore]
-        public IReadOnlyList<DiscordRole> MentionedRoles 
+        public IReadOnlyList<DiscordRole> MentionedRoles
             => this._mentionedRolesLazy.Value;
 
         [JsonIgnore]
@@ -169,7 +186,7 @@ namespace DSharpPlus.Entities
         /// Gets channels mentioned by this message.
         /// </summary>
         [JsonIgnore]
-        public IReadOnlyList<DiscordChannel> MentionedChannels 
+        public IReadOnlyList<DiscordChannel> MentionedChannels
             => this._mentionedChannelsLazy.Value;
 
         [JsonIgnore]
@@ -181,7 +198,7 @@ namespace DSharpPlus.Entities
         /// Gets files attached to this message.
         /// </summary>
         [JsonIgnore]
-        public IReadOnlyList<DiscordAttachment> Attachments 
+        public IReadOnlyList<DiscordAttachment> Attachments
             => this._attachmentsLazy.Value;
 
         [JsonProperty("attachments", NullValueHandling = NullValueHandling.Ignore)]
@@ -193,7 +210,7 @@ namespace DSharpPlus.Entities
         /// Gets embeds attached to this message.
         /// </summary>
         [JsonIgnore]
-        public IReadOnlyList<DiscordEmbed> Embeds 
+        public IReadOnlyList<DiscordEmbed> Embeds
             => this._embedsLazy.Value;
 
         [JsonProperty("embeds", NullValueHandling = NullValueHandling.Ignore)]
@@ -205,7 +222,7 @@ namespace DSharpPlus.Entities
         /// Gets reactions used on this message.
         /// </summary>
         [JsonIgnore]
-        public IReadOnlyList<DiscordReaction> Reactions 
+        public IReadOnlyList<DiscordReaction> Reactions
             => this._reactionsLazy.Value;
 
         [JsonProperty("reactions", NullValueHandling = NullValueHandling.Ignore)]
@@ -259,7 +276,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public DiscordMessageReference Reference
-            => (this.InternalReference.HasValue) ? this?.InternalBuildMessageReference() : null;
+            => this.InternalReference.HasValue ? this?.InternalBuildMessageReference() : null;
 
         /// <summary>
         /// Gets the bitwise flags for this message.
@@ -271,7 +288,7 @@ namespace DSharpPlus.Entities
         /// Gets whether the message originated from a webhook.
         /// </summary>
         [JsonIgnore]
-        public bool WebhookMessage 
+        public bool WebhookMessage
             => this.WebhookId != null;
 
         /// <summary>
@@ -318,10 +335,9 @@ namespace DSharpPlus.Entities
             var reference = new DiscordMessageReference();
 
             if (guildId.HasValue)
-                if (client._guilds.TryGetValue(guildId.Value, out var g))
-                    reference.Guild = g;
-
-                else reference.Guild = new DiscordGuild
+                reference.Guild = client._guilds.TryGetValue(guildId.Value, out var g)
+                    ? g
+                    : new DiscordGuild
                 {
                     Id = guildId.Value,
                     Discord = client
@@ -357,7 +373,7 @@ namespace DSharpPlus.Entities
                 if (messageId.HasValue)
                     reference.Message.Id = messageId.Value;
             }
-            
+
             return reference;
         }
 
@@ -365,7 +381,7 @@ namespace DSharpPlus.Entities
 
         internal void PopulateMentions()
         {
-            DiscordGuild guild = this.Channel?.Guild;
+            var guild = this.Channel?.Guild;
             this._mentionedUsers ??= new List<DiscordUser>();
             this._mentionedRoles ??= new List<DiscordRole>();
             this._mentionedChannels ??= new List<DiscordChannel>();
@@ -409,7 +425,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordMessage> ModifyAsync(Optional<string> content) 
+        public Task<DiscordMessage> ModifyAsync(Optional<string> content)
             => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, default, default);
 
         /// <summary>
@@ -477,7 +493,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task DeleteAsync(string reason = null) 
+        public Task DeleteAsync(string reason = null)
             => this.Discord.ApiClient.DeleteMessageAsync(this.ChannelId, this.Id, reason);
 
         /// <summary>
@@ -500,7 +516,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task PinAsync() 
+        public Task PinAsync()
             => this.Discord.ApiClient.PinMessageAsync(this.ChannelId, this.Id);
 
         /// <summary>
@@ -511,7 +527,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task UnpinAsync() 
+        public Task UnpinAsync()
             => this.Discord.ApiClient.UnpinMessageAsync(this.ChannelId, this.Id);
 
         /// <summary>
@@ -523,7 +539,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordMessage> RespondAsync(string content) 
+        public Task<DiscordMessage> RespondAsync(string content)
             => this.Discord.ApiClient.CreateMessageAsync(this.ChannelId, content, null, replyMessageId: this.Id, mentionReply: false, failOnInvalidReply: false);
 
         /// <summary>
@@ -588,7 +604,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the emoji does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task CreateReactionAsync(DiscordEmoji emoji) 
+        public Task CreateReactionAsync(DiscordEmoji emoji)
             => this.Discord.ApiClient.CreateReactionAsync(this.ChannelId, this.Id, emoji.ToReactionString());
 
         /// <summary>
@@ -599,7 +615,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the emoji does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task DeleteOwnReactionAsync(DiscordEmoji emoji) 
+        public Task DeleteOwnReactionAsync(DiscordEmoji emoji)
             => this.Discord.ApiClient.DeleteOwnReactionAsync(this.ChannelId, this.Id, emoji.ToReactionString());
 
         /// <summary>
@@ -613,7 +629,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the emoji does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task DeleteReactionAsync(DiscordEmoji emoji, DiscordUser user, string reason = null) 
+        public Task DeleteReactionAsync(DiscordEmoji emoji, DiscordUser user, string reason = null)
             => this.Discord.ApiClient.DeleteUserReactionAsync(this.ChannelId, this.Id, user.Id, emoji.ToReactionString(), reason);
 
         /// <summary>
@@ -626,7 +642,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the emoji does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(DiscordEmoji emoji, int limit = 25, ulong? after = null) 
+        public Task<IReadOnlyList<DiscordUser>> GetReactionsAsync(DiscordEmoji emoji, int limit = 25, ulong? after = null)
             => this.GetReactionsInternalAsync(emoji, limit, after);
 
         /// <summary>
@@ -638,7 +654,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the emoji does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task DeleteAllReactionsAsync(string reason = null) 
+        public Task DeleteAllReactionsAsync(string reason = null)
             => this.Discord.ApiClient.DeleteAllReactionsAsync(this.ChannelId, this.Id, reason);
 
         /// <summary>
@@ -685,20 +701,14 @@ namespace DSharpPlus.Entities
         /// Returns a string representation of this message.
         /// </summary>
         /// <returns>String representation of this message.</returns>
-        public override string ToString()
-        {
-            return $"Message {this.Id}; Attachment count: {this._attachments.Count}; Embed count: {this._embeds.Count}; Contents: {this.Content}";
-        }
+        public override string ToString() => $"Message {this.Id}; Attachment count: {this._attachments.Count}; Embed count: {this._embeds.Count}; Contents: {this.Content}";
 
         /// <summary>
         /// Checks whether this <see cref="DiscordMessage"/> is equal to another object.
         /// </summary>
         /// <param name="obj">Object to compare to.</param>
         /// <returns>Whether the object is equal to this <see cref="DiscordMessage"/>.</returns>
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as DiscordMessage);
-        }
+        public override bool Equals(object obj) => this.Equals(obj as DiscordMessage);
 
         /// <summary>
         /// Checks whether this <see cref="DiscordMessage"/> is equal to another <see cref="DiscordMessage"/>.
@@ -710,10 +720,7 @@ namespace DSharpPlus.Entities
             if (e is null)
                 return false;
 
-            if (ReferenceEquals(this, e))
-                return true;
-
-            return this.Id == e.Id && this.ChannelId == e.ChannelId;
+            return ReferenceEquals(this, e) ? true : this.Id == e.Id && this.ChannelId == e.ChannelId;
         }
 
         /// <summary>
@@ -722,7 +729,7 @@ namespace DSharpPlus.Entities
         /// <returns>The hash code for this <see cref="DiscordMessage"/>.</returns>
         public override int GetHashCode()
         {
-            int hash = 13;
+            var hash = 13;
 
             hash = (hash * 7) + this.Id.GetHashCode();
             hash = (hash * 7) + this.ChannelId.GetHashCode();
@@ -744,10 +751,7 @@ namespace DSharpPlus.Entities
             if ((o1 == null && o2 != null) || (o1 != null && o2 == null))
                 return false;
 
-            if (o1 == null && o2 == null)
-                return true;
-
-            return e1.Id == e2.Id && e1.ChannelId == e2.ChannelId;
+            return o1 == null && o2 == null ? true : e1.Id == e2.Id && e1.ChannelId == e2.ChannelId;
         }
 
         /// <summary>
@@ -756,7 +760,7 @@ namespace DSharpPlus.Entities
         /// <param name="e1">First message to compare.</param>
         /// <param name="e2">Second message to compare.</param>
         /// <returns>Whether the two messages are not equal.</returns>
-        public static bool operator !=(DiscordMessage e1, DiscordMessage e2) 
+        public static bool operator !=(DiscordMessage e1, DiscordMessage e2)
             => !(e1 == e2);
     }
 }

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageActivity.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageActivity.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageApplication.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageApplication.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {
@@ -33,6 +56,6 @@ namespace DSharpPlus.Entities
 
         internal DiscordMessageApplication() { }
 
-        
+
     }
 }

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -57,7 +80,7 @@ namespace DSharpPlus.Entities
         /// Gets if the Reply should mention the user.
         /// </summary>
         public bool MentionOnReply { get; private set; } = false;
-        
+
         /// <summary>
         /// Gets if the Reply will error if the Reply Message Id does not reference a valid message.
         /// <para>If set to false, invalid replies are send as a regular message.</para>
@@ -74,7 +97,7 @@ namespace DSharpPlus.Entities
         {
             this.Content = content;
             return this;
-        } 
+        }
 
         /// <summary>
         /// Sets if the message should be TTS.
@@ -97,8 +120,8 @@ namespace DSharpPlus.Entities
             this.Embed = embed;
             return this;
         }
-        
-        
+
+
 
         /// <summary>
         /// Sets if the message has allowed mentions.
@@ -139,16 +162,16 @@ namespace DSharpPlus.Entities
         /// <returns></returns>
         public DiscordMessageBuilder WithFile(string fileName, Stream stream, bool resetStreamPosition = false)
         {
-            if(this.Files.Count() >= 10)
+            if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             if (this._files.Any(x => x.FileName == fileName))
                 throw new ArgumentException("A File with that filename already exists");
 
-            if(resetStreamPosition)
+            if (resetStreamPosition)
                 this._files.Add(new DiscordMessageFile(fileName, stream, stream.Position));
             else
-                this._files.Add(new DiscordMessageFile(fileName, stream, null));            
+                this._files.Add(new DiscordMessageFile(fileName, stream, null));
 
             return this;
         }
@@ -196,7 +219,7 @@ namespace DSharpPlus.Entities
                 else
                     this._files.Add(new DiscordMessageFile(file.Key, file.Value, null));
             }
-            
+
             return this;
         }
 
@@ -214,27 +237,21 @@ namespace DSharpPlus.Entities
             this.FailOnInvalidReply = failOnInvalidReply;
             return this;
         }
-        
+
 
         /// <summary>
         /// Sends the Message to a specific channel
         /// </summary>
         /// <param name="channel">The channel the message should be sent to.</param>
         /// <returns></returns>
-        public Task<DiscordMessage> SendAsync(DiscordChannel channel)
-        {
-            return channel.SendMessageAsync(this);
-        }
+        public Task<DiscordMessage> SendAsync(DiscordChannel channel) => channel.SendMessageAsync(this);
 
         /// <summary>
         /// Sends the modified message.
         /// </summary>
         /// <param name="msg">The original Message to modify.</param>
         /// <returns></returns>
-        public Task<DiscordMessage> ModifyAsync(DiscordMessage msg)
-        {
-            return msg.ModifyAsync(this);
-        }
+        public Task<DiscordMessage> ModifyAsync(DiscordMessage msg) => msg.ModifyAsync(this);
 
         /// <summary>
         /// Allows for clearing the Message Builder so that it can be used again to send a new message.

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageFile.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageFile.cs
@@ -1,4 +1,27 @@
-﻿using System.IO;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.IO;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageInteraction.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageInteraction.cs
@@ -1,7 +1,30 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageReference.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageReference.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {
@@ -38,7 +61,7 @@ namespace DSharpPlus.Entities
 
         [JsonProperty("guild_id", NullValueHandling = NullValueHandling.Ignore)]
         internal ulong? GuildId { get; set; }
-        
+
         [JsonProperty("fail_if_not_exists", NullValueHandling = NullValueHandling.Ignore)]
         public bool FailIfNotExists { get; set; }
     }

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageSticker.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageSticker.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -55,10 +78,7 @@ namespace DSharpPlus.Entities
         [JsonProperty("tags", NullValueHandling = NullValueHandling.Ignore)]
         private string _internalTags { get; set; }
 
-        public bool Equals(DiscordMessageSticker other)
-        {
-            return this.Id == other.Id;
-        }
+        public bool Equals(DiscordMessageSticker other) => this.Id == other.Id;
     }
 
     public enum StickerFormat

--- a/DSharpPlus/Entities/Channel/Message/DiscordReaction.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordReaction.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbed.cs
+++ b/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbed.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedAuthor.cs
+++ b/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedAuthor.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using DSharpPlus.Net;
 using Newtonsoft.Json;
 

--- a/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedBuilder.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -70,7 +93,7 @@ namespace DSharpPlus.Entities
             set => this._imageUri = string.IsNullOrEmpty(value) ? null : new DiscordUri(value);
         }
         private DiscordUri _imageUri;
-        
+
         /// <summary>
         /// Gets or sets the embed's author.
         /// </summary>
@@ -90,7 +113,7 @@ namespace DSharpPlus.Entities
         /// Gets the embed's fields.
         /// </summary>
         public IReadOnlyList<DiscordEmbedField> Fields { get; }
-        private readonly List<DiscordEmbedField> _fields = new List<DiscordEmbedField>();
+        private readonly List<DiscordEmbedField> _fields = new();
 
         /// <summary>
         /// Constructs a new empty embed builder.
@@ -217,10 +240,7 @@ namespace DSharpPlus.Entities
         /// <returns>This embed builder.</returns>
         public DiscordEmbedBuilder WithTimestamp(DateTime? timestamp)
         {
-            if (timestamp == null)
-                this.Timestamp = null;
-            else
-                this.Timestamp = new DateTimeOffset(timestamp.Value);
+            this.Timestamp = timestamp == null ? null : (DateTimeOffset?)new DateTimeOffset(timestamp.Value);
             return this;
         }
 
@@ -304,10 +324,9 @@ namespace DSharpPlus.Entities
         /// <returns>This embed builder.</returns>
         public DiscordEmbedBuilder WithAuthor(string name = null, string url = null, string iconUrl = null)
         {
-            if (string.IsNullOrEmpty(name) && string.IsNullOrEmpty(url) && string.IsNullOrEmpty(iconUrl))
-                this.Author = null;
-            else
-                this.Author = new EmbedAuthor
+            this.Author = string.IsNullOrEmpty(name) && string.IsNullOrEmpty(url) && string.IsNullOrEmpty(iconUrl)
+                ? null
+                : new EmbedAuthor
                 {
                     Name = name,
                     Url = url,
@@ -327,10 +346,9 @@ namespace DSharpPlus.Entities
             if (text != null && text.Length > 2048)
                 throw new ArgumentException("Footer text length cannot exceed 2048 characters.", nameof(text));
 
-            if (string.IsNullOrEmpty(text) && string.IsNullOrEmpty(iconUrl))
-                this.Footer = null;
-            else
-                this.Footer = new EmbedFooter
+            this.Footer = string.IsNullOrEmpty(text) && string.IsNullOrEmpty(iconUrl)
+                ? null
+                : new EmbedFooter
                 {
                     Text = text,
                     IconUrl = iconUrl
@@ -447,7 +465,7 @@ namespace DSharpPlus.Entities
                 {
                     Url = this.Thumbnail._uri,
                     Height = this.Thumbnail.Height,
-                    Width =  this.Thumbnail.Width
+                    Width = this.Thumbnail.Width
                 };
 
             embed.Fields = new ReadOnlyCollection<DiscordEmbedField>(new List<DiscordEmbedField>(this._fields)); // copy the list, don't wrap it, prevents mutation

--- a/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedField.cs
+++ b/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedField.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedFooter.cs
+++ b/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedFooter.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Net;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Net;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities

--- a/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedImage.cs
+++ b/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedImage.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Net;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Net;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities

--- a/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedProvider.cs
+++ b/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedProvider.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities

--- a/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedThumbnail.cs
+++ b/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedThumbnail.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Net;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Net;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities

--- a/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedVideo.cs
+++ b/DSharpPlus/Entities/Channel/Message/Embed/DiscordEmbedVideo.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities

--- a/DSharpPlus/Entities/Channel/Message/Mentions.cs
+++ b/DSharpPlus/Entities/Channel/Message/Mentions.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -8,7 +31,7 @@ namespace DSharpPlus.Entities
     /// Interface for mentionables
     /// </summary>
     public interface IMention { }
-    
+
 
     /// <summary>
     /// Allows a reply to ping the user being replied to.
@@ -19,19 +42,19 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Mention the user being replied to.  Alias to <see cref="RepliedUserMention()"/> constructor.
         /// </summary>
-        public static readonly RepliedUserMention All = new RepliedUserMention();
+        public static readonly RepliedUserMention All = new();
     }
-    
+
     /// <summary>
     /// Allows @everyone and @here pings to mention in the message.
     /// </summary>
-    public readonly struct EveryoneMention : IMention 
+    public readonly struct EveryoneMention : IMention
     {
         //This is pointless because new EveryoneMention() will work, but it is here for consistency with the other mentionables.
         /// <summary>
         /// Allow the mentioning of @everyone and @here. Alias to <see cref="EveryoneMention()"/> constructor.
         /// </summary>
-        public static readonly EveryoneMention All = new EveryoneMention();
+        public static readonly EveryoneMention All = new();
     }
 
     /// <summary>
@@ -42,7 +65,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Allow mentioning of all users. Alias to <see cref="UserMention()"/> constructor.
         /// </summary>
-        public static readonly UserMention All = new UserMention();
+        public static readonly UserMention All = new();
 
         /// <summary>
         /// Optional Id of the user that is allowed to be mentioned. If null, then all user mentions will be allowed. 
@@ -53,7 +76,7 @@ namespace DSharpPlus.Entities
         /// Allows the specific user to be mentioned
         /// </summary>
         /// <param name="id"></param>
-        public UserMention(ulong id) { this.Id = id;  }
+        public UserMention(ulong id) { this.Id = id; }
 
         /// <summary>
         /// Allows the specific user to be mentioned
@@ -61,7 +84,7 @@ namespace DSharpPlus.Entities
         /// <param name="user"></param>
         public UserMention(DiscordUser user) : this(user.Id) { }
 
-        public static implicit operator UserMention(DiscordUser user) => new UserMention(user.Id);
+        public static implicit operator UserMention(DiscordUser user) => new(user.Id);
     }
 
     /// <summary>
@@ -72,7 +95,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Allow the mentioning of all roles.  Alias to <see cref="RoleMention()"/> constructor.
         /// </summary>
-        public static readonly RoleMention All = new RoleMention();
+        public static readonly RoleMention All = new();
 
         /// <summary>
         /// Optional Id of the role that is allowed to be mentioned. If null, then all role mentions will be allowed. 
@@ -91,7 +114,7 @@ namespace DSharpPlus.Entities
         /// <param name="role"></param>
         public RoleMention(DiscordRole role) : this(role.Id) { }
 
-        public static implicit operator RoleMention(DiscordRole role) => new RoleMention(role.Id);
+        public static implicit operator RoleMention(DiscordRole role) => new(role.Id);
     }
 
     /// <summary>

--- a/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwrite.cs
+++ b/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwrite.cs
@@ -1,6 +1,29 @@
-﻿using Newtonsoft.Json;
-using System.Threading.Tasks;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {
@@ -63,9 +86,9 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public async Task<DiscordMember> GetMemberAsync()
         {
-            if (this.Type != OverwriteType.Member)
-                throw new ArgumentException(nameof(this.Type), "This overwrite is for a role, not a member.");
-            return await (await this.Discord.ApiClient.GetChannelAsync(this._channel_id).ConfigureAwait(false)).Guild.GetMemberAsync(this.Id).ConfigureAwait(false);
+            return this.Type != OverwriteType.Member
+                ? throw new ArgumentException(nameof(this.Type), "This overwrite is for a role, not a member.")
+                : await (await this.Discord.ApiClient.GetChannelAsync(this._channel_id).ConfigureAwait(false)).Guild.GetMemberAsync(this.Id).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -77,9 +100,9 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public async Task<DiscordRole> GetRoleAsync()
         {
-            if (this.Type != OverwriteType.Role)
-                throw new ArgumentException(nameof(this.Type), "This overwrite is for a member, not a role.");
-            return (await this.Discord.ApiClient.GetChannelAsync(this._channel_id).ConfigureAwait(false)).Guild.GetRole(this.Id);
+            return this.Type != OverwriteType.Role
+                ? throw new ArgumentException(nameof(this.Type), "This overwrite is for a member, not a role.")
+                : (await this.Discord.ApiClient.GetChannelAsync(this._channel_id).ConfigureAwait(false)).Guild.GetRole(this.Id);
         }
 
         internal DiscordOverwrite() { }
@@ -91,11 +114,9 @@ namespace DSharpPlus.Entities
         /// <returns>Whether given permissions are allowed, denied, or not set.</returns>
         public PermissionLevel CheckPermission(Permissions permission)
         {
-            if ((Allowed & permission) != 0)
+            if ((this.Allowed & permission) != 0)
                 return PermissionLevel.Allowed;
-            if ((Denied & permission) != 0)
-                return PermissionLevel.Denied;
-            return PermissionLevel.Unset;
+            return (this.Denied & permission) != 0 ? PermissionLevel.Denied : PermissionLevel.Unset;
         }
     }
 }

--- a/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwriteBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwriteBuilder.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
@@ -52,7 +75,7 @@ namespace DSharpPlus.Entities
         [Obsolete("Will be removed in 5.0. Use specialized constructors instead", false)]
         public DiscordOverwriteBuilder()
         {
-            
+
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Color/DiscordColor.Colors.cs
+++ b/DSharpPlus/Entities/Color/DiscordColor.Colors.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Entities
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Entities
 {
     public partial struct DiscordColor
     {
@@ -125,7 +148,7 @@
         /// Gold, or #FFD700.
         /// </summary>
         public static DiscordColor Gold { get; } = new DiscordColor(0xFFD700);
-        
+
         // To be fair, you have to have a very high IQ to understand Goldenrod . 
         // The tones are extremely subtle, and without a solid grasp of artistic
         // theory most of the beauty will go over a typical painter's head.

--- a/DSharpPlus/Entities/Color/DiscordColor.cs
+++ b/DSharpPlus/Entities/Color/DiscordColor.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Globalization;
 using System.Linq;
 
@@ -19,19 +42,19 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the red component of this color as an 8-bit integer.
         /// </summary>
-        public byte R 
+        public byte R
             => (byte)((this.Value >> 16) & 0xFF);
 
         /// <summary>
         /// Gets the green component of this color as an 8-bit integer.
         /// </summary>
-        public byte G 
+        public byte G
             => (byte)((this.Value >> 8) & 0xFF);
 
         /// <summary>
         /// Gets the blue component of this color as an 8-bit integer.
         /// </summary>
-        public byte B 
+        public byte B
             => (byte)(this.Value & 0xFF);
 
         /// <summary>
@@ -51,7 +74,7 @@ namespace DSharpPlus.Entities
         /// <param name="b">Value of the blue component.</param>
         public DiscordColor(byte r, byte g, byte b)
         {
-            this.Value = r << 16 | g << 8 | b;
+            this.Value = (r << 16) | (g << 8) | b;
         }
 
         /// <summary>
@@ -69,7 +92,7 @@ namespace DSharpPlus.Entities
             var gb = (byte)(g * 255);
             var bb = (byte)(b * 255);
 
-            this.Value = rb << 16 | gb << 8 | bb;
+            this.Value = (rb << 16) | (gb << 8) | bb;
         }
 
         /// <summary>
@@ -100,12 +123,9 @@ namespace DSharpPlus.Entities
         /// Gets a string representation of this color.
         /// </summary>
         /// <returns>String representation of this color.</returns>
-        public override string ToString()
-        {
-            return $"#{this.Value.ToString("X6")}";
-        }
+        public override string ToString() => $"#{this.Value:X6}";
 
         public static implicit operator DiscordColor(int value)
-            => new DiscordColor(value);
+            => new(value);
     }
 }

--- a/DSharpPlus/Entities/DiscordApplication.cs
+++ b/DSharpPlus/Entities/DiscordApplication.cs
@@ -1,8 +1,31 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using System.Globalization;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {
@@ -91,29 +114,14 @@ namespace DSharpPlus.Entities
                 throw new ArgumentOutOfRangeException(nameof(size));
 
             var sfmt = "";
-            switch (fmt)
+            sfmt = fmt switch
             {
-                case ImageFormat.Gif:
-                    sfmt = "gif";
-                    break;
-
-                case ImageFormat.Jpeg:
-                    sfmt = "jpg";
-                    break;
-
-                case ImageFormat.Auto:
-                case ImageFormat.Png:
-                    sfmt = "png";
-                    break;
-
-                case ImageFormat.WebP:
-                    sfmt = "webp";
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(fmt));
-            }
-
+                ImageFormat.Gif => "gif",
+                ImageFormat.Jpeg => "jpg",
+                ImageFormat.Auto or ImageFormat.Png => "png",
+                ImageFormat.WebP => "webp",
+                _ => throw new ArgumentOutOfRangeException(nameof(fmt)),
+            };
             var ssize = size.ToString(CultureInfo.InvariantCulture);
             if (!string.IsNullOrWhiteSpace(this.CoverImageHash))
             {
@@ -145,7 +153,7 @@ namespace DSharpPlus.Entities
             return new QueryUriBuilder("https://discord.com/oauth2/authorize")
                 .AddParameter("client_id", this.Id.ToString(CultureInfo.InvariantCulture))
                 .AddParameter("scope", "bot")
-                .AddParameter("permissions", ((long) permissions).ToString(CultureInfo.InvariantCulture))
+                .AddParameter("permissions", ((long)permissions).ToString(CultureInfo.InvariantCulture))
                 .ToString();
         }
 
@@ -154,10 +162,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="obj">Object to compare to.</param>
         /// <returns>Whether the object is equal to this <see cref="DiscordApplication"/>.</returns>
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as DiscordApplication);
-        }
+        public override bool Equals(object obj) => this.Equals(obj as DiscordApplication);
 
         /// <summary>
         /// Checks whether this <see cref="DiscordApplication"/> is equal to another <see cref="DiscordApplication"/>.
@@ -166,23 +171,17 @@ namespace DSharpPlus.Entities
         /// <returns>Whether the <see cref="DiscordApplication"/> is equal to this <see cref="DiscordApplication"/>.</returns>
         public bool Equals(DiscordApplication e)
         {
-            if (ReferenceEquals(e, null))
+            if (e is null)
                 return false;
 
-            if (ReferenceEquals(this, e))
-                return true;
-
-            return this.Id == e.Id;
+            return ReferenceEquals(this, e) ? true : this.Id == e.Id;
         }
 
         /// <summary>
         /// Gets the hash code for this <see cref="DiscordApplication"/>.
         /// </summary>
         /// <returns>The hash code for this <see cref="DiscordApplication"/>.</returns>
-        public override int GetHashCode()
-        {
-            return this.Id.GetHashCode();
-        }
+        public override int GetHashCode() => this.Id.GetHashCode();
 
         /// <summary>
         /// Gets whether the two <see cref="DiscordApplication"/> objects are equal.
@@ -198,10 +197,7 @@ namespace DSharpPlus.Entities
             if ((o1 == null && o2 != null) || (o1 != null && o2 == null))
                 return false;
 
-            if (o1 == null && o2 == null)
-                return true;
-
-            return e1.Id == e2.Id;
+            return o1 == null && o2 == null ? true : e1.Id == e2.Id;
         }
 
         /// <summary>
@@ -258,7 +254,7 @@ namespace DSharpPlus.Entities
         /// Gets the Url of this asset.
         /// </summary>
         public override Uri Url
-            => new Uri($"https://cdn.discordapp.com/app-assets/{this.Application.Id.ToString(CultureInfo.InvariantCulture)}/{this.Id}.png");
+            => new($"https://cdn.discordapp.com/app-assets/{this.Application.Id.ToString(CultureInfo.InvariantCulture)}/{this.Id}.png");
 
         internal DiscordApplicationAsset() { }
 
@@ -272,10 +268,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="obj">Object to compare to.</param>
         /// <returns>Whether the object is equal to this <see cref="DiscordApplicationAsset"/>.</returns>
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as DiscordApplicationAsset);
-        }
+        public override bool Equals(object obj) => this.Equals(obj as DiscordApplicationAsset);
 
         /// <summary>
         /// Checks whether this <see cref="DiscordApplicationAsset"/> is equal to another <see cref="DiscordApplicationAsset"/>.
@@ -284,23 +277,17 @@ namespace DSharpPlus.Entities
         /// <returns>Whether the <see cref="DiscordApplicationAsset"/> is equal to this <see cref="DiscordApplicationAsset"/>.</returns>
         public bool Equals(DiscordApplicationAsset e)
         {
-            if (ReferenceEquals(e, null))
+            if (e is null)
                 return false;
 
-            if (ReferenceEquals(this, e))
-                return true;
-
-            return this.Id == e.Id;
+            return ReferenceEquals(this, e) ? true : this.Id == e.Id;
         }
 
         /// <summary>
         /// Gets the hash code for this <see cref="DiscordApplication"/>.
         /// </summary>
         /// <returns>The hash code for this <see cref="DiscordApplication"/>.</returns>
-        public override int GetHashCode()
-        {
-            return this.Id.GetHashCode();
-        }
+        public override int GetHashCode() => this.Id.GetHashCode();
 
         /// <summary>
         /// Gets whether the two <see cref="DiscordApplicationAsset"/> objects are equal.
@@ -316,10 +303,7 @@ namespace DSharpPlus.Entities
             if ((o1 == null && o2 != null) || (o1 != null && o2 == null))
                 return false;
 
-            if (o1 == null && o2 == null)
-                return true;
-
-            return e1.Id == e2.Id;
+            return o1 == null && o2 == null ? true : e1.Id == e2.Id;
         }
 
         /// <summary>
@@ -340,7 +324,7 @@ namespace DSharpPlus.Entities
         public override Uri Url
             => this._url.Value;
 
-        private Lazy<Uri> _url;
+        private readonly Lazy<Uri> _url;
 
         public DiscordSpotifyAsset()
         {

--- a/DSharpPlus/Entities/DiscordAuditLogObjects.cs
+++ b/DSharpPlus/Entities/DiscordAuditLogObjects.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 
 namespace DSharpPlus.Entities
 {
@@ -211,7 +234,7 @@ namespace DSharpPlus.Entities
         /// Gets the number inactivity days after which members were pruned.
         /// </summary>
         public int Days { get; internal set; }
-        
+
         /// <summary>
         /// Gets the number of members pruned.
         /// </summary>
@@ -356,7 +379,7 @@ namespace DSharpPlus.Entities
         /// Gets the affected webhook.
         /// </summary>
         public DiscordWebhook Target { get; internal set; }
-        
+
         /// <summary>
         /// Gets the description of webhook's name change.
         /// </summary>

--- a/DSharpPlus/Entities/DiscordConnection.cs
+++ b/DSharpPlus/Entities/DiscordConnection.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities

--- a/DSharpPlus/Entities/DiscordTeam.cs
+++ b/DSharpPlus/Entities/DiscordTeam.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using DSharpPlus.Net.Abstractions;
@@ -49,7 +72,7 @@ namespace DSharpPlus.Entities
         /// <param name="obj">Object to compare this team to.</param>
         /// <returns>Whether this team is equal to the given object.</returns>
         public override bool Equals(object obj)
-            => obj is DiscordTeam other ? this == other : false;
+            => obj is DiscordTeam other && this == other;
 
         /// <summary>
         /// Compares this team to another team and returns whether they are equal.
@@ -117,7 +140,7 @@ namespace DSharpPlus.Entities
         /// <param name="obj">Object to compare to.</param>
         /// <returns>Whether this team is equal to given object.</returns>
         public override bool Equals(object obj)
-            => obj is DiscordTeamMember other ? this == other : false;
+            => obj is DiscordTeamMember other && this == other;
 
         /// <summary>
         /// Compares this team member to another team member and returns whether they are equal.
@@ -133,9 +156,9 @@ namespace DSharpPlus.Entities
         /// <returns>Hash code of this team member.</returns>
         public override int GetHashCode()
         {
-            int hash = 13;
-            hash = hash * 7 + this.User.GetHashCode();
-            hash = hash * 7 + this.Team.GetHashCode();
+            var hash = 13;
+            hash = (hash * 7) + this.User.GetHashCode();
+            hash = (hash * 7) + this.Team.GetHashCode();
             return hash;
         }
 

--- a/DSharpPlus/Entities/DiscordUri.cs
+++ b/DSharpPlus/Entities/DiscordUri.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Runtime.CompilerServices;
 using Newtonsoft.Json;
 
@@ -67,10 +90,7 @@ namespace DSharpPlus.Net
 
         internal sealed class DiscordUriJsonConverter : JsonConverter
         {
-            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-            {
-                writer.WriteValue((value as DiscordUri)._value);
-            }
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => writer.WriteValue((value as DiscordUri)._value);
 
             public override object ReadJson(JsonReader reader, Type objectType, object existingValue,
                 JsonSerializer serializer)
@@ -78,12 +98,11 @@ namespace DSharpPlus.Net
                 var val = reader.Value;
                 if (val == null)
                     return null;
-                
-                if (!(val is string s))
-                    throw new JsonReaderException("DiscordUri value invalid format! This is a bug in DSharpPlus. " +
-                                                  $"Include the type in your bug report: [[{reader.TokenType}]]");
-                
-                return IsStandard(s)
+
+                return val is not string s
+                    ? throw new JsonReaderException("DiscordUri value invalid format! This is a bug in DSharpPlus. " +
+                                                  $"Include the type in your bug report: [[{reader.TokenType}]]")
+                    : IsStandard(s)
                     ? new DiscordUri(new Uri(s))
                     : new DiscordUri(s);
             }

--- a/DSharpPlus/Entities/Emoji/DiscordEmoji.EmojiUtils.cs
+++ b/DSharpPlus/Entities/Emoji/DiscordEmoji.EmojiUtils.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System.Collections.Generic;
 
 namespace DSharpPlus.Entities

--- a/DSharpPlus/Entities/Emoji/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/Emoji/DiscordEmoji.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -26,7 +49,7 @@ namespace DSharpPlus.Entities
 
         [JsonProperty("roles", NullValueHandling = NullValueHandling.Ignore)]
         internal List<ulong> _roles;
-        private Lazy<IReadOnlyList<ulong>> _rolesLazy;
+        private readonly Lazy<IReadOnlyList<ulong>> _rolesLazy;
 
         /// <summary>
         /// Gets whether this emoji requires colons to use.
@@ -57,10 +80,9 @@ namespace DSharpPlus.Entities
                 if (this.Id == 0)
                     throw new InvalidOperationException("Cannot get URL of unicode emojis.");
 
-                if (this.IsAnimated)
-                    return $"https://cdn.discordapp.com/emojis/{this.Id.ToString(CultureInfo.InvariantCulture)}.gif";
-
-                return $"https://cdn.discordapp.com/emojis/{this.Id.ToString(CultureInfo.InvariantCulture)}.png";
+                return this.IsAnimated
+                    ? $"https://cdn.discordapp.com/emojis/{this.Id.ToString(CultureInfo.InvariantCulture)}.gif"
+                    : $"https://cdn.discordapp.com/emojis/{this.Id.ToString(CultureInfo.InvariantCulture)}.png";
             }
         }
 
@@ -83,10 +105,7 @@ namespace DSharpPlus.Entities
         {
             DiscordNameLookup.TryGetValue(this.Name, out var name);
 
-            if (name == null)
-                return $":{ this.Name }:";
-
-            return name;
+            return name == null ? $":{ this.Name }:" : name;
         }
 
         /// <summary>
@@ -97,10 +116,9 @@ namespace DSharpPlus.Entities
         {
             if (this.Id != 0)
             {
-                if (this.IsAnimated)
-                    return $"<a:{this.Name}:{this.Id.ToString(CultureInfo.InvariantCulture)}>";
-                else
-                    return $"<:{this.Name}:{this.Id.ToString(CultureInfo.InvariantCulture)}>";
+                return this.IsAnimated
+                    ? $"<a:{this.Name}:{this.Id.ToString(CultureInfo.InvariantCulture)}>"
+                    : $"<:{this.Name}:{this.Id.ToString(CultureInfo.InvariantCulture)}>";
             }
 
             return this.Name;
@@ -111,10 +129,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="obj">Object to compare to.</param>
         /// <returns>Whether the object is equal to this <see cref="DiscordEmoji"/>.</returns>
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as DiscordEmoji);
-        }
+        public override bool Equals(object obj) => this.Equals(obj as DiscordEmoji);
 
         /// <summary>
         /// Checks whether this <see cref="DiscordEmoji"/> is equal to another <see cref="DiscordEmoji"/>.
@@ -123,13 +138,10 @@ namespace DSharpPlus.Entities
         /// <returns>Whether the <see cref="DiscordEmoji"/> is equal to this <see cref="DiscordEmoji"/>.</returns>
         public bool Equals(DiscordEmoji e)
         {
-            if (ReferenceEquals(e, null))
+            if (e is null)
                 return false;
 
-            if (ReferenceEquals(this, e))
-                return true;
-
-            return this.Id == e.Id && this.Name == e.Name;
+            return ReferenceEquals(this, e) ? true : this.Id == e.Id && this.Name == e.Name;
         }
 
         /// <summary>
@@ -147,9 +159,7 @@ namespace DSharpPlus.Entities
 
         internal string ToReactionString()
         {
-            if (this.Id != 0)
-                return $"{this.Name}:{this.Id.ToString(CultureInfo.InvariantCulture)}";
-            return this.Name;
+            return this.Id != 0 ? $"{this.Name}:{this.Id.ToString(CultureInfo.InvariantCulture)}" : this.Name;
         }
 
         /// <summary>
@@ -166,10 +176,7 @@ namespace DSharpPlus.Entities
             if ((o1 == null && o2 != null) || (o1 != null && o2 == null))
                 return false;
 
-            if (o1 == null && o2 == null)
-                return true;
-
-            return e1.Id == e2.Id && e1.Name == e2.Name;
+            return o1 == null && o2 == null ? true : e1.Id == e2.Id && e1.Name == e2.Name;
         }
 
         /// <summary>
@@ -178,14 +185,14 @@ namespace DSharpPlus.Entities
         /// <param name="e1">First emoji to compare.</param>
         /// <param name="e2">Second emoji to compare.</param>
         /// <returns>Whether the two emoji are not equal.</returns>
-        public static bool operator !=(DiscordEmoji e1, DiscordEmoji e2) 
+        public static bool operator !=(DiscordEmoji e1, DiscordEmoji e2)
             => !(e1 == e2);
 
         /// <summary>
         /// Implicitly converts this emoji to its string representation.
         /// </summary>
         /// <param name="e1">Emoji to convert.</param>
-        public static implicit operator string(DiscordEmoji e1) 
+        public static implicit operator string(DiscordEmoji e1)
             => e1.ToString();
 
         /// <summary>
@@ -204,10 +211,9 @@ namespace DSharpPlus.Entities
         /// <returns>Create <see cref="DiscordEmoji"/> object.</returns>
         public static DiscordEmoji FromUnicode(BaseDiscordClient client, string unicodeEntity)
         {
-            if (!IsValidUnicode(unicodeEntity))
-                throw new ArgumentException("Specified unicode entity is not a valid unicode emoji.", nameof(unicodeEntity));
-
-            return new DiscordEmoji { Name = unicodeEntity, Discord = client };
+            return !IsValidUnicode(unicodeEntity)
+                ? throw new ArgumentException("Specified unicode entity is not a valid unicode emoji.", nameof(unicodeEntity))
+                : new DiscordEmoji { Name = unicodeEntity, Discord = client };
         }
 
         /// <summary>
@@ -266,7 +272,7 @@ namespace DSharpPlus.Entities
                 if (guild.Emojis.TryGetValue(id, out var found))
                     return found;
             }
-            
+
             throw new KeyNotFoundException("Given emote was not found.");
         }
 

--- a/DSharpPlus/Entities/Guild/DiscordBan.cs
+++ b/DSharpPlus/Entities/Guild/DiscordBan.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Net.Abstractions;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Net.Abstractions;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
@@ -13,7 +36,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("reason", NullValueHandling = NullValueHandling.Ignore)]
         public string Reason { get; internal set; }
-        
+
         /// <summary>
         /// Gets the banned user
         /// </summary>

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -596,7 +596,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordChannel> CreateTextChannelAsync(string name, DiscordChannel parent = null, Optional<string> topic = default, IEnumerable<DiscordOverwriteBuilder> overwrites = null, bool? nsfw = null, Optional<int?> perUserRateLimit = default, string reason = null)
-            => this.CreateChannelAsync(name, ChannelType.Text, parent, topic, null, null, overwrites, nsfw, perUserRateLimit, reason);
+            => this.CreateChannelAsync(name, ChannelType.Text, parent, topic, null, null, overwrites, nsfw, perUserRateLimit, null, reason);
 
         /// <summary>
         /// Creates a new channel category in this guild.
@@ -610,7 +610,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordChannel> CreateChannelCategoryAsync(string name, IEnumerable<DiscordOverwriteBuilder> overwrites = null, string reason = null)
-            => this.CreateChannelAsync(name, ChannelType.Category, null, Optional.FromNoValue<string>(), null, null, overwrites, null, Optional.FromNoValue<int?>(), reason);
+            => this.CreateChannelAsync(name, ChannelType.Category, null, Optional.FromNoValue<string>(), null, null, overwrites, null, Optional.FromNoValue<int?>(), null, reason);
 
         /// <summary>
         /// Creates a new voice channel in this guild.
@@ -626,8 +626,8 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the guild does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordChannel> CreateVoiceChannelAsync(string name, DiscordChannel parent = null, int? bitrate = null, int? user_limit = null, IEnumerable<DiscordOverwriteBuilder> overwrites = null, string reason = null)
-            => this.CreateChannelAsync(name, ChannelType.Voice, parent, Optional.FromNoValue<string>(), bitrate, user_limit, overwrites, null, Optional.FromNoValue<int?>(), reason);
+        public Task<DiscordChannel> CreateVoiceChannelAsync(string name, DiscordChannel parent = null, int? bitrate = null, int? user_limit = null, IEnumerable<DiscordOverwriteBuilder> overwrites = null, ChannelQualityMode? channelQualityMode = default, string reason = null)
+            => this.CreateChannelAsync(name, ChannelType.Voice, parent, Optional.FromNoValue<string>(), bitrate, user_limit, overwrites, null, Optional.FromNoValue<int?>(), channelQualityMode, reason);
 
         /// <summary>
         /// Creates a new channel in this guild.
@@ -640,14 +640,15 @@ namespace DSharpPlus.Entities
         /// <param name="userLimit">Maximum number of users in the channel. Applies to voice only.</param>
         /// <param name="overwrites">Permission overwrites for this channel.</param>
         /// <param name="nsfw">Whether the channel is to be flagged as not safe for work. Applies to text only.</param>
-        /// <param name="reason">Reason for audit logs.</param>
         /// <param name="perUserRateLimit">Slow mode timeout for users.</param>
+        /// <param name="channelQualityMode">Video quality of the channel.</param>
+        /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The newly-created channel.</returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.ManageChannels"/> permission.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the guild does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordChannel> CreateChannelAsync(string name, ChannelType type, DiscordChannel parent = null, Optional<string> topic = default, int? bitrate = null, int? userLimit = null, IEnumerable<DiscordOverwriteBuilder> overwrites = null, bool? nsfw = null, Optional<int?> perUserRateLimit = default, string reason = null)
+        public Task<DiscordChannel> CreateChannelAsync(string name, ChannelType type, DiscordChannel parent = null, Optional<string> topic = default, int? bitrate = null, int? userLimit = null, IEnumerable<DiscordOverwriteBuilder> overwrites = null, bool? nsfw = null, Optional<int?> perUserRateLimit = default, ChannelQualityMode? channelQualityMode = default, string reason = null)
         {
             // technically you can create news/store channels but not always
             if (type != ChannelType.Text && type != ChannelType.Voice && type != ChannelType.Category && type != ChannelType.News && type != ChannelType.Store && type != ChannelType.Stage)
@@ -655,7 +656,7 @@ namespace DSharpPlus.Entities
 
             return type == ChannelType.Category && parent != null
                 ? throw new ArgumentException("Cannot specify parent of a channel category.", nameof(parent))
-                : this.Discord.ApiClient.CreateGuildChannelAsync(this.Id, name, type, parent?.Id, topic, bitrate, userLimit, overwrites, nsfw, perUserRateLimit, reason);
+                : this.Discord.ApiClient.CreateGuildChannelAsync(this.Id, name, type, parent?.Id, topic, bitrate, userLimit, overwrites, nsfw, perUserRateLimit, channelQualityMode, reason);
         }
 
         // this is to commemorate the Great DAPI Channel Massacre of 2017-11-19.

--- a/DSharpPlus/Entities/Guild/DiscordGuildEmbed.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuildEmbed.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Guild/DiscordGuildEmoji.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuildEmoji.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
@@ -31,7 +54,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the emoji does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordGuildEmoji> ModifyAsync(string name, IEnumerable<DiscordRole> roles = null, string reason = null) 
+        public Task<DiscordGuildEmoji> ModifyAsync(string name, IEnumerable<DiscordRole> roles = null, string reason = null)
             => this.Guild.ModifyEmojiAsync(this, name, roles, reason);
 
         /// <summary>
@@ -43,7 +66,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the emoji does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task DeleteAsync(string reason = null) 
+        public Task DeleteAsync(string reason = null)
             => this.Guild.DeleteEmojiAsync(this, reason);
     }
 }

--- a/DSharpPlus/Entities/Guild/DiscordGuildMembershipScreening.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuildMembershipScreening.cs
@@ -1,6 +1,29 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Guild/DiscordGuildMembershipScreeningField.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuildMembershipScreeningField.cs
@@ -1,6 +1,29 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Guild/DiscordGuildPreview.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuildPreview.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using DSharpPlus.Net.Serialization;

--- a/DSharpPlus/Entities/Guild/DiscordGuildTemplate.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuildTemplate.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using Newtonsoft.Json;
 

--- a/DSharpPlus/Entities/Guild/DiscordGuildWelcomeScreen.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuildWelcomeScreen.cs
@@ -1,7 +1,30 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Guild/DiscordGuildWelcomeScreenChannel.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuildWelcomeScreenChannel.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {
@@ -35,12 +58,12 @@ namespace DSharpPlus.Entities
         {
             this.ChannelId = channelId;
             this.Description = description;
-            if(emoji != null)
+            if (emoji != null)
             {
                 if (emoji.Id == 0)
-                    EmojiName = emoji.Name;
+                    this.EmojiName = emoji.Name;
                 else
-                    EmojiId = emoji.Id;
+                    this.EmojiId = emoji.Id;
             }
         }
     }

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -1,12 +1,35 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Newtonsoft.Json;
-using System.Linq;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using DSharpPlus.Net.Abstractions;
 using DSharpPlus.Net.Models;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {
@@ -54,26 +77,26 @@ namespace DSharpPlus.Entities
         /// Gets this member's display name.
         /// </summary>
         [JsonIgnore]
-        public string DisplayName 
+        public string DisplayName
             => this.Nickname ?? this.Username;
 
         /// <summary>
         /// List of role ids
         /// </summary>
         [JsonIgnore]
-        internal IReadOnlyList<ulong> RoleIds 
+        internal IReadOnlyList<ulong> RoleIds
             => this._role_ids_lazy.Value;
 
         [JsonProperty("roles", NullValueHandling = NullValueHandling.Ignore)]
         internal List<ulong> _role_ids;
         [JsonIgnore]
-        private Lazy<IReadOnlyList<ulong>> _role_ids_lazy;
+        private readonly Lazy<IReadOnlyList<ulong>> _role_ids_lazy;
 
         /// <summary>
         /// Gets the list of roles associated with this member.
         /// </summary>
         [JsonIgnore]
-        public IEnumerable<DiscordRole> Roles 
+        public IEnumerable<DiscordRole> Roles
             => this.RoleIds.Select(id => this.Guild.GetRole(id)).Where(x => x != null);
 
         /// <summary>
@@ -85,9 +108,7 @@ namespace DSharpPlus.Entities
             get
             {
                 var role = this.Roles.OrderByDescending(xr => xr.Position).FirstOrDefault(xr => xr.Color.Value != 0);
-                if (role != null)
-                    return role.Color;
-                return new DiscordColor();
+                return role != null ? role.Color : new DiscordColor();
             }
         }
 
@@ -125,7 +146,7 @@ namespace DSharpPlus.Entities
         /// Gets this member's voice state.
         /// </summary>
         [JsonIgnore]
-        public DiscordVoiceState VoiceState 
+        public DiscordVoiceState VoiceState
             => this.Discord.Guilds[this._guild_id].VoiceStates.TryGetValue(this.Id, out var voiceState) ? voiceState : null;
 
         [JsonIgnore]
@@ -135,14 +156,14 @@ namespace DSharpPlus.Entities
         /// Gets the guild of which this member is a part of.
         /// </summary>
         [JsonIgnore]
-        public DiscordGuild Guild 
+        public DiscordGuild Guild
             => this.Discord.Guilds[_guild_id];
 
         /// <summary>
         /// Gets whether this member is the Guild owner.
         /// </summary>
         [JsonIgnore]
-        public bool IsOwner 
+        public bool IsOwner
             => this.Id == this.Guild.OwnerId;
 
         /// <summary>
@@ -154,7 +175,7 @@ namespace DSharpPlus.Entities
 
         #region Overridden user properties
         [JsonIgnore]
-        internal DiscordUser User 
+        internal DiscordUser User
             => this.Discord.UserCache[this.Id];
 
         /// <summary>
@@ -234,19 +255,19 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the user's flags.
         /// </summary>
-        public override UserFlags? OAuthFlags 
-        { 
-            get => this.User.OAuthFlags; 
-            internal set => this.User.OAuthFlags = value; 
+        public override UserFlags? OAuthFlags
+        {
+            get => this.User.OAuthFlags;
+            internal set => this.User.OAuthFlags = value;
         }
 
         /// <summary>
         /// Gets the member's flags for OAuth.
         /// </summary>
-        public override UserFlags? Flags 
-        { 
-            get => this.User.Flags; 
-            internal set => this.User.Flags = value; 
+        public override UserFlags? Flags
+        {
+            get => this.User.Flags;
+            internal set => this.User.Flags = value;
         }
         #endregion
 
@@ -264,7 +285,7 @@ namespace DSharpPlus.Entities
 
             if (this.Discord is DiscordClient dc)
                 dm = dc._privateChannels.Values.FirstOrDefault(x => x.Recipients[0].Id == this.Id);
-            
+
             return dm != null ? Task.FromResult(dm) : this.Discord.ApiClient.CreateDmAsync(this.Id);
         }
 
@@ -281,7 +302,7 @@ namespace DSharpPlus.Entities
         {
             if (this.IsBot && this.Discord.CurrentUser.IsBot)
                 throw new ArgumentException("Bots cannot DM each other.");
-            
+
             var chn = await this.CreateDmChannelAsync().ConfigureAwait(false);
             return await chn.SendMessageAsync(content).ConfigureAwait(false);
         }
@@ -351,7 +372,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task SetMuteAsync(bool mute, string reason = null) 
+        public Task SetMuteAsync(bool mute, string reason = null)
             => this.Discord.ApiClient.ModifyGuildMemberAsync(_guild_id, this.Id, default, default, mute, default, default, reason);
 
         /// <summary>
@@ -364,7 +385,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task SetDeafAsync(bool deaf, string reason = null) 
+        public Task SetDeafAsync(bool deaf, string reason = null)
             => this.Discord.ApiClient.ModifyGuildMemberAsync(_guild_id, this.Id, default, default, default, deaf, default, reason);
 
         /// <summary>
@@ -411,7 +432,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task GrantRoleAsync(DiscordRole role, string reason = null) 
+        public Task GrantRoleAsync(DiscordRole role, string reason = null)
             => this.Discord.ApiClient.AddGuildMemberRoleAsync(this.Guild.Id, this.Id, role.Id, reason);
 
         /// <summary>
@@ -424,7 +445,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task RevokeRoleAsync(DiscordRole role, string reason = null) 
+        public Task RevokeRoleAsync(DiscordRole role, string reason = null)
             => this.Discord.ApiClient.RemoveGuildMemberRoleAsync(this.Guild.Id, this.Id, role.Id, reason);
 
         /// <summary>
@@ -437,7 +458,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task ReplaceRolesAsync(IEnumerable<DiscordRole> roles, string reason = null) 
+        public Task ReplaceRolesAsync(IEnumerable<DiscordRole> roles, string reason = null)
             => this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, default,
                 new Optional<IEnumerable<ulong>>(roles.Select(xr => xr.Id)), default, default, default, reason);
 
@@ -451,7 +472,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task BanAsync(int delete_message_days = 0, string reason = null) 
+        public Task BanAsync(int delete_message_days = 0, string reason = null)
             => this.Guild.BanMemberAsync(this, delete_message_days, reason);
 
         /// <exception cref = "Exceptions.UnauthorizedException" > Thrown when the client does not have the<see cref="Permissions.BanMembers"/> permission.</exception>
@@ -482,7 +503,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task PlaceInAsync(DiscordChannel channel) 
+        public Task PlaceInAsync(DiscordChannel channel)
             => channel.PlaceMemberAsync(this);
 
         /// <summary>
@@ -504,27 +525,21 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="channel">Channel to calculate permissions for.</param>
         /// <returns>Calculated permissions for this member in the channel.</returns>
-        public Permissions PermissionsIn(DiscordChannel channel) 
+        public Permissions PermissionsIn(DiscordChannel channel)
             => channel.PermissionsFor(this);
 
         /// <summary>
         /// Returns a string representation of this member.
         /// </summary>
         /// <returns>String representation of this member.</returns>
-        public override string ToString()
-        {
-            return $"Member {this.Id}; {this.Username}#{this.Discriminator} ({this.DisplayName})";
-        }
+        public override string ToString() => $"Member {this.Id}; {this.Username}#{this.Discriminator} ({this.DisplayName})";
 
         /// <summary>
         /// Checks whether this <see cref="DiscordMember"/> is equal to another object.
         /// </summary>
         /// <param name="obj">Object to compare to.</param>
         /// <returns>Whether the object is equal to this <see cref="DiscordMember"/>.</returns>
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as DiscordMember);
-        }
+        public override bool Equals(object obj) => this.Equals(obj as DiscordMember);
 
         /// <summary>
         /// Checks whether this <see cref="DiscordMember"/> is equal to another <see cref="DiscordMember"/>.
@@ -533,13 +548,10 @@ namespace DSharpPlus.Entities
         /// <returns>Whether the <see cref="DiscordMember"/> is equal to this <see cref="DiscordMember"/>.</returns>
         public bool Equals(DiscordMember e)
         {
-            if (ReferenceEquals(e, null))
+            if (e is null)
                 return false;
 
-            if (ReferenceEquals(this, e))
-                return true;
-
-            return this.Id == e.Id && this._guild_id == e._guild_id;
+            return ReferenceEquals(this, e) ? true : this.Id == e.Id && this._guild_id == e._guild_id;
         }
 
         /// <summary>
@@ -548,7 +560,7 @@ namespace DSharpPlus.Entities
         /// <returns>The hash code for this <see cref="DiscordMember"/>.</returns>
         public override int GetHashCode()
         {
-            int hash = 13;
+            var hash = 13;
 
             hash = (hash * 7) + this.Id.GetHashCode();
             hash = (hash * 7) + this._guild_id.GetHashCode();
@@ -570,10 +582,7 @@ namespace DSharpPlus.Entities
             if ((o1 == null && o2 != null) || (o1 != null && o2 == null))
                 return false;
 
-            if (o1 == null && o2 == null)
-                return true;
-
-            return e1.Id == e2.Id && e1._guild_id == e2._guild_id;
+            return o1 == null && o2 == null ? true : e1.Id == e2.Id && e1._guild_id == e2._guild_id;
         }
 
         /// <summary>
@@ -582,7 +591,7 @@ namespace DSharpPlus.Entities
         /// <param name="e1">First member to compare.</param>
         /// <param name="e2">Second member to compare.</param>
         /// <returns>Whether the two members are not equal.</returns>
-        public static bool operator !=(DiscordMember e1, DiscordMember e2) 
+        public static bool operator !=(DiscordMember e1, DiscordMember e2)
             => !(e1 == e2);
     }
 }

--- a/DSharpPlus/Entities/Guild/DiscordRole.cs
+++ b/DSharpPlus/Entities/Guild/DiscordRole.cs
@@ -1,9 +1,32 @@
-﻿using System;
-using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using DSharpPlus.Net.Abstractions;
-using System.Linq;
 using DSharpPlus.Net.Models;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {
@@ -23,7 +46,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public DiscordColor Color
-            => new DiscordColor(this._color);
+            => new(this._color);
 
         [JsonProperty("color", NullValueHandling = NullValueHandling.Ignore)]
         internal int _color;
@@ -92,10 +115,7 @@ namespace DSharpPlus.Entities
             {
                 pmds[i] = new RestGuildRoleReorderPayload { RoleId = roles[i].Id };
 
-                if (roles[i].Id == this.Id)
-                    pmds[i].Position = position;
-                else
-                    pmds[i].Position = roles[i].Position <= position ? roles[i].Position - 1 : roles[i].Position;
+                pmds[i].Position = roles[i].Id == this.Id ? position : roles[i].Position <= position ? roles[i].Position - 1 : roles[i].Position;
             }
 
             return this.Discord.ApiClient.ModifyGuildRolePositionAsync(this._guild_id, pmds, reason);
@@ -116,19 +136,19 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task ModifyAsync(string name = null, Permissions? permissions = null, DiscordColor? color = null, bool? hoist = null, bool? mentionable = null, string reason = null)
-            => this.Discord.ApiClient.ModifyGuildRoleAsync(this._guild_id, Id, name, permissions, color?.Value, hoist, mentionable, reason);
+            => this.Discord.ApiClient.ModifyGuildRoleAsync(this._guild_id, this.Id, name, permissions, color?.Value, hoist, mentionable, reason);
 
         /// <exception cref = "Exceptions.UnauthorizedException" > Thrown when the client does not have the<see cref="Permissions.ManageRoles"/> permission.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the role does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task ModifyAsync(Action<RoleEditModel> action)
-		{
-			var mdl = new RoleEditModel();
-			action(mdl);
+        {
+            var mdl = new RoleEditModel();
+            action(mdl);
 
-			return this.ModifyAsync(mdl.Name, mdl.Permissions, mdl.Color, mdl.Hoist, mdl.Mentionable, mdl.AuditLogReason);
-		}
+            return this.ModifyAsync(mdl.Name, mdl.Permissions, mdl.Color, mdl.Hoist, mdl.Mentionable, mdl.AuditLogReason);
+        }
 
         /// <summary>
         /// Deletes this role.
@@ -150,30 +170,20 @@ namespace DSharpPlus.Entities
         /// <param name="permission">Permissions to check for.</param>
         /// <returns>Whether the permissions are allowed or not.</returns>
         public PermissionLevel CheckPermission(Permissions permission)
-        {
-            if ((Permissions & permission) != 0)
-                return PermissionLevel.Allowed;
-            return PermissionLevel.Unset;
-        }
+            => (this.Permissions & permission) != 0 ? PermissionLevel.Allowed : PermissionLevel.Unset;
 
         /// <summary>
         /// Returns a string representation of this role.
         /// </summary>
         /// <returns>String representation of this role.</returns>
-        public override string ToString()
-        {
-            return $"Role {this.Id}; {this.Name}";
-        }
+        public override string ToString() => $"Role {this.Id}; {this.Name}";
 
         /// <summary>
         /// Checks whether this <see cref="DiscordRole"/> is equal to another object.
         /// </summary>
         /// <param name="obj">Object to compare to.</param>
         /// <returns>Whether the object is equal to this <see cref="DiscordRole"/>.</returns>
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as DiscordRole);
-        }
+        public override bool Equals(object obj) => this.Equals(obj as DiscordRole);
 
         /// <summary>
         /// Checks whether this <see cref="DiscordRole"/> is equal to another <see cref="DiscordRole"/>.
@@ -181,24 +191,17 @@ namespace DSharpPlus.Entities
         /// <param name="e"><see cref="DiscordRole"/> to compare to.</param>
         /// <returns>Whether the <see cref="DiscordRole"/> is equal to this <see cref="DiscordRole"/>.</returns>
         public bool Equals(DiscordRole e)
-        {
-            if (ReferenceEquals(e, null))
-                return false;
-
-            if (ReferenceEquals(this, e))
-                return true;
-
-            return this.Id == e.Id;
-        }
+            => e switch
+            {
+                null => false,
+                _ => ReferenceEquals(this, e) || this.Id == e.Id
+            };
 
         /// <summary>
         /// Gets the hash code for this <see cref="DiscordRole"/>.
         /// </summary>
         /// <returns>The hash code for this <see cref="DiscordRole"/>.</returns>
-        public override int GetHashCode()
-        {
-            return this.Id.GetHashCode();
-        }
+        public override int GetHashCode() => this.Id.GetHashCode();
 
         /// <summary>
         /// Gets whether the two <see cref="DiscordRole"/> objects are equal.
@@ -207,18 +210,8 @@ namespace DSharpPlus.Entities
         /// <param name="e2">Second role to compare.</param>
         /// <returns>Whether the two roles are equal.</returns>
         public static bool operator ==(DiscordRole e1, DiscordRole e2)
-        {
-            var o1 = e1 as object;
-            var o2 = e2 as object;
-
-            if ((o1 == null && o2 != null) || (o1 != null && o2 == null))
-                return false;
-
-            if (o1 == null && o2 == null)
-                return true;
-
-            return e1.Id == e2.Id;
-        }
+            => e1 is null == e2 is null
+            && ((e1 is null && e2 is null) || e1.Id == e2.Id);
 
         /// <summary>
         /// Gets whether the two <see cref="DiscordRole"/> objects are not equal.

--- a/DSharpPlus/Entities/Guild/DiscordRoleTags.cs
+++ b/DSharpPlus/Entities/Guild/DiscordRoleTags.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Guild/Widget/DiscordWidget.cs
+++ b/DSharpPlus/Entities/Guild/Widget/DiscordWidget.cs
@@ -1,5 +1,28 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Guild/Widget/DiscordWidgetMember.cs
+++ b/DSharpPlus/Entities/Guild/Widget/DiscordWidgetMember.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Guild/Widget/DiscordWidgetSettings.cs
+++ b/DSharpPlus/Entities/Guild/Widget/DiscordWidgetSettings.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Integration/DiscordIntegration.cs
+++ b/DSharpPlus/Entities/Integration/DiscordIntegration.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities

--- a/DSharpPlus/Entities/Integration/DiscordIntegrationAccount.cs
+++ b/DSharpPlus/Entities/Integration/DiscordIntegrationAccount.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -43,7 +66,7 @@ namespace DSharpPlus.Entities
         /// <param name="options">Optional parameters for this command.</param>
         public DiscordApplicationCommand(string name, string description, IEnumerable<DiscordApplicationCommandOption> options = null)
         {
-            if(name.Length > 32)
+            if (name.Length > 32)
                 throw new ArgumentException("Slash command name cannot exceed 32 characters.", nameof(name));
             if (description.Length > 100)
                 throw new ArgumentException("Slash command description cannot exceed 100 characters.", nameof(description));
@@ -88,10 +111,7 @@ namespace DSharpPlus.Entities
         /// <returns>Whether the two <see cref="DiscordApplicationCommand"/> objects are not equal.</returns>
         public override bool Equals(object other)
         {
-            if (other is DiscordApplicationCommand dac)
-                return this.Equals(dac);
-
-            return false;
+            return other is DiscordApplicationCommand dac ? this.Equals(dac) : false;
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOption.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOption.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Newtonsoft.Json;

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOptionChoice.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOptionChoice.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities

--- a/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -45,20 +68,20 @@ namespace DSharpPlus.Entities
         /// Embeds to send on followup message.
         /// </summary>
         public IReadOnlyList<DiscordEmbed> Embeds { get; }
-        private readonly List<DiscordEmbed> _embeds = new List<DiscordEmbed>();
+        private readonly List<DiscordEmbed> _embeds = new();
 
         /// <summary>
         /// Files to send on this followup message.
         /// </summary>
         public IReadOnlyCollection<DiscordMessageFile> Files => this._files;
 
-        internal readonly List<DiscordMessageFile> _files = new List<DiscordMessageFile>();
+        internal readonly List<DiscordMessageFile> _files = new();
 
         /// <summary>
         /// Mentions to send on this followup message.
         /// </summary>
         public IEnumerable<IMention> Mentions { get; }
-        private readonly List<IMention> _mentions = new List<IMention>();
+        private readonly List<IMention> _mentions = new();
 
         /// <summary>
         /// Constructs a new empty followup message builder.

--- a/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
@@ -1,5 +1,28 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
@@ -1,5 +1,28 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionData.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionData.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -33,23 +56,16 @@ namespace DSharpPlus.Entities
         {
             get
             {
-                switch (this.Type)
+                return this.Type switch
                 {
-                    case ApplicationCommandOptionType.Boolean:
-                        return bool.Parse(this._value);
-                    case ApplicationCommandOptionType.Integer:
-                        return long.Parse(this._value);
-                    case ApplicationCommandOptionType.String:
-                        return this._value;
-                    case ApplicationCommandOptionType.Channel:
-                        return ulong.Parse(this._value);
-                    case ApplicationCommandOptionType.User:
-                        return ulong.Parse(this._value);
-                    case ApplicationCommandOptionType.Role:
-                        return ulong.Parse(this._value);
-                    default:
-                        return this._value;
-                }
+                    ApplicationCommandOptionType.Boolean => bool.Parse(this._value),
+                    ApplicationCommandOptionType.Integer => long.Parse(this._value),
+                    ApplicationCommandOptionType.String => this._value,
+                    ApplicationCommandOptionType.Channel => ulong.Parse(this._value),
+                    ApplicationCommandOptionType.User => ulong.Parse(this._value),
+                    ApplicationCommandOptionType.Role => ulong.Parse(this._value),
+                    _ => this._value,
+                };
             }
         }
 

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResolvedCollection.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResolvedCollection.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
@@ -38,13 +61,13 @@ namespace DSharpPlus.Entities
         /// Embeds to send on this interaction response.
         /// </summary>
         public IReadOnlyList<DiscordEmbed> Embeds { get; }
-        private readonly List<DiscordEmbed> _embeds = new List<DiscordEmbed>();
+        private readonly List<DiscordEmbed> _embeds = new();
 
         /// <summary>
         /// Mentions to send on this interaction response.
         /// </summary>
         public IEnumerable<IMention> Mentions { get; }
-        private readonly List<IMention> _mentions = new List<IMention>();
+        private readonly List<IMention> _mentions = new();
 
         /// <summary>
         /// Constructs a new empty interaction response builder.

--- a/DSharpPlus/Entities/Invite/DiscordInvite.cs
+++ b/DSharpPlus/Entities/Invite/DiscordInvite.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
@@ -106,7 +129,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the emoji does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordInvite> DeleteAsync(string reason = null) 
+        public Task<DiscordInvite> DeleteAsync(string reason = null)
             => this.Discord.ApiClient.DeleteInviteAsync(this.Code, reason);
 
         /*
@@ -125,9 +148,6 @@ namespace DSharpPlus.Entities
         /// Converts this invite into an invite link.
         /// </summary>
         /// <returns>A discord.gg invite link.</returns>
-        public override string ToString()
-        {
-            return $"https://discord.gg/{this.Code}";
-        }
+        public override string ToString() => $"https://discord.gg/{this.Code}";
     }
 }

--- a/DSharpPlus/Entities/Invite/DiscordInviteChannel.cs
+++ b/DSharpPlus/Entities/Invite/DiscordInviteChannel.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {

--- a/DSharpPlus/Entities/Invite/DiscordInviteGuild.cs
+++ b/DSharpPlus/Entities/Invite/DiscordInviteGuild.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using System.Globalization;
 using Newtonsoft.Json;
 
@@ -26,7 +49,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public string IconUrl
-            => !string.IsNullOrWhiteSpace(this.IconHash) ? $"https://cdn.discordapp.com/icons/{this.Id.ToString(CultureInfo.InvariantCulture)}/{IconHash}.jpg" : null;
+            => !string.IsNullOrWhiteSpace(this.IconHash) ? $"https://cdn.discordapp.com/icons/{this.Id.ToString(CultureInfo.InvariantCulture)}/{this.IconHash}.jpg" : null;
 
         /// <summary>
         /// Gets the hash of guild's invite splash.
@@ -38,8 +61,8 @@ namespace DSharpPlus.Entities
         /// Gets the URL of guild's invite splash.
         /// </summary>
         [JsonIgnore]
-        public string SplashUrl 
-            => !string.IsNullOrWhiteSpace(this.SplashHash) ? $"https://cdn.discordapp.com/splashes/{this.Id.ToString(CultureInfo.InvariantCulture)}/{SplashHash}.jpg" : null;
+        public string SplashUrl
+            => !string.IsNullOrWhiteSpace(this.SplashHash) ? $"https://cdn.discordapp.com/splashes/{this.Id.ToString(CultureInfo.InvariantCulture)}/{this.SplashHash}.jpg" : null;
 
         /// <summary>
         /// Gets the guild's banner hash, when applicable.

--- a/DSharpPlus/Entities/SnowflakeObject.cs
+++ b/DSharpPlus/Entities/SnowflakeObject.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities

--- a/DSharpPlus/Entities/User/DiscordActivity.cs
+++ b/DSharpPlus/Entities/User/DiscordActivity.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Globalization;
 using DSharpPlus.Net.Abstractions;
 using Newtonsoft.Json;
@@ -73,24 +96,14 @@ namespace DSharpPlus.Entities
         {
             // Active sessions are indicated with an "online", "idle", or "dnd" string per platform. If a user is
             // offline or invisible, the corresponding field is not present.
-            switch (reader.Value?.ToString().ToLowerInvariant()) // reader.Value can be a string, DateTime or DateTimeOffset (yes, it's weird)
+            return (reader.Value?.ToString().ToLowerInvariant()) switch // reader.Value can be a string, DateTime or DateTimeOffset (yes, it's weird)
             {
-                case "online":
-                    return UserStatus.Online;
-
-                case "idle":
-                    return UserStatus.Idle;
-
-                case "dnd":
-                    return UserStatus.DoNotDisturb;
-
-                case "invisible":
-                    return UserStatus.Invisible;
-
-                case "offline":
-                default:
-                    return UserStatus.Offline;
-            }
+                "online" => UserStatus.Online,
+                "idle" => UserStatus.Idle,
+                "dnd" => UserStatus.DoNotDisturb,
+                "invisible" => UserStatus.Invisible,
+                _ => UserStatus.Offline,
+            };
         }
 
         public override bool CanConvert(Type objectType) => objectType == typeof(UserStatus);
@@ -180,21 +193,17 @@ namespace DSharpPlus.Entities
 
             if (rawActivity?.IsRichPresence() == true && this.RichPresence != null)
                 this.RichPresence.UpdateWith(rawActivity);
-            else if (rawActivity?.IsRichPresence() == true)
-                this.RichPresence = new DiscordRichPresence(rawActivity);
-            else
-                this.RichPresence = null;
+            else this.RichPresence = rawActivity?.IsRichPresence() == true ? new DiscordRichPresence(rawActivity) : null;
 
             if (rawActivity?.IsCustomStatus() == true && this.CustomStatus != null)
                 this.CustomStatus.UpdateWith(rawActivity.State, rawActivity.Emoji);
-            else if (rawActivity?.IsCustomStatus() == true)
-                this.CustomStatus = new DiscordCustomStatus
+            else this.CustomStatus = rawActivity?.IsCustomStatus() == true
+                ? new DiscordCustomStatus
                 {
                     Name = rawActivity.State,
                     Emoji = rawActivity.Emoji
-                };
-            else
-                this.CustomStatus = null;
+                }
+                : null;
         }
     }
 

--- a/DSharpPlus/Entities/User/DiscordPresence.cs
+++ b/DSharpPlus/Entities/User/DiscordPresence.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using DSharpPlus.Net.Abstractions;
 using Newtonsoft.Json;
 
@@ -20,7 +43,7 @@ namespace DSharpPlus.Entities
         /// Gets the user that owns this presence.
         /// </summary>
         [JsonIgnore]
-        public DiscordUser User 
+        public DiscordUser User
             => this.Discord.GetCachedOrEmptyUserInternal(this.InternalUser.Id);
 
         /// <summary>
@@ -36,13 +59,13 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordActivity> Activities => InternalActivities;
-        
+
         [JsonIgnore]
         internal DiscordActivity[] InternalActivities;
-        
+
         [JsonProperty("activities", NullValueHandling = NullValueHandling.Ignore)]
         internal TransportActivity[] RawActivities { get; set; }
-        
+
         /// <summary>
         /// Gets this user's status.
         /// </summary>
@@ -56,7 +79,7 @@ namespace DSharpPlus.Entities
         /// Gets the guild for which this presence was set.
         /// </summary>
         [JsonIgnore]
-        public DiscordGuild Guild 
+        public DiscordGuild Guild
             => this.GuildId != 0 ? this.Discord._guilds[this.GuildId] : null;
 
         /// <summary>
@@ -64,7 +87,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("client_status", NullValueHandling = NullValueHandling.Ignore)]
         public DiscordClientStatus ClientStatus { get; internal set; }
-        
+
         internal DiscordPresence() { }
 
         internal DiscordPresence(DiscordPresence other)
@@ -72,8 +95,8 @@ namespace DSharpPlus.Entities
             this.Discord = other.Discord;
             this.Activity = other.Activity;
             this.RawActivity = other.RawActivity;
-            this.InternalActivities = (DiscordActivity[]) other.InternalActivities?.Clone();
-            this.RawActivities = (TransportActivity[]) other.RawActivities?.Clone();
+            this.InternalActivities = (DiscordActivity[])other.InternalActivities?.Clone();
+            this.RawActivities = (TransportActivity[])other.RawActivities?.Clone();
             this.Status = other.Status;
             this.InternalUser = new TransportUser(other.InternalUser);
         }
@@ -86,13 +109,13 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("desktop", NullValueHandling = NullValueHandling.Ignore)]
         public Optional<UserStatus> Desktop { get; internal set; }
-        
+
         /// <summary>
         /// Gets the user's status set for an active mobile (iOS, Android) application session.
         /// </summary>
         [JsonProperty("mobile", NullValueHandling = NullValueHandling.Ignore)]
         public Optional<UserStatus> Mobile { get; internal set; }
-        
+
         /// <summary>
         /// Gets the user's status set for an active web (browser, bot account) application session.
         /// </summary>

--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
@@ -43,7 +66,7 @@ namespace DSharpPlus.Entities
         public virtual string Discriminator { get; internal set; }
 
         [JsonIgnore]
-        internal int DiscriminatorInt 
+        internal int DiscriminatorInt
             => int.Parse(this.Discriminator, NumberStyles.Integer, CultureInfo.InvariantCulture);
 
         /// <summary>
@@ -56,14 +79,14 @@ namespace DSharpPlus.Entities
         /// Gets the user's avatar URL.
         /// </summary>
         [JsonIgnore]
-        public string AvatarUrl 
-            => !string.IsNullOrWhiteSpace(this.AvatarHash) ? (this.AvatarHash.StartsWith("a_") ? $"https://cdn.discordapp.com/avatars/{this.Id.ToString(CultureInfo.InvariantCulture)}/{AvatarHash}.gif?size=1024" : $"https://cdn.discordapp.com/avatars/{Id}/{AvatarHash}.png?size=1024") : this.DefaultAvatarUrl;
+        public string AvatarUrl
+            => !string.IsNullOrWhiteSpace(this.AvatarHash) ? (this.AvatarHash.StartsWith("a_") ? $"https://cdn.discordapp.com/avatars/{this.Id.ToString(CultureInfo.InvariantCulture)}/{this.AvatarHash}.gif?size=1024" : $"https://cdn.discordapp.com/avatars/{this.Id}/{this.AvatarHash}.png?size=1024") : this.DefaultAvatarUrl;
 
         /// <summary>
         /// Gets the URL of default avatar for this user.
         /// </summary>
         [JsonIgnore]
-        public string DefaultAvatarUrl 
+        public string DefaultAvatarUrl
             => $"https://cdn.discordapp.com/embed/avatars/{(this.DiscriminatorInt % 5).ToString(CultureInfo.InvariantCulture)}.png?size=1024";
 
         /// <summary>
@@ -109,7 +132,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("locale", NullValueHandling = NullValueHandling.Ignore)]
         public virtual string Locale { get; internal set; }
-        
+
         /// <summary>
         /// Gets the user's flags for OAuth.
         /// </summary>
@@ -126,14 +149,14 @@ namespace DSharpPlus.Entities
         /// Gets the user's mention string.
         /// </summary>
         [JsonIgnore]
-        public string Mention 
+        public string Mention
             => Formatter.Mention(this, this is DiscordMember);
 
         /// <summary>
         /// Gets whether this user is the Client which created this object.
         /// </summary>
         [JsonIgnore]
-        public bool IsCurrent 
+        public bool IsCurrent
             => this.Id == this.Discord.CurrentUser.Id;
 
         /// <summary>
@@ -146,7 +169,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the user does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task UnbanAsync(DiscordGuild guild, string reason = null) 
+        public Task UnbanAsync(DiscordGuild guild, string reason = null)
             => guild.UnbanMemberAsync(this, reason);
 
         /// <summary>
@@ -157,9 +180,7 @@ namespace DSharpPlus.Entities
         {
             get
             {
-                if (this.Discord is DiscordClient dc)
-                    return dc.Presences.TryGetValue(this.Id, out var presence) ? presence : null;
-                return null;
+                return this.Discord is DiscordClient dc ? dc.Presences.TryGetValue(this.Id, out var presence) ? presence : null : null;
             }
         }
 
@@ -182,32 +203,15 @@ namespace DSharpPlus.Entities
                 throw new ArgumentOutOfRangeException(nameof(size));
 
             var sfmt = "";
-            switch (fmt)
+            sfmt = fmt switch
             {
-                case ImageFormat.Gif:
-                    sfmt = "gif";
-                    break;
-
-                case ImageFormat.Jpeg:
-                    sfmt = "jpg";
-                    break;
-
-                case ImageFormat.Png:
-                    sfmt = "png";
-                    break;
-
-                case ImageFormat.WebP:
-                    sfmt = "webp";
-                    break;
-
-                case ImageFormat.Auto:
-                    sfmt = !string.IsNullOrWhiteSpace(this.AvatarHash) ? (this.AvatarHash.StartsWith("a_") ? "gif" : "png") : "png";
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(fmt));
-            }
-
+                ImageFormat.Gif => "gif",
+                ImageFormat.Jpeg => "jpg",
+                ImageFormat.Png => "png",
+                ImageFormat.WebP => "webp",
+                ImageFormat.Auto => !string.IsNullOrWhiteSpace(this.AvatarHash) ? (this.AvatarHash.StartsWith("a_") ? "gif" : "png") : "png",
+                _ => throw new ArgumentOutOfRangeException(nameof(fmt)),
+            };
             var ssize = size.ToString(CultureInfo.InvariantCulture);
             if (!string.IsNullOrWhiteSpace(this.AvatarHash))
             {
@@ -225,20 +229,14 @@ namespace DSharpPlus.Entities
         /// Returns a string representation of this user.
         /// </summary>
         /// <returns>String representation of this user.</returns>
-        public override string ToString()
-        {
-            return $"User {this.Id}; {this.Username}#{this.Discriminator}";
-        }
+        public override string ToString() => $"User {this.Id}; {this.Username}#{this.Discriminator}";
 
         /// <summary>
         /// Checks whether this <see cref="DiscordUser"/> is equal to another object.
         /// </summary>
         /// <param name="obj">Object to compare to.</param>
         /// <returns>Whether the object is equal to this <see cref="DiscordUser"/>.</returns>
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as DiscordUser);
-        }
+        public override bool Equals(object obj) => this.Equals(obj as DiscordUser);
 
         /// <summary>
         /// Checks whether this <see cref="DiscordUser"/> is equal to another <see cref="DiscordUser"/>.
@@ -247,23 +245,17 @@ namespace DSharpPlus.Entities
         /// <returns>Whether the <see cref="DiscordUser"/> is equal to this <see cref="DiscordUser"/>.</returns>
         public bool Equals(DiscordUser e)
         {
-            if (ReferenceEquals(e, null))
+            if (e is null)
                 return false;
 
-            if (ReferenceEquals(this, e))
-                return true;
-
-            return this.Id == e.Id;
+            return ReferenceEquals(this, e) ? true : this.Id == e.Id;
         }
 
         /// <summary>
         /// Gets the hash code for this <see cref="DiscordUser"/>.
         /// </summary>
         /// <returns>The hash code for this <see cref="DiscordUser"/>.</returns>
-        public override int GetHashCode()
-        {
-            return this.Id.GetHashCode();
-        }
+        public override int GetHashCode() => this.Id.GetHashCode();
 
         /// <summary>
         /// Gets whether the two <see cref="DiscordUser"/> objects are equal.
@@ -279,10 +271,7 @@ namespace DSharpPlus.Entities
             if ((o1 == null && o2 != null) || (o1 != null && o2 == null))
                 return false;
 
-            if (o1 == null && o2 == null)
-                return true;
-
-            return e1.Id == e2.Id;
+            return o1 == null && o2 == null ? true : e1.Id == e2.Id;
         }
 
         /// <summary>
@@ -291,20 +280,14 @@ namespace DSharpPlus.Entities
         /// <param name="e1">First user to compare.</param>
         /// <param name="e2">Second user to compare.</param>
         /// <returns>Whether the two users are not equal.</returns>
-        public static bool operator !=(DiscordUser e1, DiscordUser e2) 
+        public static bool operator !=(DiscordUser e1, DiscordUser e2)
             => !(e1 == e2);
     }
 
     internal class DiscordUserComparer : IEqualityComparer<DiscordUser>
     {
-        public bool Equals(DiscordUser x, DiscordUser y)
-        {
-            return x.Equals(y);
-        }
+        public bool Equals(DiscordUser x, DiscordUser y) => x.Equals(y);
 
-        public int GetHashCode(DiscordUser obj)
-        {
-            return obj.Id.GetHashCode();
-        }
+        public int GetHashCode(DiscordUser obj) => obj.Id.GetHashCode();
     }
 }

--- a/DSharpPlus/Entities/Voice/DiscordVoiceRegion.cs
+++ b/DSharpPlus/Entities/Voice/DiscordVoiceRegion.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {
@@ -63,15 +86,9 @@ namespace DSharpPlus.Entities
         public bool Equals(DiscordVoiceRegion region)
             => this == region;
 
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as DiscordVoiceRegion);
-        }
+        public override bool Equals(object obj) => this.Equals(obj as DiscordVoiceRegion);
 
-        public override int GetHashCode()
-        {
-            return this.Id.GetHashCode();
-        }
+        public override int GetHashCode() => this.Id.GetHashCode();
 
         /// <summary>
         /// Gets whether the two <see cref="DiscordVoiceRegion"/> objects are equal.
@@ -79,7 +96,7 @@ namespace DSharpPlus.Entities
         /// <param name="left">First voice region to compare.</param>
         /// <param name="right">Second voice region to compare.</param>
         /// <returns>Whether the two voice regions are equal.</returns>
-        public static bool operator==(DiscordVoiceRegion left, DiscordVoiceRegion right)
+        public static bool operator ==(DiscordVoiceRegion left, DiscordVoiceRegion right)
         {
             var o1 = left as object;
             var o2 = right as object;
@@ -87,10 +104,7 @@ namespace DSharpPlus.Entities
             if ((o1 == null && o2 != null) || (o1 != null && o2 == null))
                 return false;
 
-            if (o1 == null && o2 == null)
-                return true;
-
-            return left.Id == right.Id;
+            return o1 == null && o2 == null ? true : left.Id == right.Id;
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Voice/DiscordVoiceState.cs
+++ b/DSharpPlus/Entities/Voice/DiscordVoiceState.cs
@@ -1,164 +1,184 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {
-	/// <summary>
-	/// Represents a Discord voice state.
-	/// </summary>
-	public class DiscordVoiceState
-	{
-		internal DiscordClient Discord { get; set; }
+    /// <summary>
+    /// Represents a Discord voice state.
+    /// </summary>
+    public class DiscordVoiceState
+    {
+        internal DiscordClient Discord { get; set; }
 
-		/// <summary>
-		/// Gets ID of the guild this voice state is associated with.
-		/// </summary>
-		[JsonProperty("guild_id", NullValueHandling = NullValueHandling.Ignore)]
-		internal ulong? GuildId { get; set; }
+        /// <summary>
+        /// Gets ID of the guild this voice state is associated with.
+        /// </summary>
+        [JsonProperty("guild_id", NullValueHandling = NullValueHandling.Ignore)]
+        internal ulong? GuildId { get; set; }
 
-		/// <summary>
-		/// Gets the guild associated with this voice state.
-		/// </summary>
-		[JsonIgnore]
-		public DiscordGuild Guild
-			=> this.GuildId != null ? this.Discord.Guilds[this.GuildId.Value] : (this.Channel != null ? this.Channel.Guild : null);
+        /// <summary>
+        /// Gets the guild associated with this voice state.
+        /// </summary>
+        [JsonIgnore]
+        public DiscordGuild Guild
+            => this.GuildId != null ? this.Discord.Guilds[this.GuildId.Value] : this.Channel?.Guild;
 
-		/// <summary>
-		/// Gets ID of the channel this user is connected to.
-		/// </summary>
-		[JsonProperty("channel_id", NullValueHandling = NullValueHandling.Include)]
-		internal ulong? ChannelId { get; set; }
+        /// <summary>
+        /// Gets ID of the channel this user is connected to.
+        /// </summary>
+        [JsonProperty("channel_id", NullValueHandling = NullValueHandling.Include)]
+        internal ulong? ChannelId { get; set; }
 
-		/// <summary>
-		/// Gets the channel this user is connected to.
-		/// </summary>
-		[JsonIgnore]
-		public DiscordChannel Channel
-			=> this.ChannelId != null && this.ChannelId.Value != 0 ? this.Discord.InternalGetCachedChannel(this.ChannelId.Value) : null;
+        /// <summary>
+        /// Gets the channel this user is connected to.
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel Channel
+            => this.ChannelId != null && this.ChannelId.Value != 0 ? this.Discord.InternalGetCachedChannel(this.ChannelId.Value) : null;
 
-		/// <summary>
-		/// Gets ID of the user to which this voice state belongs.
-		/// </summary>
-		[JsonProperty("user_id", NullValueHandling = NullValueHandling.Ignore)]
-		internal ulong UserId { get; set; }
+        /// <summary>
+        /// Gets ID of the user to which this voice state belongs.
+        /// </summary>
+        [JsonProperty("user_id", NullValueHandling = NullValueHandling.Ignore)]
+        internal ulong UserId { get; set; }
 
-		/// <summary>
-		/// Gets the user associated with this voice state.
-		/// <para>This can be cast to a <see cref="DiscordMember"/> if this voice state was in a guild.</para>
-		/// </summary>
-		[JsonIgnore]
-		public DiscordUser User
-		{
-			get
-			{
-				var usr = null as DiscordUser;
+        /// <summary>
+        /// Gets the user associated with this voice state.
+        /// <para>This can be cast to a <see cref="DiscordMember"/> if this voice state was in a guild.</para>
+        /// </summary>
+        [JsonIgnore]
+        public DiscordUser User
+        {
+            get
+            {
+                var usr = null as DiscordUser;
 
-				if (this.Guild != null)
-					usr = this.Guild._members.TryGetValue(this.UserId, out var member) ? member : null;
+                if (this.Guild != null)
+                    usr = this.Guild._members.TryGetValue(this.UserId, out var member) ? member : null;
 
-				if (usr == null)
-					usr = this.Discord.GetCachedOrEmptyUserInternal(this.UserId);
+                if (usr == null)
+                    usr = this.Discord.GetCachedOrEmptyUserInternal(this.UserId);
 
-				return usr;
-			}
-		}
+                return usr;
+            }
+        }
 
-		/// <summary>
-		/// Gets ID of the session of this voice state.
-		/// </summary>
-		[JsonProperty("session_id", NullValueHandling = NullValueHandling.Ignore)]
-		internal string SessionId { get; set; }
+        /// <summary>
+        /// Gets ID of the session of this voice state.
+        /// </summary>
+        [JsonProperty("session_id", NullValueHandling = NullValueHandling.Ignore)]
+        internal string SessionId { get; set; }
 
-		/// <summary>
-		/// Gets whether this user is deafened.
-		/// </summary>
-		[JsonProperty("deaf", NullValueHandling = NullValueHandling.Ignore)]
-		public bool IsServerDeafened { get; internal set; }
+        /// <summary>
+        /// Gets whether this user is deafened.
+        /// </summary>
+        [JsonProperty("deaf", NullValueHandling = NullValueHandling.Ignore)]
+        public bool IsServerDeafened { get; internal set; }
 
-		/// <summary>
-		/// Gets whether this user is muted.
-		/// </summary>
-		[JsonProperty("mute", NullValueHandling = NullValueHandling.Ignore)]
-		public bool IsServerMuted { get; internal set; }
+        /// <summary>
+        /// Gets whether this user is muted.
+        /// </summary>
+        [JsonProperty("mute", NullValueHandling = NullValueHandling.Ignore)]
+        public bool IsServerMuted { get; internal set; }
 
-		/// <summary>
-		/// Gets whether this user is locally deafened.
-		/// </summary>
-		[JsonProperty("self_deaf", NullValueHandling = NullValueHandling.Ignore)]
-		public bool IsSelfDeafened { get; internal set; }
+        /// <summary>
+        /// Gets whether this user is locally deafened.
+        /// </summary>
+        [JsonProperty("self_deaf", NullValueHandling = NullValueHandling.Ignore)]
+        public bool IsSelfDeafened { get; internal set; }
 
-		/// <summary>
-		/// Gets whether this user is locally muted.
-		/// </summary>
-		[JsonProperty("self_mute", NullValueHandling = NullValueHandling.Ignore)]
-		public bool IsSelfMuted { get; internal set; }
+        /// <summary>
+        /// Gets whether this user is locally muted.
+        /// </summary>
+        [JsonProperty("self_mute", NullValueHandling = NullValueHandling.Ignore)]
+        public bool IsSelfMuted { get; internal set; }
 
-		/// <summary>
-		/// Gets whether this user's camera is enabled.
-		/// </summary>
-		[JsonProperty("self_video", NullValueHandling = NullValueHandling.Ignore)]
-		public bool IsSelfVideo { get; internal set; }
+        /// <summary>
+        /// Gets whether this user's camera is enabled.
+        /// </summary>
+        [JsonProperty("self_video", NullValueHandling = NullValueHandling.Ignore)]
+        public bool IsSelfVideo { get; internal set; }
 
-		/// <summary>
-		/// Gets whether this user is using the Go Live feature.
-		/// </summary>
-		[JsonProperty("self_stream", NullValueHandling = NullValueHandling.Ignore)]
-		public bool IsSelfStream { get; internal set; }
+        /// <summary>
+        /// Gets whether this user is using the Go Live feature.
+        /// </summary>
+        [JsonProperty("self_stream", NullValueHandling = NullValueHandling.Ignore)]
+        public bool IsSelfStream { get; internal set; }
 
-		/// <summary>
-		/// Gets whether the current user has suppressed this user.
-		/// </summary>
-		[JsonProperty("suppress", NullValueHandling = NullValueHandling.Ignore)]
-		public bool IsSuppressed { get; internal set; }
+        /// <summary>
+        /// Gets whether the current user has suppressed this user.
+        /// </summary>
+        [JsonProperty("suppress", NullValueHandling = NullValueHandling.Ignore)]
+        public bool IsSuppressed { get; internal set; }
 
-		/// <summary>
-		/// Gets the time at which this user requested to speak.
-		/// </summary>
-		[JsonProperty("request_to_speak_timestamp", NullValueHandling = NullValueHandling.Ignore)]
-		internal DateTimeOffset? RequestToSpeakTimestamp { get; set; }
+        /// <summary>
+        /// Gets the time at which this user requested to speak.
+        /// </summary>
+        [JsonProperty("request_to_speak_timestamp", NullValueHandling = NullValueHandling.Ignore)]
+        internal DateTimeOffset? RequestToSpeakTimestamp { get; set; }
 
-		internal DiscordVoiceState() { }
+        internal DiscordVoiceState() { }
 
-		// copy constructor for reduced boilerplate
-		internal DiscordVoiceState(DiscordVoiceState other)
-		{
-			this.Discord = other.Discord;
+        // copy constructor for reduced boilerplate
+        internal DiscordVoiceState(DiscordVoiceState other)
+        {
+            this.Discord = other.Discord;
 
-			this.UserId = other.UserId;
-			this.ChannelId = other.ChannelId;
-			this.GuildId = other.GuildId;
+            this.UserId = other.UserId;
+            this.ChannelId = other.ChannelId;
+            this.GuildId = other.GuildId;
 
-			this.IsServerDeafened = other.IsServerDeafened;
-			this.IsServerMuted = other.IsServerMuted;
-			this.IsSuppressed = other.IsSuppressed;
-			this.IsSelfDeafened = other.IsSelfDeafened;
-			this.IsSelfMuted = other.IsSelfMuted;
-			this.IsSelfStream = other.IsSelfStream;
-			this.IsSelfVideo = other.IsSelfVideo;
+            this.IsServerDeafened = other.IsServerDeafened;
+            this.IsServerMuted = other.IsServerMuted;
+            this.IsSuppressed = other.IsSuppressed;
+            this.IsSelfDeafened = other.IsSelfDeafened;
+            this.IsSelfMuted = other.IsSelfMuted;
+            this.IsSelfStream = other.IsSelfStream;
+            this.IsSelfVideo = other.IsSelfVideo;
 
-			this.SessionId = other.SessionId;
-			this.RequestToSpeakTimestamp = other.RequestToSpeakTimestamp;
-		}
+            this.SessionId = other.SessionId;
+            this.RequestToSpeakTimestamp = other.RequestToSpeakTimestamp;
+        }
 
-		internal DiscordVoiceState(DiscordMember m)
-		{
-			this.Discord = m.Discord as DiscordClient;
+        internal DiscordVoiceState(DiscordMember m)
+        {
+            this.Discord = m.Discord as DiscordClient;
 
-			this.UserId = m.Id;
-			this.ChannelId = 0;
-			this.GuildId = m._guild_id;
+            this.UserId = m.Id;
+            this.ChannelId = 0;
+            this.GuildId = m._guild_id;
 
-			this.IsServerDeafened = m.IsDeafened;
-			this.IsServerMuted = m.IsMuted;
+            this.IsServerDeafened = m.IsDeafened;
+            this.IsServerMuted = m.IsMuted;
 
-			// Values not filled out are values that are not known from a DiscordMember
-		}
+            // Values not filled out are values that are not known from a DiscordMember
+        }
 
-		public override string ToString()
-		{
-			return $"{this.UserId.ToString(CultureInfo.InvariantCulture)} in {(this.GuildId ?? this.Channel.GuildId.Value).ToString(CultureInfo.InvariantCulture)}";
-		}
-	}
+        public override string ToString() => $"{this.UserId.ToString(CultureInfo.InvariantCulture)} in {(this.GuildId ?? this.Channel.GuildId.Value).ToString(CultureInfo.InvariantCulture)}";
+    }
 }

--- a/DSharpPlus/Entities/Webhook/DiscordWebhook.cs
+++ b/DSharpPlus/Entities/Webhook/DiscordWebhook.cs
@@ -1,10 +1,33 @@
-﻿using System;
-using System.IO;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using DSharpPlus.Net;
 using Newtonsoft.Json;
-using System.Linq;
 
 namespace DSharpPlus.Entities
 {
@@ -48,7 +71,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the default avatar url for this webhook.
         /// </summary>
-        public string AvatarUrl 
+        public string AvatarUrl
             => !string.IsNullOrWhiteSpace(this.AvatarHash) ? $"https://cdn.discordapp.com/avatars/{this.Id}/{this.AvatarHash}.png?size=1024" : null;
 
         /// <summary>
@@ -80,7 +103,7 @@ namespace DSharpPlus.Entities
             else if (avatar.HasValue)
                 avatarb64 = null;
 
-            var newChannelId = channelId.HasValue ? channelId.Value : this.ChannelId;
+            var newChannelId = channelId ?? this.ChannelId;
 
             return this.Discord.ApiClient.ModifyWebhookAsync(this.Id, newChannelId, name, avatarb64, reason);
         }
@@ -93,8 +116,8 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the webhook does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task DeleteAsync() 
-            => this.Discord.ApiClient.DeleteWebhookAsync(this.Id, Token);
+        public Task DeleteAsync()
+            => this.Discord.ApiClient.DeleteWebhookAsync(this.Id, this.Token);
 
         /// <summary>
         /// Executes this webhook with the given <see cref="DiscordWebhookBuilder"/>.
@@ -114,8 +137,8 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the webhook does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task ExecuteSlackAsync(string json) 
-            => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookSlackAsync(Id, Token, json);
+        public Task ExecuteSlackAsync(string json)
+            => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookSlackAsync(this.Id, this.Token, json);
 
         /// <summary>
         /// Executes this webhook in GitHub compatibility mode.
@@ -125,8 +148,8 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the webhook does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task ExecuteGithubAsync(string json) 
-            => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookGithubAsync(Id, Token, json);
+        public Task ExecuteGithubAsync(string json)
+            => (this.Discord?.ApiClient ?? this.ApiClient).ExecuteWebhookGithubAsync(this.Id, this.Token, json);
 
         /// <summary>
         /// Edits a previously-sent webhook message.
@@ -141,7 +164,7 @@ namespace DSharpPlus.Entities
         {
             builder.Validate(true);
 
-            return await(this.Discord?.ApiClient ?? this.ApiClient).EditWebhookMessageAsync(this.Id, this.Token, messageId, builder).ConfigureAwait(false);
+            return await (this.Discord?.ApiClient ?? this.ApiClient).EditWebhookMessageAsync(this.Id, this.Token, messageId, builder).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -160,10 +183,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="obj">Object to compare to.</param>
         /// <returns>Whether the object is equal to this <see cref="DiscordWebhook"/>.</returns>
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as DiscordWebhook);
-        }
+        public override bool Equals(object obj) => this.Equals(obj as DiscordWebhook);
 
         /// <summary>
         /// Checks whether this <see cref="DiscordWebhook"/> is equal to another <see cref="DiscordWebhook"/>.
@@ -172,23 +192,17 @@ namespace DSharpPlus.Entities
         /// <returns>Whether the <see cref="DiscordWebhook"/> is equal to this <see cref="DiscordWebhook"/>.</returns>
         public bool Equals(DiscordWebhook e)
         {
-            if (ReferenceEquals(e, null))
+            if (e is null)
                 return false;
 
-            if (ReferenceEquals(this, e))
-                return true;
-
-            return this.Id == e.Id;
+            return ReferenceEquals(this, e) ? true : this.Id == e.Id;
         }
 
         /// <summary>
         /// Gets the hash code for this <see cref="DiscordWebhook"/>.
         /// </summary>
         /// <returns>The hash code for this <see cref="DiscordWebhook"/>.</returns>
-        public override int GetHashCode()
-        {
-            return this.Id.GetHashCode();
-        }
+        public override int GetHashCode() => this.Id.GetHashCode();
 
         /// <summary>
         /// Gets whether the two <see cref="DiscordWebhook"/> objects are equal.
@@ -204,10 +218,7 @@ namespace DSharpPlus.Entities
             if ((o1 == null && o2 != null) || (o1 != null && o2 == null))
                 return false;
 
-            if (o1 == null && o2 == null)
-                return true;
-
-            return e1.Id == e2.Id;
+            return o1 == null && o2 == null ? true : e1.Id == e2.Id;
         }
 
         /// <summary>
@@ -216,7 +227,7 @@ namespace DSharpPlus.Entities
         /// <param name="e1">First webhook to compare.</param>
         /// <param name="e2">Second webhook to compare.</param>
         /// <returns>Whether the two webhooks are not equal.</returns>
-        public static bool operator !=(DiscordWebhook e1, DiscordWebhook e2) 
+        public static bool operator !=(DiscordWebhook e1, DiscordWebhook e2)
             => !(e1 == e2);
     }
 }

--- a/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -16,12 +39,12 @@ namespace DSharpPlus.Entities
         /// Username to use for this webhook request.
         /// </summary>
         public Optional<string> Username { get; set; }
-        
+
         /// <summary>
         /// Avatar url to use for this webhook request.
         /// </summary>
         public Optional<string> AvatarUrl { get; set; }
-        
+
         /// <summary>
         /// Whether this webhook request is text-to-speech.
         /// </summary>
@@ -41,25 +64,25 @@ namespace DSharpPlus.Entities
             }
         }
         private string _content;
-        
+
         /// <summary>
         /// Embeds to send on this webhook request.
         /// </summary>
         public IReadOnlyList<DiscordEmbed> Embeds { get; }
-        private readonly List<DiscordEmbed> _embeds = new List<DiscordEmbed>();
+        private readonly List<DiscordEmbed> _embeds = new();
 
         /// <summary>
         /// Files to send on this webhook request.
         /// </summary>
         public IReadOnlyCollection<DiscordMessageFile> Files => this._files;
 
-        internal readonly List<DiscordMessageFile> _files = new List<DiscordMessageFile>();
+        internal readonly List<DiscordMessageFile> _files = new();
 
         /// <summary>
         /// Mentions to send on this webhook request.
         /// </summary>
         public IEnumerable<IMention> Mentions { get; }
-        private readonly List<IMention> _mentions = new List<IMention>();
+        private readonly List<IMention> _mentions = new();
 
         /// <summary>
         /// Constructs a new empty webhook request builder.
@@ -194,7 +217,7 @@ namespace DSharpPlus.Entities
                 else
                     this._files.Add(new DiscordMessageFile(file.Key, file.Value, null));
             }
-                
+
 
             return this;
         }
@@ -224,10 +247,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="webhook">The webhook that should be executed.</param>
         /// <returns>The message sent</returns>
-        public async Task<DiscordMessage> SendAsync(DiscordWebhook webhook)
-        {
-            return await webhook.ExecuteAsync(this).ConfigureAwait(false);
-        }
+        public async Task<DiscordMessage> SendAsync(DiscordWebhook webhook) => await webhook.ExecuteAsync(this).ConfigureAwait(false);
 
         /// <summary>
         /// Sends the modified webhook message.
@@ -235,20 +255,14 @@ namespace DSharpPlus.Entities
         /// <param name="webhook">The webhook that should be executed.</param>
         /// <param name="message">The message to modify.</param>
         /// <returns>The modified message</returns>
-        public async Task<DiscordMessage> ModifyAsync(DiscordWebhook webhook, DiscordMessage message)
-        {
-            return await this.ModifyAsync(webhook, message.Id).ConfigureAwait(false);
-        }
+        public async Task<DiscordMessage> ModifyAsync(DiscordWebhook webhook, DiscordMessage message) => await this.ModifyAsync(webhook, message.Id).ConfigureAwait(false);
         /// <summary>
         /// Sends the modified webhook message.
         /// </summary>
         /// <param name="webhook">The webhook that should be executed.</param>
         /// <param name="messageId">The id of the message to modify.</param>
         /// <returns>The modified message</returns>
-        public async Task<DiscordMessage> ModifyAsync(DiscordWebhook webhook, ulong messageId)
-        {
-            return await webhook.EditMessageAsync(messageId, this).ConfigureAwait(false);
-        }
+        public async Task<DiscordMessage> ModifyAsync(DiscordWebhook webhook, ulong messageId) => await webhook.EditMessageAsync(messageId, this).ConfigureAwait(false);
 
         /// <summary>
         /// Allows for clearing the Webhook Builder so that it can be used again to send a new message.

--- a/DSharpPlus/Enums/ApplicationCommandOptionType.cs
+++ b/DSharpPlus/Enums/ApplicationCommandOptionType.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
 {
     /// <summary>
     /// Represents the type of parameter when invoking an interaction.

--- a/DSharpPlus/Enums/Channel/ChannelQualityMode.cs
+++ b/DSharpPlus/Enums/Channel/ChannelQualityMode.cs
@@ -1,0 +1,23 @@
+﻿namespace DSharpPlus
+{
+    /// <summary>
+    /// Represents the camera quality of a voice channel.
+    /// </summary>
+    public enum ChannelQualityMode : int
+    {
+        /// <summary>
+        /// Indicates default video type, or channel is not a voice channel.
+        /// </summary>
+        DefaultValue = 0,
+
+        /// <summary>
+        /// Indicates that the camera quality is automatically chosen, or there is no value set.
+        /// </summary>
+        Auto = 1,
+
+        /// <summary>
+        /// Indicates that the camera quality is 720p.
+        /// </summary>
+        Full = 2,
+    }
+}

--- a/DSharpPlus/Enums/Channel/ChannelType.cs
+++ b/DSharpPlus/Enums/Channel/ChannelType.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
 {
     /// <summary>
     /// Represents a channel's type.

--- a/DSharpPlus/Enums/Channel/OverwriteType.cs
+++ b/DSharpPlus/Enums/Channel/OverwriteType.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
 {
     /// <summary>
     /// Represents a channelpermissions overwrite's type.

--- a/DSharpPlus/Enums/Channel/SystemChannelFlags.cs
+++ b/DSharpPlus/Enums/Channel/SystemChannelFlags.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus
 {

--- a/DSharpPlus/Enums/GatewayCompressionLevel.cs
+++ b/DSharpPlus/Enums/GatewayCompressionLevel.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
 {
     /// <summary>
     /// Determines at which level should the WebSocket traffic be compressed.

--- a/DSharpPlus/Enums/Guild/MembershipScreeningFieldType.cs
+++ b/DSharpPlus/Enums/Guild/MembershipScreeningFieldType.cs
@@ -1,6 +1,29 @@
-﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace DSharpPlus
 {

--- a/DSharpPlus/Enums/Guild/PremiumTier.cs
+++ b/DSharpPlus/Enums/Guild/PremiumTier.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
 {
     /// <summary>
     /// Represents a server's premium tier.

--- a/DSharpPlus/Enums/InteractionResponseType.cs
+++ b/DSharpPlus/Enums/InteractionResponseType.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
 {
     /// <summary>
     /// Represents the type of interaction response
@@ -9,7 +32,7 @@
         /// Acknowledges a Ping.
         /// </summary>
         Pong = 1,
-        
+
         /// <summary>
         /// Responds to the interaction with a message.
         /// </summary>

--- a/DSharpPlus/Enums/InteractionType.cs
+++ b/DSharpPlus/Enums/InteractionType.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
 {
     /// <summary>
     /// Represents the type of interaction used.

--- a/DSharpPlus/Enums/Message/MentionType.cs
+++ b/DSharpPlus/Enums/Message/MentionType.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
 {
     /// <summary>
     /// Type of mention being made

--- a/DSharpPlus/Enums/Message/MessageActivityType.cs
+++ b/DSharpPlus/Enums/Message/MessageActivityType.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
 {
     /// <summary>
     /// Indicates the type of MessageActivity for the Rich Presence.

--- a/DSharpPlus/Enums/Message/MessageFlags.cs
+++ b/DSharpPlus/Enums/Message/MessageFlags.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus
 {
@@ -33,12 +56,12 @@ namespace DSharpPlus
         /// Whether any embeds in the message are hidden.
         /// </summary>
         SuppressedEmbeds = 1 << 2,
-        
+
         /// <summary>
         /// The source message for this crosspost has been deleted.
         /// </summary>
         SourceMessageDelete = 1 << 3,
-        
+
         /// <summary>
         /// The message came from the urgent message system.
         /// </summary>

--- a/DSharpPlus/Enums/Message/MessageType.cs
+++ b/DSharpPlus/Enums/Message/MessageType.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
 {
     /// <summary>
     /// Represents the type of a message.

--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus
 {
@@ -12,7 +35,7 @@ namespace DSharpPlus
         /// <param name="p">The permissions to calculate from</param>
         /// <param name="permission">permission you want to check</param>
         /// <returns></returns>
-        public static bool HasPermission(this Permissions p, Permissions permission) 
+        public static bool HasPermission(this Permissions p, Permissions permission)
             => p.HasFlag(Permissions.Administrator) || (p & permission) == permission;
 
         /// <summary>
@@ -249,7 +272,7 @@ namespace DSharpPlus
         /// Allows the user to go live.
         /// </summary>
         [PermissionString("Allow stream")]
-        Stream	= 0x0000000000000200,
+        Stream  = 0x0000000000000200,
 
         /// <summary>
         /// Allows the user to use slash commands.

--- a/DSharpPlus/Enums/TokenType.cs
+++ b/DSharpPlus/Enums/TokenType.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus
 {

--- a/DSharpPlus/Enums/User/PremiumType.cs
+++ b/DSharpPlus/Enums/User/PremiumType.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
 {
     /// <summary>
     /// The type of Nitro subscription on a user's account.

--- a/DSharpPlus/Enums/User/TargetUserType.cs
+++ b/DSharpPlus/Enums/User/TargetUserType.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
 {
     /// <summary>
     /// Represents the type of user who the invite is for.

--- a/DSharpPlus/Enums/User/UserFlags.cs
+++ b/DSharpPlus/Enums/User/UserFlags.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus
 {

--- a/DSharpPlus/EventArgs/ApplicationCommandEventArgs.cs
+++ b/DSharpPlus/EventArgs/ApplicationCommandEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Channel/ChannelCreateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Channel/ChannelCreateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Channel/ChannelDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/Channel/ChannelDeleteEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Channel/ChannelPinsUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Channel/ChannelPinsUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs

--- a/DSharpPlus/EventArgs/Channel/ChannelUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Channel/ChannelUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Channel/DMChannelDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/Channel/DMChannelDeleteEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/ClientErrorEventArgs.cs
+++ b/DSharpPlus/EventArgs/ClientErrorEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/DiscordEventArgs.cs
+++ b/DSharpPlus/EventArgs/DiscordEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using Emzi0767.Utilities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Emzi0767.Utilities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Guild/Ban/GuildBanAddEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/Ban/GuildBanAddEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Guild/Ban/GuildBanRemoveEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/Ban/GuildBanRemoveEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Guild/GuildCreateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/GuildCreateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Guild/GuildDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/GuildDeleteEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Guild/GuildDownloadCompletedEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/GuildDownloadCompletedEventArgs.cs
@@ -1,5 +1,28 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System.Collections.Generic;
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {
@@ -13,7 +36,7 @@ namespace DSharpPlus.EventArgs
         /// </summary>
         public IReadOnlyDictionary<ulong, DiscordGuild> Guilds { get; }
 
-        internal GuildDownloadCompletedEventArgs(IReadOnlyDictionary<ulong, DiscordGuild> guilds) 
+        internal GuildDownloadCompletedEventArgs(IReadOnlyDictionary<ulong, DiscordGuild> guilds)
             : base()
         {
             this.Guilds = guilds;

--- a/DSharpPlus/EventArgs/Guild/GuildEmojisUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/GuildEmojisUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs

--- a/DSharpPlus/EventArgs/Guild/GuildIntegrationsUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/GuildIntegrationsUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Guild/GuildUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/GuildUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Guild/Member/GuildMemberAddEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/Member/GuildMemberAddEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Guild/Member/GuildMemberRemoveEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/Member/GuildMemberRemoveEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Guild/Member/GuildMemberUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/Member/GuildMemberUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs

--- a/DSharpPlus/EventArgs/Guild/Member/GuildMembersChunkEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/Member/GuildMembersChunkEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs

--- a/DSharpPlus/EventArgs/Guild/Role/GuildRoleCreateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/Role/GuildRoleCreateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Guild/Role/GuildRoleDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/Role/GuildRoleDeleteEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Guild/Role/GuildRoleUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/Role/GuildRoleUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/HeartBeatEventArgs.cs
+++ b/DSharpPlus/EventArgs/HeartBeatEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/InteractionCreateEventArgs.cs
+++ b/DSharpPlus/EventArgs/InteractionCreateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Invite/InviteCreateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Invite/InviteCreateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Invite/InviteDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/Invite/InviteDeleteEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Message/MessageAcknowledgeEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/MessageAcknowledgeEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {
@@ -15,7 +38,7 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the channel for which the message was acknowledged.
         /// </summary>
-        public DiscordChannel Channel 
+        public DiscordChannel Channel
             => this.Message.Channel;
 
         internal MessageAcknowledgeEventArgs() : base() { }

--- a/DSharpPlus/EventArgs/Message/MessageBulkDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/MessageBulkDeleteEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs

--- a/DSharpPlus/EventArgs/Message/MessageCreateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/MessageCreateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
@@ -16,19 +39,19 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the channel this message belongs to.
         /// </summary>
-        public DiscordChannel Channel 
+        public DiscordChannel Channel
             => this.Message.Channel;
 
         /// <summary>
         /// Gets the guild this message belongs to.
         /// </summary>
-        public DiscordGuild Guild 
+        public DiscordGuild Guild
             => this.Channel.Guild;
 
         /// <summary>
         /// Gets the author of the message.
         /// </summary>
-        public DiscordUser Author 
+        public DiscordUser Author
             => this.Message.Author;
 
         /// <summary>

--- a/DSharpPlus/EventArgs/Message/MessageDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/MessageDeleteEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Message/MessageUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/MessageUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
@@ -21,19 +44,19 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the channel this message belongs to.
         /// </summary>
-        public DiscordChannel Channel 
+        public DiscordChannel Channel
             => this.Message.Channel;
 
         /// <summary>
         /// Gets the guild this message belongs to.
         /// </summary>
-        public DiscordGuild Guild 
+        public DiscordGuild Guild
             => this.Channel.Guild;
 
         /// <summary>
         /// Gets the author of the message.
         /// </summary>
-        public DiscordUser Author 
+        public DiscordUser Author
             => this.Message.Author;
 
         /// <summary>

--- a/DSharpPlus/EventArgs/Message/Reaction/MessageReactionAddEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/Reaction/MessageReactionAddEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {
@@ -20,7 +43,7 @@ namespace DSharpPlus.EventArgs
         /// DM channels in which no prior messages were received or sent.
         /// </remarks>
         public DiscordChannel Channel
-            => Message.Channel;
+            => this.Message.Channel;
 
         /// <summary>
         /// Gets the user who created the reaction.

--- a/DSharpPlus/EventArgs/Message/Reaction/MessageReactionRemoveEmojiEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/Reaction/MessageReactionRemoveEmojiEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Message/Reaction/MessageReactionRemoveEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/Reaction/MessageReactionRemoveEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {
@@ -20,7 +43,7 @@ namespace DSharpPlus.EventArgs
         /// DM channels in which no prior messages were received or sent.
         /// </remarks>
         public DiscordChannel Channel
-            => Message.Channel;
+            => this.Message.Channel;
 
         /// <summary>
         /// Gets the users whose reaction was removed.

--- a/DSharpPlus/EventArgs/Message/Reaction/MessageReactionsClearEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/Reaction/MessageReactionsClearEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {
@@ -20,7 +43,7 @@ namespace DSharpPlus.EventArgs
         /// DM channels in which no prior messages were received or sent.
         /// </remarks>
         public DiscordChannel Channel
-            => Message.Channel;
+            => this.Message.Channel;
 
         /// <summary>
         /// Gets the guild in which the reactions were cleared.

--- a/DSharpPlus/EventArgs/ReadyEventArgs.cs
+++ b/DSharpPlus/EventArgs/ReadyEventArgs.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.EventArgs
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.EventArgs
 {
     /// <summary>
     /// Represents arguments for <see cref="DiscordClient.Ready"/> event.

--- a/DSharpPlus/EventArgs/Socket/SocketDisconnectEventArgs.cs
+++ b/DSharpPlus/EventArgs/Socket/SocketDisconnectEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.EventArgs
 {
@@ -16,7 +39,7 @@ namespace DSharpPlus.EventArgs
         /// Gets the close message sent by remote host.
         /// </summary>
         public string CloseMessage { get; internal set; }
-        
+
         public SocketCloseEventArgs() : base() { }
     }
 

--- a/DSharpPlus/EventArgs/Socket/SocketEventArgs.cs
+++ b/DSharpPlus/EventArgs/Socket/SocketEventArgs.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.EventArgs
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.EventArgs
 {
     /// <summary>
     /// Represents basic socket event arguments. 

--- a/DSharpPlus/EventArgs/Socket/WebSocketMessageEventArgs.cs
+++ b/DSharpPlus/EventArgs/Socket/WebSocketMessageEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using Emzi0767.Utilities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Emzi0767.Utilities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/TypingStartEventArgs.cs
+++ b/DSharpPlus/EventArgs/TypingStartEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs

--- a/DSharpPlus/EventArgs/UnknownEventArgs.cs
+++ b/DSharpPlus/EventArgs/UnknownEventArgs.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.EventArgs
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.EventArgs
 {
     /// <summary>
     /// Represents arguments for <see cref="DiscordClient.UnknownEvent"/> event.

--- a/DSharpPlus/EventArgs/User/PresenceUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/User/PresenceUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/User/UserSettingsUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/User/UserSettingsUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/User/UserSpeakingEventArgs.cs
+++ b/DSharpPlus/EventArgs/User/UserSpeakingEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/User/UserUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/User/UserUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/Voice/VoiceServerUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Voice/VoiceServerUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.EventArgs

--- a/DSharpPlus/EventArgs/Voice/VoiceStateUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Voice/VoiceStateUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/EventArgs/WebhooksUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/WebhooksUpdateEventArgs.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
 {

--- a/DSharpPlus/Exceptions/BadRequestException.cs
+++ b/DSharpPlus/Exceptions/BadRequestException.cs
@@ -1,6 +1,29 @@
-﻿using Newtonsoft.Json.Linq;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using DSharpPlus.Net;
+using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.Exceptions
 {
@@ -41,7 +64,7 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                JObject j = JObject.Parse(response.Response);
+                var j = JObject.Parse(response.Response);
 
                 if (j["code"] != null)
                     this.Code = (int)j["code"];

--- a/DSharpPlus/Exceptions/NotFoundException.cs
+++ b/DSharpPlus/Exceptions/NotFoundException.cs
@@ -1,6 +1,29 @@
-﻿using Newtonsoft.Json.Linq;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using DSharpPlus.Net;
+using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.Exceptions
 {
@@ -31,10 +54,10 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                JObject j = JObject.Parse(response.Response);
+                var j = JObject.Parse(response.Response);
 
                 if (j["message"] != null)
-                    JsonMessage = j["message"].ToString();
+                    this.JsonMessage = j["message"].ToString();
             }
             catch (Exception) { }
         }

--- a/DSharpPlus/Exceptions/RateLimitException.cs
+++ b/DSharpPlus/Exceptions/RateLimitException.cs
@@ -1,6 +1,29 @@
-﻿using Newtonsoft.Json.Linq;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using DSharpPlus.Net;
+using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.Exceptions
 {
@@ -31,10 +54,10 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                JObject j = JObject.Parse(response.Response);
+                var j = JObject.Parse(response.Response);
 
                 if (j["message"] != null)
-                    JsonMessage = j["message"].ToString();
+                    this.JsonMessage = j["message"].ToString();
             }
             catch (Exception) { }
         }

--- a/DSharpPlus/Exceptions/RequestSizeException.cs
+++ b/DSharpPlus/Exceptions/RequestSizeException.cs
@@ -1,6 +1,29 @@
-﻿using System;
-using Newtonsoft.Json.Linq;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using DSharpPlus.Net;
+using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.Exceptions
 {
@@ -31,10 +54,10 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                JObject j = JObject.Parse(response.Response);
+                var j = JObject.Parse(response.Response);
 
                 if (j["message"] != null)
-                    JsonMessage = j["message"].ToString();
+                    this.JsonMessage = j["message"].ToString();
             }
             catch (Exception) { }
         }

--- a/DSharpPlus/Exceptions/ServerErrorException.cs
+++ b/DSharpPlus/Exceptions/ServerErrorException.cs
@@ -1,6 +1,29 @@
-﻿using Newtonsoft.Json.Linq;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using DSharpPlus.Net;
+using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.Exceptions
 {
@@ -34,7 +57,7 @@ namespace DSharpPlus.Exceptions
                 var j = JObject.Parse(response.Response);
 
                 if (j["message"] != null)
-                    JsonMessage = j["message"].ToString();
+                    this.JsonMessage = j["message"].ToString();
             }
             catch (Exception) { }
         }

--- a/DSharpPlus/Exceptions/UnauthorizedException.cs
+++ b/DSharpPlus/Exceptions/UnauthorizedException.cs
@@ -1,6 +1,29 @@
-﻿using Newtonsoft.Json.Linq;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using DSharpPlus.Net;
+using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.Exceptions
 {
@@ -31,10 +54,10 @@ namespace DSharpPlus.Exceptions
 
             try
             {
-                JObject j = JObject.Parse(response.Response);
+                var j = JObject.Parse(response.Response);
 
                 if (j["message"] != null)
-                    JsonMessage = j["message"].ToString();
+                    this.JsonMessage = j["message"].ToString();
             }
             catch (Exception) { }
         }

--- a/DSharpPlus/Formatter.cs
+++ b/DSharpPlus/Formatter.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using DSharpPlus.Entities;
@@ -19,7 +42,7 @@ namespace DSharpPlus
         /// <param name="content">Contents of the block.</param>
         /// <param name="language">Language to use for highlighting.</param>
         /// <returns>Formatted block of code.</returns>
-        public static string BlockCode(string content, string language = "") 
+        public static string BlockCode(string content, string language = "")
             => $"```{language}\n{content}\n```";
 
         /// <summary>
@@ -27,7 +50,7 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="content">Contents of the snippet.</param>
         /// <returns>Formatted inline code snippet.</returns>
-        public static string InlineCode(string content) 
+        public static string InlineCode(string content)
             => $"`{content}`";
 
         /// <summary>
@@ -35,7 +58,7 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="content">Text to bolden.</param>
         /// <returns>Formatted text.</returns>
-        public static string Bold(string content) 
+        public static string Bold(string content)
             => $"**{content}**";
 
         /// <summary>
@@ -43,7 +66,7 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="content">Text to italicize.</param>
         /// <returns>Formatted text.</returns>
-        public static string Italic(string content) 
+        public static string Italic(string content)
             => $"*{content}*";
 
         /// <summary>
@@ -59,7 +82,7 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="content">Text to underline.</param>
         /// <returns>Formatted text.</returns>
-        public static string Underline(string content) 
+        public static string Underline(string content)
             => $"__{content}__";
 
         /// <summary>
@@ -67,7 +90,7 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="content">Text to strikethrough.</param>
         /// <returns>Formatted text.</returns>
-        public static string Strike(string content) 
+        public static string Strike(string content)
             => $"~~{content}~~";
 
         /// <summary>
@@ -75,8 +98,8 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="url">Url to prevent from being previewed.</param>
         /// <returns>Formatted url.</returns>
-        public static string EmbedlessUrl(Uri url) 
-            => $"<{url.ToString()}>";
+        public static string EmbedlessUrl(Uri url)
+            => $"<{url}>";
 
         /// <summary>
         /// Creates a masked link. This link will display as specified text, and alternatively provided alt text. This can only be used in embeds.
@@ -85,7 +108,7 @@ namespace DSharpPlus
         /// <param name="url">Url that the link will lead to.</param>
         /// <param name="alt_text">Alt text to display on hover.</param>
         /// <returns>Formatted url.</returns>
-        public static string MaskedUrl(string text, Uri url, string alt_text = "") 
+        public static string MaskedUrl(string text, Uri url, string alt_text = "")
             => $"[{text}]({url}{(!string.IsNullOrWhiteSpace(alt_text) ? $" \"{alt_text}\"" : "")})";
 
         /// <summary>
@@ -93,7 +116,7 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="text">Text to sanitize.</param>
         /// <returns>Sanitized text.</returns>
-        public static string Sanitize(string text) 
+        public static string Sanitize(string text)
             => MdSanitizeRegex.Replace(text, m => $"\\{m.Groups[1].Value}");
 
         /// <summary>
@@ -101,7 +124,7 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="text">Text to strip of formatting.</param>
         /// <returns>Formatting-stripped text.</returns>
-        public static string Strip(string text) 
+        public static string Strip(string text)
             => MdStripRegex.Replace(text, m => string.Empty);
 
         /// <summary>
@@ -110,15 +133,17 @@ namespace DSharpPlus
         /// <param name="user">User to create mention for.</param>
         /// <param name="nickname">Whether the mention should resolve nicknames or not.</param>
         /// <returns>Formatted mention.</returns>
-        public static string Mention(DiscordUser user, bool nickname = false) 
-            => (nickname ? $"<@!{user.Id.ToString(CultureInfo.InvariantCulture)}>" : $"<@{user.Id.ToString(CultureInfo.InvariantCulture)}>");
+        public static string Mention(DiscordUser user, bool nickname = false)
+            => nickname
+            ? $"<@!{user.Id.ToString(CultureInfo.InvariantCulture)}>"
+            : $"<@{user.Id.ToString(CultureInfo.InvariantCulture)}>";
 
         /// <summary>
         /// Creates a mention for specified channel.
         /// </summary>
         /// <param name="channel">Channel to mention.</param>
         /// <returns>Formatted mention.</returns>
-        public static string Mention(DiscordChannel channel) 
+        public static string Mention(DiscordChannel channel)
             => $"<#{channel.Id.ToString(CultureInfo.InvariantCulture)}>";
 
         /// <summary>
@@ -126,7 +151,7 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="role">Role to mention.</param>
         /// <returns>Formatted mention.</returns>
-        public static string Mention(DiscordRole role) 
+        public static string Mention(DiscordRole role)
             => $"<@&{role.Id.ToString(CultureInfo.InvariantCulture)}>";
 
         /// <summary>
@@ -134,7 +159,7 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="emoji">Emoji to display.</param>
         /// <returns>Formatted emoji.</returns>
-        public static string Emoji(DiscordEmoji emoji) 
+        public static string Emoji(DiscordEmoji emoji)
             => $"<:{emoji.Name}:{emoji.Id.ToString(CultureInfo.InvariantCulture)}>";
 
         /// <summary>
@@ -142,7 +167,7 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="filename">Name of attached image to display</param>
         /// <returns></returns>
-        public static string AttachedImageUrl(string filename) 
+        public static string AttachedImageUrl(string filename)
             => $"attachment://{filename}";
     }
 }

--- a/DSharpPlus/ImageTool.cs
+++ b/DSharpPlus/ImageTool.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.IO;
 using System.Text;
 
@@ -40,7 +63,7 @@ namespace DSharpPlus
 
             if (!stream.CanRead || !stream.CanSeek)
                 throw new ArgumentException("The stream needs to be both readable and seekable.", nameof(stream));
-            
+
             this.SourceStream = stream;
             this.SourceStream.Seek(0, SeekOrigin.Begin);
 

--- a/DSharpPlus/Logging/CompositeDefaultLogger.cs
+++ b/DSharpPlus/Logging/CompositeDefaultLogger.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -25,9 +48,6 @@ namespace DSharpPlus
                 logger.Log(logLevel, eventId, state, exception, formatter);
         }
 
-        public IDisposable BeginScope<TState>(TState state)
-        {
-            throw new NotImplementedException();
-        }
+        public IDisposable BeginScope<TState>(TState state) => throw new NotImplementedException();
     }
 }

--- a/DSharpPlus/Logging/DefaultLogger.cs
+++ b/DSharpPlus/Logging/DefaultLogger.cs
@@ -1,11 +1,34 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus
 {
     public class DefaultLogger : ILogger<BaseDiscordClient>
     {
-        private static readonly object _lock = new object();
+        private static readonly object _lock = new();
 
         private LogLevel MinimumLevel { get; }
         private string TimestampFormat { get; }
@@ -58,16 +81,16 @@ namespace DSharpPlus
                         Console.ForegroundColor = ConsoleColor.Black;
                         break;
                 }
-                Console.Write(logLevel switch 
+                Console.Write(logLevel switch
                 {
-                    LogLevel.Trace =>       "[Trace] ",
-                    LogLevel.Debug =>       "[Debug] ",
+                    LogLevel.Trace => "[Trace] ",
+                    LogLevel.Debug => "[Debug] ",
                     LogLevel.Information => "[Info ] ",
-                    LogLevel.Warning =>     "[Warn ] ",
-                    LogLevel.Error =>       "[Error] ",
-                    LogLevel.Critical =>    "[Crit ]",
-                    LogLevel.None =>        "[None ] ",
-                    _ =>                    "[?????] "
+                    LogLevel.Warning => "[Warn ] ",
+                    LogLevel.Error => "[Error] ",
+                    LogLevel.Critical => "[Crit ]",
+                    LogLevel.None => "[None ] ",
+                    _ => "[?????] "
                 });
                 Console.ResetColor();
 
@@ -85,9 +108,6 @@ namespace DSharpPlus
         public bool IsEnabled(LogLevel logLevel)
             => logLevel >= this.MinimumLevel;
 
-        public IDisposable BeginScope<TState>(TState state)
-        {
-            throw new NotImplementedException();
-        }
+        public IDisposable BeginScope<TState>(TState state) => throw new NotImplementedException();
     }
 }

--- a/DSharpPlus/Logging/DefaultLoggerFactory.cs
+++ b/DSharpPlus/Logging/DefaultLoggerFactory.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
@@ -9,20 +32,16 @@ namespace DSharpPlus
         private List<ILoggerProvider> Providers { get; } = new List<ILoggerProvider>();
         private bool _isDisposed = false;
 
-        public void AddProvider(ILoggerProvider provider)
-        {
-            this.Providers.Add(provider);
-        }
+        public void AddProvider(ILoggerProvider provider) => this.Providers.Add(provider);
 
         public ILogger CreateLogger(string categoryName)
         {
             if (this._isDisposed)
                 throw new InvalidOperationException("This logger factory is already disposed.");
 
-            if (categoryName != typeof(BaseDiscordClient).FullName && categoryName != typeof(DiscordWebhookClient).FullName)
-                throw new ArgumentException($"This factory can only provide instances of loggers for {typeof(BaseDiscordClient).FullName} or {typeof(DiscordWebhookClient).FullName}.", nameof(categoryName));
-
-            return new CompositeDefaultLogger(this.Providers);
+            return categoryName != typeof(BaseDiscordClient).FullName && categoryName != typeof(DiscordWebhookClient).FullName
+                ? throw new ArgumentException($"This factory can only provide instances of loggers for {typeof(BaseDiscordClient).FullName} or {typeof(DiscordWebhookClient).FullName}.", nameof(categoryName))
+                : new CompositeDefaultLogger(this.Providers);
         }
 
         public void Dispose()

--- a/DSharpPlus/Logging/DefaultLoggerProvider.cs
+++ b/DSharpPlus/Logging/DefaultLoggerProvider.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus
@@ -29,15 +52,11 @@ namespace DSharpPlus
             if (this._isDisposed)
                 throw new InvalidOperationException("This logger provider is already disposed.");
 
-            if (categoryName != typeof(BaseDiscordClient).FullName && categoryName != typeof(DiscordWebhookClient).FullName)
-                throw new ArgumentException($"This provider can only provide instances of loggers for {typeof(BaseDiscordClient).FullName} or {typeof(DiscordWebhookClient).FullName}.", nameof(categoryName));
-
-            return new DefaultLogger(this.MinimumLevel, this.TimestampFormat);
+            return categoryName != typeof(BaseDiscordClient).FullName && categoryName != typeof(DiscordWebhookClient).FullName
+                ? throw new ArgumentException($"This provider can only provide instances of loggers for {typeof(BaseDiscordClient).FullName} or {typeof(DiscordWebhookClient).FullName}.", nameof(categoryName))
+                : new DefaultLogger(this.MinimumLevel, this.TimestampFormat);
         }
 
-        public void Dispose()
-        {
-            this._isDisposed = true;
-        }
+        public void Dispose() => this._isDisposed = true;
     }
 }

--- a/DSharpPlus/Logging/LoggerEvents.cs
+++ b/DSharpPlus/Logging/LoggerEvents.cs
@@ -1,4 +1,27 @@
-﻿using Microsoft.Extensions.Logging;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus
 {

--- a/DSharpPlus/Logging/ShardedLoggerFactory.cs
+++ b/DSharpPlus/Logging/ShardedLoggerFactory.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus
@@ -12,17 +35,13 @@ namespace DSharpPlus
             this.Logger = instance;
         }
 
-        public void AddProvider(ILoggerProvider provider)
-        {
-            throw new InvalidOperationException("This is a passthrough logger container, it cannot register new providers.");
-        }
+        public void AddProvider(ILoggerProvider provider) => throw new InvalidOperationException("This is a passthrough logger container, it cannot register new providers.");
 
         public ILogger CreateLogger(string categoryName)
         {
-            if (categoryName != typeof(BaseDiscordClient).FullName)
-                throw new ArgumentException($"This factory can only provide instances of loggers for {typeof(BaseDiscordClient).FullName}.", nameof(categoryName));
-
-            return this.Logger;
+            return categoryName != typeof(BaseDiscordClient).FullName
+                ? throw new ArgumentException($"This factory can only provide instances of loggers for {typeof(BaseDiscordClient).FullName}.", nameof(categoryName))
+                : this.Logger;
         }
 
         public void Dispose()

--- a/DSharpPlus/Net/Abstractions/AuditLogAbstractions.cs
+++ b/DSharpPlus/Net/Abstractions/AuditLogAbstractions.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using DSharpPlus.Entities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -48,15 +71,15 @@ namespace DSharpPlus.Net.Abstractions
         public object OldValue { get; set; }
 
         [JsonIgnore]
-        public IEnumerable<JObject> OldValues 
+        public IEnumerable<JObject> OldValues
             => (this.OldValue as JArray)?.ToObject<IEnumerable<JObject>>();
 
         [JsonIgnore]
-        public ulong OldValueUlong 
+        public ulong OldValueUlong
             => (ulong)this.OldValue;
 
         [JsonIgnore]
-        public string OldValueString 
+        public string OldValueString
             => (string)this.OldValue;
 
         // this can be a string or an array
@@ -64,15 +87,15 @@ namespace DSharpPlus.Net.Abstractions
         public object NewValue { get; set; }
 
         [JsonIgnore]
-        public IEnumerable<JObject> NewValues 
+        public IEnumerable<JObject> NewValues
             => (this.NewValue as JArray)?.ToObject<IEnumerable<JObject>>();
 
         [JsonIgnore]
-        public ulong NewValueUlong 
+        public ulong NewValueUlong
             => (ulong)this.NewValue;
 
         [JsonIgnore]
-        public string NewValueString 
+        public string NewValueString
             => (string)this.NewValue;
 
         [JsonProperty("key")]
@@ -95,7 +118,7 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("count")]
         public int Count { get; set; }
-        
+
         [JsonProperty("delete_member_days")]
         public int DeleteMemberDays { get; set; }
 

--- a/DSharpPlus/Net/Abstractions/ClientProperties.cs
+++ b/DSharpPlus/Net/Abstractions/ClientProperties.cs
@@ -1,4 +1,27 @@
-﻿using System.Reflection;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 using Newtonsoft.Json;
 
@@ -39,9 +62,7 @@ namespace DSharpPlus.Net.Abstractions
                     return "desktopbsd";
                 else if (plat.Contains("darwin"))
                     return "osx";
-                else if (plat.Contains("unix"))
-                    return "unix";
-                else return "toaster (unknown)";
+                else return plat.Contains("unix") ? "unix" : "toaster (unknown)";
             }
         }
 
@@ -63,21 +84,21 @@ namespace DSharpPlus.Net.Abstractions
         /// Gets the client's device.
         /// </summary>
         [JsonProperty("$device")]
-        public string Device 
+        public string Device
             => this.Browser;
 
         /// <summary>
         /// Gets the client's referrer.
         /// </summary>
         [JsonProperty("$referrer")]
-        public string Referrer 
+        public string Referrer
             => "";
 
         /// <summary>
         /// Gets the client's referring domain.
         /// </summary>
         [JsonProperty("$referring_domain")]
-        public string ReferringDomain 
+        public string ReferringDomain
             => "";
     }
 }

--- a/DSharpPlus/Net/Abstractions/FollowedChannelAddPayload.cs
+++ b/DSharpPlus/Net/Abstractions/FollowedChannelAddPayload.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions
 {

--- a/DSharpPlus/Net/Abstractions/Gateway/GatewayHello.cs
+++ b/DSharpPlus/Net/Abstractions/Gateway/GatewayHello.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions

--- a/DSharpPlus/Net/Abstractions/Gateway/GatewayIdentifyResume.cs
+++ b/DSharpPlus/Net/Abstractions/Gateway/GatewayIdentifyResume.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions
@@ -42,7 +65,7 @@ namespace DSharpPlus.Net.Abstractions
         /// Gets or sets the presence for this connection.
         /// </summary>
 		[JsonProperty("presence", NullValueHandling = NullValueHandling.Ignore)]
-		public StatusUpdate Presence { get; set; } = null;
+        public StatusUpdate Presence { get; set; } = null;
 
         /// <summary>
         /// Gets or sets the intent flags for this connection.

--- a/DSharpPlus/Net/Abstractions/Gateway/GatewayInfo.cs
+++ b/DSharpPlus/Net/Abstractions/Gateway/GatewayInfo.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Net

--- a/DSharpPlus/Net/Abstractions/Gateway/GatewayOpCode.cs
+++ b/DSharpPlus/Net/Abstractions/Gateway/GatewayOpCode.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Net.Abstractions
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Net.Abstractions
 {
     /// <summary>
     /// Specifies an OP code in a gateway payload.
@@ -24,7 +47,7 @@
         /// Used to update client status.
         /// </summary>
         StatusUpdate = 3,
-        
+
         /// <summary>
         /// Used to update voice state, when joining, leaving, or moving between voice channels.
         /// </summary>

--- a/DSharpPlus/Net/Abstractions/Gateway/GatewayPayload.cs
+++ b/DSharpPlus/Net/Abstractions/Gateway/GatewayPayload.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions
 {

--- a/DSharpPlus/Net/Abstractions/Gateway/GatewayRequestGuildMembers.cs
+++ b/DSharpPlus/Net/Abstractions/Gateway/GatewayRequestGuildMembers.cs
@@ -1,6 +1,29 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using DSharpPlus.Entities;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions
 {
@@ -25,6 +48,8 @@ namespace DSharpPlus.Net.Abstractions
         public string Nonce { get; internal set; }
 
         public GatewayRequestGuildMembers(DiscordGuild guild)
-            => this.GuildId = guild.Id;
+        {
+            this.GuildId = guild.Id;
+        }
     }
 }

--- a/DSharpPlus/Net/Abstractions/IOAuth2Payload.cs
+++ b/DSharpPlus/Net/Abstractions/IOAuth2Payload.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Net.Abstractions
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Net.Abstractions
 {
     internal interface IOAuth2Payload
     {

--- a/DSharpPlus/Net/Abstractions/ReadyPayload.cs
+++ b/DSharpPlus/Net/Abstractions/ReadyPayload.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using DSharpPlus.Entities;
 using Newtonsoft.Json;
 

--- a/DSharpPlus/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
@@ -1,6 +1,29 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System.Collections.Generic;
 using DSharpPlus.Entities;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions
 {

--- a/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
@@ -55,6 +55,9 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("rate_limit_per_user")]
         public Optional<int?> PerUserRateLimit { get; set; }
+
+        [JsonProperty("video_quality_mode", NullValueHandling = NullValueHandling.Ignore)]
+        public ChannelQualityMode? ChannelQualityMode { get; set; }
     }
 
     internal sealed class RestChannelModifyPayload
@@ -85,6 +88,9 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("rtc_region")]
         public Optional<string> RtcRegion { get; set; }
+
+        [JsonProperty("video_quality_mode", NullValueHandling = NullValueHandling.Ignore)]
+        public ChannelQualityMode? ChannelQualityMode { get; set; }
     }
 
     internal class RestChannelMessageEditPayload

--- a/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System.Collections.Generic;
 using DSharpPlus.Entities;
 using Newtonsoft.Json;
@@ -41,7 +64,7 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("position", NullValueHandling = NullValueHandling.Ignore)]
         public int? Position { get; set; }
-        
+
         [JsonProperty("topic")]
         public Optional<string> Topic { get; set; }
 
@@ -71,7 +94,7 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonIgnore]
         public bool HasContent { get; set; }
-        
+
         [JsonProperty("embed", NullValueHandling = NullValueHandling.Include)]
         public DiscordEmbed Embed { get; set; }
 
@@ -81,10 +104,10 @@ namespace DSharpPlus.Net.Abstractions
         [JsonIgnore]
         public bool HasEmbed { get; set; }
 
-        public bool ShouldSerializeContent() 
+        public bool ShouldSerializeContent()
             => this.HasContent;
 
-        public bool ShouldSerializeEmbed() 
+        public bool ShouldSerializeEmbed()
             => this.HasEmbed;
     }
 
@@ -92,7 +115,7 @@ namespace DSharpPlus.Net.Abstractions
     {
         [JsonProperty("tts", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsTTS { get; set; }
-        
+
         [JsonProperty("message_reference", NullValueHandling = NullValueHandling.Ignore)]
         public InternalDiscordMessageReference? MessageReference { get; set; }
     }
@@ -110,7 +133,7 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("allowed_mentions", NullValueHandling = NullValueHandling.Ignore)]
         public DiscordMentions Mentions { get; set; }
-        
+
         [JsonProperty("message_reference", NullValueHandling = NullValueHandling.Ignore)]
         public InternalDiscordMessageReference? MessageReference { get; set; }
     }

--- a/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using DSharpPlus.Entities;
 using Newtonsoft.Json;
@@ -53,7 +76,7 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("region")]
         public Optional<string> RegionId { get; set; }
-        
+
         [JsonProperty("icon")]
         public Optional<string> IconBase64 { get; set; }
 
@@ -84,7 +107,7 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("system_channel_id", NullValueHandling = NullValueHandling.Include)]
         public Optional<ulong?> SystemChannelId { get; set; }
     }
-    
+
     internal sealed class RestGuildMemberAddPayload : IOAuth2Payload
     {
         [JsonProperty("access_token")]
@@ -203,7 +226,7 @@ namespace DSharpPlus.Net.Abstractions
     {
         [JsonProperty("enabled", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Enabled { get; set; }
-        
+
         [JsonProperty("channel_id", NullValueHandling = NullValueHandling.Ignore)]
         public ulong? ChannelId { get; set; }
     }

--- a/DSharpPlus/Net/Abstractions/Rest/RestUserPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestUserPayloads.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions

--- a/DSharpPlus/Net/Abstractions/Rest/RestWebhookPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestWebhookPayloads.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using DSharpPlus.Entities;
 using Newtonsoft.Json;
 

--- a/DSharpPlus/Net/Abstractions/ShardInfo.cs
+++ b/DSharpPlus/Net/Abstractions/ShardInfo.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -32,7 +55,7 @@ namespace DSharpPlus.Net.Abstractions
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var arr = ReadArrayObject(reader, serializer);
+            var arr = this.ReadArrayObject(reader, serializer);
             return new ShardInfo
             {
                 ShardId = (int)arr[0],
@@ -42,15 +65,11 @@ namespace DSharpPlus.Net.Abstractions
 
         private JArray ReadArrayObject(JsonReader reader, JsonSerializer serializer)
         {
-            var arr = serializer.Deserialize<JToken>(reader) as JArray;
-            if (arr == null || arr.Count != 2)
-                throw new JsonSerializationException("Expected array of length 2");
-            return arr;
+            return serializer.Deserialize<JToken>(reader) is not JArray arr || arr.Count != 2
+                ? throw new JsonSerializationException("Expected array of length 2")
+                : arr;
         }
 
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType == typeof(ShardInfo);
-        }
+        public override bool CanConvert(Type objectType) => objectType == typeof(ShardInfo);
     }
 }

--- a/DSharpPlus/Net/Abstractions/StatusUpdate.cs
+++ b/DSharpPlus/Net/Abstractions/StatusUpdate.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions
@@ -31,23 +54,14 @@ namespace DSharpPlus.Net.Abstractions
         {
             get
             {
-                switch (this.Status)
+                return this.Status switch
                 {
-                    case UserStatus.Online:
-                        return "online";
-                        
-                    case UserStatus.Idle:
-                        return "idle";
-
-                    case UserStatus.DoNotDisturb:
-                        return "dnd";
-
-                    case UserStatus.Invisible:
-                    case UserStatus.Offline:
-                        return "invisible";
-                }
-
-                return "online";
+                    UserStatus.Online => "online",
+                    UserStatus.Idle => "idle",
+                    UserStatus.DoNotDisturb => "dnd",
+                    UserStatus.Invisible or UserStatus.Offline => "invisible",
+                    _ => "online",
+                };
             }
         }
 

--- a/DSharpPlus/Net/Abstractions/Transport/TransportActivity.cs
+++ b/DSharpPlus/Net/Abstractions/Transport/TransportActivity.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Globalization;
 using DSharpPlus.Entities;
 using Newtonsoft.Json;
@@ -198,7 +221,7 @@ namespace DSharpPlus.Net.Abstractions
             /// Gets the time the game has started.
             /// </summary>
             [JsonIgnore]
-            public DateTimeOffset? Start 
+            public DateTimeOffset? Start
                 => this._start != null ? (DateTimeOffset?)Utilities.GetDateTimeOffsetFromMilliseconds(this._start.Value, false) : null;
 
             [JsonProperty("start", NullValueHandling = NullValueHandling.Ignore)]
@@ -208,7 +231,7 @@ namespace DSharpPlus.Net.Abstractions
             /// Gets the time the game is going to end.
             /// </summary>
             [JsonIgnore]
-            public DateTimeOffset? End 
+            public DateTimeOffset? End
                 => this._end != null ? (DateTimeOffset?)Utilities.GetDateTimeOffsetFromMilliseconds(this._end.Value, false) : null;
 
             [JsonProperty("end", NullValueHandling = NullValueHandling.Ignore)]
@@ -244,14 +267,15 @@ namespace DSharpPlus.Net.Abstractions
     {
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            var sinfo = value as TransportActivity.GameParty.GamePartySize;
-            var obj = sinfo != null ? new object[] { sinfo.Current, sinfo.Maximum } : null;
+            var obj = value is TransportActivity.GameParty.GamePartySize sinfo
+                ? new object[] { sinfo.Current, sinfo.Maximum }
+                : null;
             serializer.Serialize(writer, obj);
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            var arr = ReadArrayObject(reader, serializer);
+            var arr = this.ReadArrayObject(reader, serializer);
             return new TransportActivity.GameParty.GamePartySize
             {
                 Current = (long)arr[0],
@@ -261,15 +285,11 @@ namespace DSharpPlus.Net.Abstractions
 
         private JArray ReadArrayObject(JsonReader reader, JsonSerializer serializer)
         {
-            var arr = serializer.Deserialize<JToken>(reader) as JArray;
-            if (arr == null || arr.Count != 2)
-                throw new JsonSerializationException("Expected array of length 2");
-            return arr;
+            return serializer.Deserialize<JToken>(reader) is not JArray arr || arr.Count != 2
+                ? throw new JsonSerializationException("Expected array of length 2")
+                : arr;
         }
 
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType == typeof(TransportActivity.GameParty.GamePartySize);
-        }
+        public override bool CanConvert(Type objectType) => objectType == typeof(TransportActivity.GameParty.GamePartySize);
     }
 }

--- a/DSharpPlus/Net/Abstractions/Transport/TransportApplication.cs
+++ b/DSharpPlus/Net/Abstractions/Transport/TransportApplication.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions

--- a/DSharpPlus/Net/Abstractions/Transport/TransportMember.cs
+++ b/DSharpPlus/Net/Abstractions/Transport/TransportMember.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/DSharpPlus/Net/Abstractions/Transport/TransportTeam.cs
+++ b/DSharpPlus/Net/Abstractions/Transport/TransportTeam.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions

--- a/DSharpPlus/Net/Abstractions/Transport/TransportUser.cs
+++ b/DSharpPlus/Net/Abstractions/Transport/TransportUser.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions
 {

--- a/DSharpPlus/Net/Abstractions/VoiceStateUpdate.cs
+++ b/DSharpPlus/Net/Abstractions/VoiceStateUpdate.cs
@@ -1,4 +1,27 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions
 {

--- a/DSharpPlus/Net/ConnectionEndpoint.cs
+++ b/DSharpPlus/Net/ConnectionEndpoint.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 
 namespace DSharpPlus.Net
 {
@@ -39,19 +62,13 @@ namespace DSharpPlus.Net
         /// Gets the hash code of this endpoint.
         /// </summary>
         /// <returns>Hash code of this endpoint.</returns>
-        public override int GetHashCode()
-        {
-            return 13 + 7 * this.Hostname.GetHashCode() + 7 * this.Port;
-        }
+        public override int GetHashCode() => 13 + (7 * this.Hostname.GetHashCode()) + (7 * this.Port);
 
         /// <summary>
         /// Gets the string representation of this connection endpoint.
         /// </summary>
         /// <returns>String representation of this endpoint.</returns>
-        public override string ToString()
-        {
-            return $"{this.Hostname}:{this.Port}";
-        }
+        public override string ToString() => $"{this.Hostname}:{this.Port}";
 
         internal string ToHttpString()
         {

--- a/DSharpPlus/Net/Models/ApplicationCommandEditModel.cs
+++ b/DSharpPlus/Net/Models/ApplicationCommandEditModel.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using DSharpPlus.Entities;
 
@@ -25,10 +48,11 @@ namespace DSharpPlus.Net.Models
         /// Sets the command's new description
         /// </summary>
         public Optional<string> Description
-        {   internal get => this._description;
-            set 
+        {
+            internal get => this._description;
+            set
             {
-                if(value.Value.Length > 100)
+                if (value.Value.Length > 100)
                     throw new ArgumentException("Slash command description cannot exceed 100 characters.", nameof(value));
                 this._description = value;
             }

--- a/DSharpPlus/Net/Models/BaseEditModel.cs
+++ b/DSharpPlus/Net/Models/BaseEditModel.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Net.Models
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Net.Models
 {
     public class BaseEditModel
     {

--- a/DSharpPlus/Net/Models/ChannelEditModel.cs
+++ b/DSharpPlus/Net/Models/ChannelEditModel.cs
@@ -76,6 +76,11 @@ namespace DSharpPlus.Net.Models
         /// </summary>
         public Optional<DiscordVoiceRegion> RtcRegion { internal get; set; }
 
+        /// <summary>
+        /// <para>Sets the voice channel's video quality.</para>
+        /// </summary>
+        public ChannelQualityMode? ChannelQualityMode { internal get; set; }
+
         internal ChannelEditModel() { }
     }
 }

--- a/DSharpPlus/Net/Models/ChannelEditModel.cs
+++ b/DSharpPlus/Net/Models/ChannelEditModel.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models
 {

--- a/DSharpPlus/Net/Models/GuildEditModel.cs
+++ b/DSharpPlus/Net/Models/GuildEditModel.cs
@@ -1,4 +1,27 @@
-﻿using System.IO;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.IO;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models
@@ -69,7 +92,7 @@ namespace DSharpPlus.Net.Models
         /// The new guild rules channel.
         /// </summary>
         public Optional<DiscordChannel> RulesChannel { internal get; set; }
-        
+
         /// <summary>
         /// The new guild public updates channel.
         /// </summary>

--- a/DSharpPlus/Net/Models/MemberEditModel.cs
+++ b/DSharpPlus/Net/Models/MemberEditModel.cs
@@ -1,9 +1,32 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models
 {
@@ -29,7 +52,7 @@ namespace DSharpPlus.Net.Models
         /// Voice channel to move this user to, set to null to kick
         /// </summary>
         public Optional<DiscordChannel> VoiceChannel { internal get; set; }
-        
+
         internal MemberEditModel()
         {
 

--- a/DSharpPlus/Net/Models/MembershipScreeningEditModel.cs
+++ b/DSharpPlus/Net/Models/MembershipScreeningEditModel.cs
@@ -1,4 +1,27 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models
 {

--- a/DSharpPlus/Net/Models/RoleEditModel.cs
+++ b/DSharpPlus/Net/Models/RoleEditModel.cs
@@ -1,9 +1,32 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models
 {
@@ -30,13 +53,13 @@ namespace DSharpPlus.Net.Models
         /// </summary>
 		public bool? Mentionable { internal get; set; }
 
-		internal RoleEditModel()
-		{
-			this.Name = null;
-			this.Permissions = null;
-			this.Color = null;
-			this.Hoist = null;
-			this.Mentionable = null;
-		}
+        internal RoleEditModel()
+        {
+            this.Name = null;
+            this.Permissions = null;
+            this.Color = null;
+            this.Hoist = null;
+            this.Mentionable = null;
+        }
     }
 }

--- a/DSharpPlus/Net/Models/WelcomeScreenEditModel.cs
+++ b/DSharpPlus/Net/Models/WelcomeScreenEditModel.cs
@@ -1,7 +1,30 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
 using System.Text;
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models
 {

--- a/DSharpPlus/Net/Rest/BaseRestRequest.cs
+++ b/DSharpPlus/Net/Rest/BaseRestRequest.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -76,16 +99,16 @@ namespace DSharpPlus.Net
         /// Asynchronously waits for this request to complete.
         /// </summary>
         /// <returns>HTTP response to this request.</returns>
-        public Task<RestResponse> WaitForCompletionAsync() 
+        public Task<RestResponse> WaitForCompletionAsync()
             => this.RequestTaskSource.Task;
 
-        protected internal void SetCompleted(RestResponse response) 
+        protected internal void SetCompleted(RestResponse response)
             => this.RequestTaskSource.SetResult(response);
 
-        protected internal void SetFaulted(Exception ex) 
+        protected internal void SetFaulted(Exception ex)
             => this.RequestTaskSource.SetException(ex);
 
-        protected internal bool TrySetFaulted(Exception ex) 
+        protected internal bool TrySetFaulted(Exception ex)
             => this.RequestTaskSource.TrySetException(ex);
 
     }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -706,7 +706,7 @@ namespace DSharpPlus.Net
         #endregion
 
         #region Channel
-        internal async Task<DiscordChannel> CreateGuildChannelAsync(ulong guild_id, string name, ChannelType type, ulong? parent, Optional<string> topic, int? bitrate, int? user_limit, IEnumerable<DiscordOverwriteBuilder> overwrites, bool? nsfw, Optional<int?> perUserRateLimit, string reason)
+        internal async Task<DiscordChannel> CreateGuildChannelAsync(ulong guild_id, string name, ChannelType type, ulong? parent, Optional<string> topic, int? bitrate, int? user_limit, IEnumerable<DiscordOverwriteBuilder> overwrites, bool? nsfw, Optional<int?> perUserRateLimit, ChannelQualityMode? channelQualityMode,string reason)
         {
             var restoverwrites = new List<DiscordRestOverwrite>();
             if (overwrites != null)
@@ -723,7 +723,8 @@ namespace DSharpPlus.Net
                 UserLimit = user_limit,
                 PermissionOverwrites = restoverwrites,
                 Nsfw = nsfw,
-                PerUserRateLimit = perUserRateLimit
+                PerUserRateLimit = perUserRateLimit,
+                ChannelQualityMode = channelQualityMode
             };
 
             var headers = Utilities.GetBaseHeaders();
@@ -747,7 +748,7 @@ namespace DSharpPlus.Net
             return ret;
         }
 
-        internal Task ModifyChannelAsync(ulong channel_id, string name, int? position, Optional<string> topic, bool? nsfw, Optional<ulong?> parent, int? bitrate, int? user_limit, Optional<int?> perUserRateLimit, Optional<string> rtcRegion, string reason)
+        internal Task ModifyChannelAsync(ulong channel_id, string name, int? position, Optional<string> topic, bool? nsfw, Optional<ulong?> parent, int? bitrate, int? user_limit, Optional<int?> perUserRateLimit, Optional<string> rtcRegion, ChannelQualityMode? channelQualityMode, string reason)
         {
             var pld = new RestChannelModifyPayload
             {
@@ -759,7 +760,8 @@ namespace DSharpPlus.Net
                 Bitrate = bitrate,
                 UserLimit = user_limit,
                 PerUserRateLimit = perUserRateLimit,
-                RtcRegion = rtcRegion
+                RtcRegion = rtcRegion,
+                ChannelQualityMode = channelQualityMode
             };
 
             var headers = Utilities.GetBaseHeaders();

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
@@ -53,14 +76,14 @@ namespace DSharpPlus.Net
             var ret = msg_raw.ToDiscordObject<DiscordMessage>();
             ret.Discord = this.Discord;
 
-            PopulateMessage(author, ret);
+            this.PopulateMessage(author, ret);
 
             var referencedMsg = msg_raw["referenced_message"];
             if (ret.MessageType == MessageType.Reply && !string.IsNullOrWhiteSpace(referencedMsg?.ToString()))
             {
                 author = referencedMsg["author"].ToObject<TransportUser>();
                 ret.ReferencedMessage.Discord = this.Discord;
-                PopulateMessage(author, ret.ReferencedMessage);
+                this.PopulateMessage(author, ret.ReferencedMessage);
             }
 
             return ret;
@@ -454,23 +477,19 @@ namespace DSharpPlus.Net
             ret.Discord = this.Discord;
             ret.Guild = this.Discord.Guilds[guild_id];
 
-            if (ret.Guild == null)
-            {
-                ret.Channels = rawChannels.Select(r => new DiscordChannel {
+            ret.Channels = ret.Guild == null
+                ? rawChannels.Select(r => new DiscordChannel
+                {
                     Id = (ulong)r["id"],
                     Name = r["name"].ToString(),
                     Position = (int)r["position"]
-                }).ToList();
-            }
-            else
-            {
-                ret.Channels = rawChannels.Select(r =>
+                }).ToList()
+                : rawChannels.Select(r =>
                 {
-                    DiscordChannel c = ret.Guild.GetChannel((ulong)r["id"]);
+                    var c = ret.Guild.GetChannel((ulong)r["id"]);
                     c.Position = (int)r["position"];
                     return c;
                 }).ToList();
-            }
 
             return ret;
         }
@@ -828,7 +847,7 @@ namespace DSharpPlus.Net
             if (replyMessageId != null)
                 pld.MessageReference = new InternalDiscordMessageReference { MessageId = replyMessageId, FailIfNotExists = failOnInvalidReply };
 
-                if (replyMessageId != null)
+            if (replyMessageId != null)
                 pld.Mentions = new DiscordMentions(Mentions.None, mentionReply);
 
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
@@ -859,7 +878,7 @@ namespace DSharpPlus.Net
             };
 
             if (builder.ReplyId != null)
-                pld.MessageReference = new InternalDiscordMessageReference { MessageId = builder.ReplyId, FailIfNotExists = builder.FailOnInvalidReply};
+                pld.MessageReference = new InternalDiscordMessageReference { MessageId = builder.ReplyId, FailIfNotExists = builder.FailOnInvalidReply };
 
 
             if (builder.Mentions != null || builder.ReplyId != null)
@@ -1523,7 +1542,7 @@ namespace DSharpPlus.Net
                 var roleArray = include_roles.ToArray();
                 var roleArrayCount = roleArray.Count();
 
-                for (int i = 0; i < roleArrayCount; i++)
+                for (var i = 0; i < roleArrayCount; i++)
                     sb.Append($"&include_roles={roleArray[i]}");
             }
 
@@ -1555,7 +1574,7 @@ namespace DSharpPlus.Net
                 var roleArray = include_roles.ToArray();
                 var roleArrayCount = roleArray.Count();
 
-                for (int i = 0; i < roleArrayCount; i++)
+                for (var i = 0; i < roleArrayCount; i++)
                     sb.Append($"&include_roles={roleArray[i]}");
             }
 
@@ -2222,10 +2241,9 @@ namespace DSharpPlus.Net
             emoji.Guild = gld;
 
             var xtu = emoji_raw["user"]?.ToObject<TransportUser>();
-            if (xtu != null)
-                emoji.User = gld != null && gld.Members.TryGetValue(xtu.Id, out var member) ? member : new DiscordUser(xtu);
-            else
-                emoji.User = this.Discord.CurrentUser;
+            emoji.User = xtu != null
+                ? gld != null && gld.Members.TryGetValue(xtu.Id, out var member) ? member : new DiscordUser(xtu)
+                : this.Discord.CurrentUser;
 
             return emoji;
         }
@@ -2293,7 +2311,7 @@ namespace DSharpPlus.Net
         internal async Task<IReadOnlyList<DiscordApplicationCommand>> BulkOverwriteGlobalApplicationCommandsAsync(ulong application_id, IEnumerable<DiscordApplicationCommand> commands)
         {
             var pld = new List<RestApplicationCommandCreatePayload>();
-            foreach(var command in commands)
+            foreach (var command in commands)
             {
                 pld.Add(new RestApplicationCommandCreatePayload
                 {
@@ -2608,7 +2626,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route, headers).ConfigureAwait(false);
 
-            var info = (JObject.Parse(res.Response)).ToObject<GatewayInfo>();
+            var info = JObject.Parse(res.Response).ToObject<GatewayInfo>();
             info.SessionBucket.ResetAfter = DateTimeOffset.UtcNow + TimeSpan.FromMilliseconds(info.SessionBucket.resetAfter);
             return info;
         }

--- a/DSharpPlus/Net/Rest/Endpoints.cs
+++ b/DSharpPlus/Net/Rest/Endpoints.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Net
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Net
 {
     internal static class Endpoints
     {

--- a/DSharpPlus/Net/Rest/IpEndpoint.cs
+++ b/DSharpPlus/Net/Rest/IpEndpoint.cs
@@ -1,4 +1,27 @@
-﻿using System.Net;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Net;
 
 namespace DSharpPlus.Net
 {

--- a/DSharpPlus/Net/Rest/MultipartWebRequest.cs
+++ b/DSharpPlus/Net/Rest/MultipartWebRequest.cs
@@ -1,9 +1,32 @@
-﻿using DSharpPlus.Entities;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net
 {
@@ -22,7 +45,7 @@ namespace DSharpPlus.Net
         /// </summary>
         public IReadOnlyDictionary<string, Stream> Files { get; }
 
-        internal MultipartWebRequest(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, string route, IReadOnlyDictionary<string, string> headers = null, IReadOnlyDictionary<string, string> values = null, 
+        internal MultipartWebRequest(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, string route, IReadOnlyDictionary<string, string> headers = null, IReadOnlyDictionary<string, string> values = null,
             IReadOnlyCollection<DiscordMessageFile> files = null, double? ratelimit_wait_override = null)
             : base(client, bucket, url, method, route, headers, ratelimit_wait_override)
         {

--- a/DSharpPlus/Net/Rest/RateLimitBucket.cs
+++ b/DSharpPlus/Net/Rest/RateLimitBucket.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
@@ -33,16 +56,13 @@ namespace DSharpPlus.Net
         /// <summary>
         /// Gets or sets the ratelimit hash of this bucket.
         /// </summary>
-        public string Hash 
-        { 
+        public string Hash
+        {
             get => Volatile.Read(ref this._hash);
 
             internal set
             {
-                if (value.Contains(UNLIMITED_HASH))
-                    this.IsUnlimited = true;
-                else
-                    this.IsUnlimited = false;
+                this.IsUnlimited = value.Contains(UNLIMITED_HASH);
 
                 if (this.BucketId != null && !this.BucketId.StartsWith(value))
                 {
@@ -70,7 +90,7 @@ namespace DSharpPlus.Net
         /// <summary>
         /// Gets the number of uses left before pre-emptive rate limit is triggered.
         /// </summary>
-        public int Remaining 
+        public int Remaining
             => this._remaining;
 
         /// <summary>
@@ -185,13 +205,10 @@ namespace DSharpPlus.Net
         /// <returns>Whether the <see cref="RateLimitBucket"/> is equal to this <see cref="RateLimitBucket"/>.</returns>
         public bool Equals(RateLimitBucket e)
         {
-            if (ReferenceEquals(e, null))
+            if (e is null)
                 return false;
 
-            if (ReferenceEquals(this, e))
-                return true;
-
-            return this.BucketId == e.BucketId;
+            return ReferenceEquals(this, e) ? true : this.BucketId == e.BucketId;
         }
 
         /// <summary>

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
@@ -44,7 +67,7 @@ namespace DSharpPlus.Net
             this.HttpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", Utilities.GetFormattedToken(client));
         }
 
-        internal RestClient(IWebProxy proxy, TimeSpan timeout, bool useRelativeRatelimit, 
+        internal RestClient(IWebProxy proxy, TimeSpan timeout, bool useRelativeRatelimit,
             ILogger logger) // This is for meta-clients, such as the webhook client
         {
             this.Logger = logger;
@@ -88,10 +111,7 @@ namespace DSharpPlus.Net
                     rparams[xp.Name] = dt.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture);
                 else if (val is DateTimeOffset dto)
                     rparams[xp.Name] = dto.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture);
-                else if (val is IFormattable xf)
-                    rparams[xp.Name] = xf.ToString(null, CultureInfo.InvariantCulture);
-                else
-                    rparams[xp.Name] = val.ToString();
+                else rparams[xp.Name] = val is IFormattable xf ? xf.ToString(null, CultureInfo.InvariantCulture) : val.ToString();
             }
 
             var guild_id = rparams.ContainsKey("guild_id") ? rparams["guild_id"] : "";
@@ -145,12 +165,9 @@ namespace DSharpPlus.Net
 
         public Task ExecuteRequestAsync(BaseRestRequest request)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
-
-            return ExecuteRequestAsync(request, null, null);
+            return request == null ? throw new ArgumentNullException(nameof(request)) : this.ExecuteRequestAsync(request, null, null);
         }
-        
+
         // to allow proper rescheduling of the first request from a bucket
         private async Task ExecuteRequestAsync(BaseRestRequest request, RateLimitBucket bucket, TaskCompletionSource<bool> ratelimitTcs)
         {
@@ -216,7 +233,7 @@ namespace DSharpPlus.Net
                     if (this._disposed)
                         return;
 
-                    res = await HttpClient.SendAsync(req, HttpCompletionOption.ResponseContentRead, CancellationToken.None).ConfigureAwait(false);
+                    res = await this.HttpClient.SendAsync(req, HttpCompletionOption.ResponseContentRead, CancellationToken.None).ConfigureAwait(false);
 
                     var bts = await res.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
                     var txt = Utilities.UTF8.GetString(bts, 0, bts.Length);
@@ -352,7 +369,7 @@ namespace DSharpPlus.Net
             bucket._limitTesting = 0;
 
             //Reset to initial values.
-            if(resetToInitial)
+            if (resetToInitial)
             {
                 this.UpdateHashCaches(request, bucket);
                 bucket.Maximum = 0;
@@ -385,7 +402,7 @@ namespace DSharpPlus.Net
                 // it can take a couple of cycles for the task to be allocated, so wait until it happens or we are no longer probing for the limits
                 Task waitTask = null;
                 while (bucket._limitTesting != 0 && (waitTask = bucket._limitTestFinished) == null)
-                    await Task.Yield(); 
+                    await Task.Yield();
                 if (waitTask != null)
                     await waitTask.ConfigureAwait(false);
 
@@ -413,7 +430,7 @@ namespace DSharpPlus.Net
             {
                 this.Logger.LogTrace(LoggerEvents.RestTx, "<multipart request>");
 
-                string boundary = "---------------------------" + DateTime.Now.Ticks.ToString("x");
+                var boundary = "---------------------------" + DateTime.Now.Ticks.ToString("x");
 
                 req.Headers.Add("Connection", "keep-alive");
                 req.Headers.Add("Keep-Alive", "600");
@@ -427,7 +444,7 @@ namespace DSharpPlus.Net
                 {
                     var i = 1;
                     foreach (var f in mprequest.Files)
-                        content.Add(new StreamContent(f.Value), $"file{(i++).ToString(CultureInfo.InvariantCulture)}", f.Key);
+                        content.Add(new StreamContent(f.Value), $"file{i++.ToString(CultureInfo.InvariantCulture)}", f.Key);
                 }
 
                 req.Content = content;
@@ -554,7 +571,7 @@ namespace DSharpPlus.Net
                 return;
 
             // This is an unlimited bucket, which we don't need to keep track of.
-            if(newHash == null)
+            if (newHash == null)
             {
                 _ = this.RoutesToHashes.TryRemove(hashKey, out _);
                 _ = this.HashesToBuckets.TryRemove(bucket.BucketId, out _);
@@ -577,7 +594,7 @@ namespace DSharpPlus.Net
 
                     // Remove the old unlimited bucket.
                     _ = this.HashesToBuckets.TryRemove(oldBucketId, out _);
-                    _ = this.HashesToBuckets.AddOrUpdate(bucketId, bucket, (key, oldBucket) => { return bucket; });
+                    _ = this.HashesToBuckets.AddOrUpdate(bucketId, bucket, (key, oldBucket) => bucket);
 
                     return newHash;
                 });
@@ -588,7 +605,7 @@ namespace DSharpPlus.Net
 
         private async Task CleanupBucketsAsync()
         {
-            while(!this._bucketCleanerTokenSource.IsCancellationRequested)
+            while (!this._bucketCleanerTokenSource.IsCancellationRequested)
             {
                 try
                 {
@@ -604,11 +621,11 @@ namespace DSharpPlus.Net
                 {
                     var bucket = this.HashesToBuckets.Values.FirstOrDefault(x => x.RouteHashes.Contains(key));
 
-                    if(bucket == null || bucket != null && bucket.LastAttemptAt.AddSeconds(5) < DateTimeOffset.UtcNow)
+                    if (bucket == null || (bucket != null && bucket.LastAttemptAt.AddSeconds(5) < DateTimeOffset.UtcNow))
                         _ = this.RequestQueue.TryRemove(key, out _);
                 }
 
-                int removedBuckets = 0;
+                var removedBuckets = 0;
                 StringBuilder bucketIdStrBuilder = default;
 
                 foreach (var kvp in this.HashesToBuckets)
@@ -626,7 +643,7 @@ namespace DSharpPlus.Net
                     var resetOffset = this.UseResetAfter ? value._resetAfterOffset : value.Reset;
 
                     // Don't remove the bucket if it's reset date is less than now + the additional wait time, unless it's an unlimited bucket.
-                    if (resetOffset != null && !value.IsUnlimited && (resetOffset > DateTimeOffset.UtcNow || (DateTimeOffset.UtcNow - resetOffset) < this._bucketCleanupDelay))
+                    if (resetOffset != null && !value.IsUnlimited && (resetOffset > DateTimeOffset.UtcNow || DateTimeOffset.UtcNow - resetOffset < this._bucketCleanupDelay))
                         continue;
 
                     _ = this.HashesToBuckets.TryRemove(key, out _);

--- a/DSharpPlus/Net/Rest/RestRequest.cs
+++ b/DSharpPlus/Net/Rest/RestRequest.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 
 namespace DSharpPlus.Net

--- a/DSharpPlus/Net/Rest/RestRequestMethod.cs
+++ b/DSharpPlus/Net/Rest/RestRequestMethod.cs
@@ -1,4 +1,27 @@
-﻿namespace DSharpPlus.Net
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Net
 {
     /// <summary>
     /// Defines the HTTP method to use for an HTTP request.

--- a/DSharpPlus/Net/Rest/RestResponse.cs
+++ b/DSharpPlus/Net/Rest/RestResponse.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections.Generic;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
 
 namespace DSharpPlus.Net
 {

--- a/DSharpPlus/Net/Rest/SessionBucket.cs
+++ b/DSharpPlus/Net/Rest/SessionBucket.cs
@@ -1,5 +1,28 @@
-﻿using Newtonsoft.Json;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
+using Newtonsoft.Json;
 
 namespace DSharpPlus.Net
 {

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -22,22 +45,17 @@ namespace DSharpPlus.Net.Serialization
         /// <summary>Serializes the specified object to a JSON string.</summary>
         /// <param name="value">The object to serialize.</param>
         /// <returns>A JSON string representation of the object.</returns>
-        public static string SerializeObject(object value)
-        {
-            return SerializeObjectInternal(value, null, Serializer);
-        }
+        public static string SerializeObject(object value) => SerializeObjectInternal(value, null, Serializer);
 
         /// <summary>Populates an object with the values from a JSON node.</summary>
         /// <param name="value">The token to populate the object with.</param>
         /// <param name="target">The object to populate.</param>
         public static void PopulateObject(JToken value, object target)
         {
-            using (var reader = value.CreateReader())
-            {
-                Serializer.Populate(reader, target);
-            }
+            using var reader = value.CreateReader();
+            Serializer.Populate(reader, target);
         }
-        
+
         /// <summary>
         /// Converts this token into an object, passing any properties through extra <see cref="JsonConverter"/>s if
         /// needed.
@@ -45,11 +63,8 @@ namespace DSharpPlus.Net.Serialization
         /// <param name="token">The token to convert</param>
         /// <typeparam name="T">Type to convert to</typeparam>
         /// <returns>The converted token</returns>
-        public static T ToDiscordObject<T>(this JToken token)
-        {
-            return token.ToObject<T>(Serializer);
-        }
-        
+        public static T ToDiscordObject<T>(this JToken token) => token.ToObject<T>(Serializer);
+
         private static string SerializeObjectInternal(object value, Type type, JsonSerializer jsonSerializer)
         {
             var stringWriter = new StringWriter(new StringBuilder(256), CultureInfo.InvariantCulture);

--- a/DSharpPlus/Net/Serialization/SnowflakeArrayAsDictionaryJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/SnowflakeArrayAsDictionaryJsonConverter.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
@@ -47,12 +70,12 @@ namespace DSharpPlus.Net.Serialization
             {
                 properties.SetValue(dict, entry, new object[]
                 {
-                    (entry as SnowflakeObject)?.Id 
-                    ?? (entry as DiscordVoiceState)?.UserId 
+                    (entry as SnowflakeObject)?.Id
+                    ?? (entry as DiscordVoiceState)?.UserId
                     ?? throw new InvalidOperationException($"Type {entry?.GetType()} is not deserializable")
                 });
             }
-            
+
             return dict;
         }
 

--- a/DSharpPlus/Net/Udp/BaseUdpClient.cs
+++ b/DSharpPlus/Net/Udp/BaseUdpClient.cs
@@ -1,4 +1,27 @@
-﻿using System.Threading.Tasks;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Threading.Tasks;
 
 namespace DSharpPlus.Net.Udp
 {

--- a/DSharpPlus/Net/Udp/DspUdpClient.cs
+++ b/DSharpPlus/Net/Udp/DspUdpClient.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Concurrent;
 using System.Net.Sockets;
 using System.Threading;
@@ -54,10 +77,7 @@ namespace DSharpPlus.Net.Udp
         /// <returns>The received bytes.</returns>
         public override Task<byte[]> ReceiveAsync()
         {
-            if (this.PacketQueue.Count > 0)
-                return Task.FromResult(this.PacketQueue.Take());
-
-            return Task.Run(() => this.PacketQueue.Take());
+            return this.PacketQueue.Count > 0 ? Task.FromResult(this.PacketQueue.Take()) : Task.Run(() => this.PacketQueue.Take());
         }
 
         /// <summary>
@@ -75,7 +95,7 @@ namespace DSharpPlus.Net.Udp
             // dequeue all the packets
             this.PacketQueue.Dispose();
         }
-        
+
         private async Task ReceiverLoopAsync()
         {
             while (!this.Token.IsCancellationRequested)

--- a/DSharpPlus/Net/WebSocket/IWebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/IWebSocketClient.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;

--- a/DSharpPlus/Net/WebSocket/PayloadDecompressor.cs
+++ b/DSharpPlus/Net/WebSocket/PayloadDecompressor.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Buffers.Binary;
 using System.IO;
 using System.IO.Compression;

--- a/DSharpPlus/Net/WebSocket/SocketLock.cs
+++ b/DSharpPlus/Net/WebSocket/SocketLock.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/DSharpPlus/Net/WebSocket/WebSocketClient.cs
+++ b/DSharpPlus/Net/WebSocket/WebSocketClient.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -26,7 +49,7 @@ namespace DSharpPlus.Net.WebSocket
 
         /// <inheritdoc />
         public IReadOnlyDictionary<string, string> DefaultHeaders { get; }
-        private Dictionary<string, string> _defaultHeaders;
+        private readonly Dictionary<string, string> _defaultHeaders;
 
         private Task _receiverTask;
         private CancellationTokenSource _receiverTokenSource;
@@ -211,61 +234,59 @@ namespace DSharpPlus.Net.WebSocket
 
             try
             {
-                using (var bs = new MemoryStream())
+                using var bs = new MemoryStream();
+                while (!token.IsCancellationRequested)
                 {
-                    while (!token.IsCancellationRequested)
+                    // See https://github.com/RogueException/Discord.Net/commit/ac389f5f6823e3a720aedd81b7805adbdd78b66d 
+                    // for explanation on the cancellation token
+
+                    WebSocketReceiveResult result;
+                    byte[] resultBytes;
+                    do
                     {
-                        // See https://github.com/RogueException/Discord.Net/commit/ac389f5f6823e3a720aedd81b7805adbdd78b66d 
-                        // for explanation on the cancellation token
+                        result = await this._ws.ReceiveAsync(buffer, CancellationToken.None).ConfigureAwait(false);
 
-                        WebSocketReceiveResult result;
-                        byte[] resultBytes;
-                        do
-                        {
-                            result = await this._ws.ReceiveAsync(buffer, CancellationToken.None).ConfigureAwait(false);
-
-                            if (result.MessageType == WebSocketMessageType.Close)
-                                break;
-
-                            bs.Write(buffer.Array, 0, result.Count);
-                        }
-                        while (!result.EndOfMessage);
-
-                        resultBytes = new byte[bs.Length];
-                        bs.Position = 0;
-                        bs.Read(resultBytes, 0, resultBytes.Length);
-                        bs.Position = 0;
-                        bs.SetLength(0);
-
-                        if (!this._isConnected && result.MessageType != WebSocketMessageType.Close)
-                        {
-                            this._isConnected = true;
-                            await this._connected.InvokeAsync(this, new SocketEventArgs()).ConfigureAwait(false);
-                        }
-
-                        if (result.MessageType == WebSocketMessageType.Binary)
-                        {
-                            await this._messageReceived.InvokeAsync(this, new SocketBinaryMessageEventArgs(resultBytes)).ConfigureAwait(false);
-                        }
-                        else if (result.MessageType == WebSocketMessageType.Text)
-                        {
-                            await this._messageReceived.InvokeAsync(this, new SocketTextMessageEventArgs(Utilities.UTF8.GetString(resultBytes))).ConfigureAwait(false);
-                        }
-                        else // close
-                        {
-                            if (!this._isClientClose)
-                            {
-                                var code = result.CloseStatus.Value;
-                                code = code == WebSocketCloseStatus.NormalClosure || code == WebSocketCloseStatus.EndpointUnavailable
-                                    ? (WebSocketCloseStatus)4000
-                                    : code;
-
-                                await this._ws.CloseOutputAsync(code, result.CloseStatusDescription, CancellationToken.None).ConfigureAwait(false);
-                            }
-
-                            await this._disconnected.InvokeAsync(this, new SocketCloseEventArgs() { CloseCode = (int)result.CloseStatus, CloseMessage = result.CloseStatusDescription }).ConfigureAwait(false);
+                        if (result.MessageType == WebSocketMessageType.Close)
                             break;
+
+                        bs.Write(buffer.Array, 0, result.Count);
+                    }
+                    while (!result.EndOfMessage);
+
+                    resultBytes = new byte[bs.Length];
+                    bs.Position = 0;
+                    bs.Read(resultBytes, 0, resultBytes.Length);
+                    bs.Position = 0;
+                    bs.SetLength(0);
+
+                    if (!this._isConnected && result.MessageType != WebSocketMessageType.Close)
+                    {
+                        this._isConnected = true;
+                        await this._connected.InvokeAsync(this, new SocketEventArgs()).ConfigureAwait(false);
+                    }
+
+                    if (result.MessageType == WebSocketMessageType.Binary)
+                    {
+                        await this._messageReceived.InvokeAsync(this, new SocketBinaryMessageEventArgs(resultBytes)).ConfigureAwait(false);
+                    }
+                    else if (result.MessageType == WebSocketMessageType.Text)
+                    {
+                        await this._messageReceived.InvokeAsync(this, new SocketTextMessageEventArgs(Utilities.UTF8.GetString(resultBytes))).ConfigureAwait(false);
+                    }
+                    else // close
+                    {
+                        if (!this._isClientClose)
+                        {
+                            var code = result.CloseStatus.Value;
+                            code = code == WebSocketCloseStatus.NormalClosure || code == WebSocketCloseStatus.EndpointUnavailable
+                                ? (WebSocketCloseStatus)4000
+                                : code;
+
+                            await this._ws.CloseOutputAsync(code, result.CloseStatusDescription, CancellationToken.None).ConfigureAwait(false);
                         }
+
+                        await this._disconnected.InvokeAsync(this, new SocketCloseEventArgs() { CloseCode = (int)result.CloseStatus, CloseMessage = result.CloseStatusDescription }).ConfigureAwait(false);
+                        break;
                     }
                 }
             }
@@ -297,7 +318,7 @@ namespace DSharpPlus.Net.WebSocket
             add => this._connected.Register(value);
             remove => this._connected.Unregister(value);
         }
-        private AsyncEvent<WebSocketClient, SocketEventArgs> _connected;
+        private readonly AsyncEvent<WebSocketClient, SocketEventArgs> _connected;
 
         /// <summary>
         /// Triggered when the client is disconnected.
@@ -307,7 +328,7 @@ namespace DSharpPlus.Net.WebSocket
             add => this._disconnected.Register(value);
             remove => this._disconnected.Unregister(value);
         }
-        private AsyncEvent<WebSocketClient, SocketCloseEventArgs> _disconnected;
+        private readonly AsyncEvent<WebSocketClient, SocketCloseEventArgs> _disconnected;
 
         /// <summary>
         /// Triggered when the client receives a message from the remote party.
@@ -317,7 +338,7 @@ namespace DSharpPlus.Net.WebSocket
             add => this._messageReceived.Register(value);
             remove => this._messageReceived.Unregister(value);
         }
-        private AsyncEvent<WebSocketClient, SocketMessageEventArgs> _messageReceived;
+        private readonly AsyncEvent<WebSocketClient, SocketMessageEventArgs> _messageReceived;
 
         /// <summary>
         /// Triggered when an error occurs in the client.
@@ -327,7 +348,7 @@ namespace DSharpPlus.Net.WebSocket
             add => this._exceptionThrown.Register(value);
             remove => this._exceptionThrown.Unregister(value);
         }
-        private AsyncEvent<WebSocketClient, SocketErrorEventArgs> _exceptionThrown;
+        private readonly AsyncEvent<WebSocketClient, SocketErrorEventArgs> _exceptionThrown;
 
         private void EventErrorHandler<TArgs>(AsyncEvent<WebSocketClient, TArgs> asyncEvent, Exception ex, AsyncEventHandler<WebSocketClient, TArgs> handler, WebSocketClient sender, TArgs eventArgs)
             where TArgs : AsyncEventArgs

--- a/DSharpPlus/Properties/AssemblyProperties.cs
+++ b/DSharpPlus/Properties/AssemblyProperties.cs
@@ -1,4 +1,26 @@
-﻿// This defines properties of this assembly
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("DSharpPlus.CommandsNext")]

--- a/DSharpPlus/QueryUriBuilder.cs
+++ b/DSharpPlus/QueryUriBuilder.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,13 +32,13 @@ namespace DSharpPlus
         public Uri SourceUri { get; }
 
         public IReadOnlyList<KeyValuePair<string, string>> QueryParameters => this._queryParams;
-        private readonly List<KeyValuePair<string, string>> _queryParams = new List<KeyValuePair<string, string>>();
+        private readonly List<KeyValuePair<string, string>> _queryParams = new();
 
         public QueryUriBuilder(string uri)
         {
             if (uri == null)
                 throw new ArgumentNullException(nameof(uri));
-            
+
             this.SourceUri = new Uri(uri);
         }
 
@@ -23,7 +46,7 @@ namespace DSharpPlus
         {
             if (uri == null)
                 throw new ArgumentNullException(nameof(uri));
-            
+
             this.SourceUri = uri;
         }
 
@@ -42,9 +65,6 @@ namespace DSharpPlus
             }.Uri;
         }
 
-        public override string ToString()
-        {
-            return Build().ToString();
-        }
+        public override string ToString() => this.Build().ToString();
     }
 }

--- a/DSharpPlus/ReadOnlyConcurrentDictionary.cs
+++ b/DSharpPlus/ReadOnlyConcurrentDictionary.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
@@ -34,7 +57,7 @@ namespace DSharpPlus
         public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => this._underlyingDict.GetEnumerator();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable) this._underlyingDict).GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)this._underlyingDict).GetEnumerator();
 
         public int Count => this._underlyingDict.Count;
 

--- a/DSharpPlus/ReadOnlySet.cs
+++ b/DSharpPlus/ReadOnlySet.cs
@@ -1,4 +1,27 @@
-﻿using System.Collections;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -33,7 +56,7 @@ namespace DSharpPlus
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IEnumerator<T> GetEnumerator()
             => this._underlyingSet.GetEnumerator();
-        
+
         /// <summary>
         /// Returns an enumerator that iterates through this set view.
         /// </summary>

--- a/DSharpPlus/RingBuffer.cs
+++ b/DSharpPlus/RingBuffer.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,13 +47,13 @@ namespace DSharpPlus
         /// <summary>
         /// Gets the number of items in this ring buffer.
         /// </summary>
-        public int Count 
+        public int Count
             => this._reached_end ? this.Capacity : this.CurrentIndex;
 
         /// <summary>
         /// Gets whether this ring buffer is read-only.
         /// </summary>
-        public bool IsReadOnly 
+        public bool IsReadOnly
             => false;
 
         /// <summary>
@@ -124,7 +147,7 @@ namespace DSharpPlus
                 }
             }
 
-            item = default(T);
+            item = default;
             return false;
         }
 
@@ -134,7 +157,7 @@ namespace DSharpPlus
         public void Clear()
         {
             for (var i = 0; i < this.InternalBuffer.Length; i++)
-                this.InternalBuffer[i] = default(T);
+                this.InternalBuffer[i] = default;
 
             this.CurrentIndex = 0;
         }
@@ -145,20 +168,14 @@ namespace DSharpPlus
         /// <param name="item">Item to check for.</param>
         /// <returns>Whether the buffer contains the item.</returns>
         /// <exception cref="NotImplementedException" />
-        public bool Contains(T item)
-        {
-            throw new NotImplementedException("This method is not implemented. Use .Contains(predicate) instead.");
-        }
+        public bool Contains(T item) => throw new NotImplementedException("This method is not implemented. Use .Contains(predicate) instead.");
 
         /// <summary>
         /// Checks whether given item is present in the buffer using given predicate to find it.
         /// </summary>
         /// <param name="predicate">Predicate used to check for the item.</param>
         /// <returns>Whether the buffer contains the item.</returns>
-        public bool Contains(Func<T, bool> predicate)
-        {
-            return this.InternalBuffer.Any(predicate);
-        }
+        public bool Contains(Func<T, bool> predicate) => this.InternalBuffer.Any(predicate);
 
         /// <summary>
         /// Copies this ring buffer to target array, attempting to maintain the order of items within.
@@ -182,10 +199,7 @@ namespace DSharpPlus
         /// </summary>
         /// <param name="item">Item to remove.</param>
         /// <returns>Whether an item was removed or not.</returns>
-        public bool Remove(T item)
-        {
-            throw new NotImplementedException("This method is not implemented. Use .Remove(predicate) instead.");
-        }
+        public bool Remove(T item) => throw new NotImplementedException("This method is not implemented. Use .Remove(predicate) instead.");
 
         /// <summary>
         /// Removes an item from the buffer using given predicate to find it.
@@ -198,7 +212,7 @@ namespace DSharpPlus
             {
                 if (this.InternalBuffer[i] != null && predicate(this.InternalBuffer[i]))
                 {
-                    this.InternalBuffer[i] = default(T);
+                    this.InternalBuffer[i] = default;
                     return true;
                 }
             }
@@ -212,10 +226,9 @@ namespace DSharpPlus
         /// <returns>Enumerator for this ring buffer.</returns>
         public IEnumerator<T> GetEnumerator()
         {
-            if (!this._reached_end)
-                return this.InternalBuffer.AsEnumerable().GetEnumerator();
-
-            return this.InternalBuffer.Skip(this.CurrentIndex)
+            return !this._reached_end
+                ? this.InternalBuffer.AsEnumerable().GetEnumerator()
+                : this.InternalBuffer.Skip(this.CurrentIndex)
                 .Concat(this.InternalBuffer.Take(this.CurrentIndex))
                 .GetEnumerator();
         }
@@ -224,9 +237,6 @@ namespace DSharpPlus
         /// Returns an enumerator for this ring buffer.
         /// </summary>
         /// <returns>Enumerator for this ring buffer.</returns>
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return this.GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
     }
 }

--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -1,4 +1,27 @@
-﻿using System;
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -57,76 +80,68 @@ namespace DSharpPlus
             VersionHeader = $"DiscordBot (https://github.com/DSharpPlus/DSharpPlus, v{vs})";
         }
 
-        internal static string GetApiBaseUri() 
+        internal static string GetApiBaseUri()
             => Endpoints.BASE_URI;
 
         internal static Uri GetApiUriFor(string path)
-            => new Uri($"{GetApiBaseUri()}{path}");
+            => new($"{GetApiBaseUri()}{path}");
 
         internal static Uri GetApiUriFor(string path, string queryString)
-            => new Uri($"{GetApiBaseUri()}{path}{queryString}");
+            => new($"{GetApiBaseUri()}{path}{queryString}");
 
         internal static QueryUriBuilder GetApiUriBuilderFor(string path)
-            => new QueryUriBuilder($"{GetApiBaseUri()}{path}");
+            => new($"{GetApiBaseUri()}{path}");
 
-        internal static string GetFormattedToken(BaseDiscordClient client)
-        {
-            return GetFormattedToken(client.Configuration);
-        }
+        internal static string GetFormattedToken(BaseDiscordClient client) => GetFormattedToken(client.Configuration);
 
         internal static string GetFormattedToken(DiscordConfiguration config)
-        { 
-            switch (config.TokenType)
+        {
+            return config.TokenType switch
             {
-                case TokenType.Bearer:
-                    return $"Bearer {config.Token}";
-
-                case TokenType.Bot:
-                    return $"Bot {config.Token}";
-
-                default:
-                    throw new ArgumentException("Invalid token type specified.", nameof(config.Token));
-            }
+                TokenType.Bearer => $"Bearer {config.Token}",
+                TokenType.Bot => $"Bot {config.Token}",
+                _ => throw new ArgumentException("Invalid token type specified.", nameof(config.Token)),
+            };
         }
 
         internal static Dictionary<string, string> GetBaseHeaders()
-            => new Dictionary<string, string>();
+            => new();
 
         internal static string GetUserAgent()
             => VersionHeader;
 
         internal static bool ContainsUserMentions(string message)
         {
-            string pattern = @"<@(\d+)>";
-            Regex regex = new Regex(pattern, RegexOptions.ECMAScript);
+            var pattern = @"<@(\d+)>";
+            var regex = new Regex(pattern, RegexOptions.ECMAScript);
             return regex.IsMatch(message);
         }
 
         internal static bool ContainsNicknameMentions(string message)
         {
-            string pattern = @"<@!(\d+)>";
-            Regex regex = new Regex(pattern, RegexOptions.ECMAScript);
+            var pattern = @"<@!(\d+)>";
+            var regex = new Regex(pattern, RegexOptions.ECMAScript);
             return regex.IsMatch(message);
         }
 
         internal static bool ContainsChannelMentions(string message)
         {
-            string pattern = @"<#(\d+)>";
-            Regex regex = new Regex(pattern, RegexOptions.ECMAScript);
+            var pattern = @"<#(\d+)>";
+            var regex = new Regex(pattern, RegexOptions.ECMAScript);
             return regex.IsMatch(message);
         }
 
         internal static bool ContainsRoleMentions(string message)
         {
-            string pattern = @"<@&(\d+)>";
-            Regex regex = new Regex(pattern, RegexOptions.ECMAScript);
+            var pattern = @"<@&(\d+)>";
+            var regex = new Regex(pattern, RegexOptions.ECMAScript);
             return regex.IsMatch(message);
         }
 
         internal static bool ContainsEmojis(string message)
         {
-            string pattern = @"<a?:(.*):(\d+)>";
-            Regex regex = new Regex(pattern, RegexOptions.ECMAScript);
+            var pattern = @"<a?:(.*):(\d+)>";
+            var regex = new Regex(pattern, RegexOptions.ECMAScript);
             return regex.IsMatch(message);
         }
 
@@ -161,7 +176,7 @@ namespace DSharpPlus
             foreach (Match match in matches)
                 yield return ulong.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
         }
-        
+
         internal static bool HasMessageIntents(DiscordIntents intents)
             => intents.HasIntent(DiscordIntents.GuildMessages) || intents.HasIntent(DiscordIntents.DirectMessages);
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Mike Santiago
-Copyright (c) 2016-2018 DSharpPlus Development Team
+Copyright (c) 2016-2021 DSharpPlus Development Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -65,7 +65,7 @@
     ],
     "dest": "_site",
     "globalMetadata": {
-      "_appFooter": "© 2017-2020 DSharpPlus Contributors",
+      "_appFooter": "© 2016-2021 DSharpPlus Contributors",
       "_enableSearch": "true"
     },
     "globalMetadataFiles": [],


### PR DESCRIPTION
# Summary
Implements voice quality modes for voice channels, as listed in #825.

# Details
Added an enum, ChannelQualityMode, to store the quality modes a channel can have and added that to DiscordChannel. Tried to remain locally consistent with the rest of library with the names and XML comments where possible.

I modified functions that edit or create channels to account for the new property where applicable. I might have missed some, please let me know if I did. 

# Changes proposed
* Added new enum, ChannelQualityMode
* Added enum as parameter to DiscordChannel
* Updated ChannelEditModel 
* Updated `CloneAsync()` and `ModifyAsync()` in DiscordChannel.cs
* Updated `CreateGuildChannelAsync()` and both `ModifyChannelAsync()` methods in DiscordRestClient.cs
* Updated `CreateVoiceChannelAsync() `and `CreateChannelAsync()` in DiscordGuild.cs
* Updated `CreateGuildChannelAsync()` and `ModifyChannelAsync()` in DiscordApiClient.cs
* Updated `OnChannelUpdateEventAsync()` in DiscordClient.Dispatch.cs
* Updated RestChannelCreatePayload and RestChannelModifyPayload classes in RestChannelPayloads.cs

# Notes
* It seems Discord returns a value of 0 for `video_quality_mode` until a voice channel's quality mode setting is touched (not even changed). This is the same value it returns for text channels.
* I have not touched anything relating to audit log or audit log objects (like DiscordAuditLogChannelEntry ) as I do not quite understand how they work. If anyone could give me pointers or advice on this it would be appreciated.
* I've done testing to check that the create and modify methods work as intended, I would appreciate if someone else also tested them on their machine.