### PR TITLE
fix: Grab guild from cache rather than msg object.

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -946,7 +946,9 @@ namespace DSharpPlus
 
         private void PopulateMessageReactionsAndCache(DiscordMessage message, TransportUser author, TransportMember member)
         {
-            this.UpdateMessage(message, author, message.Channel?.Guild, member);
+            var guild = message.Channel?.Guild ?? this.InternalGetCachedGuild(message.GuildId);
+
+            this.UpdateMessage(message, author, guild, member);
 
             if (message._reactions == null)
                 message._reactions = new List<DiscordReaction>();


### PR DESCRIPTION
Fixes #880 by ensuring the guild is grabbed from cache, and not from the message object itself. The guild object is not sent from the gateway.