### PR TITLE
Update UserFlags to include Discord Certified Moderator

### DIFF
--- a/DSharpPlus/Enums/User/UserFlags.cs
+++ b/DSharpPlus/Enums/User/UserFlags.cs
@@ -99,6 +99,11 @@ namespace DSharpPlus
         /// <summary>
         /// The user is a verified bot developer.
         /// </summary>
-        VerifiedBotDeveloper = 1 << 17
+        VerifiedBotDeveloper = 1 << 17,
+        
+        /// <summary>
+        /// The user is a discord certified moderator.
+        /// </summary>
+        CertifiedModerator = 1 << 18
     }
 }

--- a/DSharpPlus/Enums/User/UserFlags.cs
+++ b/DSharpPlus/Enums/User/UserFlags.cs
@@ -104,6 +104,6 @@ namespace DSharpPlus
         /// <summary>
         /// The user is a discord certified moderator.
         /// </summary>
-        CertifiedModerator = 1 << 18
+        DiscordCertifiedModerator = 1 << 18
     }
 }


### PR DESCRIPTION
# Summary

Implements the following flag to `DSharpPlus.User.UserFlags`:

- `DiscordCertifiedModerator`
# Details

Adds the following flag to the `UserFlags` enum.
- `DiscordCertifiedModerator`

# Changes proposed

  - Add `DiscordCertifiedModerator` with a value of `1<<18`



Discord-API-Docs: https://github.com/discord/discord-api-docs/pull/2946
Data Mining: https://github.com/Discord-Datamining/Discord-Datamining/commit/6258cfefc7dde95d7c340397e9704c30da9a6280#commitcomment-50961513
This badge was internally already announced at the beginning of the year.