### PR TITLE
Make DiscordApiClient public

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -215,41 +215,8 @@ namespace DSharpPlus
         /// <param name="limit">Member download limit</param>
         /// <param name="after">Gets members after this ID</param>
         /// <returns></returns>
-        public async Task<IReadOnlyList<DiscordMember>> ListGuildMembersAsync(ulong guild_id, int? limit, ulong? after)
-        {
-            var recmbr = new List<DiscordMember>();
-
-            var recd = limit ?? 1000;
-            var lim = limit ?? 1000;
-            var last = after;
-            while (recd == lim)
-            {
-                var tms = await this.ApiClient.ListGuildMembersAsync(guild_id, lim, last == 0 ? null : (ulong?)last).ConfigureAwait(false);
-                recd = tms.Count;
-
-                foreach (var xtm in tms)
-                {
-                    last = xtm.User.Id;
-
-                    if (this.UserCache.ContainsKey(xtm.User.Id))
-                        continue;
-
-                    var usr = new DiscordUser(xtm.User) { Discord = this };
-                    this.UserCache.AddOrUpdate(xtm.User.Id, usr, (id, old) =>
-                    {
-                        old.Username = usr.Username;
-                        old.Discord = usr.Discord;
-                        old.AvatarHash = usr.AvatarHash;
-
-                        return old;
-                    });
-                }
-
-                recmbr.AddRange(tms.Select(xtm => new DiscordMember(xtm) { Discord = this, _guild_id = guild_id }));
-            }
-
-            return new ReadOnlyCollection<DiscordMember>(recmbr);
-        }
+        public Task<IReadOnlyList<DiscordMember>> ListGuildMembersAsync(ulong guild_id, int? limit, ulong? after)
+            => this.ApiClient.ListGuildMembersAsync(guild_id, limit, after);
 
         /// <summary>
         /// Add role to guild member
@@ -299,13 +266,8 @@ namespace DSharpPlus
         /// <param name="reason">Reason this position was modified</param>
         /// <returns></returns>
         public Task UpdateChannelPositionAsync(ulong guild_id, ulong channel_id, int position, string reason)
-        {
-            var rgcrps = new List<RestGuildChannelReorderPayload>()
-            {
-                new RestGuildChannelReorderPayload { ChannelId = channel_id, Position = position }
-            };
-            return this.ApiClient.ModifyGuildChannelPositionAsync(guild_id, rgcrps, reason);
-        }
+
+            => this.ApiClient.ModifyGuildChannelPositionAsync(guild_id, channel_id, position, reason);
 
         /// <summary>
         /// Gets a guild's widget
@@ -360,7 +322,7 @@ namespace DSharpPlus
         /// <summary>
         /// Creates a guild channel
         /// </summary>
-        /// <param name="id">Channel id</param>
+        /// <param name="id">Guild id</param>
         /// <param name="name">Channel name</param>
         /// <param name="type">Channel type</param>
         /// <param name="parent">Channel parent id</param>
@@ -633,7 +595,7 @@ namespace DSharpPlus
             => this.ApiClient.GetPinnedMessagesAsync(channel_id);
 
         /// <summary>
-        /// Unpuns a message
+        /// Unpins a message
         /// </summary>
         /// <param name="channel_id">Channel id</param>
         /// <param name="message_id">Message id</param>

--- a/DSharpPlus/Clients/BaseDiscordClient.cs
+++ b/DSharpPlus/Clients/BaseDiscordClient.cs
@@ -40,7 +40,10 @@ namespace DSharpPlus
     /// </summary>
     public abstract class BaseDiscordClient : IDisposable
     {
-        internal protected DiscordApiClient ApiClient { get; }
+        /// <summary>
+        /// The ApiClient associated with this client.
+        /// </summary>
+        public DiscordApiClient ApiClient { get; }
         internal protected DiscordConfiguration Configuration { get; }
 
         /// <summary>

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageFile.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageFile.cs
@@ -30,7 +30,13 @@ namespace DSharpPlus.Entities
     /// </summary>
     public class DiscordMessageFile
     {
-        internal DiscordMessageFile(string fileName, Stream stream, long? resetPositionTo)
+        /// <summary>
+        /// Builds a message file to be sent on a multipart request.
+        /// </summary>
+        /// <param name="fileName">The name of the file.</param>
+        /// <param name="stream">The stream of the file.</param>
+        /// <param name="resetPositionTo">The position the file should be reset to.</param>
+        public DiscordMessageFile(string fileName, Stream stream, long? resetPositionTo)
         {
             this.FileName = fileName;
             this.Stream = stream;

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -914,7 +914,7 @@ namespace DSharpPlus.Entities
             var last = 0ul;
             while (recd > 0)
             {
-                var tms = await this.Discord.ApiClient.ListGuildMembersAsync(this.Id, 1000, last == 0 ? null : (ulong?)last).ConfigureAwait(false);
+                var tms = await this.Discord.ApiClient.InternalListGuildMembersAsync(this.Id, 1000, last == 0 ? null : (ulong?)last).ConfigureAwait(false);
                 recd = tms.Count;
 
                 foreach (var xtm in tms)

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -150,9 +150,9 @@ namespace DSharpPlus.Net
         /// <param name="payload">The payload to send with the request.</param>
         /// <param name="queryString">The query string to add on the url.</param>
         /// <returns>The API response.</returns>
-        public Task<RestResponse> DoRequestAsync(string route, object routeParams, RestRequestMethod method, IReadOnlyDictionary<string, string> headers = null, object payload = null, string queryString = null)
+        public Task<RestResponse> DoRequestAsync(string route, object routeParams, RestRequestMethod method, IReadOnlyDictionary<string, string> headers = null, string payload = null, string queryString = null)
         {
-            var req = new RestRequest(this.Discord, this.Rest.GetBucket(method, route, routeParams, out var path), Utilities.GetApiUriFor(path, queryString), method, route, headers, DiscordJson.SerializeObject(payload), null);
+            var req = new RestRequest(this.Discord, this.Rest.GetBucket(method, route, routeParams, out var path), Utilities.GetApiUriFor(path, queryString), method, route, headers, payload, null);
 
             if (this.Discord != null)
                 this.Rest.ExecuteRequestAsync(req).LogTaskFault(this.Discord.Logger, LogLevel.Error, LoggerEvents.RestError, "Error while executing request");

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -33,6 +33,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DSharpPlus.Entities;
 using DSharpPlus.Net.Abstractions;
+using DSharpPlus.Net.Models;
 using DSharpPlus.Net.Serialization;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -209,6 +210,15 @@ namespace DSharpPlus.Net
         }
 
         #region Guild
+        /// <summary>
+        /// Creates a new guild
+        /// </summary>
+        /// <param name="name">New guild's name</param>
+        /// <param name="region_id">New guild's region ID</param>
+        /// <param name="iconb64">New guild's icon (base64)</param>
+        /// <param name="verification_level">New guild's verification level</param>
+        /// <param name="default_message_notifications">New guild's default message notification level</param>
+        /// <returns></returns>
         public async Task<DiscordGuild> CreateGuildAsync(string name, string region_id, Optional<string> iconb64, VerificationLevel? verification_level,
             DefaultMessageNotifications? default_message_notifications)
         {
@@ -236,6 +246,13 @@ namespace DSharpPlus.Net
             return guild;
         }
 
+        /// <summary>
+        /// Creates a guild from a template. This requires the bot to be in less than 10 guilds total.
+        /// </summary>
+        /// <param name="template_code">The template code.</param>
+        /// <param name="name">Name of the guild.</param>
+        /// <param name="iconb64">Stream containing the icon for the guild.</param>
+        /// <returns>The created guild.</returns>
         public async Task<DiscordGuild> CreateGuildFromTemplateAsync(string template_code, string name, Optional<string> iconb64)
         {
             var pld = new RestGuildCreateFromTemplatePayload
@@ -259,6 +276,11 @@ namespace DSharpPlus.Net
             return guild;
         }
 
+        /// <summary>
+        /// Deletes a guild
+        /// </summary>
+        /// <param name="guild_id">guild id</param>
+        /// <returns></returns>
         public async Task DeleteGuildAsync(ulong guild_id)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id";
@@ -274,6 +296,24 @@ namespace DSharpPlus.Net
             }
         }
 
+        /// <summary>
+        /// Modifies a guild
+        /// </summary>
+        /// <param name="guildId">Guild ID</param>
+        /// <param name="name">New guild Name</param>
+        /// <param name="region">New guild voice region</param>
+        /// <param name="verificationLevel">New guild verification level</param>
+        /// <param name="defaultMessageNotifications">New guild default message notification level</param>
+        /// <param name="mfaLevel">New guild MFA level</param>
+        /// <param name="explicitContentFilter">New guild explicit content filter level</param>
+        /// <param name="afkChannelId">New guild AFK channel id</param>
+        /// <param name="afkTimeout">New guild AFK timeout in seconds</param>
+        /// <param name="iconb64">New guild icon (base64)</param>
+        /// <param name="ownerId">New guild owner id</param>
+        /// <param name="splashb64">New guild spalsh (base64)</param>
+        /// <param name="systemChannelId">New guild system channel id</param>
+        /// <param name="reason">Modify reason</param>
+        /// <returns></returns>
         public async Task<DiscordGuild> ModifyGuildAsync(ulong guildId, Optional<string> name,
             Optional<string> region, Optional<VerificationLevel> verificationLevel,
             Optional<DefaultMessageNotifications> defaultMessageNotifications, Optional<MfaLevel> mfaLevel,
@@ -317,7 +357,45 @@ namespace DSharpPlus.Net
                 await dc.OnGuildUpdateEventAsync(guild, rawMembers).ConfigureAwait(false);
             return guild;
         }
+        /// <summary>
+        /// Modifies a guild
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="action">Guild modifications</param>
+        /// <returns></returns>
+        public async Task<DiscordGuild> ModifyGuildAsync(ulong guild_id, Action<GuildEditModel> action)
+        {
+            var mdl = new GuildEditModel();
+            action(mdl);
 
+            if (mdl.AfkChannel.HasValue)
+                if (mdl.AfkChannel.Value.Type != ChannelType.Voice)
+                    throw new ArgumentException("AFK channel needs to be a voice channel!");
+
+            var iconb64 = Optional.FromNoValue<string>();
+            if (mdl.Icon.HasValue && mdl.Icon.Value != null)
+                using (var imgtool = new ImageTool(mdl.Icon.Value))
+                    iconb64 = imgtool.GetBase64();
+            else if (mdl.Icon.HasValue)
+                iconb64 = null;
+
+            var splashb64 = Optional.FromNoValue<string>();
+            if (mdl.Splash.HasValue && mdl.Splash.Value != null)
+                using (var imgtool = new ImageTool(mdl.Splash.Value))
+                    splashb64 = imgtool.GetBase64();
+            else if (mdl.Splash.HasValue)
+                splashb64 = null;
+
+            return await this.ModifyGuildAsync(guild_id, mdl.Name, mdl.Region.IfPresent(x => x.Id), mdl.VerificationLevel, mdl.DefaultMessageNotifications,
+                mdl.MfaLevel, mdl.ExplicitContentFilter, mdl.AfkChannel.IfPresent(x => x?.Id), mdl.AfkTimeout, iconb64, mdl.Owner.IfPresent(x => x.Id),
+                splashb64, mdl.SystemChannel.IfPresent(x => x?.Id), mdl.AuditLogReason).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets guild bans
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <returns></returns>
         public async Task<IReadOnlyList<DiscordBan>> GetGuildBansAsync(ulong guild_id)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.BANS}";
@@ -348,6 +426,14 @@ namespace DSharpPlus.Net
             return bans;
         }
 
+        /// <summary>
+        /// Creates guild ban
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="user_id">User id</param>
+        /// <param name="delete_message_days">Days to delete messages</param>
+        /// <param name="reason">Reason why this member was banned</param>
+        /// <returns></returns>
         public Task CreateGuildBanAsync(ulong guild_id, ulong user_id, int delete_message_days, string reason)
         {
             if (delete_message_days < 0 || delete_message_days > 7)
@@ -367,6 +453,13 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, route);
         }
 
+        /// <summary>
+        /// Removes a guild ban
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="user_id">User to unban</param>
+        /// <param name="reason">Reason why this member was unbanned</param>
+        /// <returns></returns>
         public Task RemoveGuildBanAsync(ulong guild_id, ulong user_id, string reason)
         {
             var urlparams = new Dictionary<string, string>();
@@ -380,6 +473,11 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route);
         }
 
+        /// <summary>
+        /// Leaves a guild
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <returns></returns>
         public Task LeaveGuildAsync(ulong guild_id)
         {
             var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.GUILDS}/:guild_id";
@@ -389,6 +487,17 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route);
         }
 
+        /// <summary>
+        /// Adds a member to a guild
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="user_id">User id</param>
+        /// <param name="access_token">Access token</param>
+        /// <param name="nick">User nickname</param>
+        /// <param name="roles">User roles</param>
+        /// <param name="muted">Whether this user should be muted on join</param>
+        /// <param name="deafened">Whether this user should be deafened on join</param>
+        /// <returns></returns>
         public async Task<DiscordMember> AddGuildMemberAsync(ulong guild_id, ulong user_id, string access_token, string nick, IEnumerable<DiscordRole> roles, bool muted, bool deafened)
         {
             var pld = new RestGuildMemberAddPayload
@@ -411,7 +520,49 @@ namespace DSharpPlus.Net
             return new DiscordMember(tm) { Discord = this.Discord, _guild_id = guild_id };
         }
 
-        internal async Task<IReadOnlyList<TransportMember>> ListGuildMembersAsync(ulong guild_id, int? limit, ulong? after)
+        /// <summary>
+        /// Gets all guild members
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="limit">Member download limit</param>
+        /// <param name="after">Gets members after this ID</param>
+        /// <returns></returns>
+        public async Task<IReadOnlyList<DiscordMember>> ListGuildMembersAsync(ulong guild_id, int? limit, ulong? after)
+        {
+            var recmbr = new List<DiscordMember>();
+
+            var recd = limit ?? 1000;
+            var lim = limit ?? 1000;
+            var last = after;
+            while (recd == lim)
+            {
+                var tms = await this.InternalListGuildMembersAsync(guild_id, lim, last == 0 ? null : (ulong?)last).ConfigureAwait(false);
+                recd = tms.Count;
+
+                foreach (var xtm in tms)
+                {
+                    last = xtm.User.Id;
+
+                    if (this.Discord.UserCache.ContainsKey(xtm.User.Id))
+                        continue;
+
+                    var usr = new DiscordUser(xtm.User) { Discord = this.Discord };
+                    this.Discord.UserCache.AddOrUpdate(xtm.User.Id, usr, (id, old) =>
+                    {
+                        old.Username = usr.Username;
+                        old.Discord = usr.Discord;
+                        old.AvatarHash = usr.AvatarHash;
+
+                        return old;
+                    });
+                }
+
+                recmbr.AddRange(tms.Select(xtm => new DiscordMember(xtm) { Discord = this.Discord, _guild_id = guild_id }));
+            }
+
+            return new ReadOnlyCollection<DiscordMember>(recmbr);
+        }
+        internal async Task<IReadOnlyList<TransportMember>> InternalListGuildMembersAsync(ulong guild_id, int? limit, ulong? after)
         {
             var urlparams = new Dictionary<string, string>();
             if (limit != null && limit > 0)
@@ -429,6 +580,14 @@ namespace DSharpPlus.Net
             return new ReadOnlyCollection<TransportMember>(members_raw);
         }
 
+        /// <summary>
+        /// Add role to guild member
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="user_id">User id</param>
+        /// <param name="role_id">Role id</param>
+        /// <param name="reason">Reason this role gets added</param>
+        /// <returns></returns>
         public Task AddGuildMemberRoleAsync(ulong guild_id, ulong user_id, ulong role_id, string reason)
         {
             var headers = Utilities.GetBaseHeaders();
@@ -442,6 +601,14 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, route, headers);
         }
 
+        /// <summary>
+        /// Remove role from member
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="user_id">User id</param>
+        /// <param name="role_id">Role id</param>
+        /// <param name="reason">Reason this role gets removed</param>
+        /// <returns></returns>
         public Task RemoveGuildMemberRoleAsync(ulong guild_id, ulong user_id, ulong role_id, string reason)
         {
             var headers = Utilities.GetBaseHeaders();
@@ -455,6 +622,23 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
+        /// <summary>
+        /// Updates a channel's position
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="position">Channel position</param>
+        /// <param name="reason">Reason this position was modified</param>
+        /// <returns></returns>
+        public Task ModifyGuildChannelPositionAsync(ulong guild_id, ulong channel_id, int position, string reason)
+        {
+            var pld = new List<RestGuildChannelReorderPayload>()
+            {
+                new RestGuildChannelReorderPayload { ChannelId = channel_id }
+            };
+
+            return this.ModifyGuildChannelPositionAsync(guild_id, pld, reason);
+        }
         internal Task ModifyGuildChannelPositionAsync(ulong guild_id, IEnumerable<RestGuildChannelReorderPayload> pld, string reason)
         {
             var headers = Utilities.GetBaseHeaders();
@@ -468,6 +652,23 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld));
         }
 
+        /// <summary>
+        /// Updates a role's position
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="role_id">Role id</param>
+        /// <param name="position">Role position</param>
+        /// <param name="reason">Reason this position was modified</param>
+        /// <returns></returns>
+        public Task ModifyGuildRolePositionAsync(ulong guild_id, ulong role_id, int position, string reason = null)
+        {
+            var pld = new List<RestGuildRoleReorderPayload>()
+            {
+                new RestGuildRoleReorderPayload { RoleId = role_id }
+            };
+
+            return this.ModifyGuildRolePositionAsync(guild_id, pld, reason);
+        }
         internal Task ModifyGuildRolePositionAsync(ulong guild_id, IEnumerable<RestGuildRoleReorderPayload> pld, string reason)
         {
             var headers = Utilities.GetBaseHeaders();
@@ -507,6 +708,11 @@ namespace DSharpPlus.Net
             return audit_log_data_raw;
         }
 
+        /// <summary>
+        /// Gets the vanity invite for a guild.
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <returns>A partial vanity invite.</returns>
         public async Task<DiscordInvite> GetGuildVanityUrlAsync(ulong guild_id)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.VANITY_URL}";
@@ -520,6 +726,11 @@ namespace DSharpPlus.Net
             return invite;
         }
 
+        /// <summary>
+        /// Gets a guild's widget
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <returns></returns>
         public async Task<DiscordWidget> GetGuildWidgetAsync(ulong guild_id)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.WIDGET_JSON}";
@@ -552,6 +763,11 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Gets a guild's widget settings
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <returns></returns>
         public async Task<DiscordWidgetSettings> GetGuildWidgetSettingsAsync(ulong guild_id)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.WIDGET}";
@@ -566,6 +782,14 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Modifies a guild's widget settings
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="isEnabled">If the widget is enabled or not</param>
+        /// <param name="channelId">Widget channel id</param>
+        /// <param name="reason">Reason the widget settings were modified</param>
+        /// <returns></returns>
         public async Task<DiscordWidgetSettings> ModifyGuildWidgetSettingsAsync(ulong guild_id, bool? isEnabled, ulong? channelId, string reason)
         {
             var pld = new RestGuildWidgetSettingsPayload
@@ -590,6 +814,11 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Gets a guild's templates.
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <returns>All of the guild's templates.</returns>
         public async Task<IReadOnlyList<DiscordGuildTemplate>> GetGuildTemplatesAsync(ulong guild_id)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.TEMPLATES}";
@@ -603,6 +832,13 @@ namespace DSharpPlus.Net
             return new ReadOnlyCollection<DiscordGuildTemplate>(new List<DiscordGuildTemplate>(templates_raw));
         }
 
+        /// <summary>
+        /// Creates a guild template.
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="name">Name of the template.</param>
+        /// <param name="description">Description of the template.</param>
+        /// <returns>The template created.</returns>
         public async Task<DiscordGuildTemplate> CreateGuildTemplateAsync(ulong guild_id, string name, string description)
         {
             var pld = new RestGuildTemplateCreateOrModifyPayload
@@ -622,6 +858,12 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Syncs the template to the current guild's state.
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="template_code">The code of the template to sync.</param>
+        /// <returns>The template synced.</returns>
         public async Task<DiscordGuildTemplate> SyncGuildTemplateAsync(ulong guild_id, string template_code)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.TEMPLATES}/:template_code";
@@ -635,6 +877,14 @@ namespace DSharpPlus.Net
             return template_raw;
         }
 
+        /// <summary>
+        /// Modifies the template's metadata.
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="template_code">The template's code.</param>
+        /// <param name="name">Name of the template.</param>
+        /// <param name="description">Description of the template.</param>
+        /// <returns>The template modified.</returns>
         public async Task<DiscordGuildTemplate> ModifyGuildTemplateAsync(ulong guild_id, string template_code, string name, string description)
         {
             var pld = new RestGuildTemplateCreateOrModifyPayload
@@ -654,6 +904,12 @@ namespace DSharpPlus.Net
             return template_raw;
         }
 
+        /// <summary>
+        /// Deletes the template.
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="template_code">The code of the template to delete.</param>
+        /// <returns>The deleted template.</returns>
         public async Task<DiscordGuildTemplate> DeleteGuildTemplateAsync(ulong guild_id, string template_code)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.TEMPLATES}/:template_code";
@@ -667,6 +923,11 @@ namespace DSharpPlus.Net
             return template_raw;
         }
 
+        /// <summary>
+        /// Gets a guild's membership screening form.
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <returns>The guild's membership screening form.</returns>
         public async Task<DiscordGuildMembershipScreening> GetGuildMembershipScreeningFormAsync(ulong guild_id)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBER_VERIFICATION}";
@@ -680,6 +941,26 @@ namespace DSharpPlus.Net
             return screening_raw;
         }
 
+        /// <summary>
+        /// Modifies a guild's membership screening form.
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="action">Action to perform</param>
+        /// <returns>The modified screening form.</returns>
+        public async Task<DiscordGuildMembershipScreening> ModifyGuildMembershipScreeningFormAsync(ulong guild_id, Action<MembershipScreeningEditModel> action)
+        {
+            var mdl = new MembershipScreeningEditModel();
+            action(mdl);
+            return await this.ModifyGuildMembershipScreeningFormAsync(guild_id, mdl.Enabled, mdl.Fields, mdl.Description);
+        }
+        /// <summary>
+        /// Modifies a guild's membership screening form.
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="enabled">Sets whether membership screening should be enabled.</param>
+        /// <param name="fields">Set the fields.</param>
+        /// <param name="description">Sets the server description.</param>
+        /// <returns>The modified screening form.</returns>
         public async Task<DiscordGuildMembershipScreening> ModifyGuildMembershipScreeningFormAsync(ulong guild_id, Optional<bool> enabled, Optional<DiscordGuildMembershipScreeningField[]> fields, Optional<string> description)
         {
             var pld = new RestGuildMembershipScreeningFormModifyPayload
@@ -700,6 +981,10 @@ namespace DSharpPlus.Net
             return screening_raw;
         }
 
+        /// <summary>
+        /// Gets a guild's welcome screen.
+        /// </summary>
+        /// <returns>The guild's welcome screen object.</returns>
         public async Task<DiscordGuildWelcomeScreen> GetGuildWelcomeScreenAsync(ulong guild_id)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.WELCOME_SCREEN}";
@@ -712,6 +997,26 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Modifies a guild's welcome screen.
+        /// </summary>
+        /// <param name="guildId">The guild ID to modify.</param>
+        /// <param name="action">Action to perform.</param>
+        /// <returns>The modified welcome screen.</returns>
+        public async Task<DiscordGuildWelcomeScreen> ModifyGuildWelcomeScreenAsync(ulong guildId, Action<WelcomeScreenEditModel> action)
+        {
+            var mdl = new WelcomeScreenEditModel();
+            action(mdl);
+            return await this.ModifyGuildWelcomeScreenAsync(guildId, mdl.Enabled, mdl.WelcomeChannels, mdl.Description);
+        }
+        /// <summary>
+        /// Modifies a guild's welcome screen.
+        /// </summary>
+        /// <param name="guild_id">The guild ID to modify.</param>
+        /// <param name="enabled">Sets whether the welcome screen should be enabled.</param>
+        /// <param name="welcomeChannels">Sets the welcome channels.</param>
+        /// <param name="description">Sets the server description.</param>
+        /// <returns>The modified welcome screen.</returns>
         public async Task<DiscordGuildWelcomeScreen> ModifyGuildWelcomeScreenAsync(ulong guild_id, Optional<bool> enabled, Optional<IEnumerable<DiscordGuildWelcomeScreenChannel>> welcomeChannels, Optional<string> description)
         {
             var pld = new RestGuildWelcomeScreenModifyPayload
@@ -731,6 +1036,14 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Updates the current user's suppress state in a channel, if stage channel.
+        /// </summary>
+        /// <param name="guild_id">Guild id.</param>
+        /// <param name="channelId">Channel id.</param>
+        /// <param name="suppress">Toggles the suppress state.</param>
+        /// <param name="requestToSpeakTimestamp">Sets the time the user requested to speak.</param>
+        /// <exception cref="ArgumentException">Thrown when the channel is not a stage channel.</exception>
         public async Task UpdateCurrentUserVoiceStateAsync(ulong guild_id, ulong channelId, bool? suppress, DateTimeOffset? requestToSpeakTimestamp)
         {
             var pld = new RestGuildUpdateCurrentUserVoiceStatePayload
@@ -747,6 +1060,14 @@ namespace DSharpPlus.Net
             await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld));
         }
 
+        /// <summary>
+        /// Updates a member's suppress state in a stage channel.
+        /// </summary>
+        /// <param name="guild_id">Guild id.</param>
+        /// <param name="user_id">User id.</param>
+        /// <param name="channelId">The channel the member is currently in.</param>
+        /// <param name="suppress">Toggles the member's suppress state.</param>
+        /// <exception cref="ArgumentException">Thrown when the channel in not a voice channel.</exception>
         public async Task UpdateUserVoiceStateAsync(ulong guild_id, ulong user_id, ulong channelId, bool? suppress)
         {
             var pld = new RestGuildUpdateUserVoiceStatePayload
@@ -764,6 +1085,21 @@ namespace DSharpPlus.Net
         #endregion
 
         #region Channel
+        /// <summary>
+        /// Creates a guild channel
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="name">Channel name</param>
+        /// <param name="type">Channel type</param>
+        /// <param name="parent">Channel parent id</param>
+        /// <param name="topic">Channel topic</param>
+        /// <param name="bitrate">Voice channel bitrate</param>
+        /// <param name="user_limit">Voice channel user limit</param>
+        /// <param name="overwrites">Channel overwrites</param>
+        /// <param name="nsfw">Whether this channel should be marked as NSFW</param>
+        /// <param name="perUserRateLimit">Slow mode timeout for users.</param>
+        /// <param name="reason">Reason this channel was created</param>
+        /// <returns></returns>
         public async Task<DiscordChannel> CreateGuildChannelAsync(ulong guild_id, string name, ChannelType type, ulong? parent, Optional<string> topic, int? bitrate, int? user_limit, IEnumerable<DiscordOverwriteBuilder> overwrites, bool? nsfw, Optional<int?> perUserRateLimit, string reason)
         {
             var restoverwrites = new List<DiscordRestOverwrite>();
@@ -805,6 +1141,21 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Modifies a channel
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="name">New channel name</param>
+        /// <param name="position">New channel position</param>
+        /// <param name="topic">New channel topic</param>
+        /// <param name="nsfw">Whether this channel should be marked as NSFW</param>
+        /// <param name="parent">New channel parent</param>
+        /// <param name="bitrate">New voice channel bitrate</param>
+        /// <param name="user_limit">New voice channel user limit</param>
+        /// <param name="perUserRateLimit">Slow mode timeout for users.</param>
+        /// <param name="rtcRegion">New region override.</param>
+        /// <param name="reason">Reason why this channel was modified</param>
+        /// <returns></returns>
         public Task ModifyChannelAsync(ulong channel_id, string name, int? position, Optional<string> topic, bool? nsfw, Optional<ulong?> parent, int? bitrate, int? user_limit, Optional<int?> perUserRateLimit, Optional<string> rtcRegion, string reason)
         {
             var pld = new RestChannelModifyPayload
@@ -830,7 +1181,27 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld));
         }
+        /// <summary>
+        /// Modifies a channel
+        /// </summary>
+        /// <param name="channelId">Channel id</param>
+        /// <param name="action">Channel modifications</param>
+        /// <returns></returns>
+        public Task ModifyChannelAsync(ulong channelId, Action<ChannelEditModel> action)
+        {
+            var mdl = new ChannelEditModel();
+            action(mdl);
 
+            return this.ModifyChannelAsync(channelId, mdl.Name, mdl.Position, mdl.Topic, mdl.Nsfw,
+                mdl.Parent.HasValue ? mdl.Parent.Value?.Id : default(Optional<ulong?>), mdl.Bitrate, mdl.Userlimit, mdl.PerUserRateLimit, mdl.RtcRegion.IfPresent(e => e?.Id),
+                mdl.AuditLogReason);
+        }
+
+        /// <summary>
+        /// Gets a channel object
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <returns></returns>
         public async Task<DiscordChannel> GetChannelAsync(ulong channel_id)
         {
             var route = $"{Endpoints.CHANNELS}/:channel_id";
@@ -850,6 +1221,12 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Deletes a channel
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="reason">Reason why this channel was deleted</param>
+        /// <returns></returns>
         public Task DeleteChannelAsync(ulong channel_id, string reason)
         {
             var headers = Utilities.GetBaseHeaders();
@@ -863,6 +1240,12 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
+        /// <summary>
+        /// Gets message in a channel
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="message_id">Message id</param>
+        /// <returns></returns>
         public async Task<DiscordMessage> GetMessageAsync(ulong channel_id, ulong message_id)
         {
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id";
@@ -876,6 +1259,57 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Sends a message
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="content">Message (text) content</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, string content)
+            => this.CreateMessageAsync(channel_id, content, null, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
+
+        /// <summary>
+        /// Sends a message
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="embed">Embed to attach</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, DiscordEmbed embed)
+            => this.CreateMessageAsync(channel_id, null, embed, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
+
+        /// <summary>
+        /// Sends a message
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="content">Message (text) content</param>
+        /// <param name="embed">Embed to attach</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, string content, DiscordEmbed embed)
+            => this.CreateMessageAsync(channel_id, content, embed, replyMessageId: null, mentionReply: false, failOnInvalidReply: false);
+
+        /// <summary>
+        /// Sends a message
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="action">The Discord Mesage builder.</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> CreateMessageAsync(ulong channel_id, Action<DiscordMessageBuilder> action)
+        {
+            var builder = new DiscordMessageBuilder();
+            action(builder);
+            return this.CreateMessageAsync(channel_id, builder);
+        }
+
+        /// <summary>
+        /// Sends a message
+        /// </summary>
+        /// <param name="channel_id">Channel id.</param>
+        /// <param name="content">Content.</param>
+        /// <param name="embed">Embed.</param>
+        /// <param name="replyMessageId">Reply message id.</param>
+        /// <param name="mentionReply">Whether to mention on reply.</param>
+        /// <param name="failOnInvalidReply">Whether to fail on invalid reply.</param>
+        /// <returns></returns>
         public async Task<DiscordMessage> CreateMessageAsync(ulong channel_id, string content, DiscordEmbed embed, ulong? replyMessageId, bool mentionReply, bool failOnInvalidReply)
         {
             if (content != null && content.Length > 2000)
@@ -919,6 +1353,12 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Sends a message
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="builder">The Discord Mesage builder.</param>
+        /// <returns></returns>
         public async Task<DiscordMessage> CreateMessageAsync(ulong channel_id, DiscordMessageBuilder builder)
         {
             builder.Validate();
@@ -977,6 +1417,11 @@ namespace DSharpPlus.Net
             }
         }
 
+        /// <summary>
+        /// Gets channels from a guild
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <returns></returns>
         public async Task<IReadOnlyList<DiscordChannel>> GetGuildChannelsAsync(ulong guild_id)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.CHANNELS}";
@@ -997,6 +1442,15 @@ namespace DSharpPlus.Net
             return new ReadOnlyCollection<DiscordChannel>(new List<DiscordChannel>(channels_raw));
         }
 
+        /// <summary>
+        /// Gets messages from a channel
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="limit">Limit of messages to get</param>
+        /// <param name="before">Gets messages before this id</param>
+        /// <param name="after">Gets messages after this id</param>
+        /// <param name="around">Gets messages around this id</param>
+        /// <returns></returns>
         public async Task<IReadOnlyList<DiscordMessage>> GetChannelMessagesAsync(ulong channel_id, int limit, ulong? before, ulong? after, ulong? around)
         {
             var urlparams = new Dictionary<string, string>();
@@ -1023,6 +1477,12 @@ namespace DSharpPlus.Net
             return new ReadOnlyCollection<DiscordMessage>(new List<DiscordMessage>(msgs));
         }
 
+        /// <summary>
+        /// Gets a message from a channel
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="message_id">Message id</param>
+        /// <returns></returns>
         public async Task<DiscordMessage> GetChannelMessageAsync(ulong channel_id, ulong message_id)
         {
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id";
@@ -1036,6 +1496,7 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        //Should be removed in v9
         public Task ModifyEmbedSuppressionAsync(bool suppress, ulong channel_id, ulong message_id)
         {
             var pld = new RestChannelMessageSuppressEmbedsPayload
@@ -1050,6 +1511,49 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld));
         }
 
+        /// <summary>
+        /// Edits a message
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="message_id">Message id</param>
+        /// <param name="content">New message content</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, Optional<string> content)
+            => this.EditMessageAsync(channel_id, message_id, content, default, default);
+
+        /// <summary>
+        /// Edits a message
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="message_id">Message id</param>
+        /// <param name="embed">New message embed</param>
+        /// <returns></returns>
+        public Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, Optional<DiscordEmbed> embed)
+            => this.EditMessageAsync(channel_id, message_id, default, embed, default);
+
+        /// <summary>
+        /// Edits a message
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="message_id">Message id</param>
+        /// <param name="builder">The builder of the message to edit.</param>
+        /// <returns></returns>
+        public async Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, DiscordMessageBuilder builder)
+        {
+            builder.Validate(true);
+
+            return await this.EditMessageAsync(channel_id, message_id, builder.Content, builder.Embed, builder.Mentions).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Edits a message
+        /// </summary>
+        /// <param name="channel_id">Channel id.</param>
+        /// <param name="message_id">Message id.</param>
+        /// <param name="content">New message content.</param>
+        /// <param name="embed">New message embed.</param>
+        /// <param name="mentions">Allowed mentions.</param>
+        /// <returns></returns>
         public async Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, Optional<string> content, Optional<DiscordEmbed> embed, IEnumerable<IMention> mentions)
         {
             if (embed.HasValue && embed.Value != null && embed.Value.Timestamp != null)
@@ -1077,6 +1581,13 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Deletes a message
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="message_id">Message id</param>
+        /// <param name="reason">Why this message was deleted</param>
+        /// <returns></returns>
         public Task DeleteMessageAsync(ulong channel_id, ulong message_id, string reason)
         {
             var headers = Utilities.GetBaseHeaders();
@@ -1090,6 +1601,13 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
+        /// <summary>
+        /// Deletes multiple messages
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="message_ids">Message ids</param>
+        /// <param name="reason">Reason these messages were deleted</param>
+        /// <returns></returns>
         public Task DeleteMessagesAsync(ulong channel_id, IEnumerable<ulong> message_ids, string reason)
         {
             var pld = new RestChannelMessageBulkDeletePayload
@@ -1108,6 +1626,11 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld));
         }
 
+        /// <summary>
+        /// Gets a channel's invites
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <returns></returns>
         public async Task<IReadOnlyList<DiscordInvite>> GetChannelInvitesAsync(ulong channel_id)
         {
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.INVITES}";
@@ -1121,6 +1644,16 @@ namespace DSharpPlus.Net
             return new ReadOnlyCollection<DiscordInvite>(new List<DiscordInvite>(invites_raw));
         }
 
+        /// <summary>
+        /// Creates a channel invite
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="max_age">For how long the invite should exist</param>
+        /// <param name="max_uses">How often the invite may be used</param>
+        /// <param name="temporary">Whether this invite should be temporary</param>
+        /// <param name="unique">Whether this invite should be unique (false might return an existing invite)</param>
+        /// <param name="reason">Why you made an invite</param>
+        /// <returns></returns>
         public async Task<DiscordInvite> CreateChannelInviteAsync(ulong channel_id, int max_age, int max_uses, bool temporary, bool unique, string reason)
         {
             var pld = new RestChannelInviteCreatePayload
@@ -1147,6 +1680,13 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Deletes channel overwrite
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="overwrite_id">Overwrite id</param>
+        /// <param name="reason">Reason it was deleted</param>
+        /// <returns></returns>
         public Task DeleteChannelPermissionAsync(ulong channel_id, ulong overwrite_id, string reason)
         {
             var headers = Utilities.GetBaseHeaders();
@@ -1160,6 +1700,16 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
+        /// <summary>
+        /// Edits channel overwrite
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="overwrite_id">Overwrite id</param>
+        /// <param name="allow">Permissions to allow</param>
+        /// <param name="deny">Permissions to deny</param>
+        /// <param name="type">Overwrite type</param>
+        /// <param name="reason">Reason this overwrite was created</param>
+        /// <returns></returns>
         public Task EditChannelPermissionsAsync(ulong channel_id, ulong overwrite_id, Permissions allow, Permissions deny, string type, string reason)
         {
             var pld = new RestChannelPermissionEditPayload
@@ -1180,6 +1730,11 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, route, headers, DiscordJson.SerializeObject(pld));
         }
 
+        /// <summary>
+        /// Send a typing indicator to a channel
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <returns></returns>
         public Task TriggerTypingAsync(ulong channel_id)
         {
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.TYPING}";
@@ -1189,6 +1744,11 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route);
         }
 
+        /// <summary>
+        /// Gets pinned messages
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <returns></returns>
         public async Task<IReadOnlyList<DiscordMessage>> GetPinnedMessagesAsync(ulong channel_id)
         {
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.PINS}";
@@ -1205,6 +1765,12 @@ namespace DSharpPlus.Net
             return new ReadOnlyCollection<DiscordMessage>(new List<DiscordMessage>(msgs));
         }
 
+        /// <summary>
+        /// Pins a message to a channel.
+        /// </summary>
+        /// <param name="channel_id">Channel id.</param>
+        /// <param name="message_id">Message id.</param>
+        /// <returns></returns>
         public Task PinMessageAsync(ulong channel_id, ulong message_id)
         {
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.PINS}/:message_id";
@@ -1214,6 +1780,12 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, route);
         }
 
+        /// <summary>
+        /// Unpins a message
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="message_id">Message id</param>
+        /// <returns></returns>
         public Task UnpinMessageAsync(ulong channel_id, ulong message_id)
         {
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.PINS}/:message_id";
@@ -1223,6 +1795,14 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route);
         }
 
+        /// <summary>
+        /// Adds a member to a group DM
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="user_id">User id</param>
+        /// <param name="access_token">User's access token</param>
+        /// <param name="nickname">Nickname for user</param>
+        /// <returns></returns>
         public Task AddGroupDmRecipientAsync(ulong channel_id, ulong user_id, string access_token, string nickname)
         {
             var pld = new RestChannelGroupDmRecipientAddPayload
@@ -1238,6 +1818,21 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PUT, route, payload: DiscordJson.SerializeObject(pld));
         }
 
+        /// <summary>
+        /// Joins a group DM
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="nickname">Dm nickname</param>
+        /// <returns></returns>
+        public Task JoinGroupDmAsync(ulong channel_id, string nickname)
+            => this.AddGroupDmRecipientAsync(channel_id, this.Discord.CurrentUser.Id, this.Discord.Configuration.Token, nickname);
+
+        /// <summary>
+        /// Removes a member from a group DM
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <param name="user_id">User id</param>
+        /// <returns></returns>
         public Task RemoveGroupDmRecipientAsync(ulong channel_id, ulong user_id)
         {
             var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.CHANNELS}/:channel_id{Endpoints.RECIPIENTS}/:user_id";
@@ -1247,6 +1842,20 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route);
         }
 
+        /// <summary>
+        /// Leaves a group DM
+        /// </summary>
+        /// <param name="channel_id">Channel id</param>
+        /// <returns></returns>
+        public Task LeaveGroupDmAsync(ulong channel_id)
+            => this.RemoveGroupDmRecipientAsync(channel_id, this.Discord.CurrentUser.Id);
+
+        /// <summary>
+        /// Creates a group DM
+        /// </summary>
+        /// <param name="access_tokens">Access tokens</param>
+        /// <param name="nicks">Nicknames per user</param>
+        /// <returns></returns>
         public async Task<DiscordDmChannel> CreateGroupDmAsync(IEnumerable<string> access_tokens, IDictionary<ulong, string> nicks)
         {
             var pld = new RestUserGroupDmCreatePayload
@@ -1267,6 +1876,24 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Creates a group DM with current user
+        /// </summary>
+        /// <param name="access_tokens">Access tokens</param>
+        /// <param name="nicks">Nicknames</param>
+        /// <returns></returns>
+        public Task<DiscordDmChannel> CreateGroupDmWithCurrentUserAsync(IEnumerable<string> access_tokens, IDictionary<ulong, string> nicks)
+        {
+            var a = access_tokens.ToList();
+            a.Add(this.Discord.Configuration.Token);
+            return this.CreateGroupDmAsync(a, nicks);
+        }
+
+        /// <summary>
+        /// Creates a DM
+        /// </summary>
+        /// <param name="recipient_id">Recipient user id</param>
+        /// <returns></returns>
         public async Task<DiscordDmChannel> CreateDmAsync(ulong recipient_id)
         {
             var pld = new RestUserDmCreatePayload
@@ -1289,6 +1916,11 @@ namespace DSharpPlus.Net
             return ret;
         }
 
+        /// <summary>
+        /// Follows a news channel
+        /// </summary>
+        /// <param name="channel_id">Id of the channel to follow</param>
+        /// <param name="webhook_channel_id">Id of the channel to crosspost messages to</param>
         public async Task<DiscordFollowedChannel> FollowChannelAsync(ulong channel_id, ulong webhook_channel_id)
         {
             var pld = new FollowedChannelAddPayload
@@ -1305,6 +1937,11 @@ namespace DSharpPlus.Net
             return JsonConvert.DeserializeObject<DiscordFollowedChannel>(response.Response);
         }
 
+        /// <summary>
+        /// Publishes a message in a news channel to following channels
+        /// </summary>
+        /// <param name="channel_id">Id of the news channel the message to crosspost belongs to</param>
+        /// <param name="message_id">Id of the message to crosspost</param>
         public async Task<DiscordMessage> CrosspostMessageAsync(ulong channel_id, ulong message_id)
         {
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.CROSSPOST}";
@@ -1318,12 +1955,26 @@ namespace DSharpPlus.Net
         #endregion
 
         #region Member
+        /// <summary>
+        /// Gets current user object
+        /// </summary>
+        /// <returns></returns>
         public Task<DiscordUser> GetCurrentUserAsync()
             => this.GetUserAsync("@me");
 
+        /// <summary>
+        /// Gets user object
+        /// </summary>
+        /// <param name="user_id">User id</param>
+        /// <returns></returns>
         public Task<DiscordUser> GetUserAsync(ulong user_id)
             => this.GetUserAsync(user_id.ToString(CultureInfo.InvariantCulture));
 
+        /// <summary>
+        /// Gets user object
+        /// </summary>
+        /// <param name="user_id">User id</param>
+        /// <returns></returns>
         public async Task<DiscordUser> GetUserAsync(string user_id)
         {
             var route = $"{Endpoints.USERS}/:user_id";
@@ -1338,6 +1989,12 @@ namespace DSharpPlus.Net
             return duser;
         }
 
+        /// <summary>
+        /// Gets guild member
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="user_id">Member id</param>
+        /// <returns></returns>
         public async Task<DiscordMember> GetGuildMemberAsync(ulong guild_id, ulong user_id)
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id";
@@ -1364,6 +2021,13 @@ namespace DSharpPlus.Net
             };
         }
 
+        /// <summary>
+        /// Removes guild member
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="user_id">User id</param>
+        /// <param name="reason">Why this user was removed</param>
+        /// <returns></returns>
         public Task RemoveGuildMemberAsync(ulong guild_id, ulong user_id, string reason)
         {
             var urlparams = new Dictionary<string, string>();
@@ -1377,6 +2041,12 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route);
         }
 
+        /// <summary>
+        /// Modifies current user
+        /// </summary>
+        /// <param name="username">New username</param>
+        /// <param name="base64_avatar">New avatar (base64)</param>
+        /// <returns></returns>
         internal async Task<TransportUser> ModifyCurrentUserAsync(string username, Optional<string> base64_avatar)
         {
             var pld = new RestUserUpdateCurrentPayload
@@ -1397,6 +2067,29 @@ namespace DSharpPlus.Net
             return user_raw;
         }
 
+        /// <summary>
+        /// Modifies current user
+        /// </summary>
+        /// <param name="username">username</param>
+        /// <param name="avatar">avatar</param>
+        /// <returns></returns>
+        public async Task<DiscordUser> ModifyCurrentUserAsync(string username = null, Stream avatar = null)
+        {
+            string av64 = null;
+            if (avatar != null)
+                using (var imgtool = new ImageTool(avatar))
+                    av64 = imgtool.GetBase64();
+
+            return new DiscordUser(await this.ModifyCurrentUserAsync(username, av64).ConfigureAwait(false)) { Discord = this.Discord };
+        }
+
+        /// <summary>
+        /// Gets current user's guilds
+        /// </summary>
+        /// <param name="limit">Limit of guilds to get</param>
+        /// <param name="before">Gets guild before id</param>
+        /// <param name="after">Gets guilds after id</param>
+        /// <returns></returns>
         public async Task<IReadOnlyList<DiscordGuild>> GetCurrentUserGuildsAsync(int limit = 100, ulong? before = null, ulong? after = null)
         {
             var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.GUILDS}";
@@ -1425,6 +2118,18 @@ namespace DSharpPlus.Net
             }
         }
 
+        /// <summary>
+        /// Modifies guild member
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="user_id">User id</param>
+        /// <param name="nick">New nickname</param>
+        /// <param name="role_ids">New roles</param>
+        /// <param name="mute">Whether this user should be muted</param>
+        /// <param name="deaf">Whether this user should be deafened</param>
+        /// <param name="voice_channel_id">Voice channel to move this user to</param>
+        /// <param name="reason">Reason this user was modified</param>
+        /// <returns></returns>
         public Task ModifyGuildMemberAsync(ulong guild_id, ulong user_id, Optional<string> nick,
             Optional<IEnumerable<ulong>> role_ids, Optional<bool> mute, Optional<bool> deaf,
             Optional<ulong?> voice_channel_id, string reason)
@@ -1449,6 +2154,13 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, payload: DiscordJson.SerializeObject(pld));
         }
 
+        /// <summary>
+        /// Changes current user's nickname
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="nick">Nickname</param>
+        /// <param name="reason">Reason why you set it to this</param>
+        /// <returns></returns>
         public Task ModifyCurrentMemberNicknameAsync(ulong guild_id, string nick, string reason)
         {
             var headers = Utilities.GetBaseHeaders();

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -147,12 +147,11 @@ namespace DSharpPlus.Net
         /// <param name="method">The type of REST request to make.</param>
         /// <param name="headers">The headers to send with the request.</param>
         /// <param name="payload">The payload to send with the request.</param>
-        /// <param name="ratelimitWaitOverride"></param>
         /// <param name="queryString">The query string to add on the url.</param>
         /// <returns>The API response.</returns>
-        public Task<RestResponse> DoRequestAsync(string route, object routeParams, RestRequestMethod method, IReadOnlyDictionary<string, string> headers = null, object payload = null, double? ratelimitWaitOverride = null, string queryString = null)
+        public Task<RestResponse> DoRequestAsync(string route, object routeParams, RestRequestMethod method, IReadOnlyDictionary<string, string> headers = null, object payload = null, string queryString = null)
         {
-            var req = new RestRequest(this.Discord, this.Rest.GetBucket(method, route, routeParams, out var path), Utilities.GetApiUriFor(path, queryString), method, route, headers, DiscordJson.SerializeObject(payload), ratelimitWaitOverride);
+            var req = new RestRequest(this.Discord, this.Rest.GetBucket(method, route, routeParams, out var path), Utilities.GetApiUriFor(path, queryString), method, route, headers, DiscordJson.SerializeObject(payload), null);
 
             if (this.Discord != null)
                 this.Rest.ExecuteRequestAsync(req).LogTaskFault(this.Discord.Logger, LogLevel.Error, LoggerEvents.RestError, "Error while executing request");
@@ -182,13 +181,12 @@ namespace DSharpPlus.Net
         /// <param name="headers">The headers to send with the request.</param>
         /// <param name="values">Values to use.</param>
         /// <param name="files">The files to send on this multipart request.</param>
-        /// <param name="ratelimitWaitOverride"></param>
         /// <param name="queryString">The query string to add on the url.</param>
         /// <returns>The API response.</returns>
         public Task<RestResponse> DoMultipartAsync(string route, object routeParams, RestRequestMethod method, IReadOnlyDictionary<string, string> headers = null, IReadOnlyDictionary<string, string> values = null,
-            IReadOnlyCollection<DiscordMessageFile> files = null, double? ratelimitWaitOverride = null, string queryString = null)
+            IReadOnlyCollection<DiscordMessageFile> files = null, string queryString = null)
         {
-            var req = new MultipartWebRequest(this.Discord, this.Rest.GetBucket(method, route, routeParams, out var path), Utilities.GetApiUriFor(path, queryString), method, route, headers, values, files, ratelimitWaitOverride);
+            var req = new MultipartWebRequest(this.Discord, this.Rest.GetBucket(method, route, routeParams, out var path), Utilities.GetApiUriFor(path, queryString), method, route, headers, values, files, null);
 
             if (this.Discord != null)
                 this.Rest.ExecuteRequestAsync(req).LogTaskFault(this.Discord.Logger, LogLevel.Error, LoggerEvents.RestError, "Error while executing request");

--- a/DSharpPlus/Net/Rest/Endpoints.cs
+++ b/DSharpPlus/Net/Rest/Endpoints.cs
@@ -23,7 +23,7 @@
 
 namespace DSharpPlus.Net
 {
-    internal static class Endpoints
+    public static class Endpoints
     {
         public const string BASE_URI = "https://discord.com/api/v8";
 

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -67,6 +67,8 @@ namespace DSharpPlus.Net.Serialization
 
         private static string SerializeObjectInternal(object value, Type type, JsonSerializer jsonSerializer)
         {
+            if (value == null)
+                return null;
             var stringWriter = new StringWriter(new StringBuilder(256), CultureInfo.InvariantCulture);
             using (var jsonTextWriter = new JsonTextWriter(stringWriter))
             {


### PR DESCRIPTION
Big one, though technically not a breaking change.

# Summary
Makes the `DiscordApiClient` and it's methods public.

# Details
This allows users to use the `ApiClient` on their `DiscordClient` to make requests without needing the objects they're implemented on. Also made some public overloads for `DoRequestAsync` and `DoMultipartAsync` to allow them to use endpoints not currently implemented.

# Changes proposed
* Made the properties and methods on the `DiscordApiClient` public
* Made the `BaseDiscordClient`'s `ApiClient` public
* Made the constructor for `DiscordMessageFile` public

# Notes
A few of the methods couldn't be made public because of one of the parameters or return type being internal. These are mostly transport entities etc. It would be possible to fix this, but would require a bit of work to make sure it doesn't mess any of them up. The ones left internal (for now) are
* ListGuildMembersAsync
* ModifyGuildChannelPositionAsync
* ModifyGuildRolePositionAsync
* GetAuditLogsAsync
* ModifyCurrentUserAsync
* GetApplicationInfoAsync
Also missing xml documentation for all the endpoints, but it would be nearly impossible (or too time consuming) to do them by hand. Maybe some kind of script to copy the descriptions from the `DiscordRestClient`.