### PR TITLE
Add extension methods on CommandsNextExtension dictionaries

### DIFF
--- a/DSharpPlus.CommandsNext/ExtensionMethods.cs
+++ b/DSharpPlus.CommandsNext/ExtensionMethods.cs
@@ -25,7 +25,10 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+using DSharpPlus.CommandsNext.Builders;
+using DSharpPlus.CommandsNext.Converters;
 using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus.CommandsNext
@@ -105,6 +108,104 @@ namespace DSharpPlus.CommandsNext
             }
 
             return new ReadOnlyDictionary<int, CommandsNextExtension>(extensions);
+        }
+
+        /// <summary>
+        /// Registers all commands from a given assembly. The command classes need to be public to be considered for registration.
+        /// </summary>
+        /// <param name="extensions">Extensions to register commands on.</param>
+        /// <param name="assembly">Assembly to register commands from.</param>
+        public static void RegisterCommands(this IReadOnlyDictionary<int, CommandsNextExtension> extensions, Assembly assembly)
+        {
+            foreach (var extension in extensions.Values)
+                extension.RegisterCommands(assembly);
+        }
+        /// <summary>
+        /// Registers all commands from a given command class.
+        /// </summary>
+        /// <typeparam name="T">Class which holds commands to register.</typeparam>
+        /// <param name="extensions">Extensions to register commands on.</param>
+        public static void RegisterCommands<T>(this IReadOnlyDictionary<int, CommandsNextExtension> extensions) where T : BaseCommandModule
+        {
+            foreach (var extension in extensions.Values)
+                extension.RegisterCommands<T>();
+        }
+        /// <summary>
+        /// Registers all commands from a given command class.
+        /// </summary>
+        /// <param name="extensions">Extensions to register commands on.</param>
+        /// <param name="t">Type of the class which holds commands to register.</param>
+        public static void RegisterCommands(this IReadOnlyDictionary<int, CommandsNextExtension> extensions, Type t)
+        {
+            foreach (var extension in extensions.Values)
+                extension.RegisterCommands(t);
+        }
+        /// <summary>
+        /// Builds and registers all supplied commands.
+        /// </summary>
+        /// <param name="extensions">Extensions to register commands on.</param>
+        /// <param name="cmds">Commands to build and register.</param>
+        public static void RegisterCommands(this IReadOnlyDictionary<int, CommandsNextExtension> extensions, params CommandBuilder[] cmds)
+        {
+            foreach (var extension in extensions.Values)
+                extension.RegisterCommands(cmds);
+        }
+
+        /// <summary>
+        /// Unregisters specified commands from CommandsNext.
+        /// </summary>
+        /// <param name="extensions">Extensions to unregister commands on.</param>
+        /// <param name="cmds">Commands to unregister.</param>
+        public static void UnregisterCommands(this IReadOnlyDictionary<int, CommandsNextExtension> extensions, params Command[] cmds)
+        {
+            foreach (var extension in extensions.Values)
+                extension.UnregisterCommands(cmds);
+        }
+
+        /// <summary>
+        /// Registers an argument converter for specified type.
+        /// </summary>
+        /// <typeparam name="T">Type for which to register the converter.</typeparam>
+        /// <param name="extensions">Extensions to register the converter on.</param>
+        /// <param name="converter">Converter to register.</param>
+        public static void RegisterConverter<T>(this IReadOnlyDictionary<int, CommandsNextExtension> extensions, IArgumentConverter<T> converter)
+        {
+            foreach (var extension in extensions.Values)
+                extension.RegisterConverter(converter);
+        }
+
+        /// <summary>
+        /// Unregisters an argument converter for specified type.
+        /// </summary>
+        /// <typeparam name="T">Type for which to unregister the converter.</typeparam>
+        /// <param name="extensions">Extensions to unregister the converter on.</param>
+        public static void UnregisterConverter<T>(this IReadOnlyDictionary<int, CommandsNextExtension> extensions)
+        {
+            foreach (var extension in extensions.Values)
+                extension.UnregisterConverter<T>();
+        }
+
+        /// <summary>
+        /// Registers a user-friendly type name.
+        /// </summary>
+        /// <typeparam name="T">Type to register the name for.</typeparam>
+        /// <param name="extensions">Extensions to register the name on.</param>
+        /// <param name="value">Name to register.</param>
+        public static void RegisterUserFriendlyTypeName<T>(this IReadOnlyDictionary<int, CommandsNextExtension> extensions, string value)
+        {
+            foreach (var extension in extensions.Values)
+                extension.RegisterUserFriendlyTypeName<T>(value);
+        }
+
+        /// <summary>
+        /// Sets the help formatter to use with the default help command.
+        /// </summary>
+        /// <typeparam name="T">Type of the formatter to use.</typeparam>
+        /// <param name="extensions">Extensions to set the help formatter on.</param>
+        public static void SetHelpFormatter<T>(this IReadOnlyDictionary<int, CommandsNextExtension> extensions) where T : BaseHelpFormatter
+        {
+            foreach (var extension in extensions.Values)
+                extension.SetHelpFormatter<T>();
         }
     }
 }


### PR DESCRIPTION
Should make sharding much easier

# Summary
Adds extension methods for `Dictionary<int, CommandsNextExtension>`s that foreach through them that reflect the ones you would use for just a regular ` CommandsNextExtension`.