### PR TITLE
fix: Lavalink failed connection issues

### DIFF
--- a/DSharpPlus.Lavalink/LavalinkConfiguration.cs
+++ b/DSharpPlus.Lavalink/LavalinkConfiguration.cs
@@ -106,6 +106,9 @@ namespace DSharpPlus.Lavalink
             this.Password = other.Password;
             this.ResumeKey = other.ResumeKey;
             this.ResumeTimeout = other.ResumeTimeout;
+            this.SocketAutoReconnect = other.SocketAutoReconnect;
+            this.Region = other.Region;
+            this.WebSocketCloseTimeout = other.WebSocketCloseTimeout;
         }
     }
 }

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -253,14 +253,14 @@ namespace DSharpPlus.Lavalink
                 { throw; }
                 catch (Exception ex)
                 {
-                    if (this._backoff != MaximumBackoff)
-                    {
-                        this.Discord.Logger.LogCritical(LavalinkEvents.LavalinkConnectionError, ex, $"Failed to connect to Lavalink, retrying in {this._backoff} ms.");
-                    }
-                    else
+                    if(!this.Configuration.SocketAutoReconnect || this._backoff == MaximumBackoff)
                     {
                         this.Discord.Logger.LogCritical(LavalinkEvents.LavalinkConnectionError, ex, "Failed to connect to Lavalink.");
                         throw ex;
+                    }
+                    else
+                    {
+                        this.Discord.Logger.LogCritical(LavalinkEvents.LavalinkConnectionError, ex, $"Failed to connect to Lavalink, retrying in {this._backoff} ms.");
                     }
                 }
             }


### PR DESCRIPTION
Fixes #893

This issue was caused by the copy constructor not copying the `SocketAutoReconnect` property. This PR also rewrites how to handle failed LL connections to account for the `SocketAutoReconnect` property.