### PR TITLE
[ci skip] Fix capitalisation of Git and GitHub

### DIFF
--- a/docs/articles/hosting.md
+++ b/docs/articles/hosting.md
@@ -71,8 +71,8 @@ Now that we have covered where you can possibly host your application, now lets 
 source control solutions out there are free and also offer some type of CI/CD integration (paid and free).  Below are some of the 
 solutions that we recommend:
 
-* [**Azure Devops**](https://azure.microsoft.com/en-us/services/devops/?nav=min "Azure Devops"):  Allows for GIT source control hosting along with integrated CI/CD
-  pipelines to auto compile and publish your applications.  You can also use their CI/CD service if your code is hosted in a different source control enviorment like Github.
-* [**Github**](https://github.com/ "GitHub") Allows for GIT source control hosting.  From here you can leverage many different CI/CD options to compile and publish your 
+* [**Azure Devops**](https://azure.microsoft.com/en-us/services/devops/?nav=min "Azure Devops"):  Allows for Git source control hosting along with integrated CI/CD
+  pipelines to auto compile and publish your applications.  You can also use their CI/CD service if your code is hosted in a different source control enviorment like GitHub.
+* [**GitHub**](https://github.com/ "GitHub") Allows for Git source control hosting.  From here you can leverage many different CI/CD options to compile and publish your 
   applications.
-* [**Bitbucket**](https://bitbucket.org/ "Bitbucket"):  Allows for GIT source control hosting along with integrated CI/CD pipelines to auto compile and publish your applications.
+* [**Bitbucket**](https://bitbucket.org/ "Bitbucket"):  Allows for Git source control hosting along with integrated CI/CD pipelines to auto compile and publish your applications.


### PR DESCRIPTION
# Summary
Fixes capitalisation of Git and GitHub in https://dsharpplus.github.io/articles/hosting.html

# Details
GIT -> Git    
Github -> GitHub

# Notes
I would also suggest that, unlike Glitch and Repl.it, Heroku is actually ok for hosting bots and other non-web processes. I've been using it for years to host a bot with no issues and no hacks to keep it alive.    
However it's not significant enough to open an issue for so I'll just put it here.