### PR TITLE
Make InitializeShardsAsync public

### DIFF
--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -198,7 +198,7 @@ namespace DSharpPlus
         /// <returns>The found <see cref="DiscordClient"/> shard. Otherwise <see langword="null"/> if the shard was not found for the guild ID.</returns>
         public DiscordClient GetShard(ulong guildId)
         {
-            var index = this._manuallySharding ? this.getShardIdFromGuilds(guildId) : Utilities.GetShardId(guildId, this.ShardClients.Count);
+            var index = this._manuallySharding ? this.GetShardIdFromGuilds(guildId) : Utilities.GetShardId(guildId, this.ShardClients.Count);
 
             return index != -1 ? this._shards[index] : null;
         }
@@ -231,11 +231,11 @@ namespace DSharpPlus
             await Task.WhenAll(tasks).ConfigureAwait(false);
         }
 
-        #endregion
-
-        #region Internal Methods
-
-        internal async Task<int> InitializeShardsAsync()
+        /// <summary>
+        /// Initializes the shards.
+        /// </summary>
+        /// <returns>The number of shards.</returns>
+        public async Task<int> InitializeShardsAsync()
         {
             if (this._shards.Count != 0)
                 return this._shards.Count;
@@ -599,7 +599,7 @@ namespace DSharpPlus
             client.ApplicationCommandDeleted -= this.Client_ApplicationCommandDeleted;
         }
 
-        private int getShardIdFromGuilds(ulong id)
+        private int GetShardIdFromGuilds(ulong id)
         {
             foreach (var s in this._shards.Values)
             {


### PR DESCRIPTION
# Summary
Makes the shard client's `InitializeShardsAsync` public.

# Details
This would allow users to perform actions on shards before actually connecting, to get the shard count or register extensions.