### PR TITLE
Fix quality mode errors

### DIFF
--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -497,5 +497,42 @@ namespace DSharpPlus.Test
                 await cFull.DeleteAsync();
             }
         }
+
+        [Command("createchannel")]
+        public async Task CreateGuildChannelsAsync(CommandContext ctx, [RemainingText] string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                await ctx.RespondAsync("You must provide a channel name");
+                return;
+            }
+
+            var channel = await ctx.Guild.CreateTextChannelAsync(name);
+            var msg = await ctx.RespondAsync($"{channel.Mention} created. Delete? (Y)");
+            var result = await ctx.Message.GetNextMessageAsync(m => m.Content.Equals("y", StringComparison.OrdinalIgnoreCase), TimeSpan.FromMinutes(1));
+
+            if (!result.TimedOut)
+            {
+                await channel.DeleteAsync();
+                await ctx.RespondAsync("Channel deleted");
+            }
+        }
+
+        [Command("pc")]
+        [Aliases("purgechat")]
+        [Description("Purges chat")]
+        [RequirePermissions(Permissions.ManageChannels)]
+        public async Task PurgeChatAsync(CommandContext ctx)
+        {
+            DiscordChannel channel = ctx.Channel;
+            var z = ctx.Channel.Position;
+            var x = await channel.CloneAsync();
+            await channel.DeleteAsync();
+            await x.ModifyPositionAsync(z);
+            var embed2 = new DiscordEmbedBuilder()
+                .WithTitle("✅ Purged")
+                .WithFooter($"foo");
+            await x.SendMessageAsync(embed: embed2);
+        }
     }
 }

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -206,7 +206,7 @@ namespace DSharpPlus.Test
         }
 
         [Command("SendSomeFile")]
-        public async Task SendSomeFile(CommandContext ctx)
+        public async Task SendSomeFileAsync(CommandContext ctx)
         {
             using (var fs = new FileStream("ADumbFile.txt", FileMode.Open, FileAccess.Read))
             {
@@ -271,7 +271,7 @@ namespace DSharpPlus.Test
         }
 
         [Command("CreateSomeFile")]
-        public async Task CreateSomeFile(CommandContext ctx, string fileName, [RemainingText] string fileBody)
+        public async Task CreateSomeFileAsync(CommandContext ctx, string fileName, [RemainingText] string fileBody)
         {
             using (var fs = new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite))
             using (var sw = new StreamWriter(fs))
@@ -305,7 +305,7 @@ namespace DSharpPlus.Test
         }
 
         [Command("SendWebhookFiles")]
-        public async Task SendWebhookFiles(CommandContext ctx)
+        public async Task SendWebhookFilesAsync(CommandContext ctx)
         {
             var webhook = await ctx.Channel.CreateWebhookAsync("webhook-test");
 
@@ -409,7 +409,7 @@ namespace DSharpPlus.Test
         }
 
         [Command("mentionusers")]
-        public async Task MentionAllMentionedUsers(CommandContext ctx, [RemainingText][Description("Just a string so that DSharpPlus will parse no matter what I say")] string mentionedUsers)
+        public async Task MentionAllMentionedUsersAsync(CommandContext ctx, [RemainingText][Description("Just a string so that DSharpPlus will parse no matter what I say")] string mentionedUsers)
         {
             var content = "You didn't have any users to mention";
             if (ctx.Message.MentionedUsers.Any())
@@ -419,7 +419,7 @@ namespace DSharpPlus.Test
         }
 
         [Command("mentionroles")]
-        public async Task MentionAllMentionedRoles(CommandContext ctx, [RemainingText][Description("Just a string so that DSharpPlus will parse no matter what I say")] string mentionedRoles)
+        public async Task MentionAllMentionedRolesAsync(CommandContext ctx, [RemainingText][Description("Just a string so that DSharpPlus will parse no matter what I say")] string mentionedRoles)
         {
             var content = "You didn't have any roles to mention";
             if (ctx.Message.MentionedRoles.Any())
@@ -429,7 +429,7 @@ namespace DSharpPlus.Test
         }
 
         [Command("mentionchannels")]
-        public async Task MentionChannels(CommandContext ctx, [RemainingText][Description("Just a string so that DSharpPlus will parse no matter what I say")] string mentionedChannels)
+        public async Task MentionChannelsAsync(CommandContext ctx, [RemainingText][Description("Just a string so that DSharpPlus will parse no matter what I say")] string mentionedChannels)
         {
             var content = "You didn't have any channels to mention";
             if (ctx.Message.MentionedChannels.Any())
@@ -439,7 +439,7 @@ namespace DSharpPlus.Test
         }
 
         [Command("getmessagementions")]
-        public async Task GetMessageMentions(CommandContext ctx, ulong msgId)
+        public async Task GetMessageMentionsAsync(CommandContext ctx, ulong msgId)
         {
             var msg = await ctx.Channel.GetMessageAsync(msgId);
             var contentBuilder = new StringBuilder("You didn't mention any user, channel, or role.");
@@ -455,7 +455,7 @@ namespace DSharpPlus.Test
             await ctx.RespondAsync(contentBuilder.ToString());
         }
         [Command("getattachmenttype")]
-        public async Task GetAttachmentsTypes(CommandContext ctx, ulong? messageId = null)
+        public async Task GetAttachmentsTypesAsync(CommandContext ctx, ulong? messageId = null)
         {
             if (messageId is null)
                 messageId = ctx.Message.Id;

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -102,7 +102,7 @@ namespace DSharpPlus
                 case "channel_pins_update":
                     cid = (ulong)dat["channel_id"];
                     var ts = (string)dat["last_pin_timestamp"];
-                    await this.OnChannelPinsUpdate((ulong?)dat["guild_id"], this.InternalGetCachedChannel(cid), ts != null ? DateTimeOffset.Parse(ts, CultureInfo.InvariantCulture) : default(DateTimeOffset?)).ConfigureAwait(false);
+                    await this.OnChannelPinsUpdateAsync((ulong?)dat["guild_id"], this.InternalGetCachedChannel(cid), ts != null ? DateTimeOffset.Parse(ts, CultureInfo.InvariantCulture) : default(DateTimeOffset?)).ConfigureAwait(false);
                     break;
 
                 #endregion
@@ -663,7 +663,7 @@ namespace DSharpPlus
             }
         }
 
-        internal async Task OnChannelPinsUpdate(ulong? guildId, DiscordChannel channel, DateTimeOffset? lastPinTimestamp)
+        internal async Task OnChannelPinsUpdateAsync(ulong? guildId, DiscordChannel channel, DateTimeOffset? lastPinTimestamp)
         {
             if (channel == null)
                 return;

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -145,7 +145,7 @@ namespace DSharpPlus.Entities
         /// Gets this channel's video quality mode. This is applicable to voice channels only.
         /// </summary>
         [JsonProperty("video_quality_mode", NullValueHandling = NullValueHandling.Ignore)]
-        public VideoQualityMode QualityMode { get; internal set; }
+        public VideoQualityMode? QualityMode { get; internal set; }
 
         /// <summary>
         /// Gets when the last pinned message was pinned.

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -633,7 +633,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the guild does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordChannel> CreateVoiceChannelAsync(string name, DiscordChannel parent = null, int? bitrate = null, int? user_limit = null, IEnumerable<DiscordOverwriteBuilder> overwrites = null, VideoQualityMode? qualityMode = default, string reason = null)
+        public Task<DiscordChannel> CreateVoiceChannelAsync(string name, DiscordChannel parent = null, int? bitrate = null, int? user_limit = null, IEnumerable<DiscordOverwriteBuilder> overwrites = null, VideoQualityMode? qualityMode = null, string reason = null)
             => this.CreateChannelAsync(name, ChannelType.Voice, parent, Optional.FromNoValue<string>(), bitrate, user_limit, overwrites, null, Optional.FromNoValue<int?>(), qualityMode, reason);
 
         /// <summary>
@@ -655,7 +655,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.NotFoundException">Thrown when the guild does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordChannel> CreateChannelAsync(string name, ChannelType type, DiscordChannel parent = null, Optional<string> topic = default, int? bitrate = null, int? userLimit = null, IEnumerable<DiscordOverwriteBuilder> overwrites = null, bool? nsfw = null, Optional<int?> perUserRateLimit = default, VideoQualityMode? qualityMode = default, string reason = null)
+        public Task<DiscordChannel> CreateChannelAsync(string name, ChannelType type, DiscordChannel parent = null, Optional<string> topic = default, int? bitrate = null, int? userLimit = null, IEnumerable<DiscordOverwriteBuilder> overwrites = null, bool? nsfw = null, Optional<int?> perUserRateLimit = default, VideoQualityMode? qualityMode = null, string reason = null)
         {
             // technically you can create news/store channels but not always
             if (type != ChannelType.Text && type != ChannelType.Voice && type != ChannelType.Category && type != ChannelType.News && type != ChannelType.Store && type != ChannelType.Stage)

--- a/DSharpPlus/Enums/Channel/VideoQualityMode.cs
+++ b/DSharpPlus/Enums/Channel/VideoQualityMode.cs
@@ -33,11 +33,6 @@ namespace DSharpPlus
     public enum VideoQualityMode : int
     {
         /// <summary>
-        /// Indicates default video type, or channel is not a voice channel.
-        /// </summary>
-        DefaultValue = 0,
-
-        /// <summary>
         /// Indicates that the video quality is automatically chosen, or there is no value set.
         /// </summary>
         Auto = 1,


### PR DESCRIPTION
# Summary
Fixes bug found [here](https://discord.com/channels/379378609942560770/379378610412191753/849006162786648094) with QualityMode being an unaccepted value by Discord. Also fixes a few problems with Naming Rule Violations.

# Details
There was a bug in the way that we were handling VideoQualityMode which caused channels to be created incorrectly when cloning channels. VideoQualityMode was not nullable. The couple of places that accepted a VideoQualityMode also used a default value of default instead of null which while it technically gives the desired behavior is not as clear as null is as to what the default value being put in is. 

# Changes proposed
* Switched from using `default` as the default value to using `null` for clarity. 
* Made `DiscordChannel#QualityMode` nullable so that when parsed it isn't set equal to 0 but instead null.
* Added testing commands to ensure that the changes didn't break anything. 
* Fix Naming Rule Violations

# Notes
N/A