### PR TITLE
Breaking changes time!~ (WithComponents -> AddComponents)

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -111,8 +111,27 @@ namespace DSharpPlus.Entities
         /// <param name="components">The components to add to the message.</param>
         /// <returns>The current builder to be chained.</returns>
         /// <exception cref="ArgumentOutOfRangeException">No components were passed.</exception>
-        public DiscordMessageBuilder WithComponents(params DiscordComponent[] components)
-            => this.WithComponents((IEnumerable<DiscordComponent>)components);
+        public DiscordMessageBuilder AddComponents(params DiscordComponent[] components)
+            => this.AddComponents((IEnumerable<DiscordComponent>)components);
+
+
+        /// <summary>
+        /// Appends several rows of components to the message
+        /// </summary>
+        /// <param name="components">The rows of components to add, holding up to five each.</param>
+        /// <returns></returns>
+        public DiscordMessageBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
+        {
+            var ara = components.ToArray();
+
+            if (ara.Length + this._components.Count > 5)
+                throw new ArgumentException("ActionRow count exceeds maximum of five.");
+
+            foreach (var ar in ara)
+                this._components.Add(ar);
+
+            return this;
+        }
 
         /// <summary>
         /// Adds a row of components to a message, up to 5 components per row, and up to 5 rows per message.
@@ -120,7 +139,7 @@ namespace DSharpPlus.Entities
         /// <param name="components">The components to add to the message.</param>
         /// <returns>The current builder to be chained.</returns>
         /// <exception cref="ArgumentOutOfRangeException">No components were passed.</exception>
-        public DiscordMessageBuilder WithComponents(IEnumerable<DiscordComponent> components)
+        public DiscordMessageBuilder AddComponents(IEnumerable<DiscordComponent> components)
         {
             var cmpArr = components.ToArray();
 

--- a/DSharpPlus/Entities/Interaction/Components/DiscordActionRowComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordActionRowComponent.cs
@@ -48,7 +48,7 @@ namespace DSharpPlus.Entities
 
         internal DiscordActionRowComponent(IEnumerable<DiscordComponent> components)
         {
-            this.Components = components.ToArray();
+            this.Components = components.ToList().AsReadOnly();
         }
 
     }

--- a/DSharpPlus/Entities/Interaction/Components/DiscordActionRowComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordActionRowComponent.cs
@@ -38,19 +38,17 @@ namespace DSharpPlus.Entities
         /// The type of component this represents. Always returns type 1.
         /// </summary>
         [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]
-        public ComponentType Type { get; internal set; } = ComponentType.ActionRow;
+        internal ComponentType Type { get; set; } = ComponentType.ActionRow;
 
         /// <summary>
         /// The components contained within the action row.
         /// </summary>
         [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
-        public ReadOnlyCollection<DiscordComponent> Components { get; internal set; }
-
-        internal DiscordActionRowComponent() { }
+        public IReadOnlyCollection<DiscordComponent> Components { get; internal set; }
 
         internal DiscordActionRowComponent(IEnumerable<DiscordComponent> components)
         {
-            this.Components = components.ToList().AsReadOnly();
+            this.Components = components.ToArray();
         }
 
     }

--- a/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
@@ -92,8 +92,26 @@ namespace DSharpPlus.Entities
         /// <param name="components">The collection of components to add.</param>
         /// <returns>The builder to chain calls with.</returns>
         /// <exception cref="ArgumentException"><paramref name="components"/> contained more than 5 components.</exception>
-        public DiscordFollowupMessageBuilder WithComponents(params DiscordComponent[] components)
-            => this.WithComponents((IEnumerable<DiscordComponent>)components);
+        public DiscordFollowupMessageBuilder AddComponents(params DiscordComponent[] components)
+            => this.AddComponents((IEnumerable<DiscordComponent>)components);
+
+        /// <summary>
+        /// Appends several rows of components to the message
+        /// </summary>
+        /// <param name="components">The rows of components to add, holding up to five each.</param>
+        /// <returns></returns>
+        public DiscordFollowupMessageBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
+        {
+            var ara = components.ToArray();
+
+            if (ara.Length + this._components.Count > 5)
+                throw new ArgumentException("ActionRow count exceeds maximum of five.");
+
+            foreach (var ar in ara)
+                this._components.Add(ar);
+
+            return this;
+        }
 
         /// <summary>
         /// Appends a collection of components to the message.
@@ -101,7 +119,7 @@ namespace DSharpPlus.Entities
         /// <param name="components">The collection of components to add.</param>
         /// <returns>The builder to chain calls with.</returns>
         /// <exception cref="ArgumentException"><paramref name="components"/> contained more than 5 components.</exception>
-        public DiscordFollowupMessageBuilder WithComponents(IEnumerable<DiscordComponent> components)
+        public DiscordFollowupMessageBuilder AddComponents(IEnumerable<DiscordComponent> components)
         {
             var compArr = components.ToArray();
             var count = compArr.Length;

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -99,8 +99,26 @@ namespace DSharpPlus.Entities
         /// <param name="components">The components to append. Up to five.</param>
         /// <returns>The current builder to chain calls with.</returns>
         /// <exception cref="ArgumentException">Thrown when passing more than 5 components.</exception>
-        public DiscordInteractionResponseBuilder WithComponents(params DiscordComponent[] components)
-            => this.WithComponents((IEnumerable<DiscordComponent>)components);
+        public DiscordInteractionResponseBuilder AddComponents(params DiscordComponent[] components)
+            => this.AddComponents((IEnumerable<DiscordComponent>)components);
+
+        /// <summary>
+        /// Appends several rows of components to the message
+        /// </summary>
+        /// <param name="components">The rows of components to add, holding up to five each.</param>
+        /// <returns></returns>
+        public DiscordInteractionResponseBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
+        {
+            var ara = components.ToArray();
+
+            if (ara.Length + this._components.Count > 5)
+                throw new ArgumentException("ActionRow count exceeds maximum of five.");
+
+            foreach (var ar in ara)
+                this._components.Add(ar);
+
+            return this;
+        }
 
         /// <summary>
         /// Appends a collection of components to the builder. Each call will append to a new row.
@@ -108,7 +126,7 @@ namespace DSharpPlus.Entities
         /// <param name="components">The components to append. Up to five.</param>
         /// <returns>The current builder to chain calls with.</returns>
         /// <exception cref="ArgumentException">Thrown when passing more than 5 components.</exception>
-        public DiscordInteractionResponseBuilder WithComponents(IEnumerable<DiscordComponent> components)
+        public DiscordInteractionResponseBuilder AddComponents(IEnumerable<DiscordComponent> components)
         {
             var compArr = components.ToArray();
             var count = compArr.Length;


### PR DESCRIPTION
# Summary
A handful of people were complaining about naming conventions regarding .WithComponents, and now it's .AddComponents, to be a bit more explicit.

# Details
- Changed .WithComponents to .AddComponents to all applicable builders
- Removed the internal constructor of DiscordActionRowComponent (people complained about this too).
- Added ActionRow overloads to all applicable builders.

# Notes
Community bad x4