### PR TITLE
[Code Clean-up] Add Missing XML Doc Param and deal with warnings in code

### DIFF
--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -134,9 +134,7 @@ namespace DSharpPlus.Interactivity
                 var result = await this.ComponentInteractionWaiter
                     .WaitForMatch(new MatchRequest<ComponentInteractionCreateEventArgs>(c => c.Interaction.Type == InteractionType.Component && c.Interaction.Data.ComponentType == ComponentType.Button && c.Message.Id == message.Id && buttons.Any(b => b.CustomId == c.Id), timeout)).ConfigureAwait(false);
 
-                return result is null
-                    ? new InteractivityResult<ComponentInteractionCreateEventArgs>(true, null)
-                    : new InteractivityResult<ComponentInteractionCreateEventArgs>(false, result);
+                return new InteractivityResult<ComponentInteractionCreateEventArgs>(result is null, result);
             }
         }
 
@@ -164,9 +162,8 @@ namespace DSharpPlus.Interactivity
                 var result = await this.ComponentInteractionWaiter
                     .WaitForMatch(new MatchRequest<ComponentInteractionCreateEventArgs>(c => c.Interaction.Type == InteractionType.Component && c.Interaction.Data.ComponentType == ComponentType.Button && c.Message.Id == message.Id, timeout)).ConfigureAwait(false);
 
-                return result is null
-                    ? new InteractivityResult<ComponentInteractionCreateEventArgs>(true, null)
-                    : new InteractivityResult<ComponentInteractionCreateEventArgs>(false, result);
+                return new InteractivityResult<ComponentInteractionCreateEventArgs>(result is null, result);
+
             }
         }
 
@@ -195,9 +192,7 @@ namespace DSharpPlus.Interactivity
                 var result = await this.ComponentInteractionWaiter
                     .WaitForMatch(new MatchRequest<ComponentInteractionCreateEventArgs>(c => c.Interaction.Type == InteractionType.Component && c.Interaction.Data.ComponentType == ComponentType.Button && c.Message.Id == message.Id && c.User == user, timeout)).ConfigureAwait(false);
 
-                return result is null
-                    ? new InteractivityResult<ComponentInteractionCreateEventArgs>(true, null)
-                    : new InteractivityResult<ComponentInteractionCreateEventArgs>(false, result);
+                return new InteractivityResult<ComponentInteractionCreateEventArgs>(result is null, result);                    
             }
         }
 

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -134,10 +134,9 @@ namespace DSharpPlus.Interactivity
                 var result = await this.ComponentInteractionWaiter
                     .WaitForMatch(new MatchRequest<ComponentInteractionCreateEventArgs>(c => c.Interaction.Type == InteractionType.Component && c.Interaction.Data.ComponentType == ComponentType.Button && c.Message.Id == message.Id && buttons.Any(b => b.CustomId == c.Id), timeout)).ConfigureAwait(false);
 
-                if (result is null)
-                    return new InteractivityResult<ComponentInteractionCreateEventArgs>(true, null);
-                else
-                    return new InteractivityResult<ComponentInteractionCreateEventArgs>(false, result);
+                return result is null
+                    ? new InteractivityResult<ComponentInteractionCreateEventArgs>(true, null)
+                    : new InteractivityResult<ComponentInteractionCreateEventArgs>(false, result);
             }
         }
 
@@ -165,10 +164,9 @@ namespace DSharpPlus.Interactivity
                 var result = await this.ComponentInteractionWaiter
                     .WaitForMatch(new MatchRequest<ComponentInteractionCreateEventArgs>(c => c.Interaction.Type == InteractionType.Component && c.Interaction.Data.ComponentType == ComponentType.Button && c.Message.Id == message.Id, timeout)).ConfigureAwait(false);
 
-                if (result is null)
-                    return new InteractivityResult<ComponentInteractionCreateEventArgs>(true, null);
-                else
-                    return new InteractivityResult<ComponentInteractionCreateEventArgs>(false, result);
+                return result is null
+                    ? new InteractivityResult<ComponentInteractionCreateEventArgs>(true, null)
+                    : new InteractivityResult<ComponentInteractionCreateEventArgs>(false, result);
             }
         }
 
@@ -197,10 +195,9 @@ namespace DSharpPlus.Interactivity
                 var result = await this.ComponentInteractionWaiter
                     .WaitForMatch(new MatchRequest<ComponentInteractionCreateEventArgs>(c => c.Interaction.Type == InteractionType.Component && c.Interaction.Data.ComponentType == ComponentType.Button && c.Message.Id == message.Id && c.User == user, timeout)).ConfigureAwait(false);
 
-                if (result is null)
-                    return new InteractivityResult<ComponentInteractionCreateEventArgs>(true, null);
-                else
-                    return new InteractivityResult<ComponentInteractionCreateEventArgs>(false, result);
+                return result is null
+                    ? new InteractivityResult<ComponentInteractionCreateEventArgs>(true, null)
+                    : new InteractivityResult<ComponentInteractionCreateEventArgs>(false, result);
             }
         }
 

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -39,6 +39,8 @@ namespace DSharpPlus.Interactivity
     /// </summary>
     public class InteractivityExtension : BaseExtension
     {
+
+        #pragma warning disable IDE1006 // Naming Styles
         internal InteractivityConfiguration Config { get; }
 
         private EventWaiter<MessageCreateEventArgs> MessageCreatedWaiter;
@@ -54,6 +56,7 @@ namespace DSharpPlus.Interactivity
         private Poller Poller;
 
         private Paginator Paginator;
+        #pragma warning restore IDE1006 // Naming Styles
 
         internal InteractivityExtension(InteractivityConfiguration cfg)
         {

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -173,6 +173,7 @@ namespace DSharpPlus.Interactivity
         /// Waits for any button on the specified message to be pressed by the specified user.
         /// </summary>
         /// <param name="message">The message to wait for the button on.</param>
+        /// <param name="user">The user to wait for the button press from.</param>
         /// <param name="timeoutOverride">Override the timeout period specified in <see cref="InteractivityConfiguration"/>.</param>
         /// <returns>A <see cref="InteractivityResult{T}"/> with the result of button that was pressed, if any.</returns>
         /// <exception cref="InvalidOperationException">Thrown when attempting to wait for a message that is not authored by the current user.</exception>

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -132,7 +132,10 @@ namespace DSharpPlus.Interactivity
             while (true)
             {
                 var result = await this.ComponentInteractionWaiter
-                    .WaitForMatch(new MatchRequest<ComponentInteractionCreateEventArgs>(c => c.Interaction.Type == InteractionType.Component && c.Interaction.Data.ComponentType == ComponentType.Button && c.Message.Id == message.Id && buttons.Any(b => b.CustomId == c.Id), timeout)).ConfigureAwait(false);
+                    .WaitForMatch(new MatchRequest<ComponentInteractionCreateEventArgs>(c => c.Interaction.Type == InteractionType.Component
+                                                                                             && c.Interaction.Data.ComponentType == ComponentType.Button
+                                                                                             && c.Message == message
+                                                                                             && buttons.Any(b => b.CustomId == c.Id), timeout)).ConfigureAwait(false);
 
                 return new InteractivityResult<ComponentInteractionCreateEventArgs>(result is null, result);
             }
@@ -160,7 +163,9 @@ namespace DSharpPlus.Interactivity
             while (true)
             {
                 var result = await this.ComponentInteractionWaiter
-                    .WaitForMatch(new MatchRequest<ComponentInteractionCreateEventArgs>(c => c.Interaction.Type == InteractionType.Component && c.Interaction.Data.ComponentType == ComponentType.Button && c.Message.Id == message.Id, timeout)).ConfigureAwait(false);
+                    .WaitForMatch(new MatchRequest<ComponentInteractionCreateEventArgs>(c => c.Interaction.Type == InteractionType.Component
+                                                                                             && c.Interaction.Data.ComponentType == ComponentType.Button
+                                                                                             && c.Message == message, timeout)).ConfigureAwait(false);
 
                 return new InteractivityResult<ComponentInteractionCreateEventArgs>(result is null, result);
 


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Fixes Missing XML Parameters and cleans up code based on warnings.

# Details
Visual Studio shows a few warning that Either Should Be addressed (Missing XML Doc) or can be supressed.

# Changes proposed
* Add Missing XLM Parameter for WaitForButtonAsync(); 
* Add IDE Suppression For Naming Convention Warnings.
* Simplify If Statements By Converting To Conditional Expressions
