### PR TITLE
Fix minor typo description on DiscordComponent

### DIFF
--- a/DSharpPlus/Entities/Interaction/Components/DiscordComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordComponent.cs
@@ -36,7 +36,7 @@ namespace DSharpPlus.Entities
         public ComponentType Type { get; internal set; } = ComponentType.ActionRow;
 
         /// <summary>
-        /// The Id of this component, if applicable. Not applicable on ActionRow(s) and Link buttons.
+        /// The Id of this component, if applicable. Not applicable on ActionRow(s) and link buttons.
         /// </summary>
         [JsonProperty("custom_id", NullValueHandling = NullValueHandling.Ignore)]
         public string CustomId { get; internal set; }

--- a/DSharpPlus/Entities/Interaction/Components/DiscordComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordComponent.cs
@@ -25,7 +25,7 @@ using Newtonsoft.Json;
 namespace DSharpPlus.Entities
 {
     /// <summary>
-    /// A component to attatch to a message.
+    /// A component to attach to a message.
     /// </summary>
     public class DiscordComponent
     {
@@ -36,7 +36,7 @@ namespace DSharpPlus.Entities
         public ComponentType Type { get; internal set; } = ComponentType.ActionRow;
 
         /// <summary>
-        /// The Id of this compopnent, if applicable. Not applicable on ActionRow(s) and Link buttons.
+        /// The Id of this component, if applicable. Not applicable on ActionRow(s) and Link buttons.
         /// </summary>
         [JsonProperty("custom_id", NullValueHandling = NullValueHandling.Ignore)]
         public string CustomId { get; internal set; }


### PR DESCRIPTION
# Summary
Fixes minor typo description for DiscordComponent class.