### PR TITLE
Add type converter for DiscordComponent

### DIFF
--- a/DSharpPlus/Entities/Interaction/Components/DiscordComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordComponent.cs
@@ -58,7 +58,7 @@ namespace DSharpPlus.Entities
                 return null;
 
             var job = JObject.Load(reader);
-            var type = job["type"]?.Value<ComponentType>();
+            var type = job["type"]?.ToObject<ComponentType>();
 
             if (type == null)
                 throw new ArgumentException($"Value {reader} does not have a component type specifier");

--- a/DSharpPlus/Entities/Interaction/Components/DiscordComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordComponent.cs
@@ -20,13 +20,16 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.Entities
 {
     /// <summary>
     /// A component to attatch to a message.
     /// </summary>
+    [JsonConverter(typeof(DiscordComponentConverter))]
     public class DiscordComponent
     {
         /// <summary>
@@ -42,5 +45,38 @@ namespace DSharpPlus.Entities
         public string CustomId { get; internal set; }
 
         internal DiscordComponent() { }
+
+    }
+    internal sealed class DiscordComponentConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => throw new NotImplementedException();
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
+            var job = JObject.Load(reader);
+            var type = job["type"]?.Value<ComponentType>();
+
+            if (type == null)
+                throw new ArgumentException($"Value {reader} does not have a component type specifier");
+
+            var cmp = type switch
+            {
+                ComponentType.ActionRow => new DiscordActionRowComponent(),
+                ComponentType.Button => new DiscordButtonComponent(),
+                ComponentType.Select => new DiscordSelectComponent(),
+                _ => new DiscordComponent() { Type = type.Value }
+            };
+
+            // Populate the existing component with the values in the JObject. This avoids a recursive JsonConverter loop
+            serializer.Populate(job.CreateReader(), cmp);
+
+            return cmp;
+        }
+
+        public override bool CanConvert(Type objectType) => typeof(DiscordComponent).IsAssignableFrom(objectType);
     }
 }

--- a/DSharpPlus/Entities/Interaction/Components/DiscordComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordComponent.cs
@@ -72,7 +72,8 @@ namespace DSharpPlus.Entities
             };
 
             // Populate the existing component with the values in the JObject. This avoids a recursive JsonConverter loop
-            serializer.Populate(job.CreateReader(), cmp);
+            using var jreader = job.CreateReader();
+            serializer.Populate(jreader, cmp);
 
             return cmp;
         }

--- a/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
@@ -1,0 +1,63 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using DSharpPlus.Entities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace DSharpPlus.Net.Serialization
+{
+    internal sealed class DiscordComponentJsonConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => throw new NotImplementedException();
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+                return null;
+
+            var job = JObject.Load(reader);
+            var type = job["type"]?.ToObject<ComponentType>();
+
+            if (type == null)
+                throw new ArgumentException($"Value {reader} does not have a component type specifier");
+
+            var cmp = type switch
+            {
+                ComponentType.ActionRow => new DiscordActionRowComponent(),
+                ComponentType.Button => new DiscordButtonComponent(),
+                ComponentType.Select => new DiscordSelectComponent(),
+                _ => new DiscordComponent() { Type = type.Value }
+            };
+
+            // Populate the existing component with the values in the JObject. This avoids a recursive JsonConverter loop
+            using var jreader = job.CreateReader();
+            serializer.Populate(jreader, cmp);
+
+            return cmp;
+        }
+
+        public override bool CanConvert(Type objectType) => typeof(DiscordComponent).IsAssignableFrom(objectType);
+    }
+}


### PR DESCRIPTION
# Summary
Fixes an issue where type information is lost in `DiscordMessage#Components` because the serializer doesn't handle inheritence.

# Details
Added a type converter for the current component types. 

## Old behavior:
![](https://cdn.velvetthepanda.dev/Y26GN.png) 
## Fixed behavior:
![](https://cdn.velvetthepanda.dev/V3bVs.png)


# Changes proposed
Deserializes components to their proper types when receiving messages from gateway/REST

# Notes
I did a good for once :)