### PR TITLE
Minor Typo in comment and Exception message

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
@@ -354,7 +354,7 @@ namespace DSharpPlus.CommandsNext
             var args = new object[constructorArgs.Length];
 
             if (constructorArgs.Length != 0 && services == null)
-                throw new InvalidOperationException("Dependency collection needs to be specified for parametered constructors.");
+                throw new InvalidOperationException("Dependency collection needs to be specified for parameterized constructors.");
 
             // inject via constructor
             if (constructorArgs.Length != 0)

--- a/DSharpPlus.Interactivity/Enums/InteractionResponseBehavior.cs
+++ b/DSharpPlus.Interactivity/Enums/InteractionResponseBehavior.cs
@@ -29,7 +29,7 @@ namespace DSharpPlus.Interactivity.Enums
         /// </summary>
         Ignore,
         /// <summary>
-        /// Indiicates that invalid input should be ACK'd. The interaction will succeed, but nothing will happen.
+        /// Indicates that invalid input should be ACK'd. The interaction will succeed, but nothing will happen.
         /// </summary>
         Ack,
         /// <summary>


### PR DESCRIPTION
# Summary
Fixes typos that I found in Interactivity and CNext

# Details
One fixed typo is a Exception message in CNext, the other is a comment in Interaction

# Changes proposed
* Fixed Typo. parametered to parameterized in CommandsNextUtilities.cs
* Fixed Typo. Indiicates to Indicates in InteractionResponseBehavior.cs