### PR TITLE
Add GetGuildBan support

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -75,7 +75,6 @@ namespace DSharpPlus
         /// <param name="limit">The maximum amount of members to return. Max 1000. Defaults to 1.</param>
         /// <returns>The members found, if any.</returns>
         public Task<IReadOnlyList<DiscordMember>> SearchMembersAsync(ulong guild_id, string name, int? limit = 1)
-
             => this.ApiClient.SearchMembersAsync(guild_id, name, limit);
 
         /// <summary>
@@ -170,12 +169,21 @@ namespace DSharpPlus
         }
 
         /// <summary>
-        /// Gets guild bans
+        /// Gets guild bans.
         /// </summary>
-        /// <param name="guild_id">Guild id</param>
-        /// <returns></returns>
+        /// <param name="guild_id">The Id of the guild to get the bans from.</param>
+        /// <returns>A collection of the guild's bans.</returns>
         public Task<IReadOnlyList<DiscordBan>> GetGuildBansAsync(ulong guild_id)
             => this.ApiClient.GetGuildBansAsync(guild_id);
+
+        /// <summary>
+        /// Gets the ban of the specified user. Requires Ban Members permission.
+        /// </summary>
+        /// <param name="guild_id">The Id of the guild to get the ban from.</param>
+        /// <param name="user_id">The Id of the user to get the ban for.</param>
+        /// <returns>A guild ban object.</returns>
+        public Task<DiscordBan> GetGuildBanAsync(ulong guild_id, ulong user_id)
+            => this.ApiClient.GetGuildBanAsync(guild_id, user_id);
 
         /// <summary>
         /// Creates guild ban

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -30,6 +30,8 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using DSharpPlus.EventArgs;
+using DSharpPlus.Exceptions;
 using DSharpPlus.Net.Abstractions;
 using DSharpPlus.Net.Models;
 using DSharpPlus.Net.Serialization;
@@ -597,6 +599,24 @@ namespace DSharpPlus.Entities
             => this.Discord.ApiClient.GetGuildBansAsync(this.Id);
 
         /// <summary>
+        /// Gets a ban for a specific user.
+        /// </summary>
+        /// <param name="userId">The Id of the user to get the ban for.</param>
+        /// <exception cref="NotFoundException">Thrown when the specified user is not banned.</exception>
+        /// <returns>The requested ban object.</returns>
+        public Task<DiscordBan> GetBanAsync(ulong userId)
+            => this.Discord.ApiClient.GetGuildBanAsync(this.Id, userId);
+
+        /// <summary>
+        /// Gets a ban for a specific user.
+        /// </summary>
+        /// <param name="user">The user to get the ban for.</param>
+        /// <exception cref="NotFoundException">Thrown when the specified user is not banned.</exception>
+        /// <returns>The requested ban object.</returns>
+        public Task<DiscordBan> GetBanAsync(DiscordUser user)
+            => this.GetBanAsync(user.Id);
+
+        /// <summary>
         /// Creates a new text channel in this guild.
         /// </summary>
         /// <param name="name">Name of the new channel.</param>
@@ -965,7 +985,7 @@ namespace DSharpPlus.Entities
         /// <param name="query">Filters the returned members based on what the username starts with. Either this or <paramref name="userIds"/> must not be null.
         /// The <paramref name="limit"/> must also be greater than 0 if this is specified.</param>
         /// <param name="limit">Total number of members to request. This must be greater than 0 if <paramref name="query"/> is specified.</param>
-        /// <param name="presences">Whether to include the <see cref="EventArgs.GuildMembersChunkEventArgs.Presences"/> associated with the fetched members.</param>
+        /// <param name="presences">Whether to include the <see cref="GuildMembersChunkEventArgs.Presences"/> associated with the fetched members.</param>
         /// <param name="userIds">Whether to limit the request to the specified user ids. Either this or <paramref name="query"/> must not be null.</param>
         /// <param name="nonce">The unique string to identify the response.</param>
         public async Task RequestMembersAsync(string query = "", int limit = 0, bool? presences = null, IEnumerable<ulong> userIds = null, string nonce = null)

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -192,7 +192,7 @@ namespace DSharpPlus.Net
             var res = await this.DoRequestAsync(this.Discord, bucket, uri, RestRequestMethod.GET, route).ConfigureAwait(false);
             var json = JObject.Parse(res.Response);
 
-            var ban = json.ToDiscordObject<DiscordBan>();
+            var ban = json.ToObject<DiscordBan>();
 
             return ban;
         }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -184,6 +184,19 @@ namespace DSharpPlus.Net
             return mbrs;
         }
 
+        internal async Task<DiscordBan> GetGuildBanAsync(ulong guild_id, ulong user_id)
+        {
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.BANS}/:user_id";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new {guild_id, user_id}, out var url);
+            var uri = Utilities.GetApiUriFor(url);
+            var res = await this.DoRequestAsync(this.Discord, bucket, uri, RestRequestMethod.GET, route).ConfigureAwait(false);
+            var json = JObject.Parse(res.Response);
+
+            var ban = json.ToDiscordObject<DiscordBan>();
+
+            return ban;
+        }
+
         internal async Task<DiscordGuild> CreateGuildAsync(string name, string region_id, Optional<string> iconb64, VerificationLevel? verification_level,
             DefaultMessageNotifications? default_message_notifications)
         {


### PR DESCRIPTION
Adds the ability to get [a single guild ban](https://discord.com/developers/docs/resources/guild#get-guild-ban) instead of querying the entire list. Good for big servers.