### PR TITLE
Fix inline replies breaking mentions

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMentions.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMentions.cs
@@ -61,24 +61,24 @@ namespace DSharpPlus.Entities
         [JsonProperty("replied_user", NullValueHandling = NullValueHandling.Ignore)]
         public bool? RepliedUser { get; }
 
-        internal DiscordMentions(IEnumerable<IMention> mentions, bool mention = false)
+        internal DiscordMentions(IEnumerable<IMention> mentions, bool mention = false, bool repliedUser = false)
         {
             //Null check just to be safe
             if (mentions == null) return;
 
-            //If we have no item in our mentions, its likely to be a empty array. 
+            //If we have no item in our mentions, its likely to be a empty array.
             // This is a special case were we want parse to be a empty array
             // Doing this allows for "no parsing"
             if (!mentions.Any())
             {
                 this.Parse = Array.Empty<string>();
-                this.RepliedUser = mention;
+                this.RepliedUser = repliedUser;
                 return;
             }
 
             if (mention)
             {
-                this.RepliedUser = mention;
+                this.RepliedUser = repliedUser;
             }
 
 
@@ -112,7 +112,7 @@ namespace DSharpPlus.Entities
                         break;
 
                     case RepliedUserMention _:
-                        this.RepliedUser = mention;
+                        this.RepliedUser = repliedUser;
                         break;
                 }
             }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -883,7 +883,7 @@ namespace DSharpPlus.Net
                 pld.MessageReference = new InternalDiscordMessageReference { MessageId = replyMessageId, FailIfNotExists = failOnInvalidReply };
 
             if (replyMessageId != null)
-                pld.Mentions = new DiscordMentions(Mentions.None, mentionReply);
+                pld.Mentions = new DiscordMentions(Mentions.All, true, mentionReply);
 
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
@@ -916,9 +916,8 @@ namespace DSharpPlus.Net
             if (builder.ReplyId != null)
                 pld.MessageReference = new InternalDiscordMessageReference { MessageId = builder.ReplyId, FailIfNotExists = builder.FailOnInvalidReply };
 
-
             if (builder.Mentions != null || builder.ReplyId != null)
-                pld.Mentions = new DiscordMentions(builder.Mentions ?? Mentions.None, builder.MentionOnReply);
+                pld.Mentions = new DiscordMentions(builder.Mentions ?? Mentions.All, builder.Mentions?.Any() ?? false, builder.MentionOnReply);
 
             if (builder.Files.Count == 0)
             {
@@ -2027,7 +2026,7 @@ namespace DSharpPlus.Net
             };
 
             if (builder.Mentions != null)
-                pld.Mentions = new DiscordMentions(builder.Mentions);
+                pld.Mentions = new DiscordMentions(builder.Mentions, builder.Mentions.Any());
 
             if (!string.IsNullOrEmpty(builder.Content) || builder.Embeds?.Count() > 0 || builder.IsTTS == true || builder.Mentions != null)
                 values["payload_json"] = DiscordJson.SerializeObject(pld);
@@ -2591,7 +2590,7 @@ namespace DSharpPlus.Net
             };
 
             if (builder.Mentions != null)
-                pld.Mentions = new DiscordMentions(builder.Mentions);
+                pld.Mentions = new DiscordMentions(builder.Mentions, builder.Mentions.Any());
 
             if (!string.IsNullOrEmpty(builder.Content) || builder.Embeds?.Count() > 0 || builder.IsTTS == true || builder.Mentions != null)
                 values["payload_json"] = DiscordJson.SerializeObject(pld);


### PR DESCRIPTION
# Summary
#704 brought inline replies to the library, and a major oversight was made. This fixes #897

# Details
This PR Fixes a bug introduced by yours truly where setting inline reply to not mention would also make everything else not mention. This behavior has been corrected.

# Changes proposed
Adds new repliedUser parameter to DiscordMentions.cs, and uses that for determining whether to mention a user or not

# Notes
This seems to work in 99% of test cases. 
![](https://cdn.velvetthepanda.dev/HvSBP.png)
![](https://cdn.velvetthepanda.dev/IGvUz.png)
![](https://cdn.velvetthepanda.dev/NkCud.png)