### PR TITLE
Implementation of DiscordMessage.Content humanization (attempt number 2)

### DIFF
--- a/DSharpPlus/Entities/Emoji/DiscordEmoji.EmojiUtils.cs
+++ b/DSharpPlus/Entities/Emoji/DiscordEmoji.EmojiUtils.cs
@@ -30,12 +30,12 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets a mapping of :name: => unicode.
         /// </summary>
-        private static IReadOnlyDictionary<string, string> UnicodeEmojis { get; }
+        internal static IReadOnlyDictionary<string, string> UnicodeEmojis { get; }
 
         /// <summary>
         /// Gets a mapping of unicode => :name:.
         /// </summary>
-        private static IReadOnlyDictionary<string, string> DiscordNameLookup { get; }
+        internal static IReadOnlyDictionary<string, string> DiscordNameLookup { get; }
 
         static DiscordEmoji()
         {

--- a/DSharpPlus/Entities/Emoji/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/Emoji/DiscordEmoji.cs
@@ -277,6 +277,38 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// Creates an emoji object from a guild emote information specified in the emote message tag. If an emote is unknown, constructs an emoji object based on the provided information.
+        /// </summary>
+        /// <param name="client"><see cref="BaseDiscordClient"/> to attach to the object.</param>
+        /// <param name="id">Id of the emote.</param>
+        /// <param name="name">The expected name of the emote.</param>
+        /// <param name="isAnimated">Is the emote is expected to be animated.</param>
+        /// <returns>Create <see cref="DiscordEmoji"/> object.</returns>
+        public static DiscordEmoji FromGuildEmoteTagInfo(BaseDiscordClient client, ulong id, string name, bool isAnimated = false)
+        {
+            if (client == null)
+                throw new ArgumentNullException(nameof(client), "Client cannot be null.");
+            var found = TryFromGuildEmote(client, id, out var emote);
+            if (found)
+                return emote;
+            // We still have enough information to construct a dummy DiscordEmoji
+            // which could provide us for example an Url for the emoji
+            // This could happen if eg a Nitro user used an emoji from a server
+            // where the bot is not present
+            // We explicitely mark as IsAvailable = false to avoid it's usage
+            return new DiscordEmoji
+            {
+                Id = id,
+                Name = name,
+                IsAvailable = false,
+                IsAnimated = isAnimated,
+                Discord = client,
+                // Supposedly impossible for a guild emote to not require colons
+                RequiresColons = true
+            };
+        }
+
+        /// <summary>
         /// Attempts to create an emoji object from a guild emote.
         /// </summary>
         /// <param name="client"><see cref="BaseDiscordClient"/> to attach to the object.</param>

--- a/DSharpPlus/Formatter.cs
+++ b/DSharpPlus/Formatter.cs
@@ -34,7 +34,7 @@ namespace DSharpPlus
     public static class Formatter
     {
         private static Regex MdSanitizeRegex { get; } = new Regex(@"([`\*_~<>\[\]\(\)""@\!\&#:\|])", RegexOptions.ECMAScript);
-        private static Regex MdStripRegex { get; } = new Regex(@"([`\*_~\[\]\(\)""\|]|<@\!?\d+>|<#\d+>|<@\&\d+>|<:[a-zA-Z0-9_\-]:\d+>)", RegexOptions.ECMAScript);
+        private static Regex MdStripRegex { get; } = new Regex(@"([`\*_~\[\]\(\)""\|]|<@\!?\d+>|<#\d+>|<@\&\d+>|<a?:[a-zA-Z0-9_\-]:\d+>)", RegexOptions.ECMAScript);
 
         /// <summary>
         /// Creates a block of code.

--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -138,7 +138,7 @@ namespace DSharpPlus
             return regex.IsMatch(message);
         }
 
-        internal static bool ContainsEmojis(string message)
+        internal static bool ContainsGuildEmojis(string message)
         {
             var pattern = @"<a?:(.*):(\d+)>";
             var regex = new Regex(pattern, RegexOptions.ECMAScript);
@@ -169,12 +169,129 @@ namespace DSharpPlus
                 yield return ulong.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture);
         }
 
-        internal static IEnumerable<ulong> GetEmojis(DiscordMessage message)
+        internal static IEnumerable<(ulong id, string name, bool isAnimated)> GetGuildEmojis(DiscordMessage message)
         {
             var regex = new Regex(@"<a?:([a-zA-Z0-9_]+):(\d+)>", RegexOptions.ECMAScript);
             var matches = regex.Matches(message.Content);
             foreach (Match match in matches)
-                yield return ulong.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture);
+                yield return (ulong.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture),
+                              match.Groups[1].Value,
+                              match.Value.StartsWith("<a:"));
+        }
+
+        public static IEnumerable<DiscordEmoji> GetCommonEmojis(DiscordMessage message)
+        {
+            return DiscordEmoji.UnicodeEmojis.Keys
+                .Where(e => message.Content.Contains(e))
+                .Select(e => DiscordEmoji.FromName(message.Discord, e, false))
+                .Union(DiscordEmoji.DiscordNameLookup.Keys
+                    .Where(e => message.Content.Contains(e))
+                    .Select(e => DiscordEmoji.FromUnicode(e)))
+                .ToList();
+        }
+
+        /// <summary>
+        /// Converts all of the Discord message snowflake tags to a human-readable format
+        /// </summary>
+        /// <param name="message">The message to convert</param>
+        /// <returns>A human-readable format of the message</returns>
+        public static Task<string> HumanizeContentAsync(DiscordMessage message)
+            => HumanizeContentAsync(message, (e)
+                => (e != null && e.Id == 0) ? Task.FromResult(e.Name) : Task.FromResult(string.Empty));
+
+        /// <summary>
+        /// Converts all of the Discord message snowflake tags to a human-readable format
+        /// </summary>
+        /// <param name="message">The message to convert</param>
+        /// <param name="emojiReplacer">A callback to specify how emojis should be converted</param>
+        /// <returns>A human-readable format of the message</returns>
+        public async static Task<string> HumanizeContentAsync(DiscordMessage message, Func<DiscordEmoji, Task<string>> emojiReplacer)
+        {
+            // Preparing the parsing by retrieving all the guild emojis used
+            var guildEmojis = Utilities.GetGuildEmojis(message)
+                .Select(emojidata =>
+                {
+                    var result = DiscordEmoji.TryFromGuildEmote(message.Discord, emojidata.id, out var emoji);
+                    // If the emoji wasn't found, we still can construct it's URL from the data we got, so create a dummy object, and mark it as unavailable
+                    return result ? emoji : new DiscordEmoji
+                    {
+                        Id = emojidata.id,
+                        Name = emojidata.name,
+                        IsAvailable = false,
+                        IsAnimated = emojidata.isAnimated,
+                        Discord = message.Discord,
+                        RequiresColons = true
+                    };
+                });
+
+            // First we take care of "special tags (<>), including guild emojies"
+            var regex = new Regex(@"<(?<TagType>(@[!&]?)|(#)|(a?:([a-zA-Z0-9_]+):))(?<TagId>\d+)>", RegexOptions.ECMAScript);
+            var text = await regex.ReplaceAsync(message.Content, async m =>
+            {
+                var tagType = m.Groups["TagType"].Value;
+                var tagId = ulong.Parse(m.Groups["TagId"].Value);
+                switch (tagType)
+                {
+                    case "@": // Username mention
+                        return $"@{message.MentionedUsers.FirstOrDefault(u => u.Id == tagId).Username}";
+
+                    case "@!": // Nickname mention
+                        var user = message.MentionedUsers.FirstOrDefault(u => u.Id == tagId);
+                        if (user is DiscordMember member)
+                        {
+                            return $"@{member.DisplayName}";
+                        }
+                        if (message.Channel?.Guild != null)
+                        {
+                            member = await message.Channel.Guild.GetMemberAsync(tagId);
+                            return $"@{member.DisplayName}";
+                        }
+                        return $"@{user.Username}";
+
+                    case "@&": // Role mention
+                        return $"@{message.MentionedRoles.FirstOrDefault(r => r.Id == tagId).Name}";
+
+                    case "#": // Channel mention
+                        return $"#{message.MentionedChannels.FirstOrDefault(c => c.Id == tagId).Name}";
+
+                    case string s when s.StartsWith("a:") || s.StartsWith(":"): // Guild emoji
+                        var emoji = guildEmojis.FirstOrDefault(e => e.Id == tagId);
+                        return await emojiReplacer(emoji);
+
+                    default:
+                        throw new ArgumentException("Matched something unexpected");
+                }
+            });
+
+            // Now we take care of common emojis
+            // We sort them so we first replace the most complex ("composite") ones first
+
+            // Converting the ":emojiname:" format
+            var commonEmojis = DiscordEmoji.UnicodeEmojis.Keys
+                .Where(e => text.Contains(e))
+                .OrderByDescending(e => e.Count(c => c == ':'))
+                .ThenByDescending(e => e.Length);
+
+            foreach (var emojiName in commonEmojis)
+            {
+                var emoji = DiscordEmoji.FromName(message.Discord, emojiName, false);
+                var replacement = await emojiReplacer(emoji);
+                text = text.Replace(emojiName, replacement);
+            }
+
+            // Converting the unicode emojis
+            var unicodeEmojis = DiscordEmoji.DiscordNameLookup.Keys
+                .Where(e => text.Contains(e))
+                .OrderByDescending(e => e.Length);
+
+            foreach (var unicodeEmoji in unicodeEmojis)
+            {
+                var emoji = DiscordEmoji.FromUnicode(unicodeEmoji);
+                var replacement = await emojiReplacer(emoji);
+                text = text.Replace(unicodeEmoji, replacement);
+            }
+
+            return text;
         }
 
         internal static bool HasMessageIntents(DiscordIntents intents)
@@ -287,6 +404,33 @@ namespace DSharpPlus
                     return true;
 
             return false;
+        }
+
+        /// <summary>
+        /// An async version of Regex.Replace
+        /// </summary>
+        /// <param name="regex">The Regex object which is used to match the string for replacements</param>
+        /// <param name="input">The string to search for a match</param>
+        /// <param name="replacementFn">A custom method that examines each match and returns either the original matched string or a replacement string</param>
+        /// <returns>A new string that is identical to the input string, except that a replacement
+        /// string takes the place of each matched string. If pattern is not matched in the
+        /// current instance, the method returns the current instance unchanged</returns>
+        public static async Task<string> ReplaceAsync(this Regex regex, string input, Func<Match, Task<string>> replacementFn)
+        {
+            var sb = new StringBuilder();
+            var lastIndex = 0;
+
+            var matches = regex.Matches(input);
+            foreach (Match match in matches)
+            {
+                sb.Append(input, lastIndex, match.Index - lastIndex)
+                  .Append(await replacementFn(match).ConfigureAwait(false));
+
+                lastIndex = match.Index + match.Length;
+            }
+
+            sb.Append(input, lastIndex, input.Length - lastIndex);
+            return sb.ToString();
         }
 
         internal static void LogTaskFault(this Task task, ILogger logger, LogLevel level, EventId eventId, string message)

--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -182,17 +182,6 @@ namespace DSharpPlus
             }
         }
 
-        internal static IEnumerable<DiscordEmoji> GetCommonEmojis(DiscordMessage message)
-        {
-            return DiscordEmoji.UnicodeEmojis.Keys
-                .Where(e => message.Content.Contains(e))
-                .Select(e => DiscordEmoji.FromName(message.Discord, e, false))
-                .Union(DiscordEmoji.DiscordNameLookup.Keys
-                    .Where(e => message.Content.Contains(e))
-                    .Select(e => DiscordEmoji.FromUnicode(e)))
-                .ToList();
-        }
-
         /// <summary>
         /// The default humanizer for objects constructed from mentions (such as user, role, channel mentions or emojis).
         /// </summary>
@@ -334,8 +323,8 @@ namespace DSharpPlus
 
             var regexFullCodeBlock = new Regex(@"```[\w\W]+?```", RegexOptions.ECMAScript);
             var regexCodeBlockStart = new Regex(@"```[\w\W]+?", RegexOptions.ECMAScript);
-            var regexFullCode = new Regex(@"[^`]`[^`][\w\W]+?[^`]`[^`]", RegexOptions.ECMAScript);
-            var regexCode = new Regex(@"[^`]`[^`]", RegexOptions.ECMAScript);
+            var regexFullCode = new Regex(@"(?<!`)`[\w\W]+?`(?!`)", RegexOptions.ECMAScript);
+            var regexCode = new Regex(@"(?<!`)`(?!`)", RegexOptions.ECMAScript);
             var text = await regex.ReplaceAsync(message.Content, async m =>
             {
                 // Code block checking


### PR DESCRIPTION
# Summary
This is the implementation of the convertation to a human-readable format of DiscordMessage snowflake tags (such as mentions and emojis). Resolves #935. This is a second (and probably final) attempt, in a hope that this way of implementing stuff would be more appropriate for the project.

# Details
For some cases, a human-readable version of the message received by a bot may be useful - for example, to relay it somewhere else, eg on a website. This pull request implements the convertation to a human-readable format the most cryptic part of a bot-received message - the mentions and emojis.
Now, the way I did the first PR were probably not right, sorry - I didn't knew that. I genuinely try to do it right, I'm just new to this project.

# Changes proposed
* The implementation changed completely from extending Discord objects to a self contained Utility function doing everything inside itself. Only small changes are made to DiscordEmoji.EmojiUtils.cs by making the arrays internal instead of private.
* Added the `Utilities.HumanizeContentAsync` method for converting the snowflake tags into human-readable representation
* Because the method of converting emojis may depend on circumstances, `HumanizeContentAsync` accepts a second parameter of `Func<DiscordEmoji, Task<string>>` to allow specifying a method of formatting theese
* The default is to skip all non-unicode emojis, and output the unicode emojis in unicode format
* Sometimes the guild emoji used in a message can't be retrieved using default Discord API because the bot doesn't know about the server from which the emote originate (eg a Nitro user posted an emoji from another server). We still have enough information to construct a dummy DiscordEmoji object which could be used for retrieving the URL of the emote, for example. We explicitely mark it as IsAvailable = false to avoid it's usage elsewhere
* Along the way fixed the Formatter.Strip to account for animated emojis as well

# Notes
The `HumanizeContentAsync` method is async only because of the `message.Channel.Guild.GetMemberAsync` call, which is in turn a fallback for the case if `if (user is DiscordMember member)` fails. Now, if for guild messages this cast is always true, I can rework it to make it non-async.