### PR TITLE
Configure CNext to allow marking the MessageCreate event as handled

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
@@ -118,10 +118,10 @@ namespace DSharpPlus.CommandsNext
         public bool IgnoreExtraArguments { internal get; set; } = false;
 
         /// <summary>
-        /// <para>Gets whether subsequent MessageCreate event handlers are processed after a command was found. If this is set to true, the default command handler marks the event as handled, and subsequent MessageCreate handlers won't be called, otherwise they are called.</para>
+        /// <para>Gets or sets whether remaining MessageCreate event handlers will run if a command is successfully parsed.</para>
         /// <para>Defaults to false.</para>
         /// </summary>
-        public bool SignalHandledOnCommandFound { internal get; set; } = false;
+        public bool MarkEventAsHandled { internal get; set; } = false;
 
         /// <summary>
         /// <para>Gets or sets whether to automatically enable handling commands.</para>

--- a/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
@@ -118,6 +118,12 @@ namespace DSharpPlus.CommandsNext
         public bool IgnoreExtraArguments { internal get; set; } = false;
 
         /// <summary>
+        /// <para>Gets whether subsequent MessageCreate event handlers are processed after a command was found. If this is set to true, the default command handler marks the event as handled, and subsequent MessageCreate handlers won't be called, otherwise they are called.</para>
+        /// <para>Defaults to false.</para>
+        /// </summary>
+        public bool SignalHandledOnCommandFound { internal get; set; } = false;
+
+        /// <summary>
         /// <para>Gets or sets whether to automatically enable handling commands.</para>
         /// <para>If this is set to false, you will need to manually handle each incoming message and pass it to CommandsNext.</para>
         /// <para>Defaults to true.</para>

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -235,6 +235,9 @@ namespace DSharpPlus.CommandsNext
             }
 
             _ = Task.Run(async () => await this.ExecuteCommandAsync(ctx).ConfigureAwait(false));
+
+            if (this.Config.SignalHandledOnCommandFound)
+                e.Handled = true;
         }
 
         /// <summary>

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -236,8 +236,7 @@ namespace DSharpPlus.CommandsNext
 
             _ = Task.Run(async () => await this.ExecuteCommandAsync(ctx).ConfigureAwait(false));
 
-            if (this.Config.SignalHandledOnCommandFound)
-                e.Handled = true;
+            e.Handled = this.Config.MarkEventAsHandled;
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary
This adds a configuration option to CNext to allow marking the MessageCreate event as handled (and subsequently stopping invocation of other MessageCreate events) in case if a command was found for the message.

# Details
Sometimes you want to make sure that the command you are using won't be propagated to subsequent MessageCreate event handlers, to make sure for your custom MessageCreate handler that it is not a command message. One way to do it is to write a custom command handler, but then you need to either copy the command handler source code to retain the same behaviour, or use reflection (because the handler is private). This creates an option to mark the event as handled if a command was found and tasked to be executed, which prevents subsequent event handlers to be called.

# Changes proposed
This adds a ~~`CommandsNextConfiguration.SignalHandledOnCommandFound`~~`CommandsNextConfiguration.MarkEventAsHandled` option, which, if true, makes the default command handler (`CommandsNextExtension.HandleCommandsAsync`) to mark the MessageCreateEventArgs event as Handled (setting `e.Handled = true`).
The default value is false (which does nothing) due to backward compatibility.