### PR TITLE
Fix VNext choking the ThreadPool

### DIFF
--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -399,9 +399,9 @@ namespace DSharpPlus.VoiceNext
                 }
 
                 // Provided by Laura#0090 (214796473689178133); this is Python, but adaptable:
-                // 
+                //
                 // delay = max(0, self.delay + ((start_time + self.delay * loops) + - time.time()))
-                // 
+                //
                 // self.delay
                 //   sample size
                 // start_time
@@ -523,7 +523,7 @@ namespace DSharpPlus.VoiceNext
                 if (opusSpan[0] == 0x90)
                 {
                     // I'm not 100% sure what this header is/does, however removing the data causes no
-                    // real issues, and has the added benefit of removing a lot of noise. 
+                    // real issues, and has the added benefit of removing a lot of noise.
                     opusSpan = opusSpan.Slice(2);
                 }
 
@@ -720,8 +720,7 @@ namespace DSharpPlus.VoiceNext
             this.IsInitialized = false;
             this.TokenSource.Cancel();
             this.SenderTokenSource.Cancel();
-            if (this.Configuration.EnableIncoming)
-                this.ReceiverTokenSource.Cancel();
+            this.ReceiverTokenSource?.Cancel();
 
             try
             {

--- a/DSharpPlus/Net/Udp/DspUdpClient.cs
+++ b/DSharpPlus/Net/Udp/DspUdpClient.cs
@@ -76,9 +76,7 @@ namespace DSharpPlus.Net.Udp
         /// </summary>
         /// <returns>The received bytes.</returns>
         public override Task<byte[]> ReceiveAsync()
-        {
-            return this.PacketQueue.Count > 0 ? Task.FromResult(this.PacketQueue.Take()) : Task.Run(() => this.PacketQueue.Take());
-        }
+            => Task.FromResult(this.PacketQueue.Take());
 
         /// <summary>
         /// Closes and disposes the client.

--- a/DSharpPlus/Net/Udp/DspUdpClient.cs
+++ b/DSharpPlus/Net/Udp/DspUdpClient.cs
@@ -76,7 +76,10 @@ namespace DSharpPlus.Net.Udp
         /// </summary>
         /// <returns>The received bytes.</returns>
         public override Task<byte[]> ReceiveAsync()
-            => Task.FromResult(this.PacketQueue.Take());
+            => this.PacketQueue.Count is 0 ?
+            Task.FromResult(this.PacketQueue.Take(this.Token)) : //Do NOT remove this token or you will deadlock VNext. //
+            Task.Run(() => this.PacketQueue.Take(this.Token), this.Token);
+
 
         /// <summary>
         /// Closes and disposes the client.

--- a/DSharpPlus/Net/Udp/DspUdpClient.cs
+++ b/DSharpPlus/Net/Udp/DspUdpClient.cs
@@ -75,10 +75,7 @@ namespace DSharpPlus.Net.Udp
         /// Receives a datagram.
         /// </summary>
         /// <returns>The received bytes.</returns>
-        public override Task<byte[]> ReceiveAsync()
-            => this.PacketQueue.Count is 0 ?
-            Task.FromResult(this.PacketQueue.Take(this.Token)) : //Do NOT remove this token or you will deadlock VNext. //
-            Task.Run(() => this.PacketQueue.Take(this.Token), this.Token);
+        public override Task<byte[]> ReceiveAsync() => Task.FromResult(this.PacketQueue.Take(this.Token));
 
 
         /// <summary>


### PR DESCRIPTION
# Summary
Fixes VNext not properly canceling Udp-related tasks.

# Details
VNext would previously only cancel the receiver token if incoming voice was enabled, but the receive loop is started regardless of configuration, so an infinite task would get spun up.

Also, in the DspUdpClient, ReceiveAsync would starve threads by failing to cancel `BlockingCollection.Take()` when disposing.

# Changes proposed
- Cancel BlockingCollection.Take
- Return BlockingCollection.Take directly instead of using Task.Run
- Cancel receiver token in VoiceNextExtension

# Notes
Thanks to @alexhorner for pointing this out and helping with testing <3