### PR TITLE
Fix guild shard formula

### DIFF
--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -200,7 +200,7 @@ namespace DSharpPlus
         /// <param name="shardCount">The total amount of shards.</param>
         /// <returns>The shard id.</returns>
         public static int GetShardId(ulong guildId, int shardCount)
-            => (int)(guildId >> 22) % shardCount;
+            => (int)((guildId >> 22) % (ulong)shardCount);
 
         /// <summary>
         /// Helper method to create a <see cref="DateTimeOffset"/> from Unix time seconds for targets that do not support this natively.


### PR DESCRIPTION
# Summary
The guild shard calculation is wrong because the shifted value is cast to `int` before the modulo operation.

# Details
Here's a failing example:
```csharp
ulong guildId = 860338524707094538UL;
int shardCount = 5;
return (int)(guildId >> 22) % shardCount; // returns -1
```
Operation precedence makes the result of `(int)(guildId >> 22)` be -1037741601, as the intermediate value has too many bits for `int`, which is incorrect.

# Changes proposed
The PR makes the cast happen after the modulo:
`(int)((guildId >> 22) % (ulong)shardCount)`
The `ulong` cast of `shardCount` makes the compiler happy.

# Notes
This also fixes GetShard() returning null in cases where it shouldn't.