### PR TITLE
Fix EmojiUpdate passing the same collection

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
@@ -908,7 +909,7 @@ namespace DSharpPlus
 
         internal async Task OnGuildEmojisUpdateEventAsync(DiscordGuild guild, IEnumerable<DiscordEmoji> newEmojis)
         {
-            var oldEmojis = new ReadOnlyDictionary<ulong, DiscordEmoji>(guild._emojis);
+            var oldEmojis = guild._emojis.ToImmutableDictionary();
             guild._emojis.Clear();
 
             foreach (var emoji in newEmojis)

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -909,7 +909,7 @@ namespace DSharpPlus
 
         internal async Task OnGuildEmojisUpdateEventAsync(DiscordGuild guild, IEnumerable<DiscordEmoji> newEmojis)
         {
-            var oldEmojis = guild._emojis.ToImmutableDictionary();
+            var oldEmojis = new ConcurrentDictionary<ulong, DiscordEmoji>(guild._emojis);
             guild._emojis.Clear();
 
             foreach (var emoji in newEmojis)


### PR DESCRIPTION
# Summary
GuildEmojiUpdate wouldn't actually send the before and after, but instead the same collection in both properties

# Details

When guild emojis are updated, we simply [dump the entire cache](https://github.com/DSharpPlus/DSharpPlus/blob/master/DSharpPlus/Clients/DiscordClient.Dispatch.cs#L911-L912) and [iterate through what discord sends](https://github.com/DSharpPlus/DSharpPlus/blob/master/DSharpPlus/Clients/DiscordClient.Dispatch.cs#L917)

But the issue is [here](https://github.com/DSharpPlus/DSharpPlus/blob/master/DSharpPlus/Clients/DiscordClient.Dispatch.cs#L911). Creating a new ReadOnlyDictionary from an existing dictionary only wraps the passed dictionary, and thus when clearing the guild cache, it would clear the underlying dictionary because [it's passed by ref and nothing more](https://source.dot.net/#System.ObjectModel/System/Collections/ObjectModel/ReadOnlyDictionary.cs,25)


# Changes proposed
use `.ToImmutableDictionary()`

# Notes
Someone bad