### PR TITLE
Add support for user banners/banner color

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -223,6 +223,16 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// Gets the member's banner hash.
+        /// </summary>
+        [JsonIgnore]
+        public override string BannerHash
+        {
+            get => this.User.BannerHash;
+            internal set => this.User.BannerHash = value;
+        }
+
+        /// <summary>
         /// Gets the member's avatar hash.
         /// </summary>
         [JsonIgnore]

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -232,7 +232,10 @@ namespace DSharpPlus.Entities
             internal set => this.User.BannerHash = value;
         }
 
-        /// <summary>
+        [JsonIgnore]
+        public override DiscordColor? BannerColor => this.User.BannerColor;
+
+            /// <summary>
         /// Gets the member's avatar hash.
         /// </summary>
         [JsonIgnore]

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -223,6 +223,12 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// Gets this member's banner url.
+        /// </summary>
+        [JsonIgnore]
+        public string BannerUrl => this.User.BannerUrl;
+
+        /// <summary>
         /// Gets the member's banner hash.
         /// </summary>
         [JsonIgnore]
@@ -232,10 +238,13 @@ namespace DSharpPlus.Entities
             internal set => this.User.BannerHash = value;
         }
 
+        /// <summary>
+        /// The color of this member's banner. Mutually exclusive with <see cref="BannerHash"/>.
+        /// </summary>
         [JsonIgnore]
         public override DiscordColor? BannerColor => this.User.BannerColor;
 
-            /// <summary>
+        /// <summary>
         /// Gets the member's avatar hash.
         /// </summary>
         [JsonIgnore]

--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -75,7 +75,7 @@ namespace DSharpPlus.Entities
         public virtual DiscordColor? BannerColor
             => this._bannerColor == 0 ? null : new DiscordColor(this._bannerColor);
 
-        [JsonProperty("banner_color")]
+        [JsonProperty("accent_color")]
         internal int _bannerColor;
 
         /// <summary>

--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -43,6 +43,7 @@ namespace DSharpPlus.Entities
             this.Discriminator = transport.Discriminator;
             this.AvatarHash = transport.AvatarHash;
             this._bannerColor = transport.BannerColor;
+            this.BannerHash = transport.BannerHash;
             this.IsBot = transport.IsBot;
             this.MfaEnabled = transport.MfaEnabled;
             this.Verified = transport.Verified;

--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -98,7 +98,6 @@ namespace DSharpPlus.Entities
         [JsonProperty("avatar", NullValueHandling = NullValueHandling.Ignore)]
         public virtual string AvatarHash { get; internal set; }
 
-
         /// <summary>
         /// Gets the user's avatar URL.
         /// </summary>

--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -70,7 +70,7 @@ namespace DSharpPlus.Entities
             => int.Parse(this.Discriminator, NumberStyles.Integer, CultureInfo.InvariantCulture);
 
         /// <summary>
-        /// Gets the user's banner color, if set.
+        /// Gets the user's banner color, if set. Mutually exclusive with <see cref="BannerHash"/>.
         /// </summary>
         public virtual DiscordColor? BannerColor
             => this._bannerColor == 0 ? null : new DiscordColor(this._bannerColor);
@@ -79,13 +79,14 @@ namespace DSharpPlus.Entities
         internal int _bannerColor;
 
         /// <summary>
-        /// Gets the user's banner url
+        /// Gets the user's banner url.
         /// </summary>
         [JsonIgnore]
         public string BannerUrl
             => string.IsNullOrEmpty(this.BannerHash) ? null : $"https://cdn.discordapp.com/banners/{this.Id}/{this.BannerHash}.{(this.BannerHash.StartsWith("a") ? "gif" : "png")}?size=4096";
+
         /// <summary>
-        /// Gets the user's profile banner hash.
+        /// Gets the user's profile banner hash. Mutually exclusive with <see cref="BannerColor"/>.
         /// </summary>
         [JsonProperty("banner", NullValueHandling = NullValueHandling.Ignore)]
         public virtual string BannerHash { get; internal set; }

--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -71,7 +71,8 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the user's banner color, if set.
         /// </summary>
-        public DiscordColor? BannerColor => new DiscordColor(this._bannerColor);
+        public DiscordColor? BannerColor
+            => string.IsNullOrEmpty(this._bannerColor) ? null : new DiscordColor(this._bannerColor);
 
         [JsonProperty("banner_color")]
         internal string _bannerColor;

--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -42,6 +42,7 @@ namespace DSharpPlus.Entities
             this.Username = transport.Username;
             this.Discriminator = transport.Discriminator;
             this.AvatarHash = transport.AvatarHash;
+            this._bannerColor = transport.BannerColor;
             this.IsBot = transport.IsBot;
             this.MfaEnabled = transport.MfaEnabled;
             this.Verified = transport.Verified;
@@ -71,11 +72,11 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the user's banner color, if set.
         /// </summary>
-        public DiscordColor? BannerColor
-            => string.IsNullOrEmpty(this._bannerColor) ? null : new DiscordColor(this._bannerColor);
+        public virtual DiscordColor? BannerColor
+            => this._bannerColor == 0 ? null : new DiscordColor(this._bannerColor);
 
         [JsonProperty("banner_color")]
-        internal string _bannerColor;
+        internal int _bannerColor;
 
         /// <summary>
         /// Gets the user's banner url

--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -69,10 +69,31 @@ namespace DSharpPlus.Entities
             => int.Parse(this.Discriminator, NumberStyles.Integer, CultureInfo.InvariantCulture);
 
         /// <summary>
+        /// Gets the user's banner color, if set.
+        /// </summary>
+        public DiscordColor? BannerColor => new DiscordColor(this._bannerColor);
+
+        [JsonProperty("banner_color")]
+        internal string _bannerColor;
+
+        /// <summary>
+        /// Gets the user's banner url
+        /// </summary>
+        [JsonIgnore]
+        public string BannerUrl
+            => string.IsNullOrEmpty(this.BannerHash) ? null : $"https://cdn.discordapp.com/banners/{this.Id}/{this.BannerHash}.{(this.BannerHash.StartsWith("a") ? "gif" : "png")}?size=4096";
+        /// <summary>
+        /// Gets the user's profile banner hash.
+        /// </summary>
+        [JsonProperty("banner", NullValueHandling = NullValueHandling.Ignore)]
+        public virtual string BannerHash { get; internal set; }
+
+        /// <summary>
         /// Gets the user's avatar hash.
         /// </summary>
         [JsonProperty("avatar", NullValueHandling = NullValueHandling.Ignore)]
         public virtual string AvatarHash { get; internal set; }
+
 
         /// <summary>
         /// Gets the user's avatar URL.

--- a/DSharpPlus/Net/Abstractions/Transport/TransportUser.cs
+++ b/DSharpPlus/Net/Abstractions/Transport/TransportUser.cs
@@ -42,7 +42,7 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("banner", NullValueHandling = NullValueHandling.Ignore)]
         public string BannerHash { get; internal set; }
 
-        [JsonProperty("banner_color")]
+        [JsonProperty("accent_color")]
         public int BannerColor { get; internal set; }
 
         [JsonProperty("bot", NullValueHandling = NullValueHandling.Ignore)]

--- a/DSharpPlus/Net/Abstractions/Transport/TransportUser.cs
+++ b/DSharpPlus/Net/Abstractions/Transport/TransportUser.cs
@@ -39,6 +39,12 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("avatar", NullValueHandling = NullValueHandling.Ignore)]
         public string AvatarHash { get; internal set; }
 
+        [JsonProperty("banner", NullValueHandling = NullValueHandling.Ignore)]
+        public string BannerHash { get; internal set; }
+
+        [JsonProperty("banner_color")]
+        public int BannerColor { get; internal set; }
+
         [JsonProperty("bot", NullValueHandling = NullValueHandling.Ignore)]
         public bool IsBot { get; internal set; }
 
@@ -71,6 +77,8 @@ namespace DSharpPlus.Net.Abstractions
             this.Username = other.Username;
             this.Discriminator = other.Discriminator;
             this.AvatarHash = other.AvatarHash;
+            this.BannerHash = other.BannerHash;
+            this.BannerColor = other.BannerColor;
             this.IsBot = other.IsBot;
             this.MfaEnabled = other.MfaEnabled;
             this.Verified = other.Verified;


### PR DESCRIPTION
Whilst this change has not actually been implemented into the API yet, it was said that there are plans to "start passively serializing banner hashes for bots". Figured I'd open this PR pre-emptively.