### PR TITLE
PayloadReceived event

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -57,6 +57,13 @@ namespace DSharpPlus
                 return;
             }
 
+            /* This should be fine. I think. AsyncEvent<TS, TE> has it's own event handler. */
+            await this._payloadReceived.InvokeAsync(this, new()
+            {
+                EventName = payload.EventName,
+                PayloadObject = dat
+            }).ConfigureAwait(false);
+
             DiscordChannel chn;
             ulong gid;
             ulong cid;

--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -59,6 +59,16 @@ namespace DSharpPlus
         private AsyncEvent<DiscordClient, SocketEventArgs> _socketOpened;
 
         /// <summary>
+        /// Fired when a gateway
+        /// </summary>
+        public event AsyncEventHandler<DiscordClient, PayloadReceivedEventArgs> PayloadReceived
+        {
+            add => this._payloadReceived.Register(value);
+            remove => this._payloadReceived.Unregister(value);
+        }
+        private AsyncEvent<DiscordClient, PayloadReceivedEventArgs> _payloadReceived;
+
+        /// <summary>
         /// Fired whenever WebSocket connection is terminated.
         /// </summary>
         public event AsyncEventHandler<DiscordClient, SocketCloseEventArgs> SocketClosed

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -203,7 +203,6 @@ namespace DSharpPlus
             this._messageReactionRemovedEmoji = new AsyncEvent<DiscordClient, MessageReactionRemoveEmojiEventArgs>("MESSAGE_REACTION_REMOVED_EMOJI", EventExecutionLimit, this.EventErrorHandler);
             this._webhooksUpdated = new AsyncEvent<DiscordClient, WebhooksUpdateEventArgs>("WEBHOOKS_UPDATED", EventExecutionLimit, this.EventErrorHandler);
             this._heartbeated = new AsyncEvent<DiscordClient, HeartbeatEventArgs>("HEARTBEATED", EventExecutionLimit, this.EventErrorHandler);
-
             this._applicationCommandCreated = new AsyncEvent<DiscordClient, ApplicationCommandEventArgs>("APPLICATION_COMMAND_CREATED", EventExecutionLimit, this.EventErrorHandler);
             this._applicationCommandUpdated = new AsyncEvent<DiscordClient, ApplicationCommandEventArgs>("APPLICATION_COMMAND_UPDATED", EventExecutionLimit, this.EventErrorHandler);
             this._applicationCommandDeleted = new AsyncEvent<DiscordClient, ApplicationCommandEventArgs>("APPLICATION_COMMAND_DELETED", EventExecutionLimit, this.EventErrorHandler);

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -195,6 +195,7 @@ namespace DSharpPlus
             this._voiceStateUpdated = new AsyncEvent<DiscordClient, VoiceStateUpdateEventArgs>("VOICE_STATE_UPDATED", EventExecutionLimit, this.EventErrorHandler);
             this._voiceServerUpdated = new AsyncEvent<DiscordClient, VoiceServerUpdateEventArgs>("VOICE_SERVER_UPDATED", EventExecutionLimit, this.EventErrorHandler);
             this._guildMembersChunked = new AsyncEvent<DiscordClient, GuildMembersChunkEventArgs>("GUILD_MEMBERS_CHUNKED", EventExecutionLimit, this.EventErrorHandler);
+            this._payloadReceived = new AsyncEvent<DiscordClient, PayloadReceivedEventArgs>("PAYLOAD_RECEIVED", EventExecutionLimit, this.EventErrorHandler);
             this._unknownEvent = new AsyncEvent<DiscordClient, UnknownEventArgs>("UNKNOWN_EVENT", EventExecutionLimit, this.EventErrorHandler);
             this._messageReactionAdded = new AsyncEvent<DiscordClient, MessageReactionAddEventArgs>("MESSAGE_REACTION_ADDED", EventExecutionLimit, this.EventErrorHandler);
             this._messageReactionRemoved = new AsyncEvent<DiscordClient, MessageReactionRemoveEventArgs>("MESSAGE_REACTION_REMOVED", EventExecutionLimit, this.EventErrorHandler);
@@ -202,6 +203,7 @@ namespace DSharpPlus
             this._messageReactionRemovedEmoji = new AsyncEvent<DiscordClient, MessageReactionRemoveEmojiEventArgs>("MESSAGE_REACTION_REMOVED_EMOJI", EventExecutionLimit, this.EventErrorHandler);
             this._webhooksUpdated = new AsyncEvent<DiscordClient, WebhooksUpdateEventArgs>("WEBHOOKS_UPDATED", EventExecutionLimit, this.EventErrorHandler);
             this._heartbeated = new AsyncEvent<DiscordClient, HeartbeatEventArgs>("HEARTBEATED", EventExecutionLimit, this.EventErrorHandler);
+
             this._applicationCommandCreated = new AsyncEvent<DiscordClient, ApplicationCommandEventArgs>("APPLICATION_COMMAND_CREATED", EventExecutionLimit, this.EventErrorHandler);
             this._applicationCommandUpdated = new AsyncEvent<DiscordClient, ApplicationCommandEventArgs>("APPLICATION_COMMAND_UPDATED", EventExecutionLimit, this.EventErrorHandler);
             this._applicationCommandDeleted = new AsyncEvent<DiscordClient, ApplicationCommandEventArgs>("APPLICATION_COMMAND_DELETED", EventExecutionLimit, this.EventErrorHandler);

--- a/DSharpPlus/EventArgs/PayloadReceivedEventArgs.cs
+++ b/DSharpPlus/EventArgs/PayloadReceivedEventArgs.cs
@@ -1,0 +1,55 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using Newtonsoft.Json.Linq;
+
+namespace DSharpPlus.EventArgs
+{
+    /// <summary>
+    /// Represents a gateway payload.
+    /// </summary>
+    public class PayloadReceivedEventArgs : DiscordEventArgs
+    {
+        /// <summary>
+        /// The JSON from this payload event.
+        /// </summary>
+        public string Json
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(this._json))
+                    this._json = this.PayloadObject.ToString();
+                return this._json;
+            }
+        }
+
+        private string _json;
+        internal JObject PayloadObject { get; set; }
+
+        /// <summary>
+        /// The name of this event.
+        /// </summary>
+        public string EventName { get; internal set; }
+
+        internal PayloadReceivedEventArgs() {}
+    }
+}


### PR DESCRIPTION
# Summary
Adds a PayloadReceived event to the client, allowing for serialization of payload events. This only applies to Dispatch messages, however.