### PR TITLE
Fixed DM Channels being null on API requests

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -785,6 +785,7 @@ namespace DSharpPlus
                 : new DiscordChannel
                 {
                     Id = message.ChannelId,
+                    GuildId = guild.Id,
                     Discord = this
                 };
 

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -97,6 +97,7 @@ namespace DSharpPlus.Net
                 : new DiscordChannel
                 {
                     Id = ret.ChannelId,
+                    GuildId = ret.GuildId,
                     Discord = Discord
                 };
             ret.Channel = channel;

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -84,6 +84,23 @@ namespace DSharpPlus.Net
                 this.PopulateMessage(author, ret.ReferencedMessage);
             }
 
+            if (ret.Channel != null)
+                return ret;
+
+            var channel = !ret.GuildId.HasValue
+                ? new DiscordDmChannel
+                {
+                    Id = ret.ChannelId,
+                    Discord = Discord,
+                    Type = ChannelType.Private
+                }
+                : new DiscordChannel
+                {
+                    Id = ret.ChannelId,
+                    Discord = Discord
+                };
+            ret.Channel = channel;
+
             return ret;
         }
 


### PR DESCRIPTION
# Summary

As @cmsteffey brought up in #lib-discussion, any API request for messages within a DM returns messages with null channels. This fixes that. 

# Details
Modified `PrepareMessage()` in DiscordApiClient to check if the prepared message channel is null and construct channel objects from there. 

The code is largely ~~stolen~~ based off `UpdateMessage()` in DiscordClient. I'm not sure why GuildId isn't set either for the base channel in the original code, but if it isn't broke don't fix it.
https://github.com/DSharpPlus/DSharpPlus/blob/4281c5911997008400522111287e0b661a000d41/DSharpPlus/Clients/DiscordClient.cs#L776-L791

# Notes
I've done light testing and nothing is broken, at least with, `GetMessagesAsync()`, `GetMessageAsync()`, creating messages via builder or content, `GetPinnedMessagesAsync()`, and `ModifyAsync()`.