### PR TITLE
Fix the way module candidate types are checked

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
@@ -297,9 +297,7 @@ namespace DSharpPlus.CommandsNext
                 return false;
 
             // check if derives from the required base class
-            var tmodule = typeof(BaseCommandModule);
-            var timodule = tmodule.GetTypeInfo();
-            if (!timodule.IsAssignableFrom(ti))
+            if (!ti.IsSubclassOf(typeof(BaseCommandModule)))
                 return false;
 
             // check if anonymous


### PR DESCRIPTION
# Summary
Fixes the way module candidate types are checked in `CommandsNext` extension

# Details
Changes the function [Type#IsAssignableFrom](https://docs.microsoft.com/en-us/dotnet/api/system.type.isassignablefrom) to a proper one [Type#IsSubclassOf](https://docs.microsoft.com/en-us/dotnet/api/system.type.issubclassof)
Current solution behaviour means that a class "could be a module" and this PR fixes this