### PR TITLE
Fix arbitrary sequence number in GW payloads

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -57,8 +57,6 @@ namespace DSharpPlus
                 return;
             }
 
-
-
             DiscordChannel chn;
             ulong gid;
             ulong cid;

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -57,6 +57,8 @@ namespace DSharpPlus
                 return;
             }
 
+
+
             DiscordChannel chn;
             ulong gid;
             ulong cid;

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -220,6 +220,7 @@ namespace DSharpPlus
         internal async Task HandleSocketMessageAsync(string data)
         {
             var payload = JsonConvert.DeserializeObject<GatewayPayload>(data);
+            this._lastSequence = payload.Sequence ?? this._lastSequence;
             switch (payload.OpCode)
             {
                 case GatewayOpCode.Dispatch:
@@ -341,7 +342,7 @@ namespace DSharpPlus
             {
                 while (true)
                 {
-                    await this.SendHeartbeatAsync().ConfigureAwait(false);
+                    await this.SendHeartbeatAsync(this._lastSequence).ConfigureAwait(false);
                     await Task.Delay(this._heartbeatInterval, token).ConfigureAwait(false);
                     token.ThrowIfCancellationRequested();
                 }
@@ -397,14 +398,6 @@ namespace DSharpPlus
                 pr.Activity = act;
                 pr.Status = userStatus ?? pr.Status;
             }
-        }
-
-        internal Task SendHeartbeatAsync()
-        {
-            var _last_heartbeat = DateTimeOffset.Now;
-            var _sequence = (long)(_last_heartbeat - DiscordEpoch).TotalMilliseconds;
-
-            return this.SendHeartbeatAsync(_sequence);
         }
 
         internal async Task SendHeartbeatAsync(long seq)

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -91,14 +91,14 @@ namespace DSharpPlus.Net
                 ? new DiscordDmChannel
                 {
                     Id = ret.ChannelId,
-                    Discord = Discord,
+                    Discord = this.Discord,
                     Type = ChannelType.Private
                 }
                 : new DiscordChannel
                 {
                     Id = ret.ChannelId,
                     GuildId = ret.GuildId,
-                    Discord = Discord
+                    Discord = this.Discord
                 };
             ret.Channel = channel;
 
@@ -2738,7 +2738,7 @@ namespace DSharpPlus.Net
             foreach (var perm in ret)
                 perm.Discord = this.Discord;
             return ret.ToList();
-        } 
+        }
         #endregion
 
         #region Misc


### PR DESCRIPTION
This PR aims to fix an issue where we would pass an arbitrary sequence number based on the curernt time to Discord during applicable gateway commands. Discord states that you [should use the last sequence number given to you](https://discord.dev/topics/gateway#resuming).