### PR TITLE
Add support for new application command option types

### DIFF
--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOptionChoice.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOptionChoice.cs
@@ -38,7 +38,7 @@ namespace DSharpPlus.Entities
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets the value of this choice parameter. This will either be a type of <see cref="int"/> / <see cref="long"/> or <see cref="string"/>.
+        /// Gets the value of this choice parameter. This will either be a type of <see cref="int"/> / <see cref="long"/>, <see cref="double"/> or <see cref="string"/>.
         /// </summary>
         [JsonProperty("value")]
         public object Value { get; set; }
@@ -50,8 +50,8 @@ namespace DSharpPlus.Entities
         /// <param name="value">The value of the parameter choice.</param>
         public DiscordApplicationCommandOptionChoice(string name, object value)
         {
-            if (!(value is string || value is long || value is int))
-                throw new InvalidOperationException($"Only {typeof(string)}, {typeof(long)} or {typeof(int)} types may be passed to a command option choice.");
+            if (!(value is string || value is long || value is int || value is double))
+                throw new InvalidOperationException($"Only {typeof(string)}, {typeof(long)}, {typeof(double)} or {typeof(int)} types may be passed to a command option choice.");
 
             if (name.Length > 100)
                 throw new ArgumentException("Slash command choice name cannot exceed 100 characters.", nameof(name));

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
@@ -48,7 +48,7 @@ namespace DSharpPlus.Entities
 
         /// <summary>
         /// Gets the value of this interaction parameter. 
-        /// <para>This can be cast to a <see langword="long"/>, <see langword="bool"></see>, <see langword="string"></see> or <see langword="ulong"/> depending on the <see cref="Type"/></para>
+        /// <para>This can be cast to a <see langword="long"/>, <see langword="bool"></see>, <see langword="string"></see>, <see langword="double"></see> or <see langword="ulong"/> depending on the <see cref="Type"/></para>
         /// </summary>
         [JsonIgnore]
         public object Value
@@ -63,6 +63,8 @@ namespace DSharpPlus.Entities
                     ApplicationCommandOptionType.Channel => ulong.Parse(this._value),
                     ApplicationCommandOptionType.User => ulong.Parse(this._value),
                     ApplicationCommandOptionType.Role => ulong.Parse(this._value),
+                    ApplicationCommandOptionType.Mentionable => ulong.Parse(this._value),
+                    ApplicationCommandOptionType.Number => double.Parse(this._value),
                     _ => this._value,
                 };
             }

--- a/DSharpPlus/Enums/Interaction/ApplicationCommandOptionType.cs
+++ b/DSharpPlus/Enums/Interaction/ApplicationCommandOptionType.cs
@@ -74,7 +74,7 @@ namespace DSharpPlus
         Mentionable,
 
         /// <summary>
-        /// Whether this paramter is a double.
+        /// Whether this parameter is a double.
         /// </summary>
         Number
     }

--- a/DSharpPlus/Enums/Interaction/ApplicationCommandOptionType.cs
+++ b/DSharpPlus/Enums/Interaction/ApplicationCommandOptionType.cs
@@ -66,6 +66,16 @@ namespace DSharpPlus
         /// <summary>
         /// Whether this parameter is a Discord role.
         /// </summary>
-        Role
+        Role,
+
+        /// <summary>
+        /// Whether this parameter is a mentionable (role or user).
+        /// </summary>
+        Mentionable,
+
+        /// <summary>
+        /// Whether this paramter is a double.
+        /// </summary>
+        Number
     }
 }


### PR DESCRIPTION
# Summary
Adds support for the `Mentionable` and `Number` application command option types.

# Details
Mentionable can be a user or a role, and apparently you're supposed to check which one it is from `Resolved`. Number allows for float/double values.