### PR TITLE
Update Permissions to include newly documented External Sticker Permission

### DIFF
--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -27,7 +27,7 @@ namespace DSharpPlus
 {
     public static class PermissionMethods
     {
-        internal static Permissions FULL_PERMS { get; } = (Permissions)128849018879L;
+        internal static Permissions FULL_PERMS { get; } = (Permissions)274877906943L;
 
         /// <summary>
         /// Calculates whether this permission set contains the given permission.
@@ -92,7 +92,7 @@ namespace DSharpPlus
         /// Indicates all permissions are granted
         /// </summary>
         [PermissionString("All permissions")]
-        All = 128849018879,
+        All = 274877906943,
 
         /// <summary>
         /// Allows creation of instant channel invites.

--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -302,7 +302,13 @@ namespace DSharpPlus
         /// Allows for creating and participating in private threads.
         /// </summary>
         [PermissionString("Use Private Threads")]
-        UsePrivateThreads = 0x0000001000000000
+        UsePrivateThreads = 0x0000001000000000,
+        
+        /// <summary>
+        /// Allows the usage of custom stickers from other servers.
+        /// </summary>
+        [PermissionString("Use external Stickers")]
+        UseExternalStickers = 0x0000002000000000
     }
 
     /// <summary>


### PR DESCRIPTION
# Summary

Implements the following permissions to `DSharpPlus.Permissions`:

- `USE_EXTERNAL_STICKERS`

# Details

Adds the following permissions to the `Permissions` enum.
- `UseExternalStickers`

# Changes proposed

  - Add `Permissions.UseExternalStickers` with a value of `0x0000002000000000`

  - Modify the `FULL_PERMS` and `All` values to the result of the old `All` value and all new values resulting to a new value of `274877906943`
