### PR TITLE
Add ignoreDms for require permission attributes

### DIFF
--- a/DSharpPlus.CommandsNext/Attributes/RequireBotPermissionsAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireBotPermissionsAttribute.cs
@@ -46,9 +46,11 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// Defines that usage of this command is only possible when the bot is granted a specific permission.
         /// </summary>
         /// <param name="permissions">Permissions required to execute this command.</param>
-        public RequireBotPermissionsAttribute(Permissions permissions)
+        /// <param name="ignoreDms">Sets this check's behaviour in DMs. True means the check will always pass in DMs, whereas false means that it will always fail.</param>
+        public RequireBotPermissionsAttribute(Permissions permissions, bool ignoreDms = true)
         {
             this.Permissions = permissions;
+            this.IgnoreDms = ignoreDms;
         }
 
         public override async Task<bool> ExecuteCheckAsync(CommandContext ctx, bool help)

--- a/DSharpPlus.CommandsNext/Attributes/RequirePermissionsAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequirePermissionsAttribute.cs
@@ -46,9 +46,11 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// Defines that usage of this command is restricted to members with specified permissions. This check also verifies that the bot has the same permissions.
         /// </summary>
         /// <param name="permissions">Permissions required to execute this command.</param>
-        public RequirePermissionsAttribute(Permissions permissions)
+        /// <param name="ignoreDms">Sets this check's behaviour in DMs. True means the check will always pass in DMs, whereas false means that it will always fail.</param>
+        public RequirePermissionsAttribute(Permissions permissions, bool ignoreDms = true)
         {
             this.Permissions = permissions;
+            this.IgnoreDms = ignoreDms;
         }
 
         public override async Task<bool> ExecuteCheckAsync(CommandContext ctx, bool help)

--- a/DSharpPlus.CommandsNext/Attributes/RequireUserPermissionsAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireUserPermissionsAttribute.cs
@@ -46,9 +46,11 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// Defines that usage of this command is restricted to members with specified permissions.
         /// </summary>
         /// <param name="permissions">Permissions required to execute this command.</param>
-        public RequireUserPermissionsAttribute(Permissions permissions)
+        /// <param name="ignoreDms">Sets this check's behaviour in DMs. True means the check will always pass in DMs, whereas false means that it will always fail.</param>
+        public RequireUserPermissionsAttribute(Permissions permissions, bool ignoreDms = true)
         {
             this.Permissions = permissions;
+            this.IgnoreDms = ignoreDms;
         }
 
         public override Task<bool> ExecuteCheckAsync(CommandContext ctx, bool help)


### PR DESCRIPTION
# Summary
Makes the `IgnoreDms` property on the require permissions attributes actually be able to be set.