### PR TITLE
Fix interactivity overloads

### DIFF
--- a/DSharpPlus.Interactivity/Extensions/ChannelExtensions.cs
+++ b/DSharpPlus.Interactivity/Extensions/ChannelExtensions.cs
@@ -102,7 +102,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
         /// <exception cref="InvalidOperationException">Thrown if interactivity is not enabled for the client associated with the channel.</exception>
         public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons = null, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken? token = default)
-            => GetInteractivity(channel).SendPaginatedMessageAsync(channel, user, pages, buttons, behaviour, deletion, token);
+            => GetInteractivity(channel).SendPaginatedMessageAsync(channel, user, pages, token, buttons, behaviour, deletion);
 
         /// <summary>
         /// Retrieves an interactivity instance from a channel instance.

--- a/DSharpPlus.Interactivity/Extensions/ChannelExtensions.cs
+++ b/DSharpPlus.Interactivity/Extensions/ChannelExtensions.cs
@@ -87,7 +87,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="deletion">Deletion behaviour.</param>
         /// <param name="timeoutoverride">Override timeout period.</param>
         /// <exception cref="InvalidOperationException">Thrown if interactivity is not enabled for the client associated with the channel.</exception>
-        public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationEmojis emojis = null, PaginationBehaviour? behaviour = default, PaginationDeletion? deletion = default, TimeSpan? timeoutoverride = null)
+        public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationEmojis emojis, PaginationBehaviour? behaviour = default, PaginationDeletion? deletion = default, TimeSpan? timeoutoverride = null)
             => GetInteractivity(channel).SendPaginatedMessageAsync(channel, user, pages, emojis, behaviour, deletion, timeoutoverride);
 
         /// <summary>
@@ -101,8 +101,12 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="deletion">Deletion behaviour</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
         /// <exception cref="InvalidOperationException">Thrown if interactivity is not enabled for the client associated with the channel.</exception>
-        public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons = null, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken token = default)
+        public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken token = default)
             => GetInteractivity(channel).SendPaginatedMessageAsync(channel, user, pages, buttons, behaviour, deletion, token);
+
+        /// <inheritdoc cref="SendPaginatedMessageAsync(DSharpPlus.Entities.DiscordChannel,DSharpPlus.Entities.DiscordUser,System.Collections.Generic.IEnumerable{DSharpPlus.Interactivity.Page},DSharpPlus.Interactivity.PaginationEmojis,System.Nullable{DSharpPlus.Interactivity.Enums.PaginationBehaviour},System.Nullable{DSharpPlus.Interactivity.Enums.PaginationDeletion},System.Nullable{System.TimeSpan})"/>
+        public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken token = default)
+            => channel.SendPaginatedMessageAsync(user, pages, default, behaviour, deletion, token);
 
         /// <summary>
         /// Retrieves an interactivity instance from a channel instance.

--- a/DSharpPlus.Interactivity/Extensions/ChannelExtensions.cs
+++ b/DSharpPlus.Interactivity/Extensions/ChannelExtensions.cs
@@ -101,8 +101,8 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="deletion">Deletion behaviour</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
         /// <exception cref="InvalidOperationException">Thrown if interactivity is not enabled for the client associated with the channel.</exception>
-        public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons = null, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken? token = default)
-            => GetInteractivity(channel).SendPaginatedMessageAsync(channel, user, pages, token, buttons, behaviour, deletion);
+        public static Task SendPaginatedMessageAsync(this DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons = null, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken token = default)
+            => GetInteractivity(channel).SendPaginatedMessageAsync(channel, user, pages, buttons, behaviour, deletion, token);
 
         /// <summary>
         /// Retrieves an interactivity instance from a channel instance.

--- a/DSharpPlus.Interactivity/Extensions/MessageExtensions.cs
+++ b/DSharpPlus.Interactivity/Extensions/MessageExtensions.cs
@@ -75,7 +75,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// </summary>
         /// <param name="message">The message to wait on.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, CancellationToken? token)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, CancellationToken token = default)
             => GetInteractivity(message).WaitForButtonAsync(message, token);
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="message">The message to wait on.</param>
         /// <param name="id">The Id of the button to wait for.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, string id, CancellationToken? token)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, string id, CancellationToken token = default)
             => GetInteractivity(message).WaitForButtonAsync(message, id, token);
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="message">The message to wait on.</param>
         /// <param name="user">The user to wait for button input from.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, DiscordUser user, CancellationToken? token)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, DiscordUser user, CancellationToken token = default)
             => GetInteractivity(message).WaitForButtonAsync(message, user, token);
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="message">The message to wait on.</param>
         /// <param name="id">The Id of the dropdown to wait for.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, string id, CancellationToken? token)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, string id, CancellationToken token = default)
             => GetInteractivity(message).WaitForSelectAsync(message, id, token);
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="id">The Id of the dropdown to wait for.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
 
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, DiscordUser user, string id, CancellationToken? token)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, DiscordUser user, string id, CancellationToken token = default)
             => GetInteractivity(message).WaitForSelectAsync(message, user, id, token);
 
 

--- a/DSharpPlus.Interactivity/Extensions/MessageExtensions.cs
+++ b/DSharpPlus.Interactivity/Extensions/MessageExtensions.cs
@@ -75,7 +75,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// </summary>
         /// <param name="message">The message to wait on.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, CancellationToken? token = null)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, CancellationToken? token)
             => GetInteractivity(message).WaitForButtonAsync(message, token);
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="message">The message to wait on.</param>
         /// <param name="id">The Id of the button to wait for.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, string id, CancellationToken? token = null)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, string id, CancellationToken? token)
             => GetInteractivity(message).WaitForButtonAsync(message, id, token);
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="message">The message to wait on.</param>
         /// <param name="user">The user to wait for button input from.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, DiscordUser user, CancellationToken? token = null)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, DiscordUser user, CancellationToken? token)
             => GetInteractivity(message).WaitForButtonAsync(message, user, token);
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="message">The message to wait on.</param>
         /// <param name="id">The Id of the dropdown to wait for.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, string id, CancellationToken? token = null)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, string id, CancellationToken? token)
             => GetInteractivity(message).WaitForSelectAsync(message, id, token);
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="id">The Id of the dropdown to wait for.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
 
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, DiscordUser user, string id, CancellationToken? token = null)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, DiscordUser user, string id, CancellationToken? token)
             => GetInteractivity(message).WaitForSelectAsync(message, user, id, token);
 
 

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -134,7 +134,7 @@ namespace DSharpPlus.Interactivity
         /// <returns>A <see cref="InteractivityResult{T}"/> with the result of button that was pressed, if any.</returns>
         /// <exception cref="InvalidOperationException">Thrown when attempting to wait for a message that is not authored by the current user.</exception>
         /// <exception cref="ArgumentException">Thrown when the message does not contain a button with the specified Id, or any buttons at all.</exception>
-        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, IEnumerable<DiscordButtonComponent> buttons, CancellationToken? token)
+        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, IEnumerable<DiscordButtonComponent> buttons, CancellationToken token = default)
         {
             if (message.Author != this.Client.CurrentUser)
                 throw new InvalidOperationException("Interaction events are only sent to the application that created them.");
@@ -145,13 +145,11 @@ namespace DSharpPlus.Interactivity
             if (!buttons.Any())
                 throw new ArgumentException("You must specify at least one button to listen for.");
 
-            token ??= this.GetCancellationToken(null);
-
             var res = await this.ComponentEventWaiter
                 .WaitForMatchAsync(new(message.Id,
                     c =>
                         c.Interaction.Data.ComponentType == ComponentType.Button &&
-                        buttons.Any(b => b.CustomId == c.Id), token.Value));
+                        buttons.Any(b => b.CustomId == c.Id), token));
 
             return new(res is null, res);
         }
@@ -164,7 +162,7 @@ namespace DSharpPlus.Interactivity
         /// <exception cref="InvalidOperationException">Thrown when attempting to wait for a message that is not authored by the current user.</exception>
         /// <exception cref="ArgumentException">Thrown when the message does not contain a button with the specified Id, or any buttons at all.</exception>
         public Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message)
-            => this.WaitForButtonAsync(message, token: null);
+            => this.WaitForButtonAsync(message);
 
         /// <summary>
         /// Waits for any button on the specified message to be pressed.
@@ -185,7 +183,7 @@ namespace DSharpPlus.Interactivity
         /// <returns>A <see cref="InteractivityResult{T}"/> with the result of button that was pressed, if any.</returns>
         /// <exception cref="InvalidOperationException">Thrown when attempting to wait for a message that is not authored by the current user.</exception>
         /// <exception cref="ArgumentException">Thrown when the message does not contain a button with the specified Id, or any buttons at all.</exception>
-        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, CancellationToken? token)
+        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, CancellationToken token = default)
         {
             if (message.Author != this.Client.CurrentUser)
                 throw new InvalidOperationException("Interaction events are only sent to the application that created them.");
@@ -195,12 +193,12 @@ namespace DSharpPlus.Interactivity
 
             var ids = message.Components.SelectMany(m => m.Components).Select(c => c.CustomId);
 
-            token ??= this.GetCancellationToken(null);
+
 
             var result =
                 await this
                 .ComponentEventWaiter
-                .WaitForMatchAsync(new(message.Id, c => c.Interaction.Data.ComponentType == ComponentType.Button, token.Value))
+                .WaitForMatchAsync(new(message.Id, c => c.Interaction.Data.ComponentType == ComponentType.Button, token))
                 .ConfigureAwait(false);
 
             return new(result is null, result);
@@ -227,7 +225,7 @@ namespace DSharpPlus.Interactivity
         /// <returns>A <see cref="InteractivityResult{T}"/> with the result of button that was pressed, if any.</returns>
         /// <exception cref="InvalidOperationException">Thrown when attempting to wait for a message that is not authored by the current user.</exception>
         /// <exception cref="ArgumentException">Thrown when the message does not contain a button with the specified Id, or any buttons at all.</exception>
-        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, DiscordUser user, CancellationToken? token)
+        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, DiscordUser user, CancellationToken token = default)
         {
             if (message.Author != this.Client.CurrentUser)
                 throw new InvalidOperationException("Interaction events are only sent to the application that created them.");
@@ -235,11 +233,11 @@ namespace DSharpPlus.Interactivity
             if (message.Components is null || !message.Components.Select(a => a.Components).Any())
                 throw new ArgumentException("Message does not contain any buttons.");
 
-            token ??= this.GetCancellationToken(null);
+
 
             var result = await this
                 .ComponentEventWaiter
-                .WaitForMatchAsync(new(message.Id, (c) => c.Interaction.Data.ComponentType is ComponentType.Button && c.User == user, token.Value))
+                .WaitForMatchAsync(new(message.Id, (c) => c.Interaction.Data.ComponentType is ComponentType.Button && c.User == user, token))
                 .ConfigureAwait(false);
 
             return new(result is null, result);
@@ -267,7 +265,7 @@ namespace DSharpPlus.Interactivity
         /// <returns>A <see cref="InteractivityResult{T}"/> with the result of the operation.</returns>
         /// <exception cref="InvalidOperationException">Thrown when attempting to wait for a message that is not authored by the current user.</exception>
         /// <exception cref="ArgumentException">Thrown when the message does not contain a button with the specified Id, or any buttons at all.</exception>
-        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, string id, CancellationToken? token)
+        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, string id, CancellationToken token = default)
         {
             if (message.Author != this.Client.CurrentUser)
                 throw new InvalidOperationException("Interaction events are only sent to the application that created them.");
@@ -278,11 +276,11 @@ namespace DSharpPlus.Interactivity
             if (!message.Components.SelectMany(c => c.Components).Any(c => c.Type is ComponentType.Button && c.CustomId == id))
                 throw new ArgumentException($"Message does not contain button with Id of '{id}'.");
 
-            token ??= this.GetCancellationToken(null);
+
 
             var result = await this
                 .ComponentEventWaiter
-                .WaitForMatchAsync(new(message.Id, (c) => c.Interaction.Data.ComponentType is ComponentType.Button && c.Id == id, token.Value))
+                .WaitForMatchAsync(new(message.Id, (c) => c.Interaction.Data.ComponentType is ComponentType.Button && c.Id == id, token))
                 .ConfigureAwait(false);
 
             return new(result is null, result);
@@ -306,7 +304,7 @@ namespace DSharpPlus.Interactivity
         /// <param name="id">The Id of the dropdown to wait on.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
         /// <exception cref="ArgumentException">Thrown when the message does not have any dropdowns or any dropdown with the specified Id.</exception>
-        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(DiscordMessage message, string id, CancellationToken? token)
+        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(DiscordMessage message, string id, CancellationToken token = default)
         {
             if (!message.Components.Any())
                 throw new ArgumentException("Message doesn't contain any components!");
@@ -319,11 +317,9 @@ namespace DSharpPlus.Interactivity
             if (scmps.All(c => c.CustomId != id))
                 throw new ArgumentException("Message doesn't contain a select menu with that Id!");
 
-            token ??= this.GetCancellationToken(null);
-
             var result = await this
                 .ComponentEventWaiter
-                .WaitForMatchAsync(new(message.Id, (c) => c.Interaction.Data.ComponentType is ComponentType.Select && c.Id == id, token.Value))
+                .WaitForMatchAsync(new(message.Id, (c) => c.Interaction.Data.ComponentType is ComponentType.Select && c.Id == id, token))
                 .ConfigureAwait(false);
 
             return new(result is null, result);
@@ -348,7 +344,7 @@ namespace DSharpPlus.Interactivity
         /// <param name="id">The Id of the dropdown to wait on.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
         /// <exception cref="ArgumentException">Thrown when the message does not have any dropdowns or any dropdown with the specified Id.</exception>
-        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(DiscordMessage message, DiscordUser user, string id, CancellationToken? token)
+        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(DiscordMessage message, DiscordUser user, string id, CancellationToken token = default)
         {
             if (!message.Components.Any())
                 throw new ArgumentException("Message doesn't contain any components!");
@@ -361,11 +357,9 @@ namespace DSharpPlus.Interactivity
             if (scmps.All(c => c.CustomId != id))
                 throw new ArgumentException("Message doesn't contain a select menu with that Id!");
 
-            token ??= this.GetCancellationToken(null);
-
             var result = await this
                 .ComponentEventWaiter
-                .WaitForMatchAsync(new(message.Id, (c) => c.Id == id && c.User == user, token.Value)).ConfigureAwait(false);
+                .WaitForMatchAsync(new(message.Id, (c) => c.Id == id && c.User == user, token)).ConfigureAwait(false);
 
             return new(result is null, result);
         }

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -134,7 +134,7 @@ namespace DSharpPlus.Interactivity
         /// <returns>A <see cref="InteractivityResult{T}"/> with the result of button that was pressed, if any.</returns>
         /// <exception cref="InvalidOperationException">Thrown when attempting to wait for a message that is not authored by the current user.</exception>
         /// <exception cref="ArgumentException">Thrown when the message does not contain a button with the specified Id, or any buttons at all.</exception>
-        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, IEnumerable<DiscordButtonComponent> buttons, CancellationToken? token = null)
+        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, IEnumerable<DiscordButtonComponent> buttons, CancellationToken? token)
         {
             if (message.Author != this.Client.CurrentUser)
                 throw new InvalidOperationException("Interaction events are only sent to the application that created them.");
@@ -185,7 +185,7 @@ namespace DSharpPlus.Interactivity
         /// <returns>A <see cref="InteractivityResult{T}"/> with the result of button that was pressed, if any.</returns>
         /// <exception cref="InvalidOperationException">Thrown when attempting to wait for a message that is not authored by the current user.</exception>
         /// <exception cref="ArgumentException">Thrown when the message does not contain a button with the specified Id, or any buttons at all.</exception>
-        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, CancellationToken? token = null)
+        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, CancellationToken? token)
         {
             if (message.Author != this.Client.CurrentUser)
                 throw new InvalidOperationException("Interaction events are only sent to the application that created them.");
@@ -227,7 +227,7 @@ namespace DSharpPlus.Interactivity
         /// <returns>A <see cref="InteractivityResult{T}"/> with the result of button that was pressed, if any.</returns>
         /// <exception cref="InvalidOperationException">Thrown when attempting to wait for a message that is not authored by the current user.</exception>
         /// <exception cref="ArgumentException">Thrown when the message does not contain a button with the specified Id, or any buttons at all.</exception>
-        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, DiscordUser user, CancellationToken? token = null)
+        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, DiscordUser user, CancellationToken? token)
         {
             if (message.Author != this.Client.CurrentUser)
                 throw new InvalidOperationException("Interaction events are only sent to the application that created them.");
@@ -267,7 +267,7 @@ namespace DSharpPlus.Interactivity
         /// <returns>A <see cref="InteractivityResult{T}"/> with the result of the operation.</returns>
         /// <exception cref="InvalidOperationException">Thrown when attempting to wait for a message that is not authored by the current user.</exception>
         /// <exception cref="ArgumentException">Thrown when the message does not contain a button with the specified Id, or any buttons at all.</exception>
-        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, string id, CancellationToken? token = null)
+        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(DiscordMessage message, string id, CancellationToken? token)
         {
             if (message.Author != this.Client.CurrentUser)
                 throw new InvalidOperationException("Interaction events are only sent to the application that created them.");
@@ -306,7 +306,7 @@ namespace DSharpPlus.Interactivity
         /// <param name="id">The Id of the dropdown to wait on.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
         /// <exception cref="ArgumentException">Thrown when the message does not have any dropdowns or any dropdown with the specified Id.</exception>
-        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(DiscordMessage message, string id, CancellationToken? token = null)
+        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(DiscordMessage message, string id, CancellationToken? token)
         {
             if (!message.Components.Any())
                 throw new ArgumentException("Message doesn't contain any components!");
@@ -348,7 +348,7 @@ namespace DSharpPlus.Interactivity
         /// <param name="id">The Id of the dropdown to wait on.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
         /// <exception cref="ArgumentException">Thrown when the message does not have any dropdowns or any dropdown with the specified Id.</exception>
-        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(DiscordMessage message, DiscordUser user, string id, CancellationToken? token = null)
+        public async Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(DiscordMessage message, DiscordUser user, string id, CancellationToken? token)
         {
             if (!message.Components.Any())
                 throw new ArgumentException("Message doesn't contain any components!");
@@ -556,7 +556,7 @@ namespace DSharpPlus.Interactivity
         /// <param name="deletion">Deletion behaviour</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
         public async Task SendPaginatedMessageAsync(
-            DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons = null,
+            DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons,
             PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken? token = default)
         {
             var bhv = behaviour ?? this.Config.PaginationBehaviour;

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -551,13 +551,13 @@ namespace DSharpPlus.Interactivity
         /// <param name="channel">The channel to send it on.</param>
         /// <param name="user">User to give control.</param>
         /// <param name="pages">The pages.</param>
-        /// <param name="buttons">Pagination buttons (leave null to default to ones on configuration).</param>
+        /// <param name="buttons">Pagination buttons (pass null to use buttons defined in <see cref="InteractivityConfiguration"/>).</param>
         /// <param name="behaviour">Pagination behaviour.</param>
         /// <param name="deletion">Deletion behaviour</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
         public async Task SendPaginatedMessageAsync(
-            DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons,
-            PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken? token = default)
+            DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, CancellationToken? token, PaginationButtons buttons = null,
+            PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default)
         {
             var bhv = behaviour ?? this.Config.PaginationBehaviour;
             var del = deletion ?? this.Config.ButtonBehavior;

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -578,6 +578,12 @@ namespace DSharpPlus.Interactivity
             await this._compPaginator.DoPaginationAsync(req).ConfigureAwait(false);
         }
 
+        /// <inheritdoc cref="SendPaginatedMessageAsync(DSharpPlus.Entities.DiscordChannel,DSharpPlus.Entities.DiscordUser,System.Collections.Generic.IEnumerable{DSharpPlus.Interactivity.Page},DSharpPlus.Interactivity.EventHandling.PaginationButtons,System.Nullable{DSharpPlus.Interactivity.Enums.PaginationBehaviour},System.Nullable{DSharpPlus.Interactivity.Enums.ButtonPaginationBehavior},System.Threading.CancellationToken)"/>
+        /// <remarks>This is the "default" overload for SendPaginatedMessageAsync, and will use buttons. Feel free to specify default(PaginationEmojis) to use reactions and emojis specified in <see cref="InteractivityConfiguration"/>, instead. </remarks>
+        public async Task SendPaginatedMessageAsync(DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken token = default)
+            => this.SendPaginatedMessageAsync(channel, user, pages, default, behaviour, deletion, token);
+
+
         /// <summary>
         /// Sends a paginated message.
         /// For this Event you need the <see cref="DiscordIntents.GuildMessageReactions"/> intent specified in <seealso cref="DiscordConfiguration.Intents"/>
@@ -607,12 +613,6 @@ namespace DSharpPlus.Interactivity
 
             await this.Paginator.DoPaginationAsync(prequest).ConfigureAwait(false);
         }
-
-
-        /// <inheritdoc cref="SendPaginatedMessageAsync(DSharpPlus.Entities.DiscordChannel,DSharpPlus.Entities.DiscordUser,System.Collections.Generic.IEnumerable{DSharpPlus.Interactivity.Page},DSharpPlus.Interactivity.EventHandling.PaginationButtons,System.Nullable{DSharpPlus.Interactivity.Enums.PaginationBehaviour},System.Nullable{DSharpPlus.Interactivity.Enums.ButtonPaginationBehavior},System.Threading.CancellationToken)"/>
-        /// <remarks>This is the "default" overload for SendPaginatedMessageAsync, and will use buttons. Feel free to specify default(PaginationEmojis) to use reactions and emojis specified in <see cref="InteractivityConfiguration"/>, instead. </remarks>
-        public async Task SendPaginatedMessageAsync(DiscordChannel channel, DiscordUser user, IEnumerable<Page> pages, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken token = default)
-            => this.SendPaginatedMessageAsync(channel, user, pages, default, behaviour, deletion, token);
 
         /// <summary>
         /// Waits for a custom pagination request to finish.


### PR DESCRIPTION
Fixes a Roslyn issue induced by the library because interactivity overloads were ambiguous