### PR TITLE
Fix Xml docs for CNext Permissions related attributes

### DIFF
--- a/DSharpPlus.CommandsNext/Attributes/RequireBotPermissionsAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireBotPermissionsAttribute.cs
@@ -38,7 +38,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         public Permissions Permissions { get; }
 
         /// <summary>
-        /// Gets or sets this check's behaviour in DMs. True means the check will always pass in DMs, whereas false means that it will always fail.
+        /// Gets this check's behaviour in DMs. True means the check will always pass in DMs, whereas false means that it will always fail.
         /// </summary>
         public bool IgnoreDms { get; } = true;
 

--- a/DSharpPlus.CommandsNext/Attributes/RequirePermissionsAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequirePermissionsAttribute.cs
@@ -38,7 +38,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         public Permissions Permissions { get; }
 
         /// <summary>
-        /// Gets or sets this check's behaviour in DMs. True means the check will always pass in DMs, whereas false means that it will always fail.
+        /// Gets this check's behaviour in DMs. True means the check will always pass in DMs, whereas false means that it will always fail.
         /// </summary>
         public bool IgnoreDms { get; } = true;
 

--- a/DSharpPlus.CommandsNext/Attributes/RequireUserPermissionsAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireUserPermissionsAttribute.cs
@@ -38,7 +38,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         public Permissions Permissions { get; }
 
         /// <summary>
-        /// Gets or sets this check's behaviour in DMs. True means the check will always pass in DMs, whereas false means that it will always fail.
+        /// Gets this check's behaviour in DMs. True means the check will always pass in DMs, whereas false means that it will always fail.
         /// </summary>
         public bool IgnoreDms { get; } = true;
 


### PR DESCRIPTION
# Summary
Fix XML docs for `RequireBotPermissionsAttribute`, `RequireUserPermissionsAttribute`, `RequireUserPermissionsAttribute` by removing "sets" word from get-only property `IgnoreDms` docs