### PR TITLE
Fix interactivity acking buttons

### DIFF
--- a/DSharpPlus.Interactivity/EventHandling/ComponentBased/ComponentEventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ComponentBased/ComponentEventWaiter.cs
@@ -106,12 +106,6 @@ namespace DSharpPlus.Interactivity.EventHandling
         {
             if (this._matchRequests.TryGetValue(args.Message.Id, out var mreq))
             {
-                if (this._config.AckPaginationButtons)
-                {
-                    await args.Interaction.CreateResponseAsync(InteractionResponseType.DeferredMessageUpdate).ConfigureAwait(false);
-                    args.Handled = true;
-                }
-
                 if (mreq.IsMatch(args))
                     mreq.Tcs.TrySetResult(args);
 


### PR DESCRIPTION
# Summary
Fixes #1024 

# Details
The code for handling `WaitForButtonAsync` calls was referencing ack pagination buttons for some reason.