### PR TITLE
Implement GUILD_APPLICATION_COMMAND_COUNTS_UPDATE

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -389,6 +389,11 @@ namespace DSharpPlus
                 case "integration_delete":
                     await this.OnIntegrationDeleteAsync((ulong)dat["id"], (ulong)dat["guild_id"], (ulong?)dat["application_id"]).ConfigureAwait(false);
                     break;
+                    
+                case "guild_application_command_counts_update":
+                    var counts = dat["application_command_counts"];
+                    await this.OnGuildApplicationCommandCountsUpdateAsync((int)counts["1"], (int)counts["2"], (int)counts["3"], (ulong)dat["guild_id"]).ConfigureAwait(false);
+                    break;
 
                 #endregion
 
@@ -1849,6 +1854,30 @@ namespace DSharpPlus
             };
 
             await this._applicationCommandDeleted.InvokeAsync(this, ea).ConfigureAwait(false);
+        }
+        
+                internal async Task OnGuildApplicationCommandCountsUpdateAsync(int sc, int ucmc, int mcmc, ulong guild_id)
+        {
+            var guild = this.InternalGetCachedGuild(guild_id);
+
+            if (guild == null)
+            {
+                guild = new DiscordGuild
+                {
+                    Id = guild_id,
+                    Discord = this
+                };
+            }
+
+            var ea = new GuildApplicationCommandCountEventArgs
+            {
+                SlashCommands = sc,
+                UserContextMenuCommands = ucmc,
+                MessageContextMenuCommands = mcmc,
+                Guild = guild
+            };
+
+            await this._guildApplicationCommandCountUpdated.InvokeAsync(this, ea).ConfigureAwait(false);
         }
 
         #endregion

--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -600,6 +600,16 @@ namespace DSharpPlus
         }
         private AsyncEvent<DiscordClient, ApplicationCommandEventArgs> _applicationCommandDeleted;
 
+        /// <summary>
+        /// Fired when a new application command is registered.
+        /// </summary>
+        public event AsyncEventHandler<DiscordClient, GuildApplicationCommandCountEventArgs> GuildApplicationCommandCountUpdated
+        {
+            add => this._guildApplicationCommandCountUpdated.Register(value);
+            remove => this._guildApplicationCommandCountUpdated.Unregister(value);
+        }
+        private AsyncEvent<DiscordClient, GuildApplicationCommandCountEventArgs> _guildApplicationCommandCountUpdated;
+        
         #endregion
 
         #region Integration

--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -601,7 +601,7 @@ namespace DSharpPlus
         private AsyncEvent<DiscordClient, ApplicationCommandEventArgs> _applicationCommandDeleted;
 
         /// <summary>
-        /// Fired when a new application command is registered.
+        /// Fired when the guild application command is updated.
         /// </summary>
         public event AsyncEventHandler<DiscordClient, GuildApplicationCommandCountEventArgs> GuildApplicationCommandCountUpdated
         {

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -206,6 +206,7 @@ namespace DSharpPlus
             this._applicationCommandCreated = new AsyncEvent<DiscordClient, ApplicationCommandEventArgs>("APPLICATION_COMMAND_CREATED", EventExecutionLimit, this.EventErrorHandler);
             this._applicationCommandUpdated = new AsyncEvent<DiscordClient, ApplicationCommandEventArgs>("APPLICATION_COMMAND_UPDATED", EventExecutionLimit, this.EventErrorHandler);
             this._applicationCommandDeleted = new AsyncEvent<DiscordClient, ApplicationCommandEventArgs>("APPLICATION_COMMAND_DELETED", EventExecutionLimit, this.EventErrorHandler);
+            this._guildApplicationCommandCountUpdated = new AsyncEvent<DiscordClient, GuildApplicationCommandCountEventArgs>("GUILD_APPLICATION_COMMAND_COUNTS_UPDATED", EventExecutionLimit, this.EventErrorHandler);
             this._integrationCreated = new AsyncEvent<DiscordClient, IntegrationCreateEventArgs>("INTEGRATION_CREATED", EventExecutionLimit, this.EventErrorHandler);
             this._integrationUpdated = new AsyncEvent<DiscordClient, IntegrationUpdateEventArgs>("INTEGRATION_UPDATED", EventExecutionLimit, this.EventErrorHandler);
             this._integrationDeleted = new AsyncEvent<DiscordClient, IntegrationDeleteEventArgs>("INTEGRATION_DELETED", EventExecutionLimit, this.EventErrorHandler);

--- a/DSharpPlus/Clients/DiscordShardedClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.Events.cs
@@ -585,6 +585,16 @@ namespace DSharpPlus
         }
         private AsyncEvent<DiscordClient, ApplicationCommandEventArgs> _applicationCommandDeleted;
 
+        /// <summary>
+        /// Fired when the guild application command is updated.
+        /// </summary>
+        public event AsyncEventHandler<DiscordClient, GuildApplicationCommandCountEventArgs> GuildApplicationCommandCountUpdated
+        {
+            add => this._guildApplicationCommandCountUpdated.Register(value);
+            remove => this._guildApplicationCommandCountUpdated.Unregister(value);
+        }
+        private AsyncEvent<DiscordClient, GuildApplicationCommandCountEventArgs> _guildApplicationCommandCountUpdated;
+        
         #endregion
 
         #region Integration
@@ -864,6 +874,9 @@ namespace DSharpPlus
 
         private Task Client_ApplicationCommandDeleted(DiscordClient client, ApplicationCommandEventArgs e)
             => this._applicationCommandDeleted.InvokeAsync(client, e);
+        
+        private Task Client_GuildApplicationCommandCountUpdated(DiscordClient client, GuildApplicationCommandCountEventArgs e)
+            => this._guildApplicationCommandCountUpdated.InvokeAsync(client, e);
 
         private Task Client_IntegrationCreated(DiscordClient client, IntegrationCreateEventArgs e)
             => this._integrationCreated.InvokeAsync(client, e);

--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -488,6 +488,7 @@ namespace DSharpPlus
             this._applicationCommandCreated = new AsyncEvent<DiscordClient, ApplicationCommandEventArgs>("APPLICATION_COMMAND_CREATED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._applicationCommandUpdated = new AsyncEvent<DiscordClient, ApplicationCommandEventArgs>("APPLICATION_COMMAND_UPDATED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._applicationCommandDeleted = new AsyncEvent<DiscordClient, ApplicationCommandEventArgs>("APPLICATION_COMMAND_DELETED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
+            this._guildApplicationCommandCountUpdated = new AsyncEvent<DiscordClient, GuildApplicationCommandCountEventArgs>("GUILD_APPLICATION_COMMAND_COUNTS_UPDATED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._integrationCreated = new AsyncEvent<DiscordClient, IntegrationCreateEventArgs>("INTEGRATION_CREATED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._integrationUpdated = new AsyncEvent<DiscordClient, IntegrationUpdateEventArgs>("INTEGRATION_UPDATED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._integrationDeleted = new AsyncEvent<DiscordClient, IntegrationDeleteEventArgs>("INTEGRATION_DELETED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
@@ -548,6 +549,7 @@ namespace DSharpPlus
             client.ApplicationCommandCreated += this.Client_ApplicationCommandCreated;
             client.ApplicationCommandUpdated += this.Client_ApplicationCommandUpdated;
             client.ApplicationCommandDeleted += this.Client_ApplicationCommandDeleted;
+            client.GuildApplicationCommandCountUpdated += this.Client_GuildApplicationCommandCountUpdated;
             client.IntegrationCreated += this.Client_IntegrationCreated;
             client.IntegrationUpdated += this.Client_IntegrationUpdated;
             client.IntegrationDeleted += this.Client_IntegrationDeleted;
@@ -607,6 +609,7 @@ namespace DSharpPlus
             client.ApplicationCommandCreated -= this.Client_ApplicationCommandCreated;
             client.ApplicationCommandUpdated -= this.Client_ApplicationCommandUpdated;
             client.ApplicationCommandDeleted -= this.Client_ApplicationCommandDeleted;
+            client.GuildApplicationCommandCountUpdated -= this.Client_GuildApplicationCommandCountUpdated;
             client.IntegrationCreated -= this.Client_IntegrationCreated;
             client.IntegrationUpdated -= this.Client_IntegrationUpdated;
             client.IntegrationDeleted -= this.Client_IntegrationDeleted;

--- a/DSharpPlus/EventArgs/Guild/GuildApplicationCommandCountEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/GuildApplicationCommandCountEventArgs.cs
@@ -1,0 +1,53 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs
+{
+    /// <summary>
+    /// Represents arguments for <see cref="DiscordClient.GuildApplicationCommandCountUpdated"/> event.
+    /// </summary>
+    public sealed class GuildApplicationCommandCountEventArgs : DiscordEventArgs
+    {
+        /// <summary>
+        /// Gets the count of slash commands.
+        /// </summary>
+        public int SlashCommands { get; internal set; }
+
+        /// <summary>
+        /// Gets the count of user context menu commands.
+        /// </summary>
+        public int UserContextMenuCommands { get; internal set; }
+
+        /// <summary>
+        /// Gets the count of message context menu commands.
+        /// </summary>
+        public int MessageContextMenuCommands { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild.
+        /// </summary>
+        public DiscordGuild Guild { get; internal set; }
+    }
+}


### PR DESCRIPTION
Usage: 
```csharp
        private Task Client_GuildApplicationCommandCountUpdated(DiscordClient sender, GuildApplicationCommandCountEventArgs e)
        {
            Console.WriteLine($"Application Command count updated in {e.Guild.Name}");
            Console.ForegroundColor = ConsoleColor.Gray;
            Console.WriteLine($"Slash commands: {e.SlashCommands}");
            Console.ForegroundColor = ConsoleColor.Blue;
            Console.WriteLine($"User context menu commands: {e.UserContextMenuCommands}");
            Console.ForegroundColor = ConsoleColor.Yellow;
            Console.WriteLine($"Message context menu commands: {e.MessageContextMenuCommands}");
            Console.ResetColor();
            return Task.CompletedTask;
        }
```