### PR TITLE
Guild create and modify

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -85,9 +85,10 @@ namespace DSharpPlus
         /// <param name="iconb64">New guild's icon (base64)</param>
         /// <param name="verification_level">New guild's verification level</param>
         /// <param name="default_message_notifications">New guild's default message notification level</param>
+        /// <param name="system_channel_flags">New guild's system channel flags</param>
         /// <returns></returns>
-        public Task<DiscordGuild> CreateGuildAsync(string name, string region_id, string iconb64, VerificationLevel? verification_level, DefaultMessageNotifications? default_message_notifications)
-            => this.ApiClient.CreateGuildAsync(name, region_id, iconb64, verification_level, default_message_notifications);
+        public Task<DiscordGuild> CreateGuildAsync(string name, string region_id, string iconb64, VerificationLevel? verification_level, DefaultMessageNotifications? default_message_notifications, SystemChannelFlags? system_channel_flags)
+            => this.ApiClient.CreateGuildAsync(name, region_id, iconb64, verification_level, default_message_notifications, system_channel_flags);
 
         /// <summary>
         /// Creates a guild from a template. This requires the bot to be in less than 10 guilds total.

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -124,6 +124,14 @@ namespace DSharpPlus
         /// <param name="owner_id">New guild owner id</param>
         /// <param name="splashb64">New guild spalsh (base64)</param>
         /// <param name="systemChannelId">New guild system channel id</param>
+        /// <param name="banner">New guild banner</param>
+        /// <param name="description">New guild description</param>
+        /// <param name="discorverySplash">New guild Discovery splash</param>
+        /// <param name="features">List of new <see cref="https://discord.com/developers/docs/resources/guild#guild-object-guild-features">guild features</see></param>
+        /// <param name="preferredLocale">New preferred locale</param>
+        /// <param name="publicUpdatesChannelId">New updates channel id</param>
+        /// <param name="rulesChannelId">New rules channel id</param>
+        /// <param name="systemChannelFlags">New system channel flags</param>
         /// <param name="reason">Modify reason</param>
         /// <returns></returns>
         public Task<DiscordGuild> ModifyGuildAsync(ulong guild_id, Optional<string> name,
@@ -131,9 +139,12 @@ namespace DSharpPlus
             Optional<DefaultMessageNotifications> default_message_notifications, Optional<MfaLevel> mfa_level,
             Optional<ExplicitContentFilter> explicit_content_filter, Optional<ulong?> afk_channel_id,
             Optional<int> afk_timeout, Optional<string> iconb64, Optional<ulong> owner_id, Optional<string> splashb64,
-            Optional<ulong?> systemChannelId, string reason)
+            Optional<ulong?> systemChannelId, Optional<string> banner, Optional<string> description,
+            Optional<string> discorverySplash, Optional<IEnumerable<string>> features, Optional<string> preferredLocale,
+            Optional<ulong?> publicUpdatesChannelId, Optional<ulong?> rulesChannelId, Optional<SystemChannelFlags> systemChannelFlags,
+            string reason)
             => this.ApiClient.ModifyGuildAsync(guild_id, name, region, verification_level, default_message_notifications, mfa_level, explicit_content_filter, afk_channel_id, afk_timeout, iconb64,
-                owner_id, splashb64, systemChannelId, reason);
+                owner_id, splashb64, systemChannelId, banner, description, discorverySplash, features, preferredLocale, publicUpdatesChannelId, rulesChannelId, systemChannelFlags, reason);
 
         /// <summary>
         /// Modifies a guild
@@ -166,7 +177,8 @@ namespace DSharpPlus
 
             return await this.ApiClient.ModifyGuildAsync(guild_id, mdl.Name, mdl.Region.IfPresent(x => x.Id), mdl.VerificationLevel, mdl.DefaultMessageNotifications,
                 mdl.MfaLevel, mdl.ExplicitContentFilter, mdl.AfkChannel.IfPresent(x => x?.Id), mdl.AfkTimeout, iconb64, mdl.Owner.IfPresent(x => x.Id),
-                splashb64, mdl.SystemChannel.IfPresent(x => x?.Id), mdl.AuditLogReason).ConfigureAwait(false);
+                splashb64, mdl.SystemChannel.IfPresent(x => x?.Id), mdl.Banner, mdl.Description, mdl.DiscoverySplash, mdl.Features, mdl.PreferredLocale,
+                mdl.PublicUpdatesChannel.IfPresent(e => e?.Id), mdl.RulesChannel.IfPresent(e => e?.Id), mdl.SystemChannelFlags, mdl.AuditLogReason).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -477,12 +477,14 @@ namespace DSharpPlus
         /// <param name="icon">Stream containing the icon for the guild.</param>
         /// <param name="verificationLevel">Verification level for the guild.</param>
         /// <param name="defaultMessageNotifications">Default message notification settings for the guild.</param>
+        /// <param name="systemChannelFlags">System channel flags fopr the guild.</param>
         /// <returns>The created guild.</returns>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordGuild> CreateGuildAsync(string name, string region = null, Optional<Stream> icon = default, VerificationLevel? verificationLevel = null,
-            DefaultMessageNotifications? defaultMessageNotifications = null)
+            DefaultMessageNotifications? defaultMessageNotifications = null,
+            SystemChannelFlags? systemChannelFlags = null)
         {
             var iconb64 = Optional.FromNoValue<string>();
             if (icon.HasValue && icon.Value != null)
@@ -491,7 +493,7 @@ namespace DSharpPlus
             else if (icon.HasValue)
                 iconb64 = null;
 
-            return this.ApiClient.CreateGuildAsync(name, region, iconb64, verificationLevel, defaultMessageNotifications);
+            return this.ApiClient.CreateGuildAsync(name, region, iconb64, verificationLevel, defaultMessageNotifications, systemChannelFlags);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -536,7 +536,10 @@ namespace DSharpPlus.Entities
             return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, mdl.Name, mdl.Region.IfPresent(e => e.Id),
                 mdl.VerificationLevel, mdl.DefaultMessageNotifications, mdl.MfaLevel, mdl.ExplicitContentFilter,
                 mdl.AfkChannel.IfPresent(e => e?.Id), mdl.AfkTimeout, iconb64, mdl.Owner.IfPresent(e => e.Id), splashb64,
-                mdl.SystemChannel.IfPresent(e => e?.Id), mdl.AuditLogReason).ConfigureAwait(false);
+                mdl.SystemChannel.IfPresent(e => e?.Id), mdl.Banner,
+                mdl.Description, mdl.DiscoverySplash, mdl.Features, mdl.PreferredLocale,
+                mdl.PublicUpdatesChannel.IfPresent(e => e?.Id), mdl.RulesChannel.IfPresent(e => e?.Id),
+                mdl.SystemChannelFlags, mdl.AuditLogReason).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
@@ -58,6 +58,9 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("channels", NullValueHandling = NullValueHandling.Ignore)]
         public IEnumerable<RestChannelCreatePayload> Channels { get; set; }
+
+        [JsonProperty("system_channel_flags", NullValueHandling = NullValueHandling.Ignore)]
+        public SystemChannelFlags? SystemChannelFlags { get; set; }
     }
 
     internal sealed class RestGuildCreateFromTemplatePayload

--- a/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
@@ -109,6 +109,30 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("system_channel_id", NullValueHandling = NullValueHandling.Include)]
         public Optional<ulong?> SystemChannelId { get; set; }
+
+        [JsonProperty("banner")]
+        public Optional<string> Banner { get; set; }
+
+        [JsonProperty("discorvery_splash")]
+        public Optional<string> DiscoverySplash { get; set; }
+
+        [JsonProperty("system_channel_flags")]
+        public Optional<SystemChannelFlags> SystemChannelFlags { get; set; }
+
+        [JsonProperty("rules_channel_id")]
+        public Optional<ulong?> RulesChannelId { get; set; }
+
+        [JsonProperty("public_updates_channel_id")]
+        public Optional<ulong?> PublicUpdatesChannelId { get; set; }
+
+        [JsonProperty("preferred_locale")]
+        public Optional<string> PreferredLocale { get; set; }
+
+        [JsonProperty("description")]
+        public Optional<string> Description { get; set; }
+
+        [JsonProperty("features")]
+        public Optional<IEnumerable<string>> Features { get; set; }
     }
 
     internal sealed class RestGuildMemberAddPayload : IOAuth2Payload

--- a/DSharpPlus/Net/Models/GuildEditModel.cs
+++ b/DSharpPlus/Net/Models/GuildEditModel.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.Generic;
 using System.IO;
 using DSharpPlus.Entities;
 
@@ -102,6 +103,31 @@ namespace DSharpPlus.Net.Models
         /// The new guild preferred locale.
         /// </summary>
         public Optional<string> PreferredLocale { internal get; set; }
+
+        /// <summary>
+        /// The new description of the guild
+        /// </summary>
+        public Optional<string> Description { get; set; }
+
+        /// <summary>
+        /// The new discorvery splash image of the guild
+        /// </summary>
+        public Optional<string> DiscoverySplash { get; set; }
+
+        /// <summary>
+        /// A list of <see href="https://discord.com/developers/docs/resources/guild#guild-object-guild-features">guild features</see>
+        /// </summary>
+        public Optional<IEnumerable<string>> Features { get; set; }
+
+        /// <summary>
+        /// The new banner of the guild
+        /// </summary>
+        public Optional<string> Banner { get; set; }
+
+        /// <summary>
+        /// The new system channel flags for the guild
+        /// </summary>
+        public Optional<SystemChannelFlags> SystemChannelFlags { get; set; }
 
         internal GuildEditModel()
         {

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -217,7 +217,8 @@ namespace DSharpPlus.Net
         }
 
         internal async Task<DiscordGuild> CreateGuildAsync(string name, string region_id, Optional<string> iconb64, VerificationLevel? verification_level,
-            DefaultMessageNotifications? default_message_notifications)
+            DefaultMessageNotifications? default_message_notifications,
+            SystemChannelFlags? system_channel_flags)
         {
             var pld = new RestGuildCreatePayload
             {
@@ -225,7 +226,8 @@ namespace DSharpPlus.Net
                 RegionId = region_id,
                 DefaultMessageNotifications = default_message_notifications,
                 VerificationLevel = verification_level,
-                IconBase64 = iconb64
+                IconBase64 = iconb64,
+                SystemChannelFlags = system_channel_flags
             };
 
             var route = $"{Endpoints.GUILDS}";

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -288,7 +288,10 @@ namespace DSharpPlus.Net
             Optional<DefaultMessageNotifications> defaultMessageNotifications, Optional<MfaLevel> mfaLevel,
             Optional<ExplicitContentFilter> explicitContentFilter, Optional<ulong?> afkChannelId,
             Optional<int> afkTimeout, Optional<string> iconb64, Optional<ulong> ownerId, Optional<string> splashb64,
-            Optional<ulong?> systemChannelId, string reason)
+            Optional<ulong?> systemChannelId, Optional<string> banner, Optional<string> description,
+            Optional<string> discorverySplash, Optional<IEnumerable<string>> features, Optional<string> preferredLocale,
+            Optional<ulong?> publicUpdatesChannelId, Optional<ulong?> rulesChannelId, Optional<SystemChannelFlags> systemChannelFlags,
+            string reason)
         {
             var pld = new RestGuildModifyPayload
             {
@@ -303,7 +306,15 @@ namespace DSharpPlus.Net
                 IconBase64 = iconb64,
                 SplashBase64 = splashb64,
                 OwnerId = ownerId,
-                SystemChannelId = systemChannelId
+                SystemChannelId = systemChannelId,
+                Banner = banner,
+                Description = description,
+                DiscoverySplash = discorverySplash,
+                Features = features,
+                PreferredLocale = preferredLocale,
+                PublicUpdatesChannelId = publicUpdatesChannelId,
+                RulesChannelId = rulesChannelId,
+                SystemChannelFlags = systemChannelFlags
             };
 
             var headers = Utilities.GetBaseHeaders();


### PR DESCRIPTION
# Summary
Implements api changes for GuildCreate and Modify as specified in #825 

# Details
Testable changes in modify are working.
Create changes are being correctly sent and the response has them as specified by the request - however the flags dont actually set the guilds respective settings. From what i can tell this seems to be an api bug.