### PR TITLE
add DiscordGuild.GetChannelAsync

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -1069,13 +1069,17 @@ namespace DSharpPlus.Entities
         /// <returns>Requested channel.</returns>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public DiscordChannel GetChannel(ulong id)
-        {
-            // force the cache to update if it is either null or the channel is not found
-            if (!this._channels.TryGetValue(id, out var channel) || this._channels == null)
-                this._channels = (ConcurrentDictionary<ulong, DiscordChannel>)
-                    this.Discord.ApiClient.GetGuildChannelsAsync(this.Id).GetAwaiter().GetResult();
+            => (this._channels != null && this._channels.TryGetValue(id, out var channel)) ? channel : null;
 
-            return (channel == null) ? channel : null;
+        public async Task<DiscordChannel> GetChannelAsync(ulong id)
+        {
+            if (!this._channels.TryGetValue(id, out var channel) || this._channels == null )
+                _channels = (ConcurrentDictionary<ulong, DiscordChannel>)await this.Discord.ApiClient.GetGuildChannelsAsync(this.Id);
+
+            if (channel == null)
+                this._channels.TryGetValue(id, out channel);
+
+            return channel;
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -1069,7 +1069,14 @@ namespace DSharpPlus.Entities
         /// <returns>Requested channel.</returns>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public DiscordChannel GetChannel(ulong id)
-            => (this._channels != null && this._channels.TryGetValue(id, out var channel)) ? channel : null;
+        {
+            // force the cache to update if it is either null or the channel is not found
+            if (!this._channels.TryGetValue(id, out var channel) || this._channels == null)
+                this._channels = (ConcurrentDictionary<ulong, DiscordChannel>)
+                    this.Discord.ApiClient.GetGuildChannelsAsync(this.Id).GetAwaiter().GetResult();
+
+            return (channel == null) ? channel : null;
+        }
 
         /// <summary>
         /// Gets audit log entries for this guild.

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -1071,10 +1071,17 @@ namespace DSharpPlus.Entities
         public DiscordChannel GetChannel(ulong id)
             => (this._channels != null && this._channels.TryGetValue(id, out var channel)) ? channel : null;
 
+        /// <summary>
+        /// Gets a channel from this guild by its ID, and if it is not found cached, requests it from the API.
+        /// </summary>
+        /// <param name="id">Id of the channel to get.</param>
+        /// <returns>Requested channel.</returns>
+        /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+        /// <exception cref="Exceptions.UnauthorizedException">Thrown then the client does not have permission to access the channel.</exception>
         public async Task<DiscordChannel> GetChannelAsync(ulong id)
         {
             if (!this._channels.TryGetValue(id, out var channel) || this._channels == null )
-                _channels = (ConcurrentDictionary<ulong, DiscordChannel>)await this.Discord.ApiClient.GetGuildChannelsAsync(this.Id);
+                this._channels = (ConcurrentDictionary<ulong, DiscordChannel>)await this.Discord.ApiClient.GetGuildChannelsAsync(this.Id);
 
             if (channel == null)
                 this._channels.TryGetValue(id, out channel);


### PR DESCRIPTION
The channel could already exist, but does not yet need to be cached - which may be an uncommon race condition with GetChannel, but it is not too unrealistic. In fact, it can be observed a fair amount with high-latency connections, either when the user creates a channel that is instantly used by the application, or when the application creates a channel on one thread and requests it on another.

# Notes

This *may* cause performance regressions in the event an application keeps requesting non-existent channels. To my knowledge, there is no way to know whether a channel exists before requesting it from the API, though.