### PR TITLE
Fix builders only allowing 9 files

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -318,7 +318,7 @@ namespace DSharpPlus.Entities
         /// <returns>The current builder to be chained.</returns>
         public DiscordMessageBuilder WithFiles(Dictionary<string, Stream> files, bool resetStreamPosition = false)
         {
-            if (this.Files.Count + files.Count >= 10)
+            if (this.Files.Count + files.Count > 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             foreach (var file in files)

--- a/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
@@ -256,7 +256,7 @@ namespace DSharpPlus.Entities
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         public DiscordWebhookBuilder AddFiles(Dictionary<string, Stream> files, bool resetStreamPosition = false)
         {
-            if (this.Files.Count() + files.Count() >= 10)
+            if (this.Files.Count() + files.Count() > 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             foreach (var file in files)


### PR DESCRIPTION
Fixes an issue where attempting to send exactly 10 files would error out