### PR TITLE
Fix for uploading multiple files.

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -318,7 +318,7 @@ namespace DSharpPlus.Entities
         /// <returns>The current builder to be chained.</returns>
         public DiscordMessageBuilder WithFiles(Dictionary<string, Stream> files, bool resetStreamPosition = false)
         {
-            if (this.Files.Count + files.Count >= 10)
+            if (this.Files.Count + files.Count > 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             foreach (var file in files)

--- a/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
@@ -256,7 +256,7 @@ namespace DSharpPlus.Entities
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         public DiscordWebhookBuilder AddFiles(Dictionary<string, Stream> files, bool resetStreamPosition = false)
         {
-            if (this.Files.Count() + files.Count() >= 10)
+            if (this.Files.Count() + files.Count() > 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
 
             foreach (var file in files)

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -451,7 +451,7 @@ namespace DSharpPlus.Net
                         if (f.FileType != null)
                             f.FileName += '.' + f.FileType;
 
-                        var count = mprequest._removeFileCount ? i++.ToString(CultureInfo.InvariantCulture) : string.Empty;
+                        var count = !mprequest._removeFileCount ? i++.ToString(CultureInfo.InvariantCulture) : string.Empty;
 
                         content.Add(sc, $"file{count}", f.FileName);
                     }


### PR DESCRIPTION
Uploading multiple files with DiscordMessageBuilder and DiscordWebhookBuilder is broken.

mprequest._removeFileCount has been always false and condition for the count in RestClient.BuildRequest always returned String.Empty, which means all files had the same name and were repeating, discord counted them all as a single file.