### PR TITLE
[Semi Breaking Change] Add predicate overload to WaitForComponent 

### DIFF
--- a/DSharpPlus.Interactivity/Extensions/MessageExtensions.cs
+++ b/DSharpPlus.Interactivity/Extensions/MessageExtensions.cs
@@ -75,7 +75,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// </summary>
         /// <param name="message">The message to wait on.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, CancellationToken token = default)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, CancellationToken token)
             => GetInteractivity(message).WaitForButtonAsync(message, token);
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="message">The message to wait on.</param>
         /// <param name="id">The Id of the button to wait for.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, string id, CancellationToken token = default)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, string id, CancellationToken token)
             => GetInteractivity(message).WaitForButtonAsync(message, id, token);
 
         /// <summary>
@@ -111,8 +111,47 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="message">The message to wait on.</param>
         /// <param name="user">The user to wait for button input from.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, DiscordUser user, CancellationToken token = default)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, DiscordUser user, CancellationToken token)
             => GetInteractivity(message).WaitForButtonAsync(message, user, token);
+
+        /// <summary>
+        /// Waits for any button to be interacted with.
+        /// </summary>
+        /// <param name="message">The message to wait on.</param>
+        /// <param name="predicate">The predicate to filter interactions by.</param>
+        /// <param name="timeoutOverride">Override the timeout specified in <see cref="InteractivityConfiguration"/></param>
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, Func<ComponentInteractionCreateEventArgs, bool> predicate, TimeSpan? timeoutOverride)
+            => GetInteractivity(message).WaitForButtonAsync(message, predicate, timeoutOverride);
+
+        /// <summary>
+        /// Waits for any button to be interacted with.
+        /// </summary>
+        /// <param name="message">The message to wait on.</param>
+        /// <param name="predicate">The predicate to filter interactions by.</param>
+        /// <param name="token">A token to cancel interactivity with at any time. Pass <see cref="CancellationToken.None"/> to wait indefinitely.</param>
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForButtonAsync(this DiscordMessage message, Func<ComponentInteractionCreateEventArgs, bool> predicate, CancellationToken token)
+            => GetInteractivity(message).WaitForButtonAsync(message, predicate, token);
+
+        /// <summary>
+        /// Waits for any dropdown to be interacted with.
+        /// </summary>
+        /// <param name="message">The message to wait for.</param>
+        /// <param name="predicate">A filter predicate.</param>
+        /// <param name="timeoutOverride">Override the timeout period specified in <see cref="InteractivityConfiguration"/>.</param>
+        /// <exception cref="ArgumentException">Thrown when the message doesn't contain any dropdowns</exception>
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, Func<ComponentInteractionCreateEventArgs, bool> predicate, TimeSpan? timeoutOverride = null)
+            => GetInteractivity(message).WaitForSelectAsync(message, predicate, timeoutOverride);
+
+
+        /// <summary>
+        /// Waits for any dropdown to be interacted with.
+        /// </summary>
+        /// <param name="message">The message to wait for.</param>
+        /// <param name="predicate">A filter predicate.</param>
+        /// <param name="token">A token that can be used to cancel interactivity. Pass <see cref="CancellationToken.None"/> to wait indefinitely.</param>
+        /// <exception cref="ArgumentException">Thrown when the message doesn't contain any dropdowns</exception>
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, Func<ComponentInteractionCreateEventArgs, bool> predicate, CancellationToken token)
+            => GetInteractivity(message).WaitForSelectAsync(message, predicate, token);
 
         /// <summary>
         /// Waits for a dropdown to be interacted with.
@@ -129,7 +168,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="message">The message to wait on.</param>
         /// <param name="id">The Id of the dropdown to wait for.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, string id, CancellationToken token = default)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, string id, CancellationToken token)
             => GetInteractivity(message).WaitForSelectAsync(message, id, token);
 
         /// <summary>
@@ -150,7 +189,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="id">The Id of the dropdown to wait for.</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
 
-        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, DiscordUser user, string id, CancellationToken token = default)
+        public static Task<InteractivityResult<ComponentInteractionCreateEventArgs>> WaitForSelectAsync(this DiscordMessage message, DiscordUser user, string id, CancellationToken token)
             => GetInteractivity(message).WaitForSelectAsync(message, user, id, token);
 
 


### PR DESCRIPTION
# Summary
Fixes compiler errors about ambiguous method invocation by making the CancellationToken overloads non-optional.

This PR also adds predicate based methods for WaitForButton and WaitForSelect, which further disambiguates the method overloads, and allows for more granular control over component-based interactivity

@RocketPrinter :)