### PR TITLE
Stop DiscordIntegrationAccount inheriting from SnowflakeObject

### DIFF
--- a/DSharpPlus/Entities/Integration/DiscordIntegrationAccount.cs
+++ b/DSharpPlus/Entities/Integration/DiscordIntegrationAccount.cs
@@ -28,8 +28,14 @@ namespace DSharpPlus.Entities
     /// <summary>
     /// Represents a Discord integration account.
     /// </summary>
-    public class DiscordIntegrationAccount : SnowflakeObject
+    public class DiscordIntegrationAccount
     {
+        /// <summary>
+        /// Gets the ID of this object. This ID is a string and not a snowflake ulong.
+        /// </summary>
+        [JsonProperty("id", NullValueHandling = NullValueHandling.Ignore)]
+        public string Id { get; internal set; }
+
         /// <summary>
         /// Gets the name of the account.
         /// </summary>

--- a/DSharpPlus/Entities/Integration/DiscordIntegrationAccount.cs
+++ b/DSharpPlus/Entities/Integration/DiscordIntegrationAccount.cs
@@ -31,7 +31,7 @@ namespace DSharpPlus.Entities
     public class DiscordIntegrationAccount
     {
         /// <summary>
-        /// Gets the ID of this object. This ID is a string and not a snowflake ulong.
+        /// Gets the ID of the account.
         /// </summary>
         [JsonProperty("id", NullValueHandling = NullValueHandling.Ignore)]
         public string Id { get; internal set; }


### PR DESCRIPTION
`DiscordIntegrationAccount` is not a snowflake object and should therefore not inherit. ID is a string in this context, not a ulong.

# Summary
Stops `DiscordIntegrationAccount` inheriting from `SnowflakeObject`

# Details
This was causing a decode error when a valid object was received from Discord but decoded incorrectly:
![image](https://user-images.githubusercontent.com/33007665/129482439-46c8cb85-ba90-4988-aac3-192eb32d9aa3.png)
![image](https://user-images.githubusercontent.com/33007665/129482476-365761f0-052e-4f3e-a35e-20e6f5ad8ca5.png)


# Changes proposed
* Stop inheriting from `SnowflakeObject`