### PR TITLE
Expose a Logger for DiscordWebhookClient

### DIFF
--- a/DSharpPlus/Clients/DiscordWebhookClient.cs
+++ b/DSharpPlus/Clients/DiscordWebhookClient.cs
@@ -41,6 +41,11 @@ namespace DSharpPlus
     /// </summary>
     public class DiscordWebhookClient
     {
+        /// <summary>
+        /// Gets the logger for this client.
+        /// </summary>
+        public ILogger<DiscordWebhookClient> Logger { get; }
+
         // this regex has 2 named capture groups: "id" and "token".
         private static Regex WebhookRegex { get; } = new Regex(@"(?:https?:\/\/)?discord(?:app)?.com\/api\/(?:v\d\/)?webhooks\/(?<id>\d+)\/(?<token>[A-Za-z0-9_\-]+)", RegexOptions.ECMAScript);
 
@@ -93,11 +98,11 @@ namespace DSharpPlus
                 loggerFactory.AddProvider(new DefaultLoggerProvider(this));
             }
 
-            var logger = loggerFactory.CreateLogger<DiscordWebhookClient>();
+            this.Logger = loggerFactory.CreateLogger<DiscordWebhookClient>();
 
             var parsedTimeout = timeout ?? TimeSpan.FromSeconds(10);
 
-            this._apiclient = new DiscordApiClient(proxy, parsedTimeout, useRelativeRateLimit, logger);
+            this._apiclient = new DiscordApiClient(proxy, parsedTimeout, useRelativeRateLimit, this.Logger);
             this._hooks = new List<DiscordWebhook>();
             this.Webhooks = new ReadOnlyCollection<DiscordWebhook>(this._hooks);
         }


### PR DESCRIPTION
# Summary
Create the Logger property on `DiscordWebhookClient` for use of logging like other clients.

# Details
Based on the `ILogger<DiscordShardedClient> Logger` property in `DiscordShardedClient`, this change adds `ILogger<DiscordWebhookClient> Logger` to the `DiscordWebhookClient` allowing access to its logger.

# Changes proposed
* Exposes a Logger property of `DiscordWebhookClient`