### PR TITLE
Support for non-uids in interactivity

### DIFF
--- a/DSharpPlus.Interactivity/EventHandling/ComponentBased/ComponentEventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ComponentBased/ComponentEventWaiter.cs
@@ -107,7 +107,7 @@ namespace DSharpPlus.Interactivity.EventHandling
 
         private async Task Handle(DiscordClient _, ComponentInteractionCreateEventArgs args)
         {
-            foreach (var mreq in this._matchRequests)
+            foreach (var mreq in this._matchRequests.ToArray())
             {
                 if (mreq.Message == args.Message && mreq.IsMatch(args))
                     mreq.Tcs.TrySetResult(args);
@@ -117,7 +117,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             }
 
 
-            foreach (var creq in this._collectRequests)
+            foreach (var creq in this._collectRequests.ToArray())
             {
                 if (creq.Message == args.Message && creq.IsMatch(args))
                 {

--- a/DSharpPlus.Interactivity/EventHandling/ComponentBased/Requests/ComponentCollectRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ComponentBased/Requests/ComponentCollectRequest.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
+using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 
 namespace DSharpPlus.Interactivity.EventHandling
@@ -34,6 +35,7 @@ namespace DSharpPlus.Interactivity.EventHandling
     {
         public ConcurrentBag<ComponentInteractionCreateEventArgs> Collected { get; private set; }
 
-        public ComponentCollectRequest(string id, Func<ComponentInteractionCreateEventArgs, bool> predicate, CancellationToken cancellation) : base(id, predicate, cancellation) { }
+        public ComponentCollectRequest(DiscordMessage message, Func<ComponentInteractionCreateEventArgs, bool> predicate, CancellationToken cancellation) :
+            base(message, predicate, cancellation) { }
     }
 }

--- a/DSharpPlus.Interactivity/EventHandling/ComponentBased/Requests/ComponentMatchRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ComponentBased/Requests/ComponentMatchRequest.cs
@@ -23,6 +23,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 
 namespace DSharpPlus.Interactivity.EventHandling
@@ -35,7 +36,7 @@ namespace DSharpPlus.Interactivity.EventHandling
         /// <summary>
         /// The id to wait on. This should be uniquely formatted to avoid collisions.
         /// </summary>
-        public string Id { get; private set; }
+        public DiscordMessage Message { get; private set; }
 
         /// <summary>
         /// The completion source that represents the result of the match.
@@ -45,9 +46,9 @@ namespace DSharpPlus.Interactivity.EventHandling
         protected readonly CancellationToken _cancellation;
         protected readonly Func<ComponentInteractionCreateEventArgs, bool> _predicate;
 
-        public ComponentMatchRequest(string id, Func<ComponentInteractionCreateEventArgs, bool> predicate, CancellationToken cancellation)
+        public ComponentMatchRequest(DiscordMessage message, Func<ComponentInteractionCreateEventArgs, bool> predicate, CancellationToken cancellation)
         {
-            this.Id = id;
+            this.Message = message;
             this._predicate = predicate;
             this._cancellation = cancellation;
             this._cancellation.Register(() => this.Tcs.TrySetResult(null)); // TrySetCancelled would probably be better but I digress ~Velvet //

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -147,7 +147,7 @@ namespace DSharpPlus.Interactivity
                 throw new ArgumentException("You must specify at least one button to listen for.");
 
             var res = await this.ComponentEventWaiter
-                .WaitForMatchAsync(new(message.Id.ToString(CultureInfo.InvariantCulture),
+                .WaitForMatchAsync(new(message,
                     c =>
                         c.Interaction.Data.ComponentType == ComponentType.Button &&
                         buttons.Any(b => b.CustomId == c.Id), token));
@@ -187,7 +187,7 @@ namespace DSharpPlus.Interactivity
             var result =
                 await this
                 .ComponentEventWaiter
-                .WaitForMatchAsync(new(message.Id.ToString(), c => c.Interaction.Data.ComponentType == ComponentType.Button && ids.Contains(c.Id), token))
+                .WaitForMatchAsync(new(message, c => c.Interaction.Data.ComponentType == ComponentType.Button && ids.Contains(c.Id), token))
                 .ConfigureAwait(false);
 
             return new(result is null, result);
@@ -224,7 +224,7 @@ namespace DSharpPlus.Interactivity
 
             var result = await this
                 .ComponentEventWaiter
-                .WaitForMatchAsync(new(message.Id.ToString(CultureInfo.InvariantCulture), (c) => c.Interaction.Data.ComponentType is ComponentType.Button && c.User == user, token))
+                .WaitForMatchAsync(new(message, (c) => c.Interaction.Data.ComponentType is ComponentType.Button && c.User == user, token))
                 .ConfigureAwait(false);
 
             return new(result is null, result);
@@ -265,7 +265,7 @@ namespace DSharpPlus.Interactivity
 
             var result = await this
                 .ComponentEventWaiter
-                .WaitForMatchAsync(new(id, (c) => c.Interaction.Data.ComponentType is ComponentType.Button && c.Id == id, token))
+                .WaitForMatchAsync(new(message, (c) => c.Interaction.Data.ComponentType is ComponentType.Button && c.Id == id, token))
                 .ConfigureAwait(false);
 
             return new(result is null, result);
@@ -298,7 +298,7 @@ namespace DSharpPlus.Interactivity
 
             var result = await this
                 .ComponentEventWaiter
-                .WaitForMatchAsync(new(message.Id.ToString(CultureInfo.InvariantCulture), c => c.Interaction.Data.ComponentType is ComponentType.Select && predicate(c), token))
+                .WaitForMatchAsync(new(message, c => c.Interaction.Data.ComponentType is ComponentType.Select && predicate(c), token))
                 .ConfigureAwait(false);
 
             return new(result is null, result);
@@ -333,7 +333,7 @@ namespace DSharpPlus.Interactivity
 
             var result = await this
                 .ComponentEventWaiter
-                .WaitForMatchAsync(new(message.Id.ToString(CultureInfo.InvariantCulture), c => c.Interaction.Data.ComponentType is ComponentType.Select && predicate(c), token))
+                .WaitForMatchAsync(new(message, c => c.Interaction.Data.ComponentType is ComponentType.Select && predicate(c), token))
                 .ConfigureAwait(false);
 
             return new(result is null, result);
@@ -373,7 +373,7 @@ namespace DSharpPlus.Interactivity
 
             var result = await this
                 .ComponentEventWaiter
-                .WaitForMatchAsync(new(id, (c) => c.Interaction.Data.ComponentType is ComponentType.Select && c.Id == id, token))
+                .WaitForMatchAsync(new(message, (c) => c.Interaction.Data.ComponentType is ComponentType.Select && c.Id == id, token))
                 .ConfigureAwait(false);
 
             return new(result is null, result);
@@ -413,7 +413,7 @@ namespace DSharpPlus.Interactivity
 
             var result = await this
                 .ComponentEventWaiter
-                .WaitForMatchAsync(new(id, (c) => c.Id == id && c.User == user, token)).ConfigureAwait(false);
+                .WaitForMatchAsync(new(message, (c) => c.Id == id && c.User == user, token)).ConfigureAwait(false);
 
             return new(result is null, result);
         }

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -298,7 +298,7 @@ namespace DSharpPlus.Interactivity
 
             var result = await this
                 .ComponentEventWaiter
-                .WaitForMatchAsync(new(message, c => c.Interaction.Data.ComponentType is ComponentType.Select && predicate(c), token))
+                .WaitForMatchAsync(new(message, c => c.Interaction.Data.ComponentType is ComponentType.Button && predicate(c), token))
                 .ConfigureAwait(false);
 
             return new(result is null, result);


### PR DESCRIPTION
# Summary
Fixes an issue where using the same id in multiple messages, and then using interactivity on those same messages would overwrite the previous result, causing one time out to cancel every message with the same id

# Changes proposed
- Change `ConcurrentDictionary<string, T>` to `ConcurrentHashSet<T>`
- Change all instances of `id` and `message.Id.ToString(CultureInfo.InvariantCulture)` to `message`
- Change ComponentMatchRequest's `Id` property to `DiscordMessage` 
- Rename aforementionedProperty to Message (TargetMessage would likely be more apt)

# Notes
This *should* avoid a very minute performance regression caused by enumerating a concurrent collection, and concurrent HashSet at that by checking if the target message matches before checking the predicate. It's probably literally a fraction of a ns, but who cares.