### PR TITLE
Add support for sending files on interaction responses

### DIFF
--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 
 namespace DSharpPlus.Entities
@@ -64,6 +65,15 @@ namespace DSharpPlus.Entities
         public IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
         private readonly List<DiscordEmbed> _embeds = new();
 
+        /// <summary>
+        /// Files to send on this interaction response.
+        /// </summary>
+        public IReadOnlyList<DiscordMessageFile> Files => this._files;
+        private readonly List<DiscordMessageFile> _files = new();
+
+        /// <summary>
+        /// Components to send on this interaction response.
+        /// </summary>
         public IReadOnlyList<DiscordActionRowComponent> Components => this._components;
         private readonly List<DiscordActionRowComponent> _components = new();
 
@@ -190,6 +200,77 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// Adds a file to the interaction response.
+        /// </summary>
+        /// <param name="filename">Name of the file.</param>
+        /// <param name="data">File data.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
+        /// <returns>The builder to chain calls with.</returns>
+        public DiscordInteractionResponseBuilder AddFile(string filename, Stream data, bool resetStreamPosition = false)
+        {
+            if (this.Files.Count >= 10)
+                throw new ArgumentException("Cannot send more than 10 files with a single message.");
+
+            if (this._files.Any(x => x.FileName == filename))
+                throw new ArgumentException("A File with that filename already exists");
+
+            if (resetStreamPosition)
+                this._files.Add(new DiscordMessageFile(filename, data, data.Position));
+            else
+                this._files.Add(new DiscordMessageFile(filename, data, null));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets if the message has files to be sent.
+        /// </summary>
+        /// <param name="stream">The Stream to the file.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
+        /// <returns>The builder to chain calls with.</returns>
+        public DiscordInteractionResponseBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
+        {
+            if (this.Files.Count >= 10)
+                throw new ArgumentException("Cannot send more than 10 files with a single message.");
+
+            if (this._files.Any(x => x.FileName == stream.Name))
+                throw new ArgumentException("A File with that filename already exists");
+
+            if (resetStreamPosition)
+                this._files.Add(new DiscordMessageFile(stream.Name, stream, stream.Position));
+            else
+                this._files.Add(new DiscordMessageFile(stream.Name, stream, null));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds the given files to the interaction response builder.
+        /// </summary>
+        /// <param name="files">Dictionary of file name and file data.</param>
+        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
+        /// <returns>The builder to chain calls with.</returns>
+        public DiscordInteractionResponseBuilder AddFiles(Dictionary<string, Stream> files, bool resetStreamPosition = false)
+        {
+            if (this.Files.Count + files.Count > 10)
+                throw new ArgumentException("Cannot send more than 10 files with a single message.");
+
+            foreach (var file in files)
+            {
+                if (this._files.Any(x => x.FileName == file.Key))
+                    throw new ArgumentException("A File with that filename already exists");
+
+                if (resetStreamPosition)
+                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, file.Value.Position));
+                else
+                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, null));
+            }
+
+
+            return this;
+        }
+
+        /// <summary>
         /// Adds the mention to the mentions to parse, etc. with the interaction response.
         /// </summary>
         /// <param name="mention">Mention to add.</param>
@@ -226,6 +307,7 @@ namespace DSharpPlus.Entities
             this.IsEphemeral = false;
             this._mentions.Clear();
             this._components.Clear();
+            this._files.Clear();
         }
     }
 }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -2738,6 +2738,11 @@ namespace DSharpPlus.Net
 
         internal async Task CreateInteractionResponseAsync(ulong interaction_id, string interaction_token, InteractionResponseType type, DiscordInteractionResponseBuilder builder)
         {
+            if (builder?.Embeds != null)
+                foreach (var embed in builder.Embeds)
+                    if (embed.Timestamp != null)
+                        embed.Timestamp = embed.Timestamp.Value.ToUniversalTime();
+
             var pld = new RestInteractionResponsePayload
             {
                 Type = type,
@@ -2752,11 +2757,29 @@ namespace DSharpPlus.Net
                 } : null
             };
 
+            var values = new Dictionary<string, string>();
+
+            if (builder != null)
+                if (!string.IsNullOrEmpty(builder.Content) || builder.Embeds?.Count() > 0 || builder.IsTTS == true || builder.Mentions != null)
+                    values["payload_json"] = DiscordJson.SerializeObject(pld);
+
             var route = $"{Endpoints.INTERACTIONS}/:interaction_id/:interaction_token{Endpoints.CALLBACK}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { interaction_id, interaction_token }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
-            await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld));
+            var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
+            if (builder != null)
+            {
+                await this.DoMultipartAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files);
+
+                foreach (var file in builder.Files.Where(x => x.ResetPositionTo.HasValue))
+                {
+                    file.Stream.Position = file.ResetPositionTo.Value;
+                }
+            }
+            else
+            {
+                await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld));
+            }
         }
 
         internal async Task<DiscordMessage> GetOriginalInteractionResponseAsync(ulong application_id, string interaction_token)


### PR DESCRIPTION
# Summary
So, you could apparently send files on interaction responses for a while now. Discord documentation just doesn't reflect this because it's actually bad.

# Details
Add `AddFile` and `AddFiles` methods on the `InteractionResponseBuilder` and do a multipart request for sending files. I've done a bit of testing, I hope I didn't end up breaking something.