### PR TITLE
Fix reply mention oddities

### DIFF
--- a/DSharpPlus.Test/MentionValidation.cs
+++ b/DSharpPlus.Test/MentionValidation.cs
@@ -1,0 +1,99 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System.Text;
+using System.Threading.Tasks;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.Test
+{
+    public class MentionValidation : BaseCommandModule
+    {
+        [Command]
+        public async Task MentionTest(CommandContext ctx, DiscordRole role)
+        {
+            var progress = "";
+            var progressBuilder = new StringBuilder();
+            var progressMessage = await ctx.RespondAsync("Waiting for results");
+
+            var m1 = await new DiscordMessageBuilder().WithContent($"{ctx.User.Mention}, {role.Mention} Default").SendAsync(ctx.Channel);
+            var m2 = await new DiscordMessageBuilder().WithContent($"{ctx.User.Mention}, {role.Mention} User").WithAllowedMention(new UserMention(ctx.User)).SendAsync(ctx.Channel);
+            var m3 = await new DiscordMessageBuilder().WithContent($"{ctx.User.Mention}, {role.Mention} Role").WithAllowedMention(new RoleMention(role)).SendAsync(ctx.Channel);
+            var m4 = await new DiscordMessageBuilder().WithContent($"{ctx.User.Mention}, {role.Mention} None").WithAllowedMentions(Mentions.None).SendAsync(ctx.Channel);
+
+            var me1 = await new DiscordMessageBuilder().WithContent($"{ctx.User.Mention}, {role.Mention} Reply without mention").WithReply(ctx.Message.Id).SendAsync(ctx.Channel);
+            var me2 = await new DiscordMessageBuilder().WithContent($"{ctx.User.Mention}, {role.Mention} Reply with mention").WithReply(ctx.Message.Id, true).SendAsync(ctx.Channel);
+
+            var me1UserBefore = me1.MentionedUsers.Count;
+            var me1RoleBefore = me1.MentionedRoles.Count;
+
+            var me2UserBefore = me2.MentionedUsers.Count;
+            var me2RoleBefore = me2.MentionedRoles.Count;
+
+            await me1.ModifyAsync($"{role.Mention} Reply without mention");
+            await me2.ModifyAsync($"{role.Mention} Reply with mention");
+
+
+            var me1UserAfter = me1.MentionedUsers.Count;
+            var me1RoleAfter = me1.MentionedRoles.Count;
+
+            var me2UserAfter = me2.MentionedUsers.Count;
+            var me2RoleAfter = me2.MentionedRoles.Count;
+
+            if (m1.MentionedUsers.Count is 0 && m1.MentionedRoles.Count is 0)
+                progressBuilder.AppendLine("Default (No mentions) **PASSED**");
+            else
+                progressBuilder.AppendLine($"Default (No mentions) **FAILED** (User: Expected 0, got {m1.MentionedUsers.Count} | Role: Expected 0 got {m1.MentionedRoles.Count})");
+
+            if (m2.MentionedUsers.Count is 1 && m2.MentionedRoles.Count is 0)
+                progressBuilder.AppendLine("User mention without role **PASSED**");
+            else
+                progressBuilder.AppendLine($"User mention without role **FAILED** (User: Expected 1, got {m2.MentionedUsers.Count} | Role: Expected 0 got {m2.MentionedRoles.Count})");
+
+            if (m3.MentionedUsers.Count is 0 && m3.MentionedRoles.Count is 1)
+                progressBuilder.AppendLine("Role mention without user **PASSED**");
+            else
+                progressBuilder.AppendLine($"Role mention without user **FAILED** (User: Expected 0, got {m3.MentionedUsers.Count} | Role: Expected 1 got {m3.MentionedRoles.Count})");
+
+            if (m4.MentionedUsers.Count is 0 && m4.MentionedRoles.Count is 0)
+                progressBuilder.AppendLine("No mentions explicit **PASSED**");
+            else
+                progressBuilder.AppendLine($"No mentions explicit **FAILED** (User: Expected 0, got {m4.MentionedUsers.Count} | Role: Expected 0 got {m4.MentionedRoles.Count})");
+
+            if ((me1UserBefore is 0 && me1UserAfter is 0) && (me1RoleBefore is 0 && me1RoleAfter is 0))
+                progressBuilder.AppendLine("Reply edit (without mention) **PASSED**");
+            else
+                progressBuilder.AppendLine("Reply edit (without mention) **FAILED**");
+
+            if ((me2UserBefore is 1 && me2UserAfter is 1) && (me2RoleBefore is 0 && me2RoleAfter is 0))
+                progressBuilder.AppendLine("Reply edit (with mention) **PASSED**");
+            else
+                progressBuilder.AppendLine("Reply edit (with mention) **FAILED**");
+
+            progressBuilder.AppendLine(new string('-', 20) + "\n\n\u200b");
+            await progressMessage.ModifyAsync(progressBuilder.ToString());
+        }
+
+    }
+}

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -88,6 +88,17 @@ namespace DSharpPlus.Test
                     .WithDescription(msg.Content));
         }
 
+        [Command("editmention")]
+        public async Task EditMentionsAsync(CommandContext ctx)
+        {
+            var builder = new DiscordMessageBuilder()
+                .WithContent("Mentioning <@&879398655130472508> and <@743323785549316197>")
+                .WithReply(ctx.Message.Id, false)
+                .WithAllowedMention(new UserMention(743323785549316197));//.WithAllowedMention(new RoleMention(879398655130472508));
+
+            var msg = await builder.SendAsync(ctx.Channel);
+            await msg.ModifyAsync("Mentioning <@&879398655130472508> and <@743323785549316197>, but edited!");
+        }
 
         [Command("mention"), Description("Attempts to mention a user")]
         public async Task MentionablesAsync(CommandContext ctx, DiscordUser user)

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -93,8 +93,8 @@ namespace DSharpPlus.Test
         {
             var builder = new DiscordMessageBuilder()
                 .WithContent("Mentioning <@&879398655130472508> and <@743323785549316197>")
-                .WithReply(ctx.Message.Id, false)
-                .WithAllowedMention(new UserMention(743323785549316197));//.WithAllowedMention(new RoleMention(879398655130472508));
+                .WithReply(ctx.Message.Id, true);
+                //.WithAllowedMention(new UserMention(743323785549316197));//.WithAllowedMention(new RoleMention(879398655130472508));
 
             var msg = await builder.SendAsync(ctx.Channel);
             await msg.ModifyAsync("Mentioning <@&879398655130472508> and <@743323785549316197>, but edited!");

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -93,7 +93,8 @@ namespace DSharpPlus.Test
         {
             var builder = new DiscordMessageBuilder()
                 .WithContent("Mentioning <@&879398655130472508> and <@743323785549316197>")
-                .WithReply(ctx.Message.Id, true);
+                .WithReply(ctx.Message.Id, true)
+                .WithAllowedMention(new RoleMention(879398655130472508));
                 //.WithAllowedMention(new UserMention(743323785549316197));//.WithAllowedMention(new RoleMention(879398655130472508));
 
             var msg = await builder.SendAsync(ctx.Channel);

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -69,6 +69,9 @@ namespace DSharpPlus.Entities
                 this._mentionedChannels = new List<DiscordChannel>(other._mentionedChannels);
             if (other._mentionedRoles != null)
                 this._mentionedRoles = new List<DiscordRole>(other._mentionedRoles);
+            if (other._mentionedRoleIds != null)
+                this._mentionedRoleIds = new List<ulong>(other._mentionedRoleIds);
+
             this._mentionedUsers = new List<DiscordUser>(other._mentionedUsers);
             this._reactions = new List<DiscordReaction>(other._reactions);
             this._stickers = new List<DiscordMessageSticker>(other._stickers);
@@ -188,7 +191,8 @@ namespace DSharpPlus.Entities
         [JsonIgnore]
         internal List<DiscordRole> _mentionedRoles;
 
-        private List<DiscordRole> _rawMentionedRoles;
+        [JsonProperty("mention_roles")]
+        internal List<ulong> _mentionedRoleIds;
 
         [JsonIgnore]
         private readonly Lazy<IReadOnlyList<DiscordRole>> _mentionedRolesLazy;
@@ -404,8 +408,8 @@ namespace DSharpPlus.Entities
             if (this._mentionedUsers.Any())
                 mentions.AddRange(this._mentionedUsers.Select(m => (IMention)new UserMention(m)));
 
-            if (this._rawMentionedRoles.Any())
-                mentions.AddRange(this._rawMentionedRoles.Select(r => (IMention)new RoleMention(r)));
+            if (this._mentionedRoleIds.Any())
+                mentions.AddRange(this._mentionedRoleIds.Select(r => (IMention)new RoleMention(r)));
 
             return mentions.ToArray();
         }
@@ -434,7 +438,6 @@ namespace DSharpPlus.Entities
                 //mentionedUsers.UnionWith(Utilities.GetUserMentions(this).Select(this.Discord.GetCachedOrEmptyUserInternal));
                 if (guild != null)
                 {
-                    this._rawMentionedRoles = new List<DiscordRole>(this._mentionedRoles);
                     this._mentionedRoles = this._mentionedRoles.Union(Utilities.GetRoleMentions(this).Select(xid => guild.GetRole(xid))).ToList();
                     this._mentionedChannels = this._mentionedChannels.Union(Utilities.GetChannelMentions(this).Select(xid => guild.GetChannel(xid))).ToList();
                 }

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -176,8 +176,9 @@ namespace DSharpPlus.Entities
 
         [JsonProperty("mentions", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordUser> _mentionedUsers;
+
         [JsonIgnore]
-        readonly Lazy<IReadOnlyList<DiscordUser>> _mentionedUsersLazy;
+        internal readonly Lazy<IReadOnlyList<DiscordUser>> _mentionedUsersLazy;
 
         // TODO this will probably throw an exception in DMs since it tries to wrap around a null List...
         // this is probably low priority but need to find out a clean way to solve it...
@@ -434,15 +435,15 @@ namespace DSharpPlus.Entities
             }
             if (!string.IsNullOrWhiteSpace(this.Content))
             {
-                // un-comment if I broke it //
+                //uncomment if this breaks
                 //mentionedUsers.UnionWith(Utilities.GetUserMentions(this).Select(this.Discord.GetCachedOrEmptyUserInternal));
+
                 if (guild != null)
                 {
                     this._mentionedRoles = this._mentionedRoles.Union(Utilities.GetRoleMentions(this).Select(xid => guild.GetRole(xid))).ToList();
                     this._mentionedChannels = this._mentionedChannels.Union(Utilities.GetChannelMentions(this).Select(xid => guild.GetChannel(xid))).ToList();
                 }
             }
-
             this._mentionedUsers = mentionedUsers.ToList();
         }
 

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -465,7 +465,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> ModifyAsync(Optional<DiscordEmbed> embed = default)
-            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, default, embed.HasValue ? new[] {embed.Value} : Array.Empty<DiscordEmbed>(), default, default, Array.Empty<DiscordMessageFile>(), null, default);
+            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, default, embed.HasValue ? new[] {embed.Value} : Array.Empty<DiscordEmbed>(), this.GetMentions(), default, Array.Empty<DiscordMessageFile>(), null, default);
 
         /// <summary>
         /// Edits the message.
@@ -478,7 +478,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> ModifyAsync(Optional<string> content, Optional<DiscordEmbed> embed = default)
-            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, embed.HasValue ? new[] {embed.Value} : Array.Empty<DiscordEmbed>(), default, default, Array.Empty<DiscordMessageFile>(), null, default);
+            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, embed.HasValue ? new[] {embed.Value} : Array.Empty<DiscordEmbed>(), this.GetMentions(), default, Array.Empty<DiscordMessageFile>(), null, default);
 
         /// <summary>
         /// Edits the message.
@@ -491,7 +491,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> ModifyAsync(Optional<string> content, Optional<IEnumerable<DiscordEmbed>> embeds = default)
-            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, embeds, default, default, Array.Empty<DiscordMessageFile>(), null, default);
+            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, embeds, this.GetMentions(), default, Array.Empty<DiscordMessageFile>(), null, default);
 
 
         /// <summary>
@@ -540,7 +540,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task ModifyEmbedSuppressionAsync(bool hideEmbeds)
-            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, default, default, default, default, Array.Empty<DiscordMessageFile>(), hideEmbeds ? MessageFlags.SuppressedEmbeds : null, default);
+            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, default, default, this.GetMentions(), default, Array.Empty<DiscordMessageFile>(), hideEmbeds ? MessageFlags.SuppressedEmbeds : null, default);
 
         /// <summary>
         /// Deletes the message.

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -440,7 +440,9 @@ namespace DSharpPlus.Entities
 
                 if (guild != null)
                 {
-                    this._mentionedRoles = this._mentionedRoles.Union(Utilities.GetRoleMentions(this).Select(xid => guild.GetRole(xid))).ToList();
+                    //uncomment if this breaks
+                    //this._mentionedRoles = this._mentionedRoles.Union(Utilities.GetRoleMentions(this).Select(xid => guild.GetRole(xid))).ToList();
+                    this._mentionedRoles = this._mentionedRoles.Union(this._mentionedRoleIds.Select(xid => guild.GetRole(xid))).ToList();
                     this._mentionedChannels = this._mentionedChannels.Union(Utilities.GetChannelMentions(this).Select(xid => guild.GetChannel(xid))).ToList();
                 }
             }

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -396,10 +396,10 @@ namespace DSharpPlus.Entities
 
         private IMention[] GetMentions()
         {
-            if (this.ReferencedMessage != null && this._mentionedUsers.Contains(this.ReferencedMessage.Author))
-                return new IMention[] {new RepliedUserMention() }; // Return null to allow all mentions
-
             var mentions = new List<IMention>();
+
+            if (this.ReferencedMessage != null && this._mentionedUsers.Contains(this.ReferencedMessage.Author))
+               mentions.Add(new RepliedUserMention()); // Return null to allow all mentions
 
             if (this._mentionedUsers.Any())
                 mentions.AddRange(this._mentionedUsers.Select(m => (IMention)new UserMention(m)));

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -397,8 +397,8 @@ namespace DSharpPlus.Entities
 
             if (isModify)
             {
-                if (this.ReplyId.HasValue)
-                    throw new ArgumentException("You cannot change the ReplyID when modifying a message");
+                if (this.ReplyId.HasValue) ;
+                //throw new ArgumentException("You cannot change the ReplyID when modifying a message");
             }
             else
             {

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -347,6 +347,13 @@ namespace DSharpPlus.Entities
             this.ReplyId = messageId;
             this.MentionOnReply = mention;
             this.FailOnInvalidReply = failOnInvalidReply;
+
+            if (mention)
+            {
+                this.Mentions ??= new List<IMention>();
+                this.Mentions.Add(new RepliedUserMention());
+            }
+
             return this;
         }
 

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1200,8 +1200,7 @@ namespace DSharpPlus.Net
                 Attachments = attachments
             };
 
-            if (mentions != null)
-                pld.Mentions = new DiscordMentions(mentions);
+            pld.Mentions = new DiscordMentions(mentions ?? Mentions.None, false, mentions?.OfType<RepliedUserMention>().Any() ?? false);
 
             var values = new Dictionary<string, string>
             {
@@ -2093,7 +2092,7 @@ namespace DSharpPlus.Net
 
             return ret;
         }
-        
+
         internal async Task<DiscordMessage> GetWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong message_id)
         {
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.MESSAGES}/:message_id";
@@ -2106,7 +2105,7 @@ namespace DSharpPlus.Net
             ret.Discord = this.Discord;
             return ret;
         }
-        
+
         internal async Task<DiscordWebhook> ModifyWebhookAsync(ulong webhook_id, ulong channelId, string name, Optional<string> base64_avatar, string reason)
         {
             var pld = new RestWebhookPayload
@@ -2818,7 +2817,7 @@ namespace DSharpPlus.Net
             ret.Discord = this.Discord;
             return ret;
         }
-        
+
         internal Task<DiscordMessage> GetFollowupMessageAsync(ulong application_id, string interaction_token, ulong message_id) =>
             this.GetWebhookMessageAsync(application_id, interaction_token, message_id);
 

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1112,8 +1112,8 @@ namespace DSharpPlus.Net
             if (builder.ReplyId != null)
                 pld.MessageReference = new InternalDiscordMessageReference { MessageId = builder.ReplyId, FailIfNotExists = builder.FailOnInvalidReply };
 
-            if (builder.Mentions != null || builder.ReplyId != null)
-                pld.Mentions = new DiscordMentions(builder.Mentions ?? Mentions.All, builder.Mentions?.Any() ?? false, builder.MentionOnReply);
+            //if (builder.Mentions != null || builder.ReplyId != null)
+                pld.Mentions = new DiscordMentions(builder.Mentions ?? Mentions.None, builder.Mentions?.Any() ?? false, builder.MentionOnReply);
 
             if (builder.Files.Count == 0)
             {
@@ -1779,7 +1779,7 @@ namespace DSharpPlus.Net
 
             return result;
         }
-        
+
         #endregion
 
         #region Member

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1113,7 +1113,7 @@ namespace DSharpPlus.Net
                 pld.MessageReference = new InternalDiscordMessageReference { MessageId = builder.ReplyId, FailIfNotExists = builder.FailOnInvalidReply };
 
             //if (builder.Mentions != null || builder.ReplyId != null)
-                pld.Mentions = new DiscordMentions(builder.Mentions ?? Mentions.None, builder.Mentions?.Any() ?? false, builder.MentionOnReply);
+                pld.Mentions = new DiscordMentions(builder.Mentions ?? Mentions.All, builder.Mentions?.Any() ?? false, builder.MentionOnReply);
 
             if (builder.Files.Count == 0)
             {


### PR DESCRIPTION
# Summary
Provides a proper fix to #1044, which would've introduced more bugs regarding mentions.

# Details
This fixes an issue where editing a message would absolutely wreck mentions, which is [at least partly Discord's fault](https://github.com/discord/discord-api-docs/issues/3378)

This also closes #833.

# Changes proposed
Fix the use of `DiscordMentions`, which was the *actual* cause of the reply bug.
Add `GetMentions` method to DiscordMessage, which resolves what entities have actually been mentioned.
Remove parsing users by regex as per [this comment](https://github.com/DSharpPlus/DSharpPlus/pull/1044#issuecomment-903911763). It *could* be a breaking change.
Added a `_rawMentionedRoles` field to aid in figuring out what roles are actually mentioned, because `_mentionedRoles` contains API-provided mentions + regex'd mentions.

# Notes
Closes #1044, Closes #833 (For GitHub)

I've tested this manually for the past hour figuring out how to get it to work, so I'm gonna hope I didn't break it.