### PR TITLE
Add support for stage instances

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -755,6 +755,47 @@ namespace DSharpPlus
         /// </exception>
         public Task<DiscordMessage> CrosspostMessageAsync(ulong channel_id, ulong message_id)
             => this.ApiClient.CrosspostMessageAsync(channel_id, message_id);
+
+        /// <summary>
+        /// Creates a stage instance in a stage channel.
+        /// </summary>
+        /// <param name="channelId">The id of the stage channel to create it in.</param>
+        /// <param name="topic">The topic of the stage instance.</param>
+        /// <param name="privacyLevel">The privacy level of the stage instance.</param>
+        /// <param name="reason">The reason the stage instance was created.</param>
+        /// <returns>The created stage instance.</returns>
+        public Task<DiscordStageInstance> CreateStageInstanceAsync(ulong channelId, string topic, PrivacyLevel? privacyLevel = null, string reason = null)
+            => this.ApiClient.CreateStageInstanceAsync(channelId, topic, privacyLevel, reason);
+
+        /// <summary>
+        /// Gets a stage instance in a stage channel.
+        /// </summary>
+        /// <param name="channelId">The id of the channel.</param>
+        /// <returns>The stage instance in the channel.</returns>
+        public Task<DiscordStageInstance> GetStageInstanceAsync(ulong channelId)
+            => this.ApiClient.GetStageInstanceAsync(channelId);
+
+        /// <summary>
+        /// Modifies a stage instance in a stage channel.
+        /// </summary>
+        /// <param name="channelId">The id of the channel to modify the stage instance of.</param>
+        /// <param name="action">Action to perform.</param>
+        /// <returns>The modified stage instance.</returns>
+        public async Task<DiscordStageInstance> ModifyStageInstanceAsync(ulong channelId, Action<StageInstanceEditModel> action)
+        {
+            var mdl = new StageInstanceEditModel();
+            action(mdl);
+            return await this.ApiClient.ModifyStageInstanceAsync(channelId, mdl.Topic, mdl.PrivacyLevel, mdl.AuditLogReason);
+        }
+
+        /// <summary>
+        /// Deletes a stage instance in a stage channel.
+        /// </summary>
+        /// <param name="channelId">The id of the channel to delete the stage instance of.</param>
+        /// <param name="reason">The reason the stage instance was deleted.</param>
+        public Task DeleteStageInstanceAsync(ulong channelId, string reason = null)
+            => this.ApiClient.DeleteStageInstanceAsync(channelId, reason);
+
         #endregion
 
         #region Member

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -696,8 +696,6 @@ namespace DSharpPlus
 
         internal async Task OnGuildCreateEventAsync(DiscordGuild guild, JArray rawMembers, IEnumerable<DiscordPresence> presences)
         {
-            Console.WriteLine($"{guild.Name} : {guild.StageInstances?.Count}");
-
             if (presences != null)
             {
                 foreach (var xp in presences)

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -392,6 +392,22 @@ namespace DSharpPlus
 
                 #endregion
 
+                #region Stage Instance
+
+                case "stage_instance_create":
+                    await this.OnStageInstanceCreateAsync(dat.ToObject<DiscordStageInstance>());
+                    break;
+
+                case "stage_instance_update":
+                    await this.OnStageInstanceUpdateAsync(dat.ToObject<DiscordStageInstance>());
+                    break;
+
+                case "stage_instance_delete":
+                    await this.OnStageInstanceDeleteAsync(dat.ToObject<DiscordStageInstance>());
+                    break;
+
+                #endregion
+
                 #region Misc
 
                 case "gift_code_update": //Not supposed to be dispatched to bots
@@ -680,6 +696,8 @@ namespace DSharpPlus
 
         internal async Task OnGuildCreateEventAsync(DiscordGuild guild, JArray rawMembers, IEnumerable<DiscordPresence> presences)
         {
+            Console.WriteLine($"{guild.Name} : {guild.StageInstances?.Count}");
+
             if (presences != null)
             {
                 foreach (var xp in presences)
@@ -717,6 +735,8 @@ namespace DSharpPlus
                 guild._voiceStates = new ConcurrentDictionary<ulong, DiscordVoiceState>();
             if (guild._members == null)
                 guild._members = new ConcurrentDictionary<ulong, DiscordMember>();
+            if (guild._stageInstances == null)
+                guild._stageInstances = new ConcurrentDictionary<ulong, DiscordStageInstance>();
 
             this.UpdateCachedGuild(eventGuild, rawMembers);
 
@@ -754,6 +774,8 @@ namespace DSharpPlus
                 xr.Discord = this;
                 xr._guild_id = guild.Id;
             }
+            foreach (var instance in guild._stageInstances.Values)
+                instance.Discord = this;
 
             var old = Volatile.Read(ref this._guildDownloadCompleted);
             var dcompl = this._guilds.Values.All(xg => !xg.IsUnavailable);
@@ -1884,6 +1906,62 @@ namespace DSharpPlus
             };
 
             await this._integrationDeleted.InvokeAsync(this, ea).ConfigureAwait(false);
+        }
+
+        #endregion
+
+        #region Stage Instance
+
+        internal async Task OnStageInstanceCreateAsync(DiscordStageInstance instance)
+        {
+            instance.Discord = this;
+
+            var guild = this.InternalGetCachedGuild(instance.GuildId);
+
+            guild._stageInstances[instance.Id] = instance;
+
+            var eventArgs = new StageInstanceCreateEventArgs
+            {
+                StageInstance = instance
+            };
+
+            await this._stageInstanceCreated.InvokeAsync(this, eventArgs).ConfigureAwait(false);
+        }
+
+        internal async Task OnStageInstanceUpdateAsync(DiscordStageInstance instance)
+        {
+            instance.Discord = this;
+
+            var guild = this.InternalGetCachedGuild(instance.GuildId);
+
+            if (!guild._stageInstances.TryRemove(instance.Id, out var oldInstance))
+                oldInstance = new DiscordStageInstance { Id = instance.Id, GuildId = instance.GuildId, ChannelId = instance.ChannelId };
+
+            guild._stageInstances[instance.Id] = instance;
+
+            var eventArgs = new StageInstanceUpdateEventArgs
+            {
+                StageInstanceBefore = oldInstance,
+                StageInstanceAfter = instance
+            };
+
+            await this._stageInstanceUpdated.InvokeAsync(this, eventArgs).ConfigureAwait(false);
+        }
+
+        internal async Task OnStageInstanceDeleteAsync(DiscordStageInstance instance)
+        {
+            instance.Discord = this;
+
+            var guild = this.InternalGetCachedGuild(instance.GuildId);
+
+            guild._stageInstances.TryRemove(instance.Id, out _);
+
+            var eventArgs = new StageInstanceDeleteEventArgs
+            {
+                StageInstance = instance
+            };
+
+            await this._stageInstanceDeleted.InvokeAsync(this, eventArgs).ConfigureAwait(false);
         }
 
         #endregion

--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -646,6 +646,40 @@ namespace DSharpPlus
 
         #endregion
 
+        #region Stage Instance
+
+        /// <summary>
+        /// Fired when a stage instance is created.
+        /// </summary>
+        public event AsyncEventHandler<DiscordClient, StageInstanceCreateEventArgs> StageInstanceCreated
+        {
+            add => this._stageInstanceCreated.Register(value);
+            remove => this._stageInstanceCreated.Unregister(value);
+        }
+        private AsyncEvent<DiscordClient, StageInstanceCreateEventArgs> _stageInstanceCreated;
+
+        /// <summary>
+        /// Fired when a stage instance is updated.
+        /// </summary>
+        public event AsyncEventHandler<DiscordClient, StageInstanceUpdateEventArgs> StageInstanceUpdated
+        {
+            add => this._stageInstanceUpdated.Register(value);
+            remove => this._stageInstanceUpdated.Unregister(value);
+        }
+        private AsyncEvent<DiscordClient, StageInstanceUpdateEventArgs> _stageInstanceUpdated;
+
+        /// <summary>
+        /// Fired when a stage instance is deleted.
+        /// </summary>
+        public event AsyncEventHandler<DiscordClient, StageInstanceDeleteEventArgs> StageInstanceDeleted
+        {
+            add => this._stageInstanceDeleted.Register(value);
+            remove => this._stageInstanceDeleted.Unregister(value);
+        }
+        private AsyncEvent<DiscordClient, StageInstanceDeleteEventArgs> _stageInstanceDeleted;
+
+        #endregion
+
         #region Misc
 
         /// <summary>

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -211,6 +211,9 @@ namespace DSharpPlus
             this._integrationCreated = new AsyncEvent<DiscordClient, IntegrationCreateEventArgs>("INTEGRATION_CREATED", EventExecutionLimit, this.EventErrorHandler);
             this._integrationUpdated = new AsyncEvent<DiscordClient, IntegrationUpdateEventArgs>("INTEGRATION_UPDATED", EventExecutionLimit, this.EventErrorHandler);
             this._integrationDeleted = new AsyncEvent<DiscordClient, IntegrationDeleteEventArgs>("INTEGRATION_DELETED", EventExecutionLimit, this.EventErrorHandler);
+            this._stageInstanceCreated = new AsyncEvent<DiscordClient, StageInstanceCreateEventArgs>("STAGE_INSTANCE_CREATED", EventExecutionLimit, this.EventErrorHandler);
+            this._stageInstanceUpdated = new AsyncEvent<DiscordClient, StageInstanceUpdateEventArgs>("STAGE_INSTANCE_UPDAED", EventExecutionLimit, this.EventErrorHandler);
+            this._stageInstanceDeleted = new AsyncEvent<DiscordClient, StageInstanceDeleteEventArgs>("STAGE_INSTANCE_DELETED", EventExecutionLimit, this.EventErrorHandler);
 
             this._guilds.Clear();
 
@@ -914,6 +917,9 @@ namespace DSharpPlus
                 role._guild_id = guild.Id;
                 guild._roles[role.Id] = role;
             }
+
+            foreach (var newStageInstance in newGuild._stageInstances.Values)
+                _ = guild._stageInstances.GetOrAdd(newStageInstance.Id, _ => newStageInstance);
 
             guild.Name = newGuild.Name;
             guild.AfkChannelId = newGuild.AfkChannelId;

--- a/DSharpPlus/Clients/DiscordShardedClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.Events.cs
@@ -632,6 +632,40 @@ namespace DSharpPlus
 
         #endregion
 
+        #region Stage Instance
+
+        /// <summary>
+        /// Fired when a stage instance is created.
+        /// </summary>
+        public event AsyncEventHandler<DiscordClient, StageInstanceCreateEventArgs> StageInstanceCreated
+        {
+            add => this._stageInstanceCreated.Register(value);
+            remove => this._stageInstanceCreated.Unregister(value);
+        }
+        private AsyncEvent<DiscordClient, StageInstanceCreateEventArgs> _stageInstanceCreated;
+
+        /// <summary>
+        /// Fired when a stage instance is updated.
+        /// </summary>
+        public event AsyncEventHandler<DiscordClient, StageInstanceUpdateEventArgs> StageInstanceUpdated
+        {
+            add => this._stageInstanceUpdated.Register(value);
+            remove => this._stageInstanceUpdated.Unregister(value);
+        }
+        private AsyncEvent<DiscordClient, StageInstanceUpdateEventArgs> _stageInstanceUpdated;
+
+        /// <summary>
+        /// Fired when a stage instance is deleted.
+        /// </summary>
+        public event AsyncEventHandler<DiscordClient, StageInstanceDeleteEventArgs> StageInstanceDeleted
+        {
+            add => this._stageInstanceDeleted.Register(value);
+            remove => this._stageInstanceDeleted.Unregister(value);
+        }
+        private AsyncEvent<DiscordClient, StageInstanceDeleteEventArgs> _stageInstanceDeleted;
+
+        #endregion
+
         #region Misc
 
         /// <summary>
@@ -902,6 +936,15 @@ namespace DSharpPlus
 
         private Task Client_IntegrationDeleted(DiscordClient client, IntegrationDeleteEventArgs e)
             => this._integrationDeleted.InvokeAsync(client, e);
+
+        private Task Client_StageInstanceCreated(DiscordClient client, StageInstanceCreateEventArgs e)
+            => this._stageInstanceCreated.InvokeAsync(client, e);
+
+        private Task Client_StageInstanceUpdated(DiscordClient client, StageInstanceUpdateEventArgs e)
+            => this._stageInstanceUpdated.InvokeAsync(client, e);
+
+        private Task Client_StageInstanceDeleted(DiscordClient client, StageInstanceDeleteEventArgs e)
+            => this._stageInstanceDeleted.InvokeAsync(client, e);
 
         #endregion
     }

--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -493,6 +493,9 @@ namespace DSharpPlus
             this._integrationCreated = new AsyncEvent<DiscordClient, IntegrationCreateEventArgs>("INTEGRATION_CREATED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._integrationUpdated = new AsyncEvent<DiscordClient, IntegrationUpdateEventArgs>("INTEGRATION_UPDATED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._integrationDeleted = new AsyncEvent<DiscordClient, IntegrationDeleteEventArgs>("INTEGRATION_DELETED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
+            this._stageInstanceCreated = new AsyncEvent<DiscordClient, StageInstanceCreateEventArgs>("STAGE_INSTANCE_CREATED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
+            this._stageInstanceUpdated = new AsyncEvent<DiscordClient, StageInstanceUpdateEventArgs>("STAGE_INSTANCE_UPDAED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
+            this._stageInstanceDeleted = new AsyncEvent<DiscordClient, StageInstanceDeleteEventArgs>("STAGE_INSTANCE_DELETED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
         }
 
         private void HookEventHandlers(DiscordClient client)
@@ -555,6 +558,9 @@ namespace DSharpPlus
             client.IntegrationCreated += this.Client_IntegrationCreated;
             client.IntegrationUpdated += this.Client_IntegrationUpdated;
             client.IntegrationDeleted += this.Client_IntegrationDeleted;
+            client.StageInstanceCreated += this.Client_StageInstanceCreated;
+            client.StageInstanceUpdated += this.Client_StageInstanceUpdated;
+            client.StageInstanceDeleted += this.Client_StageInstanceDeleted;
         }
 
         private void UnhookEventHandlers(DiscordClient client)
@@ -617,6 +623,9 @@ namespace DSharpPlus
             client.IntegrationCreated -= this.Client_IntegrationCreated;
             client.IntegrationUpdated -= this.Client_IntegrationUpdated;
             client.IntegrationDeleted -= this.Client_IntegrationDeleted;
+            client.StageInstanceCreated -= this.Client_StageInstanceCreated;
+            client.StageInstanceUpdated -= this.Client_StageInstanceUpdated;
+            client.StageInstanceDeleted -= this.Client_StageInstanceDeleted;
         }
 
         private int GetShardIdFromGuilds(ulong id)

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -760,6 +760,55 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// Creates a stage instance in this stage channel.
+        /// </summary>
+        /// <param name="topic">The topic of the stage instance.</param>
+        /// <param name="privacyLevel">The privacy level of the stage instance.</param>
+        /// <param name="reason">The reason the stage instance was created.</param>
+        /// <returns>The created stage instance.</returns>
+        public async Task<DiscordStageInstance> CreateStageInstanceAsync(string topic, PrivacyLevel? privacyLevel = null, string reason = null)
+        {
+            if (this.Type != ChannelType.Stage)
+                throw new ArgumentException("A stage instance can only be created in a stage channel.");
+
+            return await this.Discord.ApiClient.CreateStageInstanceAsync(this.Id, topic, privacyLevel, reason);
+        }
+
+        /// <summary>
+        /// Gets the stage instance in this stage channel.
+        /// </summary>
+        /// <returns>The stage instance in the channel.</returns>
+        public async Task<DiscordStageInstance> GetStageInstanceAsync()
+        {
+            if (this.Type != ChannelType.Stage)
+                throw new ArgumentException("A stage instance can only be created in a stage channel.");
+
+            return await this.Discord.ApiClient.GetStageInstanceAsync(this.Id);
+        }
+
+        /// <summary>
+        /// Modifies the stage instance in this stage channel.
+        /// </summary>
+        /// <param name="action">Action to perform.</param>
+        /// <returns>The modified stage instance.</returns>
+        public async Task<DiscordStageInstance> ModifyStageInstanceAsync(Action<StageInstanceEditModel> action)
+        {
+            if (this.Type != ChannelType.Stage)
+                throw new ArgumentException("A stage instance can only be created in a stage channel.");
+
+            var mdl = new StageInstanceEditModel();
+            action(mdl);
+            return await this.Discord.ApiClient.ModifyStageInstanceAsync(this.Id, mdl.Topic, mdl.PrivacyLevel, mdl.AuditLogReason);
+        }
+
+        /// <summary>
+        /// Deletes the stage instance in this stage channel.
+        /// </summary>
+        /// <param name="reason">The reason the stage instance was deleted.</param>
+        public Task DeleteStageInstanceAsync(string reason = null)
+            => this.Discord.ApiClient.DeleteStageInstanceAsync(this.Id, reason);
+
+        /// <summary>
         /// Calculates permissions for a given member.
         /// </summary>
         /// <param name="mbr">Member to calculate permissions for.</param>

--- a/DSharpPlus/Entities/Channel/Stage/DiscordStageInstance.cs
+++ b/DSharpPlus/Entities/Channel/Stage/DiscordStageInstance.cs
@@ -1,0 +1,77 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Entities
+{
+    /// <summary>
+    /// Represents a discord stage instance.
+    /// </summary>
+    public sealed class DiscordStageInstance : SnowflakeObject
+    {
+        /// <summary>
+        /// Gets the guild this stage instance is in.
+        /// </summary>
+        [JsonIgnore]
+        public DiscordGuild Guild
+            => this.Discord.Guilds.TryGetValue(this.GuildId, out var guild) ? guild : null;
+
+        /// <summary>
+        /// Gets the id of the guild this stage instance is in.
+        /// </summary>
+        [JsonProperty("guild_id")]
+        public ulong GuildId { get; internal set; }
+
+        /// <summary>
+        /// Gets the channel this stage instance is in.
+        /// </summary>
+        [JsonIgnore]
+        public DiscordChannel Channel
+            => (this.Discord as DiscordClient)?.InternalGetCachedChannel(this.ChannelId) ?? null;
+
+        /// <summary>
+        /// Gets the id of the channel this stage instance is in.
+        /// </summary>
+        [JsonProperty("channel_id")]
+        public ulong ChannelId { get; internal set; }
+
+        /// <summary>
+        /// Gets the topic of this stage instance.
+        /// </summary>
+        [JsonProperty("topic")]
+        public string Topic { get; internal set; }
+
+        /// <summary>
+        /// Gets the privacy level of this stage instance.
+        /// </summary>
+        [JsonProperty("privacy_level")]
+        public PrivacyLevel PrivacyLevel { get; internal set; }
+
+        /// <summary>
+        /// Gets whether or not stage discovery is disabled.
+        /// </summary>
+        [JsonProperty("discoverable_disabled")]
+        public bool DiscoverableDisabled { get; internal set; }
+    }
+}

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -445,6 +445,16 @@ namespace DSharpPlus.Entities
         [JsonProperty("nsfw", NullValueHandling = NullValueHandling.Ignore)]
         public bool IsNSFW { get; internal set; }
 
+        /// <summary>
+        /// Gets the stage instances in this guild.
+        /// </summary>
+        [JsonIgnore]
+        public IReadOnlyDictionary<ulong, DiscordStageInstance> StageInstances => new ReadOnlyConcurrentDictionary<ulong, DiscordStageInstance>(_stageInstances);
+
+        [JsonProperty("stage_instances", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(SnowflakeArrayAsDictionaryJsonConverter))]
+        internal ConcurrentDictionary<ulong, DiscordStageInstance> _stageInstances;
+
         // Seriously discord?
 
         // I need to work on this

--- a/DSharpPlus/Enums/Channel/Stage/PrivacyLevel.cs
+++ b/DSharpPlus/Enums/Channel/Stage/PrivacyLevel.cs
@@ -1,0 +1,41 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus
+{
+    /// <summary>
+    /// Represents a stage instance's privacy level.
+    /// </summary>
+    public enum PrivacyLevel
+    {
+        /// <summary>
+        /// Indicates that the stage instance is publicly visible.
+        /// </summary>
+        Public = 1,
+
+        /// <summary>
+        /// Indicates that the stage instance is only visible to guild members.
+        /// </summary>
+        GuildOnly
+    }
+}

--- a/DSharpPlus/EventArgs/Stage Instance/StageInstanceCreateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Stage Instance/StageInstanceCreateEventArgs.cs
@@ -1,0 +1,50 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs
+{
+    /// <summary>
+    /// Represents arguments for <see cref="DiscordClient.StageInstanceCreated"/>.
+    /// </summary>
+    public class StageInstanceCreateEventArgs : DiscordEventArgs
+    {
+        /// <summary>
+        /// Gets the stage instance that was created.
+        /// </summary>
+        public DiscordStageInstance StageInstance { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild the stage instance was created in.
+        /// </summary>
+        public DiscordGuild Guild
+            => this.StageInstance.Guild;
+
+        /// <summary>
+        /// Gets the channel the stage instance was created in.
+        /// </summary>
+        public DiscordChannel Channel
+            => this.StageInstance.Channel;
+    }
+}

--- a/DSharpPlus/EventArgs/Stage Instance/StageInstanceDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/Stage Instance/StageInstanceDeleteEventArgs.cs
@@ -1,0 +1,50 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs
+{
+    /// <summary>
+    /// Represents arguments for <see cref="DiscordClient.StageInstanceDeleted"/>.
+    /// </summary>
+    public class StageInstanceDeleteEventArgs : DiscordEventArgs
+    {
+        /// <summary>
+        /// Gets the stage instance that was deleted.
+        /// </summary>
+        public DiscordStageInstance StageInstance { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild the stage instance was in.
+        /// </summary>
+        public DiscordGuild Guild
+            => this.StageInstance.Guild;
+
+        /// <summary>
+        /// Gets the channel the stage instance was in.
+        /// </summary>
+        public DiscordChannel Channel
+            => this.StageInstance.Channel;
+    }
+}

--- a/DSharpPlus/EventArgs/Stage Instance/StageInstanceUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Stage Instance/StageInstanceUpdateEventArgs.cs
@@ -1,0 +1,55 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs
+{
+    /// <summary>
+    /// Represents arguments for <see cref="DiscordClient.StageInstanceUpdated"/>.
+    /// </summary>
+    public class StageInstanceUpdateEventArgs : DiscordEventArgs
+    {
+        /// <summary>
+        /// Gets the stage instance before the update.
+        /// </summary>
+        public DiscordStageInstance StageInstanceBefore { get; internal set; }
+
+        /// <summary>
+        /// Gets the stage instance after the update.
+        /// </summary>
+        public DiscordStageInstance StageInstanceAfter { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild the stage instance is in.
+        /// </summary>
+        public DiscordGuild Guild
+            => this.StageInstanceAfter.Guild;
+
+        /// <summary>
+        /// Gets the channel the stage instance is in.
+        /// </summary>
+        public DiscordChannel Channel
+            => this.StageInstanceAfter.Channel;
+    }
+}

--- a/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
@@ -210,4 +210,25 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("token", NullValueHandling = NullValueHandling.Include)]
         public string Token { get; set; }
     }
+
+    internal sealed class RestCreateStageInstancePayload
+    {
+        [JsonProperty("channel_id")]
+        public ulong ChannelId { get; set; }
+
+        [JsonProperty("topic")]
+        public string Topic { get ; set; }
+
+        [JsonProperty("privacy_level", NullValueHandling = NullValueHandling.Ignore)]
+        public PrivacyLevel? PrivacyLevel { get; set; }
+    }
+
+    internal sealed class RestModifyStageInstancePayload
+    {
+        [JsonProperty("topic")]
+        public Optional<string> Topic { get; set; }
+
+        [JsonProperty("privacy_level")]
+        public Optional<PrivacyLevel> PrivacyLevel { get; set; }
+    }
 }

--- a/DSharpPlus/Net/Models/StageInstanceEditModel.cs
+++ b/DSharpPlus/Net/Models/StageInstanceEditModel.cs
@@ -1,0 +1,40 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.Net.Models
+{
+    public class StageInstanceEditModel : BaseEditModel
+    {
+        /// <summary>
+        /// The new stage instance topic.
+        /// </summary>
+        public Optional<string> Topic { internal get; set; }
+
+        /// <summary>
+        /// The new stage instance privacy level.
+        /// </summary>
+        public Optional<PrivacyLevel> PrivacyLevel { internal get; set; }
+    }
+}

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1462,6 +1462,82 @@ namespace DSharpPlus.Net
             return JsonConvert.DeserializeObject<DiscordMessage>(response.Response);
         }
 
+        internal async Task<DiscordStageInstance> CreateStageInstanceAsync(ulong channelId, string topic, PrivacyLevel? privacyLevel, string reason)
+        {
+            var headers = Utilities.GetBaseHeaders();
+            if (!string.IsNullOrWhiteSpace(reason))
+                headers[REASON_HEADER_NAME] = reason;
+
+            var pld = new RestCreateStageInstancePayload
+            {
+                ChannelId = channelId,
+                Topic = topic,
+                PrivacyLevel = privacyLevel
+            };
+
+            var route = $"{Endpoints.STAGE_INSTANCES}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
+
+            var stage = JsonConvert.DeserializeObject<DiscordStageInstance>(response.Response);
+            stage.Discord = this.Discord;
+
+            return stage;
+        }
+
+        internal async Task<DiscordStageInstance> GetStageInstanceAsync(ulong channel_id)
+        {
+            var route = $"{Endpoints.STAGE_INSTANCES}/:channel_id";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { channel_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
+
+            var stage = JsonConvert.DeserializeObject<DiscordStageInstance>(response.Response);
+            stage.Discord = this.Discord;
+
+            return stage;
+        }
+
+        internal async Task<DiscordStageInstance> ModifyStageInstanceAsync(ulong channel_id, Optional<string> topic, Optional<PrivacyLevel> privacyLevel, string reason)
+        {
+            var headers = Utilities.GetBaseHeaders();
+            if (!string.IsNullOrWhiteSpace(reason))
+                headers[REASON_HEADER_NAME] = reason;
+
+            var pld = new RestModifyStageInstancePayload
+            {
+                Topic = topic,
+                PrivacyLevel = privacyLevel
+            };
+
+            var route = $"{Endpoints.STAGE_INSTANCES}/:channel_id";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { channel_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
+
+            var stage = JsonConvert.DeserializeObject<DiscordStageInstance>(response.Response);
+            stage.Discord = this.Discord;
+
+            return stage;
+        }
+
+        internal async Task DeleteStageInstanceAsync(ulong channel_id, string reason)
+        {
+            var headers = Utilities.GetBaseHeaders();
+            if (!string.IsNullOrWhiteSpace(reason))
+                headers[REASON_HEADER_NAME] = reason;
+
+            var route = $"{Endpoints.STAGE_INSTANCES}/:channel_id";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route, headers);
+        }
+
         #endregion
 
         #region Member

--- a/DSharpPlus/Net/Rest/Endpoints.cs
+++ b/DSharpPlus/Net/Rest/Endpoints.cs
@@ -83,5 +83,6 @@ namespace DSharpPlus.Net
         public const string VOICE_STATES = "/voice-states";
         public const string STICKERS = "/stickers";
         public const string STICKERPACKS = "/sticker-packs";
+        public const string STAGE_INSTANCES = "/stage-instances";
     }
 }


### PR DESCRIPTION
# Summary
Adds support for stage instances.

# Details
Added the entities, endpoints, events and some caching for stage instances.

# Changes proposed
* Add `DiscordStageInstance` and `PrivacyLevel`
* Add stage instance endpoints to `DiscordClient` and `DiscordRestClient`
* Add stage instance events
* Add `StageInstances` to `DiscordGuild` and properly cache them on the events.