### PR TITLE
Implement permission changes

### DIFF
--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -314,13 +314,13 @@ namespace DSharpPlus
         UsePrivateThreads = 0x0000001000000000,
         
         /// <summary>
-        /// Allows for creating threads.
+        /// Allows for creating private threads.
         /// </summary>
         [PermissionString("Create Public Threads")]
         CreatePublicThreads = 0x0000000800000000,
 
         /// <summary>
-        /// Allows for private threads.
+        /// Allows for creating private threads.
         /// </summary>
         [PermissionString("Create Private Threads")]
         CreatePrivateThreads = 0x0000001000000000,

--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -27,7 +27,7 @@ namespace DSharpPlus
 {
     public static class PermissionMethods
     {
-        internal static Permissions FULL_PERMS { get; } = (Permissions)549755813887L;
+        internal static Permissions FULL_PERMS { get; } = (Permissions)1099511627775L;
 
         /// <summary>
         /// Calculates whether this permission set contains the given permission.
@@ -92,7 +92,7 @@ namespace DSharpPlus
         /// Indicates all permissions are granted
         /// </summary>
         [PermissionString("All permissions")]
-        All = 549755813887,
+        All = 1099511627775,
 
         /// <summary>
         /// Allows creation of instant channel invites.
@@ -335,7 +335,13 @@ namespace DSharpPlus
         /// Allows for sending messages in threads.
         /// </summary>
         [PermissionString("Send messages in Threads")]
-        SendMessagesInThreads = 0x0000004000000000
+        SendMessagesInThreads = 0x0000004000000000,
+        
+        /// <summary>
+        /// Allows for launching activities (applications with the `EMBEDDED` flag) in a voice channel.     
+        /// </summary>
+        [PermissionString("Start Embedded Activities")]
+        StartEmbeddedActivities = 0x0000008000000000
     }
 
     /// <summary>

--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -277,8 +277,15 @@ namespace DSharpPlus
         /// <summary>
         /// Allows the user to use slash commands.
         /// </summary>
+        [Obsolete("Replaced by UseApplicationCommands", false)]
         [PermissionString("Use slash commands")]
         UseSlashCommands = 0x0000000080000000,
+        
+        /// <summary>
+        /// Allows the user to use application commands.
+        /// </summary>
+        [PermissionString("Use application commands")]
+        UseApplicationCommands = 0x0000000080000000,
 
         /// <summary>
         /// Allows for requesting to speak in stage channels.

--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -302,14 +302,14 @@ namespace DSharpPlus
         /// <summary>
         /// Allows for creating and participating in threads.
         /// </summary>
-        [Obsolete("Replaced by CreatePublicThreads & SendMessagesInThreads", false)]
+        [Obsolete("Replaced by CreatePublicThreads and SendMessagesInThreads", false)]
         [PermissionString("Use Public Threads")]
         UsePublicThreads = 0x0000000800000000,
 
         /// <summary>
         /// Allows for creating and participating in private threads.
         /// </summary>
-        [Obsolete("Replaced by CreatePrivateThreads & SendMessagesInThreads", false)]
+        [Obsolete("Replaced by CreatePrivateThreads and SendMessagesInThreads", false)]
         [PermissionString("Use Private Threads")]
         UsePrivateThreads = 0x0000001000000000,
         

--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -27,7 +27,7 @@ namespace DSharpPlus
 {
     public static class PermissionMethods
     {
-        internal static Permissions FULL_PERMS { get; } = (Permissions)274877906943L;
+        internal static Permissions FULL_PERMS { get; } = (Permissions)549755813887L;
 
         /// <summary>
         /// Calculates whether this permission set contains the given permission.
@@ -92,7 +92,7 @@ namespace DSharpPlus
         /// Indicates all permissions are granted
         /// </summary>
         [PermissionString("All permissions")]
-        All = 274877906943,
+        All = 549755813887,
 
         /// <summary>
         /// Allows creation of instant channel invites.
@@ -155,7 +155,7 @@ namespace DSharpPlus
         AccessChannels = 0x0000000000000400,
 
         /// <summary>
-        /// Allows sending messages.
+        /// Allows sending messages (does not allow sending messages in threads).
         /// </summary>
         [PermissionString("Send messages")]
         SendMessages = 0x0000000000000800,
@@ -295,20 +295,40 @@ namespace DSharpPlus
         /// <summary>
         /// Allows for creating and participating in threads.
         /// </summary>
+        [Obsolete("Replaced by CreatePublicThreads & SendMessagesInThreads", false)]
         [PermissionString("Use Public Threads")]
         UsePublicThreads = 0x0000000800000000,
 
         /// <summary>
         /// Allows for creating and participating in private threads.
         /// </summary>
+        [Obsolete("Replaced by CreatePrivateThreads & SendMessagesInThreads", false)]
         [PermissionString("Use Private Threads")]
         UsePrivateThreads = 0x0000001000000000,
+        
+        /// <summary>
+        /// Allows for creating threads.
+        /// </summary>
+        [PermissionString("Create Public Threads")]
+        CreatePublicThreads = 0x0000000800000000,
+
+        /// <summary>
+        /// Allows for private threads.
+        /// </summary>
+        [PermissionString("Create Private Threads")]
+        CreatePrivateThreads = 0x0000001000000000,
         
         /// <summary>
         /// Allows the usage of custom stickers from other servers.
         /// </summary>
         [PermissionString("Use external Stickers")]
-        UseExternalStickers = 0x0000002000000000
+        UseExternalStickers = 0x0000002000000000,
+
+        /// <summary>
+        /// Allows for sending messages in threads.
+        /// </summary>
+        [PermissionString("Send messages in Threads")]
+        SendMessagesInThreads = 0x0000004000000000
     }
 
     /// <summary>

--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -314,7 +314,7 @@ namespace DSharpPlus
         UsePrivateThreads = 0x0000001000000000,
         
         /// <summary>
-        /// Allows for creating private threads.
+        /// Allows for creating public threads.
         /// </summary>
         [PermissionString("Create Public Threads")]
         CreatePublicThreads = 0x0000000800000000,


### PR DESCRIPTION
Update Permissions to include newly documented Permission

# Summary

Implements the following permissions to `DSharpPlus.Permissions`:

- `SEND_MESSAGES_IN_THREADS`
- `CREATE_PUBLIC_THREADS` (Replaces `USE_PUBLIC_THREADS` )
- `CREATE_PRIVATE_THREADS` (Replaces `USE_PRIVATE_THREADS`)
- `USE_APPLICATION_COMMANDS` (Replaces `USE_SLASH_COMMANDS`)
- `START_EMBEDDED_ACTIVITIES`

# Details

Adds the following permissions to the `Permissions` enum.
- `SendMessagesInThreads`
- `CreatePublicThreads`
- `CreatePrivateThreads`
- `UseApplicationCommands`
- `StartEmbeddedActivities`

Marked the following permissions as obsolete:
- `UsePublicThreads`
- `UsePrivateThreads`
- `UseSlashCommands`


# Changes proposed

  - Add `Permissions.SendMessagesInThreads` with a value of `0x0000004000000000`
  - Add `Permissions.StartEmbeddedActivities` with a value of `0x0000008000000000`

  - Modify the `FULL_PERMS` and `All` values to the result of the old `All` value and all new values resulting to a new value of `1099511627775`


# Notes
https://github.com/discord/discord-api-docs/pull/3672
https://github.com/discord/discord-api-docs/pull/3614/files#diff-83c324034ba0b1753dde3487f095f5307f7036c3e53a25bacba1879733a6ce23
https://github.com/discord/discord-api-docs/pull/3805
