### PR TITLE
Fix VNext KeepAlive token causing null ref

### DIFF
--- a/DSharpPlus.Test/VoiceNextTest.cs
+++ b/DSharpPlus.Test/VoiceNextTest.cs
@@ -1,0 +1,52 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Threading.Tasks;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.VoiceNext;
+using Microsoft.Extensions.Logging;
+
+namespace DSharpPlus.Test
+{
+    public class VoiceNextTest : BaseCommandModule
+    {
+        static VoiceNextTest() => TaskScheduler.UnobservedTaskException += OhNo;
+        private static void OhNo(object sender, UnobservedTaskExceptionEventArgs e) { Console.Error.WriteLine("SOMETHING WENT TERRIBLY WRONG WHEN DISCONNECTING"); }
+
+        [Command]
+        public async Task Join(CommandContext ctx)
+        {
+            var vnext = ctx.Client.GetVoiceNext();
+            await vnext.ConnectAsync(ctx.Member.VoiceState.Channel);
+        }
+
+        [Command]
+        public async Task Leave(CommandContext ctx)
+        {
+            var vnext = ctx.Client.GetVoiceNext();
+
+            vnext.GetConnection(ctx.Guild)?.Disconnect(); // Calls .Dispose(); //
+        }
+    }
+}

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -721,6 +721,12 @@ namespace DSharpPlus.VoiceNext
             this.TokenSource.Cancel();
             this.SenderTokenSource.Cancel();
             this.ReceiverTokenSource?.Cancel();
+            this.KeepaliveTokenSource.Cancel();
+
+            this.TokenSource.Dispose();
+            this.SenderTokenSource.Dispose();
+            this.ReceiverTokenSource?.Dispose();
+            this.KeepaliveTokenSource.Dispose();
 
             try
             {


### PR DESCRIPTION
Fixes an issue where disposing of a VoiceNextConnection would cause a silent, unhandled null ref, as seen below:

The `KeepAliveTokenSource` was never being disposed, so the heartbeat task would continue to loop and attempt to access a disposed client

```fix
[1:11:28 20 PM] [ERR] [BotExceptionHandler] Task Scheduler caught an unobserved exception: System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property.
As a result, the unobserved exception was rethrown by the finalizer thread. (Cannot access a disposed object.
Object name: 'System.Net.Sockets.UdpClient'.)
 ---> System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Net.Sockets.UdpClient'.
   at System.Net.Sockets.UdpClient.<ThrowIfDisposed>g__ThrowObjectDisposedException|69_0()
   at System.Net.Sockets.UdpClient.ValidateDatagram(Byte[] datagram, Int32 bytes, IPEndPoint endPoint)
   at System.Net.Sockets.UdpClient.SendAsync(Byte[] datagram, Int32 bytes, IPEndPoint endPoint)
   at System.Net.Sockets.UdpClient.SendAsync(Byte[] datagram, Int32 bytes, String hostname, Int32 port)
   at DSharpPlus.Net.Udp.DspUdpClient.SendAsync(Byte[] data, Int32 dataLength)
   at DSharpPlus.VoiceNext.VoiceNextConnection.KeepaliveAsync()
   --- End of inner exception stack trace ---
   ```