### PR TITLE
Fix members not being cached on voice state update and interactions

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1737,6 +1737,11 @@ namespace DSharpPlus
                 mbr.IsMuted = vstateNew.IsServerMuted;
                 mbr.IsDeafened = vstateNew.IsServerDeafened;
             }
+            else
+            {
+                var transportMbr = vstateNew.TransportMember;
+                this.UpdateUser(new DiscordUser(transportMbr.User) { Discord = this }, gid, gld, transportMbr);
+            }
 
             var ea = new VoiceStateUpdateEventArgs
             {
@@ -1972,16 +1977,21 @@ namespace DSharpPlus
         internal async Task OnInteractionCreateAsync(ulong? guildId, ulong channelId, TransportUser user, TransportMember member, DiscordInteraction interaction)
         {
             var usr = new DiscordUser(user) { Discord = this };
-            this.UpdateUserCache(usr);
 
-            if (member != null)
-                usr = new DiscordMember(member) { _guild_id = guildId.Value, Discord = this };
-
-            interaction.User = usr;
             interaction.ChannelId = channelId;
             interaction.GuildId = guildId;
             interaction.Discord = this;
             interaction.Data.Discord = this;
+
+            if (member != null)
+            {
+                usr = new DiscordMember(member) { _guild_id = guildId.Value, Discord = this };
+                this.UpdateUser(usr, guildId, interaction.Guild, member);
+            }
+            else
+                this.UpdateUserCache(usr);
+
+            interaction.User = usr;
 
             var resolved = interaction.Data.Resolved;
             if (resolved != null)

--- a/DSharpPlus/Entities/Voice/DiscordVoiceState.cs
+++ b/DSharpPlus/Entities/Voice/DiscordVoiceState.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Globalization;
+using DSharpPlus.Net.Abstractions;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
@@ -140,6 +141,16 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("request_to_speak_timestamp", NullValueHandling = NullValueHandling.Ignore)]
         internal DateTimeOffset? RequestToSpeakTimestamp { get; set; }
+
+        /// <summary>
+        /// Gets the member this voice state belongs to.
+        /// </summary>
+        [JsonIgnore]
+        public DiscordMember Member
+            => new(this.TransportMember) { Discord = this.Discord };
+
+        [JsonProperty("member", NullValueHandling = NullValueHandling.Ignore)]
+        internal TransportMember TransportMember { get; set; }
 
         internal DiscordVoiceState() { }
 

--- a/DSharpPlus/Entities/Voice/DiscordVoiceState.cs
+++ b/DSharpPlus/Entities/Voice/DiscordVoiceState.cs
@@ -147,7 +147,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public DiscordMember Member
-            => new(this.TransportMember) { Discord = this.Discord };
+            => this.Guild.Members.TryGetValue(this.TransportMember.User.Id, out var member) ? member : new DiscordMember(this.TransportMember) { Discord = this.Discord };
 
         [JsonProperty("member", NullValueHandling = NullValueHandling.Ignore)]
         internal TransportMember TransportMember { get; set; }


### PR DESCRIPTION
# Summary
Fixes #1046 

# Details
Adds the `member` property on `DiscordVoiceState`, and adds members to cache using `UpdateUser` on `VoiceStateUpdate` and the interaction events.