### PR TITLE
Add missing channel properties

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -409,10 +409,12 @@ namespace DSharpPlus
         /// <param name="perUserRateLimit">Slow mode timeout for users.</param>
         /// <param name="rtcRegion">New region override.</param>
         /// <param name="qualityMode">New video quality mode.</param>
+        /// <param name="type">New channel type.</param>
+        /// <param name="permissionOverwrites">New channel permission overwrites.</param>
         /// <param name="reason">Reason why this channel was modified</param>
         /// <returns></returns>
-        public Task ModifyChannelAsync(ulong id, string name, int? position, Optional<string> topic, bool? nsfw, Optional<ulong?> parent, int? bitrate, int? userLimit, Optional<int?> perUserRateLimit, Optional<DiscordVoiceRegion> rtcRegion, VideoQualityMode? qualityMode, string reason)
-            => this.ApiClient.ModifyChannelAsync(id, name, position, topic, nsfw, parent, bitrate, userLimit, perUserRateLimit, rtcRegion.IfPresent(e => e?.Id), qualityMode, reason);
+        public Task ModifyChannelAsync(ulong id, string name, int? position, Optional<string> topic, bool? nsfw, Optional<ulong?> parent, int? bitrate, int? userLimit, Optional<int?> perUserRateLimit, Optional<DiscordVoiceRegion> rtcRegion, VideoQualityMode? qualityMode, Optional<ChannelType> type, IEnumerable<DiscordOverwriteBuilder> permissionOverwrites, string reason)
+            => this.ApiClient.ModifyChannelAsync(id, name, position, topic, nsfw, parent, bitrate, userLimit, perUserRateLimit, rtcRegion.IfPresent(e => e?.Id), qualityMode, type, permissionOverwrites, reason);
 
         /// <summary>
         /// Modifies a channel
@@ -427,7 +429,7 @@ namespace DSharpPlus
 
             return this.ApiClient.ModifyChannelAsync(channelId, mdl.Name, mdl.Position, mdl.Topic, mdl.Nsfw,
                 mdl.Parent.HasValue ? mdl.Parent.Value?.Id : default(Optional<ulong?>), mdl.Bitrate, mdl.Userlimit, mdl.PerUserRateLimit, mdl.RtcRegion.IfPresent(e => e?.Id),
-                mdl.QualityMode, mdl.AuditLogReason);
+                mdl.QualityMode, mdl.Type, mdl.PermissionOverwrites, mdl.AuditLogReason);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -212,6 +212,12 @@ namespace DSharpPlus.Entities
         public DiscordVoiceRegion RtcRegion
             => this.RtcRegionId != null ? this.Discord.VoiceRegions[this.RtcRegionId] : null;
 
+        /// <summary>
+        /// Only sent on the resolved channels of interaction responses for application commands. Gets the permissions of the user in this channel who invoked the command.
+        /// </summary>
+        [JsonProperty("permissions")]
+        public Permissions? UserPermissions { get; internal set; }
+
         internal DiscordChannel()
         {
             this._permissionOverwritesLazy = new Lazy<IReadOnlyList<DiscordOverwrite>>(() => new ReadOnlyCollection<DiscordOverwrite>(this._permissionOverwrites));
@@ -381,7 +387,7 @@ namespace DSharpPlus.Entities
             action(mdl);
             return this.Discord.ApiClient.ModifyChannelAsync(this.Id, mdl.Name, mdl.Position, mdl.Topic, mdl.Nsfw,
                 mdl.Parent.HasValue ? mdl.Parent.Value?.Id : default(Optional<ulong?>), mdl.Bitrate, mdl.Userlimit, mdl.PerUserRateLimit, mdl.RtcRegion.IfPresent(r => r?.Id),
-                mdl.QualityMode, mdl.AuditLogReason);
+                mdl.QualityMode, mdl.Type, mdl.PermissionOverwrites, mdl.AuditLogReason);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -213,7 +213,8 @@ namespace DSharpPlus.Entities
             => this.RtcRegionId != null ? this.Discord.VoiceRegions[this.RtcRegionId] : null;
 
         /// <summary>
-        /// Only sent on the resolved channels of interaction responses for application commands. Gets the permissions of the user in this channel who invoked the command.
+        /// Gets the permissions of the user who invoked the command in this channel.
+        /// <para>Only sent on the resolved channels of interaction responses for application commands.</para>
         /// </summary>
         [JsonProperty("permissions")]
         public Permissions? UserPermissions { get; internal set; }

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageActivity.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageActivity.cs
@@ -34,7 +34,7 @@ namespace DSharpPlus.Entities
         /// Gets the activity type.
         /// </summary>
         [JsonProperty("type")]
-        public int Type { get; internal set; }
+        public MessageActivityType Type { get; internal set; }
 
         /// <summary>
         /// Gets the party id of the activity.

--- a/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
@@ -65,6 +65,9 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
         public string Name { get; set; }
 
+        [JsonProperty("type")]
+        public Optional<ChannelType> Type { get; set; }
+
         [JsonProperty("position", NullValueHandling = NullValueHandling.Ignore)]
         public int? Position { get; set; }
 
@@ -82,6 +85,9 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("user_limit", NullValueHandling = NullValueHandling.Ignore)]
         public int? UserLimit { get; set; }
+
+        [JsonProperty("permission_overwrites", NullValueHandling = NullValueHandling.Ignore)]
+        public IEnumerable<DiscordRestOverwrite> PermissionOverwrites { get; set; }
 
         [JsonProperty("rate_limit_per_user")]
         public Optional<int?> PerUserRateLimit { get; set; }

--- a/DSharpPlus/Net/Models/ChannelEditModel.cs
+++ b/DSharpPlus/Net/Models/ChannelEditModel.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.Generic;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models
@@ -80,6 +81,17 @@ namespace DSharpPlus.Net.Models
         /// <para>Sets the voice channel's video quality.</para>
         /// </summary>
         public VideoQualityMode? QualityMode { internal get; set; }
+
+        /// <summary>
+        /// <para>Sets the channel's type.</para>
+        /// <para>This can only be used to convert between text and news channels.</para>
+        /// </summary>
+        public Optional<ChannelType> Type { internal get; set; }
+
+        /// <summary>
+        /// <para>Sets the channel's permission overwrites.</para>
+        /// </summary>
+        public IEnumerable<DiscordOverwriteBuilder> PermissionOverwrites { internal get; set; }
 
         internal ChannelEditModel() { }
     }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -945,8 +945,16 @@ namespace DSharpPlus.Net
             return ret;
         }
 
-        internal Task ModifyChannelAsync(ulong channel_id, string name, int? position, Optional<string> topic, bool? nsfw, Optional<ulong?> parent, int? bitrate, int? user_limit, Optional<int?> perUserRateLimit, Optional<string> rtcRegion, VideoQualityMode? qualityMode, string reason)
+        internal Task ModifyChannelAsync(ulong channel_id, string name, int? position, Optional<string> topic, bool? nsfw, Optional<ulong?> parent, int? bitrate, int? user_limit, Optional<int?> perUserRateLimit, Optional<string> rtcRegion, VideoQualityMode? qualityMode, Optional<ChannelType> type, IEnumerable<DiscordOverwriteBuilder> permissionOverwrites, string reason)
         {
+            List<DiscordRestOverwrite> restoverwrites = null;
+            if (permissionOverwrites != null)
+            {
+                restoverwrites = new List<DiscordRestOverwrite>();
+                foreach (var ow in permissionOverwrites)
+                    restoverwrites.Add(ow.Build());
+            }
+
             var pld = new RestChannelModifyPayload
             {
                 Name = name,
@@ -959,6 +967,8 @@ namespace DSharpPlus.Net
                 PerUserRateLimit = perUserRateLimit,
                 RtcRegion = rtcRegion,
                 QualityMode = qualityMode,
+                Type = type,
+                PermissionOverwrites = restoverwrites
             };
 
             var headers = Utilities.GetBaseHeaders();


### PR DESCRIPTION
# Summary
Part 1 of several upcoming PRs that aim to go through the entire discord docs and make sure that everything is implemented. This one goes through the entire channels page.

# Changes proposed
* Adds the `Permissions` property on `DiscordChannel`
* Actually sets the message activity type to the enum
* Adds the `Type` and `PermissionOverwrites` fields on channel modify