### PR TITLE
Fix pagination buttons not enabling properly

### DIFF
--- a/DSharpPlus.Interactivity/EventHandling/ComponentBased/Requests/ButtonPaginationRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ComponentBased/Requests/ButtonPaginationRequest.cs
@@ -68,7 +68,11 @@ namespace DSharpPlus.Interactivity.EventHandling
 
             if (this.PageCount is 1)
             {
-                this._buttons.ButtonArray.Select(b => b.Disable());
+                this._buttons.SkipLeft.Disable();
+                this._buttons.Left.Disable();
+                this._buttons.Right.Disable();
+                this._buttons.SkipRight.Disable();
+
                 this._buttons.Stop.Enable();
                 return page;
             }
@@ -80,7 +84,7 @@ namespace DSharpPlus.Interactivity.EventHandling
 
             this._buttons.Left.Disabled = this._index < 1;
 
-            this._buttons.Right.Disabled = this._index == this.PageCount - 1;
+            this._buttons.Right.Disabled = this._index >= this.PageCount - 1;
 
             this._buttons.SkipRight.Disabled = this._index >= this.PageCount - 2;
 


### PR DESCRIPTION
Fixes an issue with component-based pagination where changing pages would not update what buttons were enabled.

The left and skip left buttons should be functional, now.