### PR TITLE
Fixed getter for DiscordMessage.Channel

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -92,12 +92,7 @@ namespace DSharpPlus.Entities
         [JsonIgnore]
         public DiscordChannel Channel
         {
-            get
-            {
-                return this.Discord as DiscordClient == null
-                    ? this._channel
-                    : (this.Discord as DiscordClient).InternalGetCachedThread(this.ChannelId) ?? (this.Discord as DiscordClient).InternalGetCachedChannel(this.ChannelId);
-            }
+            get => (this.Discord as DiscordClient)?.InternalGetCachedChannel(this.ChannelId) ?? (this.Discord as DiscordClient)?.InternalGetCachedThread(this.ChannelId) ?? this._channel;
             internal set => this._channel = value;
         }
 


### PR DESCRIPTION
Closes #1079. The base problem of this issue is that the getter method for DiscordMessage did not properly account for if a DM channel was not in the cache, and thus anything that did `msg.Channel` would error, not just `[RequireDirectMessage]`.

This reverts it to it's previous behavior of just returning the private channel property if everything else is null, the change that brought this issue was an oversight by me. 

I'd like to thank @VelvetThePanda for being my absentee rubber duck.