### PR TITLE
Added LavalinkSearchType.Plain

### DIFF
--- a/DSharpPlus.Lavalink/Enums/LavalinkSearchType.cs
+++ b/DSharpPlus.Lavalink/Enums/LavalinkSearchType.cs
@@ -25,7 +25,19 @@ namespace DSharpPlus.Lavalink
 {
     public enum LavalinkSearchType
     {
+        /// <summary>
+        /// Search SoundCloud through LavaLink.
+        /// </summary>
         SoundCloud,
-        Youtube
+
+        /// <summary>
+        /// Search Youtube through Lavalink.
+        /// </summary>
+        Youtube,
+
+        /// <summary>
+        /// Provide Lavalink with a plain URL.
+        /// </summary>
+        Plain
     }
 }

--- a/DSharpPlus.Lavalink/LavalinkRestClient.cs
+++ b/DSharpPlus.Lavalink/LavalinkRestClient.cs
@@ -106,8 +106,14 @@ namespace DSharpPlus.Lavalink
         /// <returns>A collection of tracks matching the criteria.</returns>
         public Task<LavalinkLoadResult> GetTracksAsync(string searchQuery, LavalinkSearchType type = LavalinkSearchType.Youtube)
         {
-            var prefix = type == LavalinkSearchType.Youtube ? "ytsearch" : "scsearch";
-            var str = WebUtility.UrlEncode($"{prefix}:{searchQuery}");
+            var prefix = type switch
+            {
+                LavalinkSearchType.Youtube => "ytsearch:",
+                LavalinkSearchType.SoundCloud => "scsearch:",
+                LavalinkSearchType.Plain => "",
+                _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+            };
+            var str = WebUtility.UrlEncode(prefix + "searchQuery");
             var tracksUri = new Uri($"{this.RestEndpoint.ToHttpString()}{Endpoints.LOAD_TRACKS}?identifier={str}");
             return this.InternalResolveTracksAsync(tracksUri);
         }


### PR DESCRIPTION
# Summary
Adds LavalinkSearchType.Plain which causes no prefix to be added to the REST url when loading tracks.

# Details
This allows you to take full advantage of Lavaplayer's capabilities, which also include Twitch, direct http urls, and local files.
