### PR TITLE
Added DiscordThreadChannel Entity Converter

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -89,6 +89,7 @@ namespace DSharpPlus.CommandsNext
                 [typeof(DiscordMember)] = new DiscordMemberConverter(),
                 [typeof(DiscordRole)] = new DiscordRoleConverter(),
                 [typeof(DiscordChannel)] = new DiscordChannelConverter(),
+                [typeof(DiscordThreadChannel)] = new DiscordThreadChannelConverter(),
                 [typeof(DiscordGuild)] = new DiscordGuildConverter(),
                 [typeof(DiscordMessage)] = new DiscordMessageConverter(),
                 [typeof(DiscordEmoji)] = new DiscordEmojiConverter(),

--- a/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
@@ -200,12 +200,12 @@ namespace DSharpPlus.CommandsNext.Converters
             }
 
             var cs = ctx.Config.CaseSensitive;
-            if (!cs)​
-                value = value.ToLowerInvariant();​​​​​
+            if (!cs)
+                value = value.ToLowerInvariant();
 
-            var thread = ctx.Guild?.Threads.Values.FirstOrDefault(x​​t => (cs ? x​​t.Name : x​​t.Name.ToLowerInvariant()) == value);
+            var thread = ctx.Guild?.Threads.Values.FirstOrDefault(xThread => (cs ? xThread.Name : xThread.Name.ToLowerInvariant()) == value);
 
-            return thread != null ? Optional.FromValue(thread) : Optional.FromNoValu​​e<DiscordThreadChannel>();
+            return thread != null ? Optional.FromValue(thread) : Optional.FromNoValue<DiscordThreadChannel>();
         }
     }
 

--- a/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
@@ -150,16 +150,14 @@ namespace DSharpPlus.CommandsNext.Converters
             if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var cid))
             {
                 var result = await ctx.Client.GetChannelAsync(cid).ConfigureAwait(false);
-                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordChannel>();
-                return ret;
+                return result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordChannel>();
             }
 
             var m = ChannelRegex.Match(value);
             if (m.Success && ulong.TryParse(m.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out cid))
             {
                 var result = await ctx.Client.GetChannelAsync(cid).ConfigureAwait(false);
-                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordChannel>();
-                return ret;
+                return result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordChannel>();
             }
 
             var cs = ctx.Config.CaseSensitive;
@@ -167,7 +165,7 @@ namespace DSharpPlus.CommandsNext.Converters
                 value = value.ToLowerInvariant();
 
             var chn = ctx.Guild?.Channels.Values.FirstOrDefault(xc => (cs ? xc.Name : xc.Name.ToLowerInvariant()) == value) ??
-            ctx.Guild?.Threads.Values.FirstOrDefault(thread => (cs ? thread.Name : thread.Name.ToLowerInvariant()) == value);
+            ctx.Guild?.Threads.Values.FirstOrDefault(xThread => (cs ? xThread.Name : xThread.Name.ToLowerInvariant()) == value);
 
             return chn != null ? Optional.FromValue(chn) : Optional.FromNoValue<DiscordChannel>();
         }
@@ -191,25 +189,23 @@ namespace DSharpPlus.CommandsNext.Converters
             if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var threadId))
             {
                 var result = ctx.Client.InternalGetCachedThread(threadId);
-                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordThreadChannel>();
-                return ret;
+                return result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordThreadChannel>();
             }
 
             var m = ThreadRegex.Match(value);
             if (m.Success && ulong.TryParse(m.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out threadId))
             {
                 var result = ctx.Client.InternalGetCachedThread(threadId);
-                var ret = result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordThreadChannel>();
-                return ret;
+                return result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordThreadChannel>();
             }
 
             var cs = ctx.Config.CaseSensitive;
             if (!cs)
                 value = value.ToLowerInvariant();
 
-            var foundThread = ctx.Guild?.Threads.Values.FirstOrDefault(thread => (cs ? thread.Name : thread.Name.ToLowerInvariant()) == value);
+            var thread = ctx.Guild?.Threads.Values.FirstOrDefault(xThread => (cs ? xThread.Name : xThread.Name.ToLowerInvariant()) == value);
 
-            return foundThread != null ? Optional.FromValue(foundThread) : Optional.FromNoValue<DiscordThreadChannel>();
+            return thread != null ? Optional.FromValue(thread) : Optional.FromNoValue<DiscordThreadChannel>();
         }
     }
 

--- a/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
@@ -203,7 +203,7 @@ namespace DSharpPlus.CommandsNext.Converters
             if (!cs)
                 value = value.ToLowerInvariant();
 
-            var thread = ctx.Guild?.Threads.Values.FirstOrDefault(xThread => (cs ? xThread.Name : xThread.Name.ToLowerInvariant()) == value);
+            var thread = ctx.Guild?.Threads.Values.FirstOrDefault(xt => (cs ? xt.Name : xt.Name.ToLowerInvariant()) == value);
 
             return thread != null ? Optional.FromValue(thread) : Optional.FromNoValue<DiscordThreadChannel>();
         }

--- a/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
@@ -200,12 +200,12 @@ namespace DSharpPlus.CommandsNext.Converters
             }
 
             var cs = ctx.Config.CaseSensitive;
-            if (!cs)
-                value = value.ToLowerInvariant();
+            if (!cs)​
+                value = value.ToLowerInvariant();​​​​​
 
-            var thread = ctx.Guild?.Threads.Values.FirstOrDefault(xThread => (cs ? xThread.Name : xThread.Name.ToLowerInvariant()) == value);
+            var thread = ctx.Guild?.Threads.Values.FirstOrDefault(x​​t => (cs ? x​​t.Name : x​​t.Name.ToLowerInvariant()) == value);
 
-            return thread != null ? Optional.FromValue(thread) : Optional.FromNoValue<DiscordThreadChannel>();
+            return thread != null ? Optional.FromValue(thread) : Optional.FromNoValu​​e<DiscordThreadChannel>();
         }
     }
 


### PR DESCRIPTION
# Summary
Adds an entity converter for `DiscordThreadChannel` and also adds name binding to the `DiscordChannel` for threads.

# Notes
- What does the x in `xc` mean??
- [x] I tested these changes
