### PR TITLE
Implement Slash Command AutoComplete

### DIFF
--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -89,6 +89,8 @@ namespace DSharpPlus.Test
             this.Discord.GuildDownloadCompleted += this.Discord_GuildDownloadCompleted;
             this.Discord.GuildUpdated += this.Discord_GuildUpdated;
             this.Discord.ChannelDeleted += this.Discord_ChannelDeleted;
+
+            this.Discord.InteractionCreated += this.Discord_InteractionCreated;
             //this.Discord.ComponentInteractionCreated += this.RoleMenu;
             //this.Discord.ComponentInteractionCreated += this.DiscordComponentInteractionCreated;
             //this.Discord.InteractionCreated += this.SendButton;
@@ -162,6 +164,26 @@ namespace DSharpPlus.Test
 
             //    _ = Task.Run(async () => await e.Message.RespondAsync(e.Message.Content)).ConfigureAwait(false);
             //};
+        }
+
+        private async Task Discord_InteractionCreated(DiscordClient sender, InteractionCreateEventArgs e)
+        {
+            if (e.Interaction.Type != InteractionType.AutoComplete)
+                return;
+
+            this.Discord.Logger.LogInformation($"AutoComplete: Focused: {e.Interaction.Data.Options.First().Focused}, Data: {e.Interaction.Data.Options.First().Value}");
+
+            var option = e.Interaction.Data.Options.First();
+
+            if (string.IsNullOrEmpty(option.Value as string))
+                return;
+
+            var builder = new DiscordInteractionResponseBuilder()
+                .AddAutoCompleteChoice(new DiscordAutoCompleteChoice(option.Value as string, "pog ig"));
+
+            await e.Interaction.CreateResponseAsync(InteractionResponseType.AutoCompleteResult, builder);
+
+            return;
         }
 
         private Task Discord_StickersUpdated(DiscordClient sender, GuildStickersUpdateEventArgs e)

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
@@ -71,7 +71,7 @@ namespace DSharpPlus.Entities
         public bool? DefaultPermission { get; internal set; }
 
         /// <summary>
-        /// Gets the autoincrementing version number for this command. 
+        /// Gets the autoincrementing version number for this command.
         /// </summary>
         [JsonProperty("version")]
         public ulong Version { get; internal set; }
@@ -86,7 +86,7 @@ namespace DSharpPlus.Entities
         /// <param name="type">The type of the application command</param>
         public DiscordApplicationCommand(string name, string description, IEnumerable<DiscordApplicationCommandOption> options = null, bool? defaultPermission = null, ApplicationCommandType type = ApplicationCommandType.SlashCommand)
         {
-            if (type == ApplicationCommandType.SlashCommand)
+            if (type is ApplicationCommandType.SlashCommand)
             {
                 if (!Utilities.IsValidSlashCommandName(name))
                     throw new ArgumentException("Invalid slash command name specified. It must be below 32 characters and not contain any whitespace.", nameof(name));

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOption.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOption.cs
@@ -53,13 +53,19 @@ namespace DSharpPlus.Entities
         public string Description { get; internal set; }
 
         /// <summary>
+        /// Gets whether this option will auto-complete.
+        /// </summary>
+        [JsonProperty("autocomplete")]
+        public bool? AutoComplete { get; internal set; }
+
+        /// <summary>
         /// Gets whether this command parameter is required.
         /// </summary>
         [JsonProperty("required", NullValueHandling = NullValueHandling.Ignore)]
         public bool? Required { get; internal set; }
 
         /// <summary>
-        /// Gets the optional choices for this command parameter.
+        /// Gets the optional choices for this command parameter. Not applicable for auto-complete options.
         /// </summary>
         [JsonProperty("choices", NullValueHandling = NullValueHandling.Ignore)]
         public IReadOnlyCollection<DiscordApplicationCommandOptionChoice> Choices { get; internal set; }
@@ -86,7 +92,7 @@ namespace DSharpPlus.Entities
         /// <param name="choices">The optional choice selection for this parameter.</param>
         /// <param name="options">The optional subcommands for this parameter.</param>
         /// <param name="channelTypes">The channel types to be restricted to for this parameter, if of type <see cref="ApplicationCommandOptionType.Channel"/>.</param>
-        public DiscordApplicationCommandOption(string name, string description, ApplicationCommandOptionType type, bool? required = null, IEnumerable<DiscordApplicationCommandOptionChoice> choices = null, IEnumerable<DiscordApplicationCommandOption> options = null, IEnumerable<ChannelType> channelTypes = null)
+        public DiscordApplicationCommandOption(string name, string description, ApplicationCommandOptionType type, bool? required = null, bool? autocomplete = null, IEnumerable<DiscordApplicationCommandOptionChoice> choices = null, IEnumerable<DiscordApplicationCommandOption> options = null, IEnumerable<ChannelType> channelTypes = null)
         {
             if (!Utilities.IsValidSlashCommandName(name))
                 throw new ArgumentException("Invalid slash command option name specified. It must be below 32 characters and not contain any whitespace.", nameof(name));
@@ -94,6 +100,8 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Slash command option name cannot have any upper case characters.", nameof(name));
             if (description.Length > 100)
                 throw new ArgumentException("Slash command option description cannot exceed 100 characters.", nameof(description));
+            if ((autocomplete ?? false) && (choices?.Any() ?? false))
+                throw new InvalidOperationException("Auto-complete slash command options cannot provide choices.");
 
             var choiceList = choices != null ? new ReadOnlyCollection<DiscordApplicationCommandOptionChoice>(choices.ToList()) : null;
             var optionList = options != null ? new ReadOnlyCollection<DiscordApplicationCommandOption>(options.ToList()) : null;
@@ -102,6 +110,7 @@ namespace DSharpPlus.Entities
             this.Name = name;
             this.Description = description;
             this.Type = type;
+            this.AutoComplete = autocomplete;
             this.Required = required;
             this.Choices = choiceList;
             this.Options = optionList;

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOption.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOption.cs
@@ -92,6 +92,7 @@ namespace DSharpPlus.Entities
         /// <param name="choices">The optional choice selection for this parameter.</param>
         /// <param name="options">The optional subcommands for this parameter.</param>
         /// <param name="channelTypes">The channel types to be restricted to for this parameter, if of type <see cref="ApplicationCommandOptionType.Channel"/>.</param>
+        /// <param name="autocomplete">Whether this parameter is autocomplete. If true, <paramref name="choices"/> must not be provided.</param>
         public DiscordApplicationCommandOption(string name, string description, ApplicationCommandOptionType type, bool? required = null, IEnumerable<DiscordApplicationCommandOptionChoice> choices = null, IEnumerable<DiscordApplicationCommandOption> options = null, IEnumerable<ChannelType> channelTypes = null, bool? autocomplete = null)
         {
             if (!Utilities.IsValidSlashCommandName(name))

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOption.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOption.cs
@@ -92,7 +92,7 @@ namespace DSharpPlus.Entities
         /// <param name="choices">The optional choice selection for this parameter.</param>
         /// <param name="options">The optional subcommands for this parameter.</param>
         /// <param name="channelTypes">The channel types to be restricted to for this parameter, if of type <see cref="ApplicationCommandOptionType.Channel"/>.</param>
-        public DiscordApplicationCommandOption(string name, string description, ApplicationCommandOptionType type, bool? required = null, bool? autocomplete = null, IEnumerable<DiscordApplicationCommandOptionChoice> choices = null, IEnumerable<DiscordApplicationCommandOption> options = null, IEnumerable<ChannelType> channelTypes = null)
+        public DiscordApplicationCommandOption(string name, string description, ApplicationCommandOptionType type, bool? required = null, IEnumerable<DiscordApplicationCommandOptionChoice> choices = null, IEnumerable<DiscordApplicationCommandOption> options = null, IEnumerable<ChannelType> channelTypes = null, bool? autocomplete = null)
         {
             if (!Utilities.IsValidSlashCommandName(name))
                 throw new ArgumentException("Invalid slash command option name specified. It must be below 32 characters and not contain any whitespace.", nameof(name));

--- a/DSharpPlus/Entities/Interaction/Application/DiscordAutoCompleteChoice.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordAutoCompleteChoice.cs
@@ -49,8 +49,8 @@ namespace DSharpPlus.Entities
         /// <param name="value">The value of this option.</param>
         public DiscordAutoCompleteChoice(string name, object value)
         {
-            if (value is not (string or int))
-                throw new ArgumentException($"Object type must be of {typeof(int)} or {typeof(string)}", nameof(value));
+            if (value is not (string or int or long))
+                throw new ArgumentException($"Object type must be of {typeof(int)} or {typeof(string)} or {typeof(long)}", nameof(value));
 
             if (name.Length > 100)
                 throw new ArgumentException("Application command choice name cannot exceed 100 characters.", nameof(name));

--- a/DSharpPlus/Entities/Interaction/Application/DiscordAutoCompleteChoice.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordAutoCompleteChoice.cs
@@ -37,18 +37,21 @@ namespace DSharpPlus.Entities
         public string Name { get; internal set; }
 
         /// <summary>
-        /// Gets the value of this option.
+        /// Gets the value of this option. This may be a string or an integer.
         /// </summary>
         [JsonProperty("value")]
-        public string Value { get; internal set; }
+        public object Value { get; internal set; }
 
         /// <summary>
         /// Creates a new instance of <see cref="DiscordAutoCompleteChoice"/>.
         /// </summary>
         /// <param name="name">The name of this option, which will be presented to the user.</param>
         /// <param name="value">The value of this option.</param>
-        public DiscordAutoCompleteChoice(string name, string value)
+        public DiscordAutoCompleteChoice(string name, object value)
         {
+            if (value is not (string or int))
+                throw new ArgumentException($"Object type must be of {typeof(int)} or {typeof(string)}", nameof(value));
+
             if (name.Length > 100)
                 throw new ArgumentException("Application command choice name cannot exceed 100 characters.", nameof(name));
             if (value is string val && val.Length > 100)

--- a/DSharpPlus/Entities/Interaction/Application/DiscordAutoCompleteChoice.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordAutoCompleteChoice.cs
@@ -20,33 +20,39 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-
-using System.Collections.Generic;
+using System;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {
-    internal class DiscordInteractionApplicationCommandCallbackData
+    public sealed class DiscordAutoCompleteChoice
     {
-        [JsonProperty("tts", NullValueHandling = NullValueHandling.Ignore)]
-        public bool? IsTTS { get; internal set; }
+        /// <summary>
+        /// Gets the name of this option which will be presented to the user.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; internal set; }
 
-        [JsonProperty("content", NullValueHandling = NullValueHandling.Ignore)]
-        public string Content { get; internal set; }
+        /// <summary>
+        /// Gets the value of this option.
+        /// </summary>
+        [JsonProperty("value")]
+        public string Value { get; internal set; }
 
-        [JsonProperty("embeds", NullValueHandling = NullValueHandling.Ignore)]
-        public IEnumerable<DiscordEmbed> Embeds { get; internal set; }
+        /// <summary>
+        /// Creates a new instance of <see cref="DiscordAutoCompleteChoice"/>.
+        /// </summary>
+        /// <param name="name">The name of this option, which will be presented to the user.</param>
+        /// <param name="value">The value of this option.</param>
+        public DiscordAutoCompleteChoice(string name, string value)
+        {
+            if (name.Length > 100)
+                throw new ArgumentException("Application command choice name cannot exceed 100 characters.", nameof(name));
+            if (value is string val && val.Length > 100)
+                throw new ArgumentException("Application command choice value cannot exceed 100 characters.", nameof(value));
 
-        [JsonProperty("allowed_mentions", NullValueHandling = NullValueHandling.Ignore)]
-        public IEnumerable<IMention> Mentions { get; internal set; }
-
-        [JsonProperty("flags", NullValueHandling = NullValueHandling.Ignore)]
-        public MessageFlags? Flags { get; internal set; }
-
-        [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
-        public IReadOnlyCollection<DiscordActionRowComponent> Components { get; internal set; }
-
-        [JsonProperty("options")]
-        public IReadOnlyCollection<DiscordAutoCompleteChoice> Choices { get; internal set; }
+            this.Name = name;
+            this.Value = value;
+        }
     }
 }

--- a/DSharpPlus/Entities/Interaction/Application/DiscordAutoCompleteChoice.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordAutoCompleteChoice.cs
@@ -25,6 +25,9 @@ using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
 {
+    /// <summary>
+    /// Represents an option for a user to select for auto-completion.
+    /// </summary>
     public sealed class DiscordAutoCompleteChoice
     {
         /// <summary>

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
@@ -46,7 +46,7 @@ namespace DSharpPlus.Entities
         [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
         public IReadOnlyCollection<DiscordActionRowComponent> Components { get; internal set; }
 
-        [JsonProperty("options")]
+        [JsonProperty("choices")]
         public IReadOnlyCollection<DiscordAutoCompleteChoice> Choices { get; internal set; }
     }
 }

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
@@ -28,7 +28,7 @@ using Newtonsoft.Json;
 namespace DSharpPlus.Entities
 {
     /// <summary>
-    /// Represents parameters for interaction commands. 
+    /// Represents parameters for interaction commands.
     /// </summary>
     public sealed class DiscordInteractionDataOption
     {
@@ -44,32 +44,32 @@ namespace DSharpPlus.Entities
         [JsonProperty("type")]
         public ApplicationCommandOptionType Type { get; internal set; }
 
+        /// <summary>
+        /// If this is an autocomplete option: Whether this option is currently active.
+        /// </summary>
+        [JsonProperty("focused")]
+        public bool Focused { get; internal set; }
+
         [JsonProperty("value")]
         internal string InternalValue { get; set; }
 
         /// <summary>
-        /// Gets the value of this interaction parameter. 
+        /// Gets the value of this interaction parameter.
         /// <para>This can be cast to a <see langword="long"/>, <see langword="bool"></see>, <see langword="string"></see>, <see langword="double"></see> or <see langword="ulong"/> depending on the <see cref="Type"/></para>
         /// </summary>
         [JsonIgnore]
-        public object Value
+        public object Value => this.Type switch
         {
-            get
-            {
-                return this.Type switch
-                {
-                    ApplicationCommandOptionType.Boolean => bool.Parse(this.InternalValue),
-                    ApplicationCommandOptionType.Integer => long.Parse(this.InternalValue),
-                    ApplicationCommandOptionType.String => this.InternalValue,
-                    ApplicationCommandOptionType.Channel => ulong.Parse(this.InternalValue),
-                    ApplicationCommandOptionType.User => ulong.Parse(this.InternalValue),
-                    ApplicationCommandOptionType.Role => ulong.Parse(this.InternalValue),
-                    ApplicationCommandOptionType.Mentionable => ulong.Parse(this.InternalValue),
-                    ApplicationCommandOptionType.Number => double.Parse(this.InternalValue, CultureInfo.InvariantCulture),
-                    _ => this.InternalValue,
-                };
-            }
-        }
+            ApplicationCommandOptionType.Boolean => bool.Parse(this.InternalValue),
+            ApplicationCommandOptionType.Integer => long.Parse(this.InternalValue),
+            ApplicationCommandOptionType.String => this.InternalValue,
+            ApplicationCommandOptionType.Channel => ulong.Parse(this.InternalValue),
+            ApplicationCommandOptionType.User => ulong.Parse(this.InternalValue),
+            ApplicationCommandOptionType.Role => ulong.Parse(this.InternalValue),
+            ApplicationCommandOptionType.Mentionable => ulong.Parse(this.InternalValue),
+            ApplicationCommandOptionType.Number => double.Parse(this.InternalValue, CultureInfo.InvariantCulture),
+            _ => this.InternalValue,
+        };
 
         /// <summary>
         /// Gets the additional parameters if this parameter is a subcommand.

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -78,6 +78,9 @@ namespace DSharpPlus.Entities
         public IReadOnlyList<DiscordActionRowComponent> Components => this._components;
         private readonly List<DiscordActionRowComponent> _components = new();
 
+        /// <summary>
+        /// The choices to send on this interaction response. Mutually exclusive with content, embed, and components.
+        /// </summary>
         public IReadOnlyList<DiscordAutoCompleteChoice> Choices => this._choices;
         private readonly List<DiscordAutoCompleteChoice> _choices = new();
 
@@ -152,18 +155,33 @@ namespace DSharpPlus.Entities
             return this;
         }
 
+        /// <summary>
+        /// Adds a single auto-complete choice to the builder.
+        /// </summary>
+        /// <param name="choice">The choice to add.</param>
+        /// <returns>The current builder to chain calls with.</returns>
         public DiscordInteractionResponseBuilder AddAutoCompleteChoice(DiscordAutoCompleteChoice choice)
         {
             this._choices.Add(choice);
             return this;
         }
 
+        /// <summary>
+        /// Adds auto-complete choices to the builder.
+        /// </summary>
+        /// <param name="choices">The choices to add.</param>
+        /// <returns>The current builder to chain calls with.</returns>
         public DiscordInteractionResponseBuilder AddAutoCompleteChoices(IEnumerable<DiscordAutoCompleteChoice> choices)
         {
             this._choices.AddRange(choices);
             return this;
         }
 
+        /// <summary>
+        /// Adds auto-complete choices to the builder.
+        /// </summary>
+        /// <param name="choices">The choices to add.</param>
+        /// <returns>The current builder to chain calls with.</returns>
         public DiscordInteractionResponseBuilder AddAutoCompleteChoices(params DiscordAutoCompleteChoice[] choices)
             => this.AddAutoCompleteChoices((IEnumerable<DiscordAutoCompleteChoice>)choices);
 

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 
 namespace DSharpPlus.Entities
 {
@@ -77,6 +78,8 @@ namespace DSharpPlus.Entities
         public IReadOnlyList<DiscordActionRowComponent> Components => this._components;
         private readonly List<DiscordActionRowComponent> _components = new();
 
+        public IReadOnlyList<DiscordAutoCompleteChoice> Choices => this._choices;
+        private readonly List<DiscordAutoCompleteChoice> _choices = new();
 
         /// <summary>
         /// Mentions to send on this interaction response.
@@ -148,6 +151,21 @@ namespace DSharpPlus.Entities
             this._components.Add(arc);
             return this;
         }
+
+        public DiscordInteractionResponseBuilder AddAutoCompleteChoice(DiscordAutoCompleteChoice choice)
+        {
+            this._choices.Add(choice);
+            return this;
+        }
+
+        public DiscordInteractionResponseBuilder AddAutoCompleteChoices(IEnumerable<DiscordAutoCompleteChoice> choices)
+        {
+            this._choices.AddRange(choices);
+            return this;
+        }
+
+        public DiscordInteractionResponseBuilder AddAutoCompleteChoices(params DiscordAutoCompleteChoice[] choices)
+            => this.AddAutoCompleteChoices((IEnumerable<DiscordAutoCompleteChoice>)choices);
 
         /// <summary>
         /// Indicates if the interaction response will be text-to-speech.

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -162,6 +162,9 @@ namespace DSharpPlus.Entities
         /// <returns>The current builder to chain calls with.</returns>
         public DiscordInteractionResponseBuilder AddAutoCompleteChoice(DiscordAutoCompleteChoice choice)
         {
+            if (this._choices.Count >= 25)
+                throw new ArgumentException("Maximum of 25 choices per response.");
+
             this._choices.Add(choice);
             return this;
         }
@@ -173,6 +176,9 @@ namespace DSharpPlus.Entities
         /// <returns>The current builder to chain calls with.</returns>
         public DiscordInteractionResponseBuilder AddAutoCompleteChoices(IEnumerable<DiscordAutoCompleteChoice> choices)
         {
+            if (this._choices.Count >= 25 || this._choices.Count + choices.Count() > 25)
+                throw new ArgumentException("Maximum of 25 choices per response.");
+
             this._choices.AddRange(choices);
             return this;
         }
@@ -346,6 +352,7 @@ namespace DSharpPlus.Entities
             this._mentions.Clear();
             this._components.Clear();
             this._files.Clear();
+            this._choices.Clear();
         }
     }
 }

--- a/DSharpPlus/Enums/Interaction/ApplicationCommandType.cs
+++ b/DSharpPlus/Enums/Interaction/ApplicationCommandType.cs
@@ -34,10 +34,14 @@ namespace DSharpPlus
         /// <summary>
         /// This command is registered as a user context menu, and is applicable when interacting a user.
         /// </summary>
-        UserContextMenu,
+        UserContextMenu = 2,
         /// <summary>
         /// This command is registered as a message context menu, and is applicable when interacting with a message.
         /// </summary>
-        MessageContextMenu
+        MessageContextMenu = 3,
+        /// <summary>
+        /// Inbound only: An auto-complete option is being interacted with.
+        /// </summary>
+        AutoCompleteRequest = 4,
     }
 }

--- a/DSharpPlus/Enums/Interaction/InteractionResponseType.cs
+++ b/DSharpPlus/Enums/Interaction/InteractionResponseType.cs
@@ -52,5 +52,10 @@ namespace DSharpPlus
         /// Responds to a component interaction by editing the message it's attached to.
         /// </summary>
         UpdateMessage = 7,
+
+        /// <summary>
+        /// Responds to an auto-complete request.
+        /// </summary>
+        AutoCompleteResult = 8
     }
 }

--- a/DSharpPlus/Enums/Interaction/InteractionType.cs
+++ b/DSharpPlus/Enums/Interaction/InteractionType.cs
@@ -32,13 +32,20 @@ namespace DSharpPlus
         /// Sent when registering an HTTP interaction endpoint with Discord. Must be replied to with a Pong.
         /// </summary>
         Ping = 1,
+
         /// <summary>
         /// An application command.
         /// </summary>
         ApplicationCommand = 2,
+
         /// <summary>
         /// A component.
         /// </summary>
-        Component = 3
+        Component = 3,
+
+        /// <summary>
+        /// An autocomplete field.
+        /// </summary>
+        AutoComplete = 4,
     }
 }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -3073,7 +3073,8 @@ namespace DSharpPlus.Net
                     IsTTS = builder.IsTTS,
                     Mentions = builder.Mentions,
                     Flags = builder.IsEphemeral ? MessageFlags.Ephemeral : 0,
-                    Components = builder.Components
+                    Components = builder.Components,
+                    Choices = builder.Choices
                 } : null
             };
 


### PR DESCRIPTION
# Summary
Adds support for slash-command auto-complete. 

# Details
This is somewhat in limbo? It exists in the API, and there was a demo server for it, which housed the build override for this, but has since been deleted. The changes have been tested, however.