### PR TITLE
Fix left pagination buttons (again)

### DIFF
--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -630,7 +630,7 @@ namespace DSharpPlus.Interactivity
 
             bts = new(bts);
 
-            if (this.Config.PaginationBehaviour is PaginationBehaviour.Ignore)
+            if (bhv is PaginationBehaviour.Ignore)
             {
                 bts.SkipLeft.Disable();
                 bts.Left.Disable();
@@ -724,8 +724,12 @@ namespace DSharpPlus.Interactivity
             var bts = buttons ?? this.Config.PaginationButtons;
 
             bts = new(bts); // Copy //
-            bts.SkipLeft.Disable();
-            bts.Left.Disable();
+
+            if (bhv is PaginationBehaviour.Ignore)
+            {
+                bts.SkipLeft.Disable();
+                bts.Left.Disable();
+            }
 
             var builder = new DiscordInteractionResponseBuilder()
                 .WithContent(pages.First().Content)


### PR DESCRIPTION
# Summary
I made the oversight of fixing `SendPaginatedMessageAsync` (buttons) in #1074. This corrects that.

# Details
I patched `SendPaginatedResponseAsync` (Which replies to interactions), and also fixed a small oversight of using the configuration behavior rather than the provided behavior (which will fallback to the config if none is specified.)

# Changes proposed
- Use `bhv` instead of hard-coding a reliance on the config directly
- Add a guard clause to disabling the left two pagination buttons, which are never re-enabled if the behavior is set to `WrapAround`

# Notes
This was pointed out by @Kaoticz.