### PR TITLE
fix: Components property is now optional.

### DIFF
--- a/DSharpPlus/Entities/Interaction/Components/DiscordActionRowComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordActionRowComponent.cs
@@ -36,8 +36,14 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// The components contained within the action row.
         /// </summary>
+        public IReadOnlyCollection<DiscordComponent> Components
+        {
+            get => _components ?? new List<DiscordComponent>();
+            set => _components = new List<DiscordComponent>(value);
+        }
+
         [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
-        public IReadOnlyCollection<DiscordComponent> Components { get; internal set; }
+        private List<DiscordComponent> _components;
 
         public DiscordActionRowComponent(IEnumerable<DiscordComponent> components) : this()
         {


### PR DESCRIPTION
Changes the component's components property to optional since this has been changed in the Discord docs.