### PR TITLE
Depreciate modify current user nick in favor of modify current member

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -954,7 +954,7 @@ namespace DSharpPlus
 
             if (mdl.Nickname.HasValue && this.CurrentUser.Id == member_id)
             {
-                await this.ApiClient.ModifyCurrentMemberNicknameAsync(guild_id, mdl.Nickname.Value,
+                await this.ApiClient.ModifyCurrentMemberAsync(guild_id, mdl.Nickname.Value,
                     mdl.AuditLogReason).ConfigureAwait(false);
                 await this.ApiClient.ModifyGuildMemberAsync(guild_id, member_id, Optional.FromNoValue<string>(),
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
@@ -975,8 +975,20 @@ namespace DSharpPlus
         /// <param name="nick">Nickname</param>
         /// <param name="reason">Reason why you set it to this</param>
         /// <returns></returns>
+        [Obsolete("This method is depreciated and will be removed in a future version. Please use ModifyCurrentMemberAsync instead.", false)]
         public Task ModifyCurrentMemberNicknameAsync(ulong guild_id, string nick, string reason)
-            => this.ApiClient.ModifyCurrentMemberNicknameAsync(guild_id, nick, reason);
+            => this.ApiClient.ModifyCurrentMemberAsync(guild_id, nick, reason);
+
+        /// <summary>
+        /// Changes the current user's nickname in a guild.
+        /// </summary>
+        /// <param name="guild_id">Guild id</param>
+        /// <param name="nickname">Nickname</param>
+        /// <param name="reason">Reason why you set it to this</param>
+        /// <returns></returns>
+        public Task ModifyCurrentMemberAsync(ulong guild_id, string nickname, string reason)
+            => this.ApiClient.ModifyCurrentMemberAsync(guild_id, nickname, reason);
+
         #endregion
 
         #region Roles

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -450,7 +450,7 @@ namespace DSharpPlus.Entities
 
             if (mdl.Nickname.HasValue && this.Discord.CurrentUser.Id == this.Id)
             {
-                await this.Discord.ApiClient.ModifyCurrentMemberNicknameAsync(this.Guild.Id, mdl.Nickname.Value,
+                await this.Discord.ApiClient.ModifyCurrentMemberAsync(this.Guild.Id, mdl.Nickname.Value,
                     mdl.AuditLogReason).ConfigureAwait(false);
 
                 await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, Optional.FromNoValue<string>(),

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1908,7 +1908,7 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, payload: DiscordJson.SerializeObject(pld));
         }
 
-        internal Task ModifyCurrentMemberNicknameAsync(ulong guild_id, string nick, string reason)
+        internal Task ModifyCurrentMemberAsync(ulong guild_id, string nick, string reason)
         {
             var headers = Utilities.GetBaseHeaders();
             if (!string.IsNullOrWhiteSpace(reason))
@@ -1919,7 +1919,7 @@ namespace DSharpPlus.Net
                 Nickname = nick
             };
 
-            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}{Endpoints.ME}{Endpoints.NICK}";
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}{Endpoints.ME}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
             var url = Utilities.GetApiUriFor(path);

--- a/DSharpPlus/Net/Rest/Endpoints.cs
+++ b/DSharpPlus/Net/Rest/Endpoints.cs
@@ -72,7 +72,6 @@ namespace DSharpPlus.Net
         public const string VOICE = "/voice";
         public const string AUDIT_LOGS = "/audit-logs";
         public const string ACK = "/ack";
-        public const string NICK = "/nick";
         public const string ASSETS = "/assets";
         public const string EMOJIS = "/emojis";
         public const string VANITY_URL = "/vanity-url";


### PR DESCRIPTION
Depreciates the ModifyCurrentUserNick method in favor of ModifyCurrentMember

This method has no changes compared to the previous version, but the previous is now depreciated in the docs.