### PR TITLE
Implement default parser culture for CNext

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using DSharpPlus.CommandsNext.Attributes;
@@ -125,6 +126,12 @@ namespace DSharpPlus.CommandsNext
         public bool UseDefaultCommandHandler { internal get; set; } = true;
 
         /// <summary>
+        /// <para>Gets or sets the default culture for parsers.</para>
+        /// <para>Defaults to invariant.</para>
+        /// </summary>
+        public CultureInfo DefaultParserCulture { internal get; set; } = CultureInfo.InvariantCulture;
+
+        /// <summary>
         /// Creates a new instance of <see cref="CommandsNextConfiguration"/>.
         /// </summary>
         public CommandsNextConfiguration() { }
@@ -146,6 +153,7 @@ namespace DSharpPlus.CommandsNext
             this.Services = other.Services;
             this.StringPrefixes = other.StringPrefixes?.ToArray();
             this.DmHelp = other.DmHelp;
+            this.DefaultParserCulture = other.DefaultParserCulture;
         }
     }
 }

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -51,6 +52,8 @@ namespace DSharpPlus.CommandsNext
         private MethodInfo ConvertGeneric { get; }
         private Dictionary<Type, string> UserFriendlyTypeNames { get; }
         internal Dictionary<Type, IArgumentConverter> ArgumentConverters { get; }
+        internal CultureInfo DefaultParserCulture
+            => this.Config.DefaultParserCulture;
 
         /// <summary>
         /// Gets the service provider this CommandsNext module was configured with.

--- a/DSharpPlus.CommandsNext/Converters/EnumConverter.cs
+++ b/DSharpPlus.CommandsNext/Converters/EnumConverter.cs
@@ -28,6 +28,10 @@ using DSharpPlus.Entities;
 
 namespace DSharpPlus.CommandsNext.Converters
 {
+    /// <summary>
+    /// Converts a string to an enum type.
+    /// </summary>
+    /// <typeparam name="T">Type of enum to convert.</typeparam>
     public class EnumConverter<T> : IArgumentConverter<T> where T : struct, IComparable, IConvertible, IFormattable
     {
         Task<Optional<T>> IArgumentConverter<T>.ConvertAsync(string value, CommandContext ctx)

--- a/DSharpPlus.CommandsNext/Converters/NumericConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/NumericConverters.cs
@@ -41,7 +41,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<sbyte>> IArgumentConverter<sbyte>.ConvertAsync(string value, CommandContext ctx)
         {
-            return sbyte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+            return sbyte.TryParse(value, NumberStyles.Integer, ctx.CommandsNext.DefaultParserCulture, out var result)
                 ? Task.FromResult(Optional.FromValue(result))
                 : Task.FromResult(Optional.FromNoValue<sbyte>());
         }
@@ -51,7 +51,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<byte>> IArgumentConverter<byte>.ConvertAsync(string value, CommandContext ctx)
         {
-            return byte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+            return byte.TryParse(value, NumberStyles.Integer, ctx.CommandsNext.DefaultParserCulture, out var result)
                 ? Task.FromResult(Optional.FromValue(result))
                 : Task.FromResult(Optional.FromNoValue<byte>());
         }
@@ -61,7 +61,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<short>> IArgumentConverter<short>.ConvertAsync(string value, CommandContext ctx)
         {
-            return short.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+            return short.TryParse(value, NumberStyles.Integer, ctx.CommandsNext.DefaultParserCulture, out var result)
                 ? Task.FromResult(Optional.FromValue(result))
                 : Task.FromResult(Optional.FromNoValue<short>());
         }
@@ -71,7 +71,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<ushort>> IArgumentConverter<ushort>.ConvertAsync(string value, CommandContext ctx)
         {
-            return ushort.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+            return ushort.TryParse(value, NumberStyles.Integer, ctx.CommandsNext.DefaultParserCulture, out var result)
                 ? Task.FromResult(Optional.FromValue(result))
                 : Task.FromResult(Optional.FromNoValue<ushort>());
         }
@@ -81,7 +81,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<int>> IArgumentConverter<int>.ConvertAsync(string value, CommandContext ctx)
         {
-            return int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+            return int.TryParse(value, NumberStyles.Integer, ctx.CommandsNext.DefaultParserCulture, out var result)
                 ? Task.FromResult(Optional.FromValue(result))
                 : Task.FromResult(Optional.FromNoValue<int>());
         }
@@ -91,7 +91,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<uint>> IArgumentConverter<uint>.ConvertAsync(string value, CommandContext ctx)
         {
-            return uint.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+            return uint.TryParse(value, NumberStyles.Integer, ctx.CommandsNext.DefaultParserCulture, out var result)
                 ? Task.FromResult(Optional.FromValue(result))
                 : Task.FromResult(Optional.FromNoValue<uint>());
         }
@@ -101,7 +101,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<long>> IArgumentConverter<long>.ConvertAsync(string value, CommandContext ctx)
         {
-            return long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+            return long.TryParse(value, NumberStyles.Integer, ctx.CommandsNext.DefaultParserCulture, out var result)
                 ? Task.FromResult(Optional.FromValue(result))
                 : Task.FromResult(Optional.FromNoValue<long>());
         }
@@ -111,7 +111,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<ulong>> IArgumentConverter<ulong>.ConvertAsync(string value, CommandContext ctx)
         {
-            return ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var result)
+            return ulong.TryParse(value, NumberStyles.Integer, ctx.CommandsNext.DefaultParserCulture, out var result)
                 ? Task.FromResult(Optional.FromValue(result))
                 : Task.FromResult(Optional.FromNoValue<ulong>());
         }
@@ -121,7 +121,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<float>> IArgumentConverter<float>.ConvertAsync(string value, CommandContext ctx)
         {
-            return float.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var result)
+            return float.TryParse(value, NumberStyles.Number, ctx.CommandsNext.DefaultParserCulture, out var result)
                 ? Task.FromResult(Optional.FromValue(result))
                 : Task.FromResult(Optional.FromNoValue<float>());
         }
@@ -131,7 +131,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<double>> IArgumentConverter<double>.ConvertAsync(string value, CommandContext ctx)
         {
-            return double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var result)
+            return double.TryParse(value, NumberStyles.Number, ctx.CommandsNext.DefaultParserCulture, out var result)
                 ? Task.FromResult(Optional.FromValue(result))
                 : Task.FromResult(Optional.FromNoValue<double>());
         }
@@ -141,7 +141,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<decimal>> IArgumentConverter<decimal>.ConvertAsync(string value, CommandContext ctx)
         {
-            return decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out var result)
+            return decimal.TryParse(value, NumberStyles.Number, ctx.CommandsNext.DefaultParserCulture, out var result)
                 ? Task.FromResult(Optional.FromValue(result))
                 : Task.FromResult(Optional.FromNoValue<decimal>());
         }

--- a/DSharpPlus.CommandsNext/Converters/TimeConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/TimeConverters.cs
@@ -33,7 +33,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<DateTime>> IArgumentConverter<DateTime>.ConvertAsync(string value, CommandContext ctx)
         {
-            return DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result)
+            return DateTime.TryParse(value, ctx.CommandsNext.DefaultParserCulture, DateTimeStyles.None, out var result)
                 ? Task.FromResult(new Optional<DateTime>(result))
                 : Task.FromResult(Optional.FromNoValue<DateTime>());
         }
@@ -43,7 +43,7 @@ namespace DSharpPlus.CommandsNext.Converters
     {
         Task<Optional<DateTimeOffset>> IArgumentConverter<DateTimeOffset>.ConvertAsync(string value, CommandContext ctx)
         {
-            return DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var result)
+            return DateTimeOffset.TryParse(value, ctx.CommandsNext.DefaultParserCulture, DateTimeStyles.None, out var result)
                 ? Task.FromResult(Optional.FromValue(result))
                 : Task.FromResult(Optional.FromNoValue<DateTimeOffset>());
         }
@@ -67,13 +67,13 @@ namespace DSharpPlus.CommandsNext.Converters
             if (value == "0")
                 return Task.FromResult(Optional.FromValue(TimeSpan.Zero));
 
-            if (int.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out _))
+            if (int.TryParse(value, NumberStyles.Number, ctx.CommandsNext.DefaultParserCulture, out _))
                 return Task.FromResult(Optional.FromNoValue<TimeSpan>());
 
             if (!ctx.Config.CaseSensitive)
                 value = value.ToLowerInvariant();
 
-            if (TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out var result))
+            if (TimeSpan.TryParse(value, ctx.CommandsNext.DefaultParserCulture, out var result))
                 return Task.FromResult(Optional.FromValue(result));
 
             var gps = new string[] { "days", "hours", "minutes", "seconds" };
@@ -92,7 +92,7 @@ namespace DSharpPlus.CommandsNext.Converters
                     continue;
 
                 var gpt = gpc[gpc.Length - 1];
-                int.TryParse(gpc.Substring(0, gpc.Length - 1), NumberStyles.Integer, CultureInfo.InvariantCulture, out var val);
+                int.TryParse(gpc.Substring(0, gpc.Length - 1), NumberStyles.Integer, ctx.CommandsNext.DefaultParserCulture, out var val);
                 switch (gpt)
                 {
                     case 'd':

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -24,16 +24,15 @@
 #pragma warning disable CS0618
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Exceptions;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
-using DSharpPlus.Exceptions;
 using DSharpPlus.Interactivity;
 using DSharpPlus.Interactivity.Enums;
 using DSharpPlus.Interactivity.EventHandling;
@@ -129,6 +128,7 @@ namespace DSharpPlus.Test
                 Services = depco.BuildServiceProvider(true),
                 IgnoreExtraArguments = false,
                 UseDefaultCommandHandler = true,
+                DefaultParserCulture = CultureInfo.InvariantCulture
             };
             this.CommandsNextService = this.Discord.UseCommandsNext(cncfg);
             this.CommandsNextService.CommandErrored += this.CommandsNextService_CommandErrored;

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -552,5 +552,9 @@ namespace DSharpPlus.Test
             await ctx.TriggerTypingAsync();
             await ctx.RespondAsync($"Pong: {ctx.Client.Ping}ms");
         }
+
+        [Command("parsedate")]
+        public async Task ParseDateTimeAsync(CommandContext ctx, DateTimeOffset dto)
+            => await ctx.RespondAsync(dto.ToString("yyyy-MM-ddTHH:mm:ss.ffffffzzz"));
     }
 }


### PR DESCRIPTION
# Summary
Implements ability to set default parser culture for some of CNext's built-in parsers.

# Details
This allows for adjusting and localizing bots better. Currently this defaults to invariant.

Specifying non-default culture can influence things like accepted date formats, digits, etc.