### PR TITLE
Implement ability to control how are commands executed in CNext

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
@@ -28,6 +28,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.CommandsNext.Converters;
+using DSharpPlus.CommandsNext.Executors;
 using DSharpPlus.Entities;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -132,6 +133,12 @@ namespace DSharpPlus.CommandsNext
         public CultureInfo DefaultParserCulture { internal get; set; } = CultureInfo.InvariantCulture;
 
         /// <summary>
+        /// <para>Gets or sets the default command exector.</para>
+        /// <para>This alters the behaviour, execution, and scheduling method of command execution.</para>
+        /// </summary>
+        public ICommandExecutor CommandExecutor { internal get; set; } = new ParallelQueuedCommandExecutor();
+
+        /// <summary>
         /// Creates a new instance of <see cref="CommandsNextConfiguration"/>.
         /// </summary>
         public CommandsNextConfiguration() { }
@@ -154,6 +161,7 @@ namespace DSharpPlus.CommandsNext
             this.StringPrefixes = other.StringPrefixes?.ToArray();
             this.DmHelp = other.DmHelp;
             this.DefaultParserCulture = other.DefaultParserCulture;
+            this.CommandExecutor = other.CommandExecutor;
         }
     }
 }

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -45,7 +45,7 @@ namespace DSharpPlus.CommandsNext
     /// <summary>
     /// This is the class which handles command registration, management, and execution. 
     /// </summary>
-    public class CommandsNextExtension : BaseExtension
+    public class CommandsNextExtension : BaseExtension, IDisposable
     {
         private CommandsNextConfiguration Config { get; }
         private HelpFormatterFactory HelpFormatter { get; }
@@ -159,6 +159,12 @@ namespace DSharpPlus.CommandsNext
         /// </summary>
         /// <typeparam name="T">Type of the formatter to use.</typeparam>
         public void SetHelpFormatter<T>() where T : BaseHelpFormatter => this.HelpFormatter.SetFormatterType<T>();
+
+        /// <summary>
+        /// Disposes of this the resources used by CNext.
+        /// </summary>
+        public void Dispose()
+            => this.Config.CommandExecutor.Dispose();
 
         #region DiscordClient Registration
         /// <summary>

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -33,6 +33,7 @@ using DSharpPlus.CommandsNext.Builders;
 using DSharpPlus.CommandsNext.Converters;
 using DSharpPlus.CommandsNext.Entities;
 using DSharpPlus.CommandsNext.Exceptions;
+using DSharpPlus.CommandsNext.Executors;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using Emzi0767.Utilities;
@@ -197,6 +198,8 @@ namespace DSharpPlus.CommandsNext
                         this.AddToCommandDictionary(xc.Build(null));
             }
 
+            if (this.Config.CommandExecutor is ParallelQueuedCommandExecutor pqce)
+                this.Client.Logger.LogDebug(CommandsNextEvents.Misc, "Using parallel executor with degree {0}", pqce.Parallelism);
         }
         #endregion
 
@@ -238,7 +241,7 @@ namespace DSharpPlus.CommandsNext
                 return;
             }
 
-            _ = Task.Run(async () => await this.ExecuteCommandAsync(ctx).ConfigureAwait(false));
+            await this.Config.CommandExecutor.ExecuteAsync(ctx).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus.CommandsNext/Executors/AsynchronousCommandExecutor.cs
+++ b/DSharpPlus.CommandsNext/Executors/AsynchronousCommandExecutor.cs
@@ -1,0 +1,43 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Threading.Tasks;
+
+namespace DSharpPlus.CommandsNext.Executors
+{
+    /// <summary>
+    /// Executes commands using <see cref="Task.Run(Func{Task})"/>.
+    /// </summary>
+    public sealed class AsynchronousCommandExecutor : ICommandExecutor
+    {
+        Task ICommandExecutor.ExecuteAsync(CommandContext ctx)
+        {
+            _ = Task.Run(() => ctx.CommandsNext.ExecuteCommandAsync(ctx).ConfigureAwait(false));
+            return Task.CompletedTask;
+        }
+
+        void IDisposable.Dispose()
+        { }
+    }
+}

--- a/DSharpPlus.CommandsNext/Executors/ICommandExecutor.cs
+++ b/DSharpPlus.CommandsNext/Executors/ICommandExecutor.cs
@@ -1,0 +1,41 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Threading.Tasks;
+
+namespace DSharpPlus.CommandsNext.Executors
+{
+    /// <summary>
+    /// Defines an API surface for all command executors.
+    /// </summary>
+    public interface ICommandExecutor : IDisposable
+    {
+        /// <summary>
+        /// Executes a command from given context.
+        /// </summary>
+        /// <param name="ctx">Context to execute in.</param>
+        /// <returns>Task encapsulating the async operation.</returns>
+        Task ExecuteAsync(CommandContext ctx);
+    }
+}

--- a/DSharpPlus.CommandsNext/Executors/ParallelQueuedCommandExecutor.cs
+++ b/DSharpPlus.CommandsNext/Executors/ParallelQueuedCommandExecutor.cs
@@ -1,0 +1,100 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace DSharpPlus.CommandsNext.Executors
+{
+    /// <summary>
+    /// A command executor which uses a bounded pool of executors to execute commands. This can limit the impact of
+    /// commands on system resources, such as CPU usage.
+    /// </summary>
+    public sealed class ParallelQueuedCommandExecutor : ICommandExecutor
+    {
+        /// <summary>
+        /// Gets the degree of parallelism of this executor.
+        /// </summary>
+        public int Parallelism { get; }
+
+        private readonly CancellationTokenSource _cts;
+        private readonly CancellationToken _ct;
+        private readonly Channel<CommandContext> _queue;
+        private readonly ChannelWriter<CommandContext> _queueWriter;
+        private readonly ChannelReader<CommandContext> _queueReader;
+        private readonly Task[] _tasks;
+
+        /// <summary>
+        /// Creates a new executor, which uses up to 75% of system CPU resources.
+        /// </summary>
+        public ParallelQueuedCommandExecutor()
+            : this((Environment.ProcessorCount + 1) * 3 / 4)
+        { }
+
+        /// <summary>
+        /// Creates a new executor with specified degree of parallelism.
+        /// </summary>
+        /// <param name="parallelism">The number of workers to use. It is recommended this number does not exceed 150% of the physical CPU count.</param>
+        public ParallelQueuedCommandExecutor(int parallelism)
+        {
+            this.Parallelism = parallelism;
+
+            this._cts = new();
+            this._ct = this._cts.Token;
+            this._queue = Channel.CreateUnbounded<CommandContext>();
+            this._queueReader = this._queue.Reader;
+            this._queueWriter = this._queue.Writer;
+
+            this._tasks = new Task[parallelism];
+            for (var i = 0; i < parallelism; i++)
+                this._tasks[i] = Task.Run(this.ExecuteAsync);
+        }
+
+        /// <summary>
+        /// Disposes of the resources used by this executor.
+        /// </summary>
+        public void Dispose()
+        {
+            this._queueWriter.Complete();
+            this._cts.Cancel();
+            this._cts.Dispose();
+        }
+
+        async Task ICommandExecutor.ExecuteAsync(CommandContext ctx)
+            => await this._queueWriter.WriteAsync(ctx, this._ct);
+
+        private async Task ExecuteAsync()
+        {
+            while (!this._ct.IsCancellationRequested)
+            {
+                var ctx = await this._queueReader.ReadAsync(this._ct);
+                if (ctx is null)
+                    continue;
+
+                await ctx.CommandsNext.ExecuteCommandAsync(ctx).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/DSharpPlus.CommandsNext/Executors/SynchronousCommandExecutor.cs
+++ b/DSharpPlus.CommandsNext/Executors/SynchronousCommandExecutor.cs
@@ -1,0 +1,40 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Threading.Tasks;
+
+namespace DSharpPlus.CommandsNext.Executors
+{
+    /// <summary>
+    /// Executes commands by awaiting them.
+    /// </summary>
+    public sealed class SynchronousCommandExecutor : ICommandExecutor
+    {
+        async Task ICommandExecutor.ExecuteAsync(CommandContext ctx)
+            => await ctx.CommandsNext.ExecuteCommandAsync(ctx).ConfigureAwait(false);
+
+        void IDisposable.Dispose()
+        { }
+    }
+}

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -31,6 +31,7 @@ using System.Text;
 using System.Threading.Tasks;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Exceptions;
+using DSharpPlus.CommandsNext.Executors;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using DSharpPlus.Interactivity;
@@ -128,7 +129,8 @@ namespace DSharpPlus.Test
                 Services = depco.BuildServiceProvider(true),
                 IgnoreExtraArguments = false,
                 UseDefaultCommandHandler = true,
-                DefaultParserCulture = CultureInfo.InvariantCulture
+                DefaultParserCulture = CultureInfo.InvariantCulture,
+                //CommandExecutor = new ParallelQueuedCommandExecutor(2),
             };
             this.CommandsNextService = this.Discord.UseCommandsNext(cncfg);
             this.CommandsNextService.CommandErrored += this.CommandsNextService_CommandErrored;

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -556,5 +556,13 @@ namespace DSharpPlus.Test
         [Command("parsedate")]
         public async Task ParseDateTimeAsync(CommandContext ctx, DateTimeOffset dto)
             => await ctx.RespondAsync(dto.ToString("yyyy-MM-ddTHH:mm:ss.ffffffzzz"));
+
+        [Command("longlongman")]
+        public async Task LongLongManAsync(CommandContext ctx)
+        {
+            await ctx.Message.CreateReactionAsync(DiscordEmoji.FromName(ctx.Client, ":mshourglass:"));
+            await Task.Delay(2_000);
+            await ctx.RespondAsync(DiscordEmoji.FromName(ctx.Client, ":msokhand:"));
+        }
     }
 }

--- a/DSharpPlus/DSharpPlus.csproj
+++ b/DSharpPlus/DSharpPlus.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Channels" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
# Summary
Implements the ability to control how commands in CNext are executed.

# Details
Long ago I discussed with people about how just throwing `Task.Run` at any issue isn't the correct approach for all problems. This PR implements one of the approach I recommended - a queued executor. The basic idea is that you create a bounded execution queue, and fixed number of workers, which pick up work items from the queue. This allows you to limit the impact of commands on CPU resources, as well as prevents potentially spawning a brand new thread every time a command is executed.

This PR also replaces the default `Task.Run` approach with the new queued executor. This behaviour is configurable via `CommandExecutor` property on CNext config object.

There are 3 implementations that are available in the library:
- `ParallelQueuedCommandExecutor` is the queued executor. By default, it uses up to 75% of CPU resources, however there is a constructor which allows for configuring the degree of parallelism explicitly, for scenarios where this is desired.
- `AsynchronousCommandExecutor` is the default `Task.Run` executor, which CNext used until now.
- `SynchronousCommandExecutor` awaits on the calling thread. Recommended for short-running commands only.

Implementing your own executor is as easy as implementing the `ICommandExecutor` interface. The instance can then be supplied to the config.