### PR TITLE
Fix PresenceEvent using new activity on old presence

### DIFF
--- a/DSharpPlus/Entities/User/DiscordActivity.cs
+++ b/DSharpPlus/Entities/User/DiscordActivity.cs
@@ -182,8 +182,10 @@ namespace DSharpPlus.Entities
             this.Name = other.Name;
             this.ActivityType = other.ActivityType;
             this.StreamUrl = other.StreamUrl;
-            this.RichPresence = new DiscordRichPresence(other.RichPresence);
-            this.CustomStatus = new DiscordCustomStatus(other.CustomStatus);
+            if(other.RichPresence != null)
+                this.RichPresence = new DiscordRichPresence(other.RichPresence);
+            if(other.CustomStatus != null)
+                this.CustomStatus = new DiscordCustomStatus(other.CustomStatus);
         }
 
         internal void UpdateWith(TransportActivity rawActivity)

--- a/DSharpPlus/Entities/User/DiscordPresence.cs
+++ b/DSharpPlus/Entities/User/DiscordPresence.cs
@@ -93,8 +93,8 @@ namespace DSharpPlus.Entities
         internal DiscordPresence(DiscordPresence other)
         {
             this.Discord = other.Discord;
-            this.Activity = other.Activity;
-            this.RawActivity = other.RawActivity;
+            this.Activity = new DiscordActivity(other.Activity);
+            this.RawActivity = new TransportActivity(this.Activity);
             this._internalActivities = (DiscordActivity[])other._internalActivities?.Clone();
             this.RawActivities = (TransportActivity[])other.RawActivities?.Clone();
             this.Status = other.Status;


### PR DESCRIPTION
# Summary
Fixes a bug in the presence event, where `event.PresenceBefore.Activity` would contain new activity (`event.PresenceAfter.Activity`)

# Details
This is actually an underlying bug with `DiscordPresence`: When cloning `DiscordPresence`, it stores a reference of `DiscordActivity` instead of cloning it. Any changes made to the `DiscordActivity` would thus affect the clones. This is the case with the presence updates: It changes the `DiscordActivity` down the line & affects the `old` clone:

Before the changes:

![2021-10-02_19-19-44](https://user-images.githubusercontent.com/39029839/135727794-5c7a9398-9b78-45f0-b78a-f46965eafe72.png)

After the changes:

![rider64_2021-10-02_19-20-06](https://user-images.githubusercontent.com/39029839/135727809-beae9c18-2f84-4664-b86a-8ad70ecf1cf1.png)

I have been able to confirm that this is caused by the old activity having the same reference as the new one:

![rider64_2021-10-02_19-22-34](https://user-images.githubusercontent.com/39029839/135728019-012e6c87-8e67-4163-a3fc-2c907f135e10.png)

This bug seems to only affect `DiscordPresence.Activity`, while `DiscordPresence.Activities` works as expected.

# Changes proposed
* When cloning a `DiscordPresence`...
  * Clone `Activity` instead of storing a reference
  * Clone `RawActivity` instead of storing a reference

# Notes
I added 2 null-checks in `DiscordActivity`'s constructor to prevent `NullReferenceException`s