### PR TITLE
Fix NRE in InteractivityExtensions on slash command

### DIFF
--- a/DSharpPlus.Interactivity/Extensions/ChannelExtensions.cs
+++ b/DSharpPlus.Interactivity/Extensions/ChannelExtensions.cs
@@ -129,7 +129,7 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <summary>
         /// Retrieves an interactivity instance from a channel instance.
         /// </summary>
-        private static InteractivityExtension GetInteractivity(DiscordChannel channel)
+        internal static InteractivityExtension GetInteractivity(DiscordChannel channel)
         {
             var client = (DiscordClient)channel.Discord;
             var interactivity = client.GetInteractivity();

--- a/DSharpPlus.Interactivity/Extensions/InteractionExtensions.cs
+++ b/DSharpPlus.Interactivity/Extensions/InteractionExtensions.cs
@@ -46,6 +46,6 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="deletion">Deletion behaviour</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
         public static Task SendPaginatedResponseAsync(this DiscordInteraction interaction, bool ephemeral, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons = null, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken token = default)
-            => MessageExtensions.GetInteractivity(interaction.Message).SendPaginatedResponseAsync(interaction, ephemeral, user, pages, buttons, behaviour, deletion, token);
+            => ChannelExtensions.GetInteractivity(interaction.Channel).SendPaginatedResponseAsync(interaction, ephemeral, user, pages, buttons, behaviour, deletion, token);
     }
 }


### PR DESCRIPTION
# Summary
Fixing NRE when using `InteractivityExtensions.SendPaginatedResponseAsync` on interaction from slash-command.

# Details
Changed the way to get interactivity extension to use `ChannelExtensions` instead because `Interaction.Message` will be null on slash-command interaction.

Example to reproduce NRE problem:
```cs
[SlashCommand("test", "A test")]
public async Task Test(InteractionContext ctx)
{
    var pages = Enumerable.Range(1, 4).Select(i => new Page($"Page {i}"));
    await ctx.Interaction.SendPaginatedResponseAsync(false, ctx.User, pages);  // throws NRE
}
```

# Changes proposed
- Changed `InteractivityExtensions.SendPaginatedResponseAsync` to use `ChannelExtensions.GetInteractivity` instead of `MessageExtensions.GetInteractivity`.
- Make `MessageExtensions.GetInteractivity` internal instead private.

# Notes
Any additional notes go here.