### PR TITLE
Fix pagination button behavior

### DIFF
--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -630,7 +630,7 @@ namespace DSharpPlus.Interactivity
 
             bts = new(bts);
 
-            if (pages.Count() is 1)
+            if (pages.Count() == 1)
             {
                 bts.SkipLeft.Disable();
                 bts.Left.Disable();
@@ -643,7 +643,7 @@ namespace DSharpPlus.Interactivity
                 bts.SkipLeft.Disable();
                 bts.Left.Disable();
 
-                if (pages.Count() is 2)
+                if (pages.Count() == 2)
                     bts.SkipRight.Disable();
             }
 
@@ -736,7 +736,7 @@ namespace DSharpPlus.Interactivity
 
             bts = new(bts); // Copy //
 
-            if (pages.Count() is 1)
+            if (pages.Count() == 1)
             {
                 bts.SkipLeft.Disable();
                 bts.Left.Disable();
@@ -749,7 +749,7 @@ namespace DSharpPlus.Interactivity
                 bts.SkipLeft.Disable();
                 bts.Left.Disable();
 
-                if (pages.Count() is 2)
+                if (pages.Count() == 2)
                     bts.SkipRight.Disable();
             }
 


### PR DESCRIPTION
# Summary
Fixes Right and SkipRight button being enabled if page count is 1. Also making SkipRight button disabled if page count is 2 for consistency.

# Details
Disable Right and SkipRight button if page count is 1 even if `PaginationBehaviour.WrapAround` enabled because there's no point to go to next/previous page if there's only 1 page.

Disable SkipRight button if page count is 2 and `PaginationBehaviour.Ignore` for consistency. Current behavior is inconsistent because SkipRight button on page 1 is enabled when initially sending the pagination, but then disabled if we go back to page 1 from page 2.

# Changes proposed
Explained in details.

# Notes
Any additional notes go here.