### PR TITLE
Add Disable and Enable method on DiscordSelectComponent

### DIFF
--- a/DSharpPlus/Entities/Interaction/Components/DiscordSelectComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordSelectComponent.cs
@@ -63,6 +63,26 @@ namespace DSharpPlus.Entities
         [JsonProperty("max_values", NullValueHandling = NullValueHandling.Ignore)]
         public int? MaximumSelectedValues { get; internal set; }
 
+        /// <summary>
+        /// Enables this component if it was disabled before.
+        /// </summary>
+        /// <returns>The current component.</returns>
+        public DiscordSelectComponent Enable()
+        {
+            this.Disabled = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Disables this component.
+        /// </summary>
+        /// <returns>The current component.</returns>
+        public DiscordSelectComponent Disable()
+        {
+            this.Disabled = true;
+            return this;
+        }
+
         internal DiscordSelectComponent()
         {
             this.Type = ComponentType.Select;


### PR DESCRIPTION
# Summary
Add `Disable` and `Enable` method on `DiscordSelectComponent` because its `Disabled` property has internal setter.

# Details
Pretty surprised that `DiscordSelectComponent` lacks these methods. Possible use case is similar with Disable and Enable method on `DiscordButtonComponent` such as disabling select menu after timeout, enabling select menu after a user pressed a button, etc.

# Changes proposed
- Add `Disable()` method on `DiscordSelectComponent`
- Add `Enable()` method on `DiscordSelectComponent`