### PR TITLE
Support for `GUILD_JOIN_REQUEST_DELETE`

### DIFF
--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -110,8 +110,7 @@ namespace DSharpPlus.SlashCommands
                 typeof(ApplicationCommandModule).IsAssignableFrom(xt) &&
                 !xt.GetTypeInfo().IsNested);
             
-            foreach (Type xt in types)
-                RegisterCommands(xt, guildId);
+            foreach (Type xt in types) this.RegisterCommands(xt, guildId);
         }
 
         //To be run on ready

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -228,6 +228,11 @@ namespace DSharpPlus
                     await this.OnInviteDeleteEventAsync(cid, gid, dat).ConfigureAwait(false);
                     break;
 
+                case "guild_join_request_delete":
+                    gid = (ulong)dat["guild_id"];
+
+                    await this.OnGuildJoinRequestDeleteEventAsync(gid, dat["user_id"].ToDiscordObject<TransportUser>()).ConfigureAwait(false);
+                    break;
                 #endregion
 
                 #region Message
@@ -476,7 +481,6 @@ namespace DSharpPlus
                     #endregion
             }
         }
-
 
         #endregion
 
@@ -1314,6 +1318,24 @@ namespace DSharpPlus
                 Invite = invite
             };
             await this._inviteDeleted.InvokeAsync(this, ea).ConfigureAwait(false);
+        }
+
+
+        private async Task OnGuildJoinRequestDeleteEventAsync(ulong gid, TransportUser tusr)
+        {
+            var guild = this.InternalGetCachedGuild(gid);
+
+            this.TryGetCachedUserInternal(tusr.Id, out var cusr);
+
+            cusr ??= new DiscordUser(tusr) { Discord = this }; // If they weren't in cache, they probably aren't worth caching? //
+
+            var ea = new GuildJoinRequestDeleteEventArgs()
+            {
+                User = cusr,
+                Guild = guild
+            };
+
+            await this._guildJoinRequestDeleted.InvokeAsync(this, ea).ConfigureAwait(false);
         }
 
         #endregion

--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -402,6 +402,17 @@ namespace DSharpPlus
         }
         private AsyncEvent<DiscordClient, InviteDeleteEventArgs> _inviteDeleted;
 
+        /// <summary>
+        /// Fired when a member leaves before passing membership screening.
+        /// For this Event you need the <see cref="DiscordIntents.Guilds"/> and <see cref="DiscordIntents.GuildMembers"/> intent specified in <seealso cref="DiscordConfiguration.Intents"/>
+        /// </summary>
+        public event AsyncEventHandler<DiscordClient, GuildJoinRequestDeleteEventArgs> GuildJoinRequestDeleted
+        {
+            add => this._guildJoinRequestDeleted.Register(value);
+            remove => this._guildJoinRequestDeleted.Unregister(value);
+        }
+        private AsyncEvent<DiscordClient, GuildJoinRequestDeleteEventArgs> _guildJoinRequestDeleted;
+
         #endregion
 
         #region Message

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -171,6 +171,7 @@ namespace DSharpPlus
             this._guildDownloadCompletedEv = new AsyncEvent<DiscordClient, GuildDownloadCompletedEventArgs>("GUILD_DOWNLOAD_COMPLETED", EventExecutionLimit, this.EventErrorHandler);
             this._inviteCreated = new AsyncEvent<DiscordClient, InviteCreateEventArgs>("INVITE_CREATED", EventExecutionLimit, this.EventErrorHandler);
             this._inviteDeleted = new AsyncEvent<DiscordClient, InviteDeleteEventArgs>("INVITE_DELETED", EventExecutionLimit, this.EventErrorHandler);
+            this._guildJoinRequestDeleted = new AsyncEvent<DiscordClient, GuildJoinRequestDeleteEventArgs>("GUILD_JOIN_REQUEST_DELETED", EventExecutionLimit, this.EventErrorHandler);
             this._messageCreated = new AsyncEvent<DiscordClient, MessageCreateEventArgs>("MESSAGE_CREATED", EventExecutionLimit, this.EventErrorHandler);
             this._presenceUpdated = new AsyncEvent<DiscordClient, PresenceUpdateEventArgs>("PRESENCE_UPDATED", EventExecutionLimit, this.EventErrorHandler);
             this._guildBanAdded = new AsyncEvent<DiscordClient, GuildBanAddEventArgs>("GUILD_BAN_ADD", EventExecutionLimit, this.EventErrorHandler);

--- a/DSharpPlus/Clients/DiscordShardedClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.Events.cs
@@ -399,6 +399,18 @@ namespace DSharpPlus
         }
         private AsyncEvent<DiscordClient, InviteDeleteEventArgs> _inviteDeleted;
 
+        /// <summary>
+        /// Fired when a member leaves before passing membership screening.
+        /// For this Event you need the <see cref="DiscordIntents.Guilds"/> and <see cref="DiscordIntents.GuildMembers"/> intent specified in <seealso cref="DiscordConfiguration.Intents"/>
+        /// </summary>
+        public event AsyncEventHandler<DiscordClient, GuildJoinRequestDeleteEventArgs> GuildJoinRequestDeleted
+        {
+            add => this._guildJoinRequestDeleted.Register(value);
+            remove => this._guildJoinRequestDeleted.Unregister(value);
+        }
+        private AsyncEvent<DiscordClient, GuildJoinRequestDeleteEventArgs> _guildJoinRequestDeleted;
+
+
         #endregion
 
         #region Message
@@ -895,6 +907,9 @@ namespace DSharpPlus
 
         private Task Client_InviteDeleted(DiscordClient client, InviteDeleteEventArgs e)
             => this._inviteDeleted.InvokeAsync(client, e);
+
+        private Task Client_GuildJoinRequestDeleted(DiscordClient client, GuildJoinRequestDeleteEventArgs e)
+            => this._guildJoinRequestDeleted.InvokeAsync(client, e);
 
         private Task Client_PresenceUpdate(DiscordClient client, PresenceUpdateEventArgs e)
             => this._presenceUpdated.InvokeAsync(client, e);

--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -454,6 +454,7 @@ namespace DSharpPlus
             this._guildDownloadCompleted = new AsyncEvent<DiscordClient, GuildDownloadCompletedEventArgs>("GUILD_DOWNLOAD_COMPLETED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._inviteCreated = new AsyncEvent<DiscordClient, InviteCreateEventArgs>("INVITE_CREATED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._inviteDeleted = new AsyncEvent<DiscordClient, InviteDeleteEventArgs>("INVITE_DELETED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
+            this._guildJoinRequestDeleted = new AsyncEvent<DiscordClient, GuildJoinRequestDeleteEventArgs>("GUILD_JOIN_REQUEST_DELETED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._messageCreated = new AsyncEvent<DiscordClient, MessageCreateEventArgs>("MESSAGE_CREATED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._presenceUpdated = new AsyncEvent<DiscordClient, PresenceUpdateEventArgs>("PRESENCE_UPDATED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._guildBanAdded = new AsyncEvent<DiscordClient, GuildBanAddEventArgs>("GUILD_BAN_ADDED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
@@ -528,6 +529,7 @@ namespace DSharpPlus
             client.GuildDownloadCompleted += this.Client_GuildDownloadCompleted;
             client.InviteCreated += this.Client_InviteCreated;
             client.InviteDeleted += this.Client_InviteDeleted;
+            client.GuildJoinRequestDeleted += this.Client_GuildJoinRequestDeleted;
             client.MessageCreated += this.Client_MessageCreated;
             client.PresenceUpdated += this.Client_PresenceUpdate;
             client.GuildBanAdded += this.Client_GuildBanAdd;
@@ -599,6 +601,7 @@ namespace DSharpPlus
             client.GuildDownloadCompleted -= this.Client_GuildDownloadCompleted;
             client.InviteCreated -= this.Client_InviteCreated;
             client.InviteDeleted -= this.Client_InviteDeleted;
+            client.GuildJoinRequestDeleted -= this.Client_GuildJoinRequestDeleted;
             client.MessageCreated -= this.Client_MessageCreated;
             client.PresenceUpdated -= this.Client_PresenceUpdate;
             client.GuildBanAdded -= this.Client_GuildBanAdd;

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -573,7 +573,7 @@ namespace DSharpPlus.Entities
         public Task<ThreadQueryResult> ListPublicArchivedThreadsAsync(DateTimeOffset? before = null, int limit = 0)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.News)
-                throw new System.InvalidOperationException();
+                throw new InvalidOperationException();
 
             return this.Discord.ApiClient.ListPublicArchivedThreadsAsync(this.GuildId.Value, this.Id, (ulong?) before?.ToUnixTimeSeconds(), limit);
         }
@@ -589,7 +589,7 @@ namespace DSharpPlus.Entities
         public Task<ThreadQueryResult> ListPrivateArchivedThreadsAsync(DateTimeOffset? before = null, int limit = 0)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.News)
-                throw new System.InvalidOperationException();
+                throw new InvalidOperationException();
 
             return this.Discord.ApiClient.ListPrivateArchivedThreadsAsync(this.GuildId.Value, this.Id, (ulong?) before?.ToUnixTimeSeconds(), limit);
         }
@@ -605,7 +605,7 @@ namespace DSharpPlus.Entities
         public Task<ThreadQueryResult> ListJoinedPrivateArchivedThreadsAsync(DateTimeOffset? before = null, int limit = 0)
         {
             if (this.Type != ChannelType.Text && this.Type != ChannelType.News)
-                throw new System.InvalidOperationException();
+                throw new InvalidOperationException();
 
             return this.Discord.ApiClient.ListJoinedPrivateArchivedThreadsAsync(this.GuildId.Value, this.Id, (ulong?) before?.ToUnixTimeSeconds(), limit);
         }

--- a/DSharpPlus/Entities/Interaction/Components/DiscordActionRowComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordActionRowComponent.cs
@@ -38,8 +38,8 @@ namespace DSharpPlus.Entities
         /// </summary>
         public IReadOnlyCollection<DiscordComponent> Components
         {
-            get => _components ?? new List<DiscordComponent>();
-            set => _components = new List<DiscordComponent>(value);
+            get => this._components ?? new List<DiscordComponent>();
+            set => this._components = new List<DiscordComponent>(value);
         }
 
         [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]

--- a/DSharpPlus/EventArgs/Invite/GuildJoinRequestDeleteEventArgs.cs
+++ b/DSharpPlus/EventArgs/Invite/GuildJoinRequestDeleteEventArgs.cs
@@ -1,0 +1,42 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs
+{
+    /// <summary>
+    /// Represents arguments for <see cref="DiscordClient.GuildJoinRequestDelete">.
+    /// </summary>
+    public class GuildJoinRequestDeleteEventArgs : DiscordEventArgs
+    {
+        /// <summary>
+        /// The user that left.
+        /// </summary>
+        public DiscordUser User { get; internal set; }
+
+        /// <summary>
+        /// The guild that was left.
+        /// </summary>
+        public DiscordGuild Guild { get; internal set; }
+    }
+}


### PR DESCRIPTION
# Summary
Adds support for the [vaguely documented](https://github.com/discord/discord-api-docs/pull/3871), and "unreleased" `GUILD_JOIN_REQUEST_DELETE` event that's plagued the consoles of D#+ users for several months now.

# Details
Seeing as this is both "unreleased" and seemingly random (I can't seem to repro even w/ membership screening), testing for this will be limited, if existent at all, but I'll try regardless.

# Changes proposed
- Add switch case for `guild_join_request_delete`
- Add event to regular and sharded client
