### PR TITLE
Add `HTTP_INTERACTIONS` user flags

### DIFF
--- a/DSharpPlus/Enums/User/UserFlags.cs
+++ b/DSharpPlus/Enums/User/UserFlags.cs
@@ -110,11 +110,5 @@ namespace DSharpPlus
         /// The bot receives interactions via HTTP.
         /// </summary>
         HttpInteractionsBot = 1 << 19,
-
-        /// <summary>
-        /// The user has been reported as a spammer.
-        /// </summary>
-        Spammer = 1 << 20
-
     }
 }


### PR DESCRIPTION
# Summary
Adds new user user flags.

# Details
1 << 19 is for bots that receive bots that receive interactions over http (as per discord/discord-api-docs/pull/3903)
1 << 20 is generally cited to be for people that spam, and is likely for the uprise of phishing attacks 
