### PR TITLE
update user cache on get ban and set User field correctly

### DIFF
--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -207,6 +207,14 @@ namespace DSharpPlus.Net
 
             var ban = json.ToObject<DiscordBan>();
 
+            if (!this.Discord.TryGetCachedUserInternal(ban.RawUser.Id, out var usr))
+            {
+                usr = new DiscordUser(ban.RawUser) { Discord = this.Discord };
+                usr = this.Discord.UpdateUserCache(usr);
+            }
+
+            ban.User = usr;
+
             return ban;
         }
 


### PR DESCRIPTION
# Summary
This change updates the internal user cache on a GET ban request and correctly returns the ban object with a set `User` field which was `null` before.

# Details
I have copied the code from the GET bans endpoint.
This should correctly update the internal user cache with the most recent data and set the `User` field in `DiscordBan` so it is no longer `null`.

Code to reproduce:
```cs

DiscordBan ban = await guild.GetBanAsync(userId);
_logger.LogWarning("is null " + (ban == null).ToString());  // False
_logger.LogWarning("user is null " + (ban.User == null).ToString());  // True
_logger.LogWarning("id " + ban.User.Id);  // NullReference
```


# Notes
The user field is always set according to [discord docs](https://discord.com/developers/docs/resources/guild#ban-object).