### PR TITLE
Fixed null Channel property in DiscordInteraction object if interaction is invoked in thread

### DIFF
--- a/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
@@ -68,7 +68,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public DiscordChannel Channel
-            => (this.Discord as DiscordClient).InternalGetCachedChannel(this.ChannelId) ?? (this.Guild == null ? new DiscordDmChannel { Id = this.ChannelId, Type = ChannelType.Private, Discord = this.Discord } : null);
+            => (this.Discord as DiscordClient).InternalGetCachedChannel(this.ChannelId) ?? (DiscordChannel)(this.Discord as DiscordClient).InternalGetCachedThread(this.ChannelId) ?? (this.Guild == null ? new DiscordDmChannel { Id = this.ChannelId, Type = ChannelType.Private, Discord = this.Discord } : null);
 
         /// <summary>
         /// Gets the user that invoked this interaction.


### PR DESCRIPTION
# Summary
 This pull request fixes a bug where the "Channel" property of an InteractionContext's "Data" property is set to null when a slash command is executed inside of a thread

# Details
Currently, when a slash command is used in a thread, the "Channel" property of the InteractionContext's "Data" property is set to null instead of the appropriate DiscordChannel object. The issue was traced back to the "DiscordInteraction" class which sets the "Channel" property of the object using a cached list of all of the channels the client has access to, and the Channel ID of the channel the slash command was executed in. 

However, the function used to set the Channel object does not check the cached list of all of the _threads_ the client has access to. Adding a call to the "InternalGetCachedThread" function during the "Channel" object's initialization in the DiscordInteraction class fixes this issue and sets the Channel property to the correct DiscordChannel object when an Interaction is invoked in a thread.

# Changes proposed
* Add a check to the DiscordInteraction class that checks to see if the provided Channel ID is a thread channel.