### PR TITLE
Add support for nullable enums

### DIFF
--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -109,9 +109,9 @@ namespace DSharpPlus.SlashCommands
             var types = assembly.ExportedTypes.Where(xt =>
                 typeof(ApplicationCommandModule).IsAssignableFrom(xt) &&
                 !xt.GetTypeInfo().IsNested);
-            
+
             foreach (Type xt in types)
-                RegisterCommands(xt, guildId);
+                this.RegisterCommands(xt, guildId);
         }
 
         //To be run on ready
@@ -393,7 +393,7 @@ namespace DSharpPlus.SlashCommands
                 //From attributes
                 var choices = this.GetChoiceAttributesFromParameter(parameter.GetCustomAttributes<ChoiceAttribute>());
                 //From enums
-                if (parameter.ParameterType.IsEnum)
+                if (parameter.ParameterType.IsEnum || Nullable.GetUnderlyingType(parameter.ParameterType)?.IsEnum == true)
                 {
                     choices = GetChoiceAttributesFromEnumParameter(parameter.ParameterType);
                 }
@@ -460,6 +460,10 @@ namespace DSharpPlus.SlashCommands
         private static List<DiscordApplicationCommandOptionChoice> GetChoiceAttributesFromEnumParameter(Type enumParam)
         {
             var choices = new List<DiscordApplicationCommandOptionChoice>();
+            if (enumParam.IsGenericType && enumParam.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                enumParam = Nullable.GetUnderlyingType(enumParam);
+            }
             foreach (Enum enumValue in Enum.GetValues(enumParam))
             {
                 choices.Add(new DiscordApplicationCommandOptionChoice(enumValue.GetName(), enumValue.ToString()));
@@ -488,7 +492,7 @@ namespace DSharpPlus.SlashCommands
                 return ApplicationCommandOptionType.String;
             if (type == typeof(SnowflakeObject))
                 return ApplicationCommandOptionType.Mentionable;
-            if (type.IsEnum)
+            if (type.IsEnum || Nullable.GetUnderlyingType(type)?.IsEnum == true)
                 return ApplicationCommandOptionType.String;
             throw new ArgumentException("Cannot convert type! Argument types must be string, long, bool, double, DiscordChannel, DiscordUser, DiscordRole, DiscordEmoji, SnowflakeObject or an Enum.");
         }
@@ -823,6 +827,8 @@ namespace DSharpPlus.SlashCommands
                         args.Add(option.Value.ToString());
                     else if (parameter.ParameterType.IsEnum)
                         args.Add(Enum.Parse(parameter.ParameterType, (string)option.Value));
+                    else if (Nullable.GetUnderlyingType(parameter.ParameterType)?.IsEnum == true)
+                        args.Add(Enum.Parse(Nullable.GetUnderlyingType(parameter.ParameterType), (string)option.Value));
                     else if (parameter.ParameterType == typeof(long) || parameter.ParameterType == typeof(long?))
                         args.Add((long?)option.Value);
                     else if (parameter.ParameterType == typeof(bool) || parameter.ParameterType == typeof(bool?))

--- a/DSharpPlus.Test/TestBotEvalCommands.cs
+++ b/DSharpPlus.Test/TestBotEvalCommands.cs
@@ -39,14 +39,22 @@ namespace DSharpPlus.Test
         {
             var msg = ctx.Message;
 
-            var cs1 = code.IndexOf("```") + 3;
-            cs1 = code.IndexOf('\n', cs1) + 1;
-            var cs2 = code.LastIndexOf("```");
+            var cs = string.Empty;
+            if (code.Trim().StartsWith("```"))
+            {
+                var cs1 = code.IndexOf("```") + 3;
+                cs1 = code.IndexOf('\n', cs1) + 1;
+                var cs2 = code.LastIndexOf("```");
 
-            if (cs1 == -1 || cs2 == -1)
-                throw new ArgumentException("You need to wrap the code into a code block.");
+                if (cs1 == -1 || cs2 == -1)
+                    throw new ArgumentException("You need to wrap the code into a code block.");
 
-            var cs = code.Substring(cs1, cs2 - cs1);
+                cs = code.Substring(cs1, cs2 - cs1);
+            }
+            else
+            {
+                cs = code;
+            }
 
             msg = await ctx.RespondAsync(embed: new DiscordEmbedBuilder()
                 .WithColor(new DiscordColor("#FF007F"))


### PR DESCRIPTION
# Summary
Addresses #1131 

# Details
Added checks for nullable enums. Also made the test bot eval command not require code blocks.

# Notes
This code is so ugly. Reflection just leads to such messy code. I hate this.