### PR TITLE
Fix ModifyAsync throwing an exception

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -406,10 +406,10 @@ namespace DSharpPlus.Entities
             if (this.ReferencedMessage != null && this._mentionedUsers.Contains(this.ReferencedMessage.Author))
                mentions.Add(new RepliedUserMention()); // Return null to allow all mentions
 
-            if (this._mentionedUsers.Any())
+            if (this._mentionedUsers?.Any() ?? false)
                 mentions.AddRange(this._mentionedUsers.Select(m => (IMention)new UserMention(m)));
 
-            if (this._mentionedRoleIds.Any())
+            if (this._mentionedRoleIds?.Any() ?? false)
                 mentions.AddRange(this._mentionedRoleIds.Select(r => (IMention)new RoleMention(r)));
 
             return mentions.ToArray();


### PR DESCRIPTION
# Summary
Fixes #1142 where modifying a message could potentially throw an exception becuase the expected field is not always sent, which means that when deserializing, the list may not always be iniialized, which causes an exception to be thrown when LINQ is evaluated against it.

# Changes proposed
Add null coallesing operator in conjunction with the null propogating operator to prevent LINQ from being evaluated if the list is in fact null

# Notes
Oops.