### PR TITLE
Fix member caching oddities

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1029,8 +1029,7 @@ namespace DSharpPlus
             var usr = new DiscordUser(user) { Discord = this };
             usr = this.UpdateUserCache(usr);
 
-            if (!guild.Members.TryGetValue(user.Id, out var mbr))
-                mbr = new DiscordMember(usr) { Discord = this, _guild_id = guild.Id };
+            var mbr = guild.GetOrCacheMember(usr);
             var ea = new GuildBanAddEventArgs
             {
                 Guild = guild,
@@ -1044,8 +1043,7 @@ namespace DSharpPlus
             var usr = new DiscordUser(user) { Discord = this };
             usr = this.UpdateUserCache(usr);
 
-            if (!guild.Members.TryGetValue(user.Id, out var mbr))
-                mbr = new DiscordMember(usr) { Discord = this, _guild_id = guild.Id };
+            var mbr = guild.GetOrCacheMember(usr);
             var ea = new GuildBanRemoveEventArgs
             {
                 Guild = guild,
@@ -1084,7 +1082,7 @@ namespace DSharpPlus
         {
             var usr = new DiscordUser(user);
 
-            if (!guild._members.TryRemove(user.Id, out var mbr))
+            if (!guild._members.TryRemove(user.Id, out var mbr)) // This is removing, so it's OK to init but not cache //
                 mbr = new DiscordMember(usr) { Discord = this, _guild_id = guild.Id };
             guild.MemberCount--;
 
@@ -1103,8 +1101,7 @@ namespace DSharpPlus
             var usr = new DiscordUser(member.User) { Discord = this };
             usr = this.UpdateUserCache(usr);
 
-            if (!guild.Members.TryGetValue(member.User.Id, out var mbr))
-                mbr = new DiscordMember(usr) { Discord = this, _guild_id = guild.Id };
+            var mbr = guild.GetOrCacheMember(usr);
 
             var nick_old = mbr.Nickname;
             var pending_old = mbr.IsPending;
@@ -1579,12 +1576,10 @@ namespace DSharpPlus
             emoji.Discord = this;
 
             if (!this.UserCache.TryGetValue(userId, out var usr))
-                usr = new DiscordUser { Id = userId, Discord = this };
+                usr = this.UpdateUserCache(new DiscordUser { Id = userId, Discord = this });
 
             if (channel?.Guild != null)
-                usr = channel.Guild.Members.TryGetValue(userId, out var member)
-                    ? member
-                    : new DiscordMember(usr) { Discord = this, _guild_id = channel.GuildId.Value };
+                usr = channel.Guild.GetOrCacheMember(usr);
 
             if (channel == null
                 || this.Configuration.MessageCacheSize == 0

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -2482,6 +2482,15 @@ namespace DSharpPlus.Entities
         /// <returns>Whether the two members are not equal.</returns>
         public static bool operator !=(DiscordGuild e1, DiscordGuild e2)
             => !(e1 == e2);
+
+        /// <summary>
+        /// A helper method to get or cache a member based on a user.
+        /// </summary>
+        /// <param name="user">The user to pull from cache, or construct a member from if they're not present.</param>
+        /// <returns>The (newly) cached member.</returns>
+        internal DiscordMember GetOrCacheMember(DiscordUser user)
+            => this.Members.TryGetValue(user.Id, out var member) ? member :
+                this._members[user.Id] = new DiscordMember(user) { Discord = this.Discord, _guild_id = this.Id };
     }
 
     /// <summary>


### PR DESCRIPTION
# Summary
This PR aims to fix a bunch of caching issues that've plagued the library for what feels like years at this point.

# Details
There's an issue that shockingly nobody's really fixed where in a lot of places, we essentially do the following:

```cs
if (!cache.TryGetValue(someId, out someObject)
        someObject = new SomeObject();
```

That *looks* fine, but unfortunately doesn't work, because you can't set keys of a dictionary through an `out` parameter (which is evidenced by this PR being open to begin with)

I've corrected this in all applicable places*, but will continue to search through other files where this erroneous logic may have been applied.


* <sub>All places being DiscordClient.Dispatch as of writing this</sub>

# Changes proposed
- Add helper method for caching in DiscordGuild.cs
- Use helper method where applicable in DiscordClient.Dispatch.cs

# Notes
![](https://cdn.discordapp.com/emojis/877045012943237200.png?size=256)