### PR TITLE
Fix null ref when creating DMs

### DIFF
--- a/DSharpPlus.Test/DMTest.cs
+++ b/DSharpPlus.Test/DMTest.cs
@@ -1,0 +1,40 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System.Threading.Tasks;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.Test
+{
+    public class DMTest : BaseCommandModule
+    {
+        [Command]
+        public async Task DM(CommandContext ctx)
+        {
+            await ctx.Member.CreateDmChannelAsync();
+            await ctx.Message.CreateReactionAsync(DiscordEmoji.FromUnicode("👌🏽"));
+        }
+
+    }
+}

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1506,20 +1506,22 @@ namespace DSharpPlus
             var channel = this.InternalGetCachedChannel(channelId) ?? this.InternalGetCachedThread(channelId);
             var guild = this.InternalGetCachedGuild(guildId);
 
+            emoji.Discord = this;
+
+            var usr = this.UpdateUser(new DiscordUser { Id = userId, Discord = this }, guildId, guild, mbr);
+
             if (channel == null)
             {
                 channel = new DiscordDmChannel
                 {
                     Id = channelId,
                     Discord = this,
-                    Type = ChannelType.Private
+                    Type = ChannelType.Private,
+                    Recipients = new DiscordUser[] { usr }
                 };
                 this._privateChannels.AddOrUpdate(channelId, (DiscordDmChannel)channel, (oldChannel, channel) => channel);
             }
 
-            emoji.Discord = this;
-
-            var usr = this.UpdateUser(new DiscordUser { Id = userId, Discord = this }, guildId, guild, mbr);
 
             if (channel == null
                 || this.Configuration.MessageCacheSize == 0

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -726,7 +726,8 @@ namespace DSharpPlus
                 {
                     Id = channelId,
                     Discord = this,
-                    Type = ChannelType.Private
+                    Type = ChannelType.Private,
+                    Recipients = new DiscordUser[] {}
                 };
                 this._privateChannels.AddOrUpdate(channelId, (DiscordDmChannel)channel, (oldChannel, channel) => channel);
             }
@@ -1431,7 +1432,9 @@ namespace DSharpPlus
                 {
                     Id = channelId,
                     Discord = this,
-                    Type = ChannelType.Private
+                    Type = ChannelType.Private,
+                    Recipients = new DiscordUser[] {}
+
                 };
                 this._privateChannels.AddOrUpdate(channelId, (DiscordDmChannel)channel, (oldChannel, channel) => channel);
             }
@@ -1567,21 +1570,22 @@ namespace DSharpPlus
         {
             var channel = this.InternalGetCachedChannel(channelId) ?? this.InternalGetCachedThread(channelId);
 
+            emoji.Discord = this;
+
+            if (!this.UserCache.TryGetValue(userId, out var usr))
+                usr = new DiscordUser { Id = userId, Discord = this };
+
             if (channel == null)
             {
                 channel = new DiscordDmChannel
                 {
                     Id = channelId,
                     Discord = this,
-                    Type = ChannelType.Private
+                    Type = ChannelType.Private,
+                    Recipients = new DiscordUser[] { usr }
                 };
                 this._privateChannels.AddOrUpdate(channelId, (DiscordDmChannel)channel, (oldChannel, channel) => channel);
             }
-
-            emoji.Discord = this;
-
-            if (!this.UserCache.TryGetValue(userId, out var usr))
-                usr = new DiscordUser { Id = userId, Discord = this };
 
             if (channel?.Guild != null)
                 usr = channel.Guild.Members.TryGetValue(userId, out var member)
@@ -1668,7 +1672,8 @@ namespace DSharpPlus
                 {
                     Id = channelId,
                     Discord = this,
-                    Type = ChannelType.Private
+                    Type = ChannelType.Private,
+                    Recipients = new DiscordUser[] { }
                 };
                 this._privateChannels.AddOrUpdate(channelId, (DiscordDmChannel)channel, (oldChannel, channel) => channel);
             }

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -727,7 +727,7 @@ namespace DSharpPlus
                     Id = channelId,
                     Discord = this,
                     Type = ChannelType.Private,
-                    Recipients = new DiscordUser[] {}
+                    Recipients = Array.Empty<DiscordUser>()
                 };
                 this._privateChannels.AddOrUpdate(channelId, (DiscordDmChannel)channel, (oldChannel, channel) => channel);
             }
@@ -1433,7 +1433,7 @@ namespace DSharpPlus
                     Id = channelId,
                     Discord = this,
                     Type = ChannelType.Private,
-                    Recipients = new DiscordUser[] {}
+                    Recipients = Array.Empty<DiscordUser>()
 
                 };
                 this._privateChannels.AddOrUpdate(channelId, (DiscordDmChannel)channel, (oldChannel, channel) => channel);
@@ -1673,7 +1673,7 @@ namespace DSharpPlus
                     Id = channelId,
                     Discord = this,
                     Type = ChannelType.Private,
-                    Recipients = new DiscordUser[] { }
+                    Recipients = Array.Empty<DiscordUser>()
                 };
                 this._privateChannels.AddOrUpdate(channelId, (DiscordDmChannel)channel, (oldChannel, channel) => channel);
             }

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -828,7 +828,8 @@ namespace DSharpPlus
                 {
                     Id = message.ChannelId,
                     Discord = this,
-                    Type = ChannelType.Private
+                    Type = ChannelType.Private,
+                    Recipients = new DiscordUser[] { message.Author }
                 }
                 : new DiscordChannel
                 {

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -327,7 +327,7 @@ namespace DSharpPlus.Entities
             DiscordDmChannel dm = default;
 
             if (this.Discord is DiscordClient dc)
-                dm = dc._privateChannels.Values.FirstOrDefault(x => x.Recipients[0].Id == this.Id);
+                dm = dc._privateChannels.Values.FirstOrDefault(x => x.Recipients.FirstOrDefault() == this);
 
             return dm != null ? Task.FromResult(dm) : this.Discord.ApiClient.CreateDmAsync(this.Id);
         }

--- a/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
@@ -68,7 +68,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public DiscordChannel Channel
-            => (this.Discord as DiscordClient).InternalGetCachedChannel(this.ChannelId) ?? (DiscordChannel)(this.Discord as DiscordClient).InternalGetCachedThread(this.ChannelId) ?? (this.Guild == null ? new DiscordDmChannel { Id = this.ChannelId, Type = ChannelType.Private, Discord = this.Discord } : null);
+            => (this.Discord as DiscordClient).InternalGetCachedChannel(this.ChannelId) ?? (DiscordChannel)(this.Discord as DiscordClient).InternalGetCachedThread(this.ChannelId) ?? (this.Guild == null ? new DiscordDmChannel { Id = this.ChannelId, Type = ChannelType.Private, Discord = this.Discord, Recipients = new DiscordUser[] { this.User }} : null);
 
         /// <summary>
         /// Gets the user that invoked this interaction.


### PR DESCRIPTION
# Summary
Fixes #1150.

# Details
This PR addresses the issue of skeleton DM channels not having their recipient set, which causes a null ref [because we use an indexer](https://github.com/DSharpPlus/DSharpPlus/blob/1cecd8dd60b8b4a01d0d68813a347e19628cb558/DSharpPlus/Entities/Guild/DiscordMember.cs#L330).

This sets the property in all applicable places when it comes to DiscordClient.Dispatch.cs. I'd assume DiscordApiClient  is *OK*, seeing as nobody's raised an issue about that yet.

# Changes proposed
Set skeleton DM channels to have an array of recepients in locations where it was not.
