### PR TITLE
Add support to paginate as EditOriginalResponse

### DIFF
--- a/DSharpPlus.Interactivity/Extensions/InteractionExtensions.cs
+++ b/DSharpPlus.Interactivity/Extensions/InteractionExtensions.cs
@@ -45,7 +45,8 @@ namespace DSharpPlus.Interactivity.Extensions
         /// <param name="behaviour">Pagination behaviour.</param>
         /// <param name="deletion">Deletion behaviour</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public static Task SendPaginatedResponseAsync(this DiscordInteraction interaction, bool ephemeral, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons = null, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken token = default)
-            => ChannelExtensions.GetInteractivity(interaction.Channel).SendPaginatedResponseAsync(interaction, ephemeral, user, pages, buttons, behaviour, deletion, token);
+        /// <param name="asEditResponse">If the response as edit of previous response.</param>
+        public static Task SendPaginatedResponseAsync(this DiscordInteraction interaction, bool ephemeral, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons = null, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken token = default, bool asEditResponse = false)
+            => ChannelExtensions.GetInteractivity(interaction.Channel).SendPaginatedResponseAsync(interaction, ephemeral, user, pages, buttons, behaviour, deletion, token, asEditResponse);
     }
 }

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -42,7 +42,7 @@ namespace DSharpPlus.Interactivity
     public class InteractivityExtension : BaseExtension
     {
 
-        #pragma warning disable IDE1006 // Naming Styles
+#pragma warning disable IDE1006 // Naming Styles
         internal InteractivityConfiguration Config { get; }
 
         private EventWaiter<MessageCreateEventArgs> MessageCreatedWaiter;
@@ -62,7 +62,7 @@ namespace DSharpPlus.Interactivity
         private Paginator Paginator;
         private  ComponentPaginator _compPaginator;
 
-        #pragma warning restore IDE1006 // Naming Styles
+#pragma warning restore IDE1006 // Naming Styles
 
         internal InteractivityExtension(InteractivityConfiguration cfg)
         {
@@ -728,7 +728,8 @@ namespace DSharpPlus.Interactivity
         /// <param name="behaviour">Pagination behaviour.</param>
         /// <param name="deletion">Deletion behaviour</param>
         /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-        public async Task SendPaginatedResponseAsync(DiscordInteraction interaction, bool ephemeral, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons = null, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken token = default)
+        /// <param name="asEditResponse">If the response as edit of previous response.</param>
+        public async Task SendPaginatedResponseAsync(DiscordInteraction interaction, bool ephemeral, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons = null, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, CancellationToken token = default, bool asEditResponse = false)
         {
             var bhv = behaviour ?? this.Config.PaginationBehaviour;
             var del = deletion ?? this.Config.ButtonBehavior;
@@ -753,13 +754,25 @@ namespace DSharpPlus.Interactivity
                     bts.SkipRight.Disable();
             }
 
-            var builder = new DiscordInteractionResponseBuilder()
-                .WithContent(pages.First().Content)
-                .AddEmbed(pages.First().Embed)
-                .AsEphemeral(ephemeral)
-                .AddComponents(bts.ButtonArray);
+            if (asEditResponse)
+            {
+                var builder = new DiscordWebhookBuilder()
+                    .WithContent(pages.First().Content)
+                    .AddEmbed(pages.First().Embed)
+                    .AddComponents(bts.ButtonArray);
 
-            await interaction.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, builder);
+                await interaction.EditOriginalResponseAsync(builder);
+            }
+            else
+            {
+                var builder = new DiscordInteractionResponseBuilder()
+                    .WithContent(pages.First().Content)
+                    .AddEmbed(pages.First().Embed)
+                    .AsEphemeral(ephemeral)
+                    .AddComponents(bts.ButtonArray);
+
+                await interaction.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, builder);
+            }
             var message = await interaction.GetOriginalResponseAsync();
 
             var req = new InteractionPaginationRequest(interaction, message, user, bhv, del, bts, pages, token);

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -754,6 +754,7 @@ namespace DSharpPlus.Interactivity
                     bts.SkipRight.Disable();
             }
 
+            DiscordMessage message;
             if (asEditResponse)
             {
                 var builder = new DiscordWebhookBuilder()
@@ -761,7 +762,7 @@ namespace DSharpPlus.Interactivity
                     .AddEmbed(pages.First().Embed)
                     .AddComponents(bts.ButtonArray);
 
-                await interaction.EditOriginalResponseAsync(builder);
+                message = await interaction.EditOriginalResponseAsync(builder);
             }
             else
             {
@@ -772,8 +773,8 @@ namespace DSharpPlus.Interactivity
                     .AddComponents(bts.ButtonArray);
 
                 await interaction.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, builder);
+                message = await interaction.GetOriginalResponseAsync();
             }
-            var message = await interaction.GetOriginalResponseAsync();
 
             var req = new InteractionPaginationRequest(interaction, message, user, bhv, del, bts, pages, token);
 


### PR DESCRIPTION
# Summary
Add support for `SendPaginatedResponseAsync` to send pagination as `EditOriginalResponse`

# Details
Currently there's no proper way to send paginated message after sending `DeferredChannelMessageWithSource`. Because you're supposed to "edit the response" after you're sending defer signal.

Another alternative to "editing the response" is by sending paginated message as follow up message. But I doubt it's standard way to send response after sending defer signal.

# Changes proposed
Add optional parameter `asEditResponse` to `SendPaginatedResponseAsync`. Default to `false`.

# Notes
Idk if there's better approach for this problem so any suggestions will be welcomed. 