### PR TITLE
Add some properties to AutocompleteContext

### DIFF
--- a/DSharpPlus.SlashCommands/Contexts/AutocompleteContext.cs
+++ b/DSharpPlus.SlashCommands/Contexts/AutocompleteContext.cs
@@ -21,8 +21,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using DSharpPlus.Entities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DSharpPlus.SlashCommands
 {
@@ -35,6 +37,44 @@ namespace DSharpPlus.SlashCommands
         /// The interaction created.
         /// </summary>
         public DiscordInteraction Interaction { get; internal set; }
+
+        /// <summary>
+        /// Gets the client for this interaction.
+        /// </summary>
+        public DiscordClient Client { get; internal set; }
+
+        /// <summary>
+        /// Gets the guild this interaction was executed in.
+        /// </summary>
+        public DiscordGuild Guild { get; internal set; }
+
+        /// <summary>
+        /// Gets the channel this interaction was executed in.
+        /// </summary>
+        public DiscordChannel Channel { get; internal set; }
+
+        /// <summary>
+        /// Gets the user which executed this interaction.
+        /// </summary>
+        public DiscordUser User { get; internal set; }
+
+        /// <summary>
+        /// Gets the member which executed this interaction, or null if the command is in a DM.
+        /// </summary>
+        public DiscordMember Member
+            => this.User is DiscordMember member ? member : null;
+
+        /// <summary>
+        /// Gets the slash command module this interaction was created in.
+        /// </summary>
+        public SlashCommandsExtension SlashCommandsExtension { get; internal set; }
+
+        /// <summary>
+        /// <para>Gets the service provider.</para>
+        /// <para>This allows passing data around without resorting to static members.</para>
+        /// <para>Defaults to null.</para>
+        /// </summary>
+        public IServiceProvider Services { get; internal set; } = new ServiceCollection().BuildServiceProvider(true);
 
         /// <summary>
         /// The options already provided.

--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -961,6 +961,12 @@ namespace DSharpPlus.SlashCommands
             var context = new AutocompleteContext
             {
                 Interaction = interaction,
+                Client = this.Client,
+                Services = this._configuration?.Services,
+                SlashCommandsExtension = this,
+                Guild = interaction.Guild,
+                Channel = interaction.Channel,
+                User = interaction.User,
                 Options = options.ToList(),
                 FocusedOption = focusedOption
             };


### PR DESCRIPTION
# Summary
Added some properties to `AutocompleteContext` which might be useful in some cases.

# Details
Found that `AutocompleteContext` lacks of some properties compared to `InteractionContext` or `ContextMenuContext` such as `Services` (main reason I made this PR).

# Changes proposed
Added these properties to `AutocompleteContext`:
- `Client`
- `Guild`
- `Channel`
- `User`
- `Member`
- `SlashCommandsExtension`
- `Services`

# Notes
Let me know if some of added properties are unnecessary or I missed some properties to be added.