### PR TITLE
Add support for creating application or stream invites

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -661,9 +661,12 @@ namespace DSharpPlus
         /// <param name="temporary">Whether this invite should be temporary</param>
         /// <param name="unique">Whether this invite should be unique (false might return an existing invite)</param>
         /// <param name="reason">Why you made an invite</param>
+        /// <param name="targetType">The target type of the invite, for stream and embedded application invites.</param>
+        /// <param name="targetUserId">The id of the target user.</param>
+        /// <param name="targetApplicationId">The id of the target application.</param>
         /// <returns></returns>
-        public Task<DiscordInvite> CreateChannelInviteAsync(ulong channel_id, int max_age, int max_uses, bool temporary, bool unique, string reason)
-            => this.ApiClient.CreateChannelInviteAsync(channel_id, max_age, max_uses, temporary, unique, reason);
+        public Task<DiscordInvite> CreateChannelInviteAsync(ulong channel_id, int max_age, int max_uses, bool temporary, bool unique, string reason, InviteTargetType? targetType = null, ulong? targetUserId = null, ulong? targetApplicationId = null)
+            => this.ApiClient.CreateChannelInviteAsync(channel_id, max_age, max_uses, temporary, unique, reason, targetType, targetUserId, targetApplicationId);
 
         /// <summary>
         /// Deletes channel overwrite

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -673,13 +673,16 @@ namespace DSharpPlus.Entities
         /// <param name="temporary">Whether this invite only grants temporary membership.  Defaults to false.</param>
         /// <param name="unique">If true, don't try to reuse a similar invite (useful for creating many unique one time use invites)</param>
         /// <param name="reason">Reason for audit logs.</param>
+        /// <param name="targetType">The target type of the invite, for stream and embedded application invites.</param>
+        /// <param name="targetUserId">The id of the target user.</param>
+        /// <param name="targetApplicationId">The id of the target application.</param>
         /// <returns></returns>
         /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.CreateInstantInvite"/> permission.</exception>
         /// <exception cref="Exceptions.NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public Task<DiscordInvite> CreateInviteAsync(int max_age = 86400, int max_uses = 0, bool temporary = false, bool unique = false, string reason = null)
-            => this.Discord.ApiClient.CreateChannelInviteAsync(this.Id, max_age, max_uses, temporary, unique, reason);
+        public Task<DiscordInvite> CreateInviteAsync(int max_age = 86400, int max_uses = 0, bool temporary = false, bool unique = false, string reason = null, InviteTargetType? targetType = null, ulong? targetUserId = null, ulong? targetApplicationId = null)
+            => this.Discord.ApiClient.CreateChannelInviteAsync(this.Id, max_age, max_uses, temporary, unique, reason, targetType, targetUserId, targetApplicationId);
 
         /// <summary>
         /// Adds a channel permission overwrite for specified member.

--- a/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
@@ -188,6 +188,15 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("unique", NullValueHandling = NullValueHandling.Ignore)]
         public bool Unique { get; set; }
+
+        [JsonProperty("target_type", NullValueHandling = NullValueHandling.Ignore)]
+        public InviteTargetType? TargetType { get; set; }
+
+        [JsonProperty("target_user_id", NullValueHandling = NullValueHandling.Ignore)]
+        public ulong? TargetUserId { get; set; }
+
+        [JsonProperty("target_application_id", NullValueHandling = NullValueHandling.Ignore)]
+        public ulong? TargetApplicationId { get; set; }
     }
 
     internal sealed class RestChannelPermissionEditPayload

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1320,14 +1320,17 @@ namespace DSharpPlus.Net
             return new ReadOnlyCollection<DiscordInvite>(new List<DiscordInvite>(invites_raw));
         }
 
-        internal async Task<DiscordInvite> CreateChannelInviteAsync(ulong channel_id, int max_age, int max_uses, bool temporary, bool unique, string reason)
+        internal async Task<DiscordInvite> CreateChannelInviteAsync(ulong channel_id, int max_age, int max_uses, bool temporary, bool unique, string reason, InviteTargetType? targetType, ulong? targetUserId, ulong? targetApplicationId)
         {
             var pld = new RestChannelInviteCreatePayload
             {
                 MaxAge = max_age,
                 MaxUses = max_uses,
                 Temporary = temporary,
-                Unique = unique
+                Unique = unique,
+                TargetType = targetType,
+                TargetUserId = targetUserId,
+                TargetApplicationId = targetApplicationId
             };
 
             var headers = Utilities.GetBaseHeaders();


### PR DESCRIPTION
# Summary
Added support for stream or application invites

# Details
Sample code for watch together:
```cs
await /*A voice channel*/.CreateInviteAsync(targetType: InviteTargetType.EmbeddedApplication, 
targetApplicationId: /* I don't know if it's legal to share the application id */)```