### PR TITLE
Fix interaction responses not respecting allowed mentions

### DIFF
--- a/DSharpPlus/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
@@ -38,7 +38,7 @@ namespace DSharpPlus.Entities
         public IEnumerable<DiscordEmbed> Embeds { get; internal set; }
 
         [JsonProperty("allowed_mentions", NullValueHandling = NullValueHandling.Ignore)]
-        public IEnumerable<IMention> Mentions { get; internal set; }
+        public DiscordMentions Mentions { get; internal set; }
 
         [JsonProperty("flags", NullValueHandling = NullValueHandling.Ignore)]
         public MessageFlags? Flags { get; internal set; }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -3121,7 +3121,7 @@ namespace DSharpPlus.Net
                     Content = builder.Content,
                     Embeds = builder.Embeds,
                     IsTTS = builder.IsTTS,
-                    Mentions = builder.Mentions,
+                    Mentions = new DiscordMentions(builder.Mentions ?? Mentions.All, builder.Mentions?.Any() ?? false),
                     Flags = builder.IsEphemeral ? MessageFlags.Ephemeral : 0,
                     Components = builder.Components,
                     Choices = builder.Choices

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -427,6 +427,8 @@ namespace DSharpPlus.Net
             if (request is MultipartWebRequest mprequest)
             {
                 this.Logger.LogTrace(LoggerEvents.RestTx, "<multipart request>");
+                if (mprequest.Values.TryGetValue("payload_json", out var payload))
+                    this.Logger.LogTrace(LoggerEvents.RestTx, payload);
 
                 var boundary = "---------------------------" + DateTime.Now.Ticks.ToString("x");
 


### PR DESCRIPTION
# Summary
Fixes an issue that for some reason no one ever *mention*ed before (maybe because no one actually uses allowed mentions).
Resolves #1158

# Details
Allowed mentions weren't being parsed like they were supposed to be. Changed the type of the `Mentions` property on the callback data to the correct type.

# Notes
Testing this was annoying because trace didn't properly log multipart requests, so added a small thing to make it do that.