### PR TITLE
Support for native mutes

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -924,7 +924,7 @@ namespace DSharpPlus
             => this.ApiClient.GetCurrentUserGuildsAsync(limit, before, after);
 
         /// <summary>
-        /// Modifies guild member
+        /// Modifies guild member.
         /// </summary>
         /// <param name="guild_id">Guild id</param>
         /// <param name="user_id">User id</param>
@@ -933,6 +933,7 @@ namespace DSharpPlus
         /// <param name="mute">Whether this user should be muted</param>
         /// <param name="deaf">Whether this user should be deafened</param>
         /// <param name="voice_channel_id">Voice channel to move this user to</param>
+        /// <param name="communication_disabled_until">How long this member should be timed out for. Requires MODERATE_MEMBERS permission.</param>
         /// <param name="reason">Reason this user was modified</param>
         /// <returns></returns>
         public Task ModifyGuildMemberAsync(ulong guild_id, ulong user_id, Optional<string> nick,

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -937,8 +937,8 @@ namespace DSharpPlus
         /// <returns></returns>
         public Task ModifyGuildMemberAsync(ulong guild_id, ulong user_id, Optional<string> nick,
             Optional<IEnumerable<ulong>> role_ids, Optional<bool> mute, Optional<bool> deaf,
-            Optional<ulong?> voice_channel_id, string reason)
-            => this.ApiClient.ModifyGuildMemberAsync(guild_id, user_id, nick, role_ids, mute, deaf, voice_channel_id, reason);
+            Optional<ulong?> voice_channel_id, Optional<DateTimeOffset?> communication_disabled_until, string reason)
+            => this.ApiClient.ModifyGuildMemberAsync(guild_id, user_id, nick, role_ids, mute, deaf, voice_channel_id, communication_disabled_until, reason);
 
         /// <summary>
         /// Modifies a member
@@ -961,13 +961,13 @@ namespace DSharpPlus
                     mdl.AuditLogReason).ConfigureAwait(false);
                 await this.ApiClient.ModifyGuildMemberAsync(guild_id, member_id, Optional.FromNoValue<string>(),
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
-                    mdl.VoiceChannel.IfPresent(e => e?.Id), mdl.AuditLogReason).ConfigureAwait(false);
+                    mdl.VoiceChannel.IfPresent(e => e?.Id), default, mdl.AuditLogReason).ConfigureAwait(false);
             }
             else
             {
                 await this.ApiClient.ModifyGuildMemberAsync(guild_id, member_id, mdl.Nickname,
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
-                    mdl.VoiceChannel.IfPresent(e => e?.Id), mdl.AuditLogReason).ConfigureAwait(false);
+                    mdl.VoiceChannel.IfPresent(e => e?.Id), mdl.CommunicationDisabledUntil, mdl.AuditLogReason).ConfigureAwait(false);
             }
         }
 

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -829,7 +829,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Cannot place a member in a non-voice channel!"); // be a little more angry, let em learn!!1
 
             await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, member.Id, default, default, default,
-                default, this.Id, null).ConfigureAwait(false);
+                default, this.Id, default, null).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -66,6 +66,7 @@ namespace DSharpPlus.Entities
             this._avatarHash = mbr.AvatarHash;
             this._role_ids = mbr.Roles ?? new List<ulong>();
             this._role_ids_lazy = new Lazy<IReadOnlyList<ulong>>(() => new ReadOnlyCollection<ulong>(this._role_ids));
+            this.CommunicationDisabledUntil = mbr.CommunicationDisabledUntil;
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -97,6 +97,13 @@ namespace DSharpPlus.Entities
         public string DisplayName
             => this.Nickname ?? this.Username;
 
+
+        /// <summary>
+        /// How long this member's communication will be supressed for.
+        /// </summary>
+        [JsonProperty("communication_disabled_until",  NullValueHandling = NullValueHandling.Include)]
+        public DateTimeOffset? CommunicationDisabledUntil { get; internal set; }
+
         /// <summary>
         /// List of role ids
         /// </summary>
@@ -406,6 +413,14 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// Disables communications on the guild for this member.
+        /// </summary>
+        /// <param name="until">The time the restriction should be lifted. Set to <langword="null"/> to enable communication.</param>
+        /// <param name="reason">Why this member is being restricted.</param>
+        public Task DisableCommunicationAsync(DateTimeOffset? until, string reason = default)
+            => this.Discord.ApiClient.ModifyGuildMemberAsync(this._guild_id, this.Id, default, default, default, default, default, until, reason);
+
+        /// <summary>
         /// Sets this member's voice mute status.
         /// </summary>
         /// <param name="mute">Whether the member is to be muted.</param>
@@ -416,7 +431,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task SetMuteAsync(bool mute, string reason = null)
-            => this.Discord.ApiClient.ModifyGuildMemberAsync(this._guild_id, this.Id, default, default, mute, default, default, reason);
+            => this.Discord.ApiClient.ModifyGuildMemberAsync(this._guild_id, this.Id, default, default, mute, default, default, default, reason);
 
         /// <summary>
         /// Sets this member's voice deaf status.
@@ -429,7 +444,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task SetDeafAsync(bool deaf, string reason = null)
-            => this.Discord.ApiClient.ModifyGuildMemberAsync(this._guild_id, this.Id, default, default, default, deaf, default, reason);
+            => this.Discord.ApiClient.ModifyGuildMemberAsync(this._guild_id, this.Id, default, default, default, deaf, default, default, reason);
 
         /// <summary>
         /// Modifies this member.
@@ -455,13 +470,13 @@ namespace DSharpPlus.Entities
 
                 await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, Optional.FromNoValue<string>(),
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
-                    mdl.VoiceChannel.IfPresent(e => e?.Id), mdl.AuditLogReason).ConfigureAwait(false);
+                    mdl.VoiceChannel.IfPresent(e => e?.Id), default, mdl.AuditLogReason).ConfigureAwait(false);
             }
             else
             {
                 await this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, mdl.Nickname,
                     mdl.Roles.IfPresent(e => e.Select(xr => xr.Id)), mdl.Muted, mdl.Deafened,
-                    mdl.VoiceChannel.IfPresent(e => e?.Id), mdl.AuditLogReason).ConfigureAwait(false);
+                    mdl.VoiceChannel.IfPresent(e => e?.Id), mdl.CommunicationDisabledUntil, mdl.AuditLogReason).ConfigureAwait(false);
             }
         }
 
@@ -503,7 +518,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task ReplaceRolesAsync(IEnumerable<DiscordRole> roles, string reason = null)
             => this.Discord.ApiClient.ModifyGuildMemberAsync(this.Guild.Id, this.Id, default,
-                new Optional<IEnumerable<ulong>>(roles.Select(xr => xr.Id)), default, default, default, reason);
+                new Optional<IEnumerable<ulong>>(roles.Select(xr => xr.Id)), default, default, default, default, reason);
 
         /// <summary>
         /// Bans a this member from their guild.

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -414,11 +414,11 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Disables communications on the guild for this member.
+        /// Times-out a member and restricts their ability to send messages, add reactions, speak in threads, and join voice channels.
         /// </summary>
-        /// <param name="until">The time the restriction should be lifted. Set to <langword="null"/> to enable communication.</param>
+        /// <param name="until">How long the timeout should last. Set to <langword="null"/> or a time in the past to remove the timeout.</param>
         /// <param name="reason">Why this member is being restricted.</param>
-        public Task DisableCommunicationAsync(DateTimeOffset? until, string reason = default)
+        public Task TimeoutAsync(DateTimeOffset? until, string reason = default)
             => this.Discord.ApiClient.ModifyGuildMemberAsync(this._guild_id, this.Id, default, default, default, default, default, until, reason);
 
         /// <summary>

--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -280,7 +280,7 @@ namespace DSharpPlus
         [Obsolete("Replaced by UseApplicationCommands", false)]
         [PermissionString("Use slash commands")]
         UseSlashCommands = 0x0000000080000000,
-        
+
         /// <summary>
         /// Allows the user to use application commands.
         /// </summary>
@@ -312,7 +312,7 @@ namespace DSharpPlus
         [Obsolete("Replaced by CreatePrivateThreads and SendMessagesInThreads", false)]
         [PermissionString("Use Private Threads")]
         UsePrivateThreads = 0x0000001000000000,
-        
+
         /// <summary>
         /// Allows for creating public threads.
         /// </summary>
@@ -324,7 +324,7 @@ namespace DSharpPlus
         /// </summary>
         [PermissionString("Create Private Threads")]
         CreatePrivateThreads = 0x0000001000000000,
-        
+
         /// <summary>
         /// Allows the usage of custom stickers from other servers.
         /// </summary>
@@ -336,12 +336,18 @@ namespace DSharpPlus
         /// </summary>
         [PermissionString("Send messages in Threads")]
         SendMessagesInThreads = 0x0000004000000000,
-        
+
         /// <summary>
-        /// Allows for launching activities (applications with the `EMBEDDED` flag) in a voice channel.     
+        /// Allows for launching activities (applications with the `EMBEDDED` flag) in a voice channel.
         /// </summary>
         [PermissionString("Start Embedded Activities")]
-        StartEmbeddedActivities = 0x0000008000000000
+        StartEmbeddedActivities = 0x0000008000000000,
+
+        /// <summary>
+        /// Allows for moderating (Timeout) members in a guild.
+        /// </summary>
+        [PermissionString("Moderate Members")]
+        ModerateMembers = 0x0000010000000000
     }
 
     /// <summary>

--- a/DSharpPlus/EventArgs/Guild/Member/GuildMemberUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/Member/GuildMemberUpdateEventArgs.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using DSharpPlus.Entities;
 
@@ -75,6 +76,16 @@ namespace DSharpPlus.EventArgs
         /// Gets whether the member had passed membership screening after the update
         /// </summary>
         public bool? PendingAfter { get; internal set; }
+
+        /// <summary>
+        /// Gets the member's communication restriction before the update
+        /// </summary>
+        public DateTimeOffset? CommunicationDisabledUntilBefore { get; internal set; }
+
+        /// <summary>
+        /// Gets the member's communication restriction after the update
+        /// </summary>
+        public DateTimeOffset? CommunicationDisabledUntilAfter { get; internal set; }
 
         /// <summary>
         /// Gets the member that was updated.

--- a/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
@@ -194,7 +194,7 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("channel_id")]
         public Optional<ulong?> VoiceChannelId { get; set; }
 
-        [JsonProperty("communication_disbaled_until")]
+        [JsonProperty("communication_disabled_until", NullValueHandling = NullValueHandling.Include)]
         public Optional<DateTimeOffset?> CommunicationDisabledUntil { get; set; }
     }
 

--- a/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
@@ -193,6 +193,9 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("channel_id")]
         public Optional<ulong?> VoiceChannelId { get; set; }
+
+        [JsonProperty("communication_disbaled_until")]
+        public Optional<DateTimeOffset?> CommunicationDisabledUntil { get; set; }
     }
 
     internal sealed class RestGuildRolePayload

--- a/DSharpPlus/Net/Abstractions/Transport/TransportMember.cs
+++ b/DSharpPlus/Net/Abstractions/Transport/TransportMember.cs
@@ -41,6 +41,9 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("roles", NullValueHandling = NullValueHandling.Ignore)]
         public List<ulong> Roles { get; internal set; }
 
+        [JsonProperty("communication_disabled_until", NullValueHandling = NullValueHandling.Include)]
+        public DateTimeOffset? CommunicationDisabledUntil { get; internal set; }
+
         [JsonProperty("joined_at", NullValueHandling = NullValueHandling.Ignore)]
         public DateTime JoinedAt { get; internal set; }
 

--- a/DSharpPlus/Net/Models/MemberEditModel.cs
+++ b/DSharpPlus/Net/Models/MemberEditModel.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 using DSharpPlus.Entities;
 
@@ -37,7 +38,7 @@ namespace DSharpPlus.Net.Models
         /// </summary>
         public Optional<List<DiscordRole>> Roles { internal get; set; }
         /// <summary>
-        /// Whether this user should be muted
+        /// Whether this user should be muted in voice channels
         /// </summary>
         public Optional<bool> Muted { internal get; set; }
         /// <summary>
@@ -48,6 +49,11 @@ namespace DSharpPlus.Net.Models
         /// Voice channel to move this user to, set to null to kick
         /// </summary>
         public Optional<DiscordChannel> VoiceChannel { internal get; set; }
+
+        /// <summary>
+        /// Whether this member should have communication restricted
+        /// </summary>
+        public Optional<DateTimeOffset?> CommunicationDisabledUntil { internal get; set; }
 
         internal MemberEditModel()
         {

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1915,7 +1915,7 @@ namespace DSharpPlus.Net
 
         internal Task ModifyGuildMemberAsync(ulong guild_id, ulong user_id, Optional<string> nick,
             Optional<IEnumerable<ulong>> role_ids, Optional<bool> mute, Optional<bool> deaf,
-            Optional<ulong?> voice_channel_id, string reason)
+            Optional<ulong?> voice_channel_id, Optional<DateTimeOffset?> communication_disabled_until, string reason)
         {
             var headers = Utilities.GetBaseHeaders();
             if (!string.IsNullOrWhiteSpace(reason))
@@ -1927,7 +1927,8 @@ namespace DSharpPlus.Net
                 RoleIds = role_ids,
                 Deafen = deaf,
                 Mute = mute,
-                VoiceChannelId = voice_channel_id
+                VoiceChannelId = voice_channel_id,
+                CommunicationDisabledUntil = communication_disabled_until
             };
 
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id";


### PR DESCRIPTION
# Summary
A new field popped up on the member object a while ago, and this adds support for that. There's no UI for this in the client as of opening the PR, but the API accepts it, so I'm opening this PR preemptively.

# Details
Adds support for the `communication_disabled_until` guild member field. Tests soon:tm:


# Changes proposed

- Add CommunicationDisabledUntil to DiscordMember
- Add CommunicationDisabledUntil to TransportMember
- Add CommunicationDisabledUntilBefore to GuildMemberUpdatedEventArgs 
- Add CommunicationDisabledUntilAfter to GuildMemberUpdatedEventArgs 

- Add DisableCommunicationAsync to DiscordMember
- Add communication_disabled_until to the DiscordApiClient
- Add CommunicationDisabledUntil to the REST payload

# Notes
This is preemptive and the feature is not released; I'm going based on what can be seen from the API, but it should work fine. 