### PR TITLE
Interaction Modal Support

### DIFF
--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -115,6 +115,14 @@ namespace DSharpPlus.Interactivity
         }
 
         /// <summary>
+        /// Waits for a user to submit a modal.
+        /// </summary>
+        /// <param name="modal_id">The id of the modal to wait for.</param>
+        /// <param name="timeoutOverride">Override the timeout period in <see cref="InteractivityConfiguration"/>.</param>
+        public Task<InteractivityResult<ModalSubmitEventArgs>> WaitForModalAsync(string modal_id, TimeSpan? timeoutOverride = null)
+            => this.WaitForEventArgsAsync<ModalSubmitEventArgs>(m => m.Interaction.Data.CustomId == modal_id, timeoutOverride);
+
+        /// <summary>
         /// Waits for any button in the specified collection to be pressed.
         /// </summary>
         /// <param name="message">The message to wait on.</param>

--- a/DSharpPlus.Test/ModalCommand.cs
+++ b/DSharpPlus.Test/ModalCommand.cs
@@ -20,22 +20,16 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+using System.Threading.Tasks;
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
 using DSharpPlus.Entities;
 
-namespace DSharpPlus
+namespace DSharpPlus.Test
 {
-    /// <summary>
-    /// The style for a <see cref="DiscordModalInputComponent"/>
-    /// </summary>
-    public enum TextInputStyle
+    public class ModalCommand : BaseCommandModule
     {
-        /// <summary>
-        /// A short, single-line input
-        /// </summary>
-        Short = 1,
-        /// <summary>
-        /// A longer, multi-line input
-        /// </summary>
-        Paragraph = 2
+        [Command]
+        public async Task Modal(CommandContext ctx) => await ctx.RespondAsync(m => m.WithContent("\u200b").AddComponents(new DiscordButtonComponent(ButtonStyle.Primary, "modal", "Press for modal")));
     }
 }

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -69,7 +69,7 @@ namespace DSharpPlus.Test
             {
                 AutoReconnect = true,
                 LargeThreshold = 250,
-                MinimumLogLevel = LogLevel.Debug,
+                MinimumLogLevel = LogLevel.Trace,
                 Token = this.Config.Token,
                 TokenType = TokenType.Bot,
                 ShardId = shardid,

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -94,6 +94,8 @@ namespace DSharpPlus.Test
             this.Discord.ChannelDeleted += this.Discord_ChannelDeleted;
 
             this.Discord.InteractionCreated += this.Discord_InteractionCreated;
+            this.Discord.ComponentInteractionCreated+= this.Discord_ModalCheck;
+            this.Discord.ModalSubmitted += this.Discord_ModalSubmitted;
             //this.Discord.ComponentInteractionCreated += this.RoleMenu;
             //this.Discord.ComponentInteractionCreated += this.DiscordComponentInteractionCreated;
             //this.Discord.InteractionCreated += this.SendButton;
@@ -176,6 +178,23 @@ namespace DSharpPlus.Test
 
             //    _ = Task.Run(async () => await e.Message.RespondAsync(e.Message.Content)).ConfigureAwait(false);
             //};
+        }
+
+
+        private async Task Discord_ModalSubmitted(DiscordClient sender, ModalSubmitEventArgs e)
+        {
+            await e.Interaction.CreateResponseAsync(InteractionResponseType.UpdateMessage, new DiscordInteractionResponseBuilder().WithContent("Thank you!"));
+
+            this.Discord.Logger.LogInformation("Got callback from user {User}, {Modal}", e.Interaction.User, e.Values);
+        }
+
+        private async Task Discord_ModalCheck(DiscordClient sender, ComponentInteractionCreateEventArgs e)
+        {
+            if (e.Id == "modal")
+                await e.Interaction.CreateResponseAsync(InteractionResponseType.Modal, new DiscordInteractionResponseBuilder()
+                    .WithTitle("Test!")
+                    .WithCustomId("owo")
+                    .AddComponents(new DiscordModalInputComponent("Some label", "some_id", "Placeholder!")));
         }
 
         private async Task Discord_InteractionCreated(DiscordClient sender, InteractionCreateEventArgs e)

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -194,7 +194,11 @@ namespace DSharpPlus.Test
                 await e.Interaction.CreateResponseAsync(InteractionResponseType.Modal, new DiscordInteractionResponseBuilder()
                     .WithTitle("Test!")
                     .WithCustomId("owo")
-                    .AddComponents(new DiscordModalInputComponent("Some label", "some_id", "Placeholder!")));
+                    .AddComponents(new DiscordModalInputComponent("Short, optional", "short_opt", "Placeholder!"))
+                    .AddComponents(new DiscordModalInputComponent("Long, optional", "long_opt", "Placeholder 2!", style: TextInputStyle.Paragraph))
+                    .AddComponents(new DiscordModalInputComponent("Short, required", "short_req", "Placeholder 3!", style:  TextInputStyle.Short, min_length: 10, max_length: 20))
+                    .AddComponents(new DiscordModalInputComponent("Long, required", "long_req", "Placeholder 4!", "Lorem Ipsum", true, TextInputStyle.Paragraph, 100, 300))
+                );
         }
 
         private async Task Discord_InteractionCreated(DiscordClient sender, InteractionCreateEventArgs e)

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -94,7 +94,7 @@ namespace DSharpPlus.Test
             this.Discord.ChannelDeleted += this.Discord_ChannelDeleted;
 
             this.Discord.InteractionCreated += this.Discord_InteractionCreated;
-            this.Discord.ComponentInteractionCreated+= this.Discord_ModalCheck;
+            this.Discord.ComponentInteractionCreated += this.Discord_ModalCheck;
             this.Discord.ModalSubmitted += this.Discord_ModalSubmitted;
             //this.Discord.ComponentInteractionCreated += this.RoleMenu;
             //this.Discord.ComponentInteractionCreated += this.DiscordComponentInteractionCreated;

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -194,10 +194,10 @@ namespace DSharpPlus.Test
                 await e.Interaction.CreateResponseAsync(InteractionResponseType.Modal, new DiscordInteractionResponseBuilder()
                     .WithTitle("Test!")
                     .WithCustomId("owo")
-                    .AddComponents(new DiscordModalInputComponent("Short, optional", "short_opt", "Placeholder!"))
-                    .AddComponents(new DiscordModalInputComponent("Long, optional", "long_opt", "Placeholder 2!", style: TextInputStyle.Paragraph))
-                    .AddComponents(new DiscordModalInputComponent("Short, required", "short_req", "Placeholder 3!", style:  TextInputStyle.Short, min_length: 10, max_length: 20))
-                    .AddComponents(new DiscordModalInputComponent("Long, required", "long_req", "Placeholder 4!", "Lorem Ipsum", true, TextInputStyle.Paragraph, 100, 300))
+                    .AddComponents(new TextInputComponent("Short, optional", "short_opt", "Placeholder!"))
+                    .AddComponents(new TextInputComponent("Long, optional", "long_opt", "Placeholder 2!", style: TextInputStyle.Paragraph))
+                    .AddComponents(new TextInputComponent("Short, required", "short_req", "Placeholder 3!", style:  TextInputStyle.Short, min_length: 10, max_length: 20))
+                    .AddComponents(new TextInputComponent("Long, required", "long_req", "Placeholder 4!", "Lorem Ipsum", true, TextInputStyle.Paragraph, 100, 300))
                 );
         }
 

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -2350,6 +2350,12 @@ namespace DSharpPlus
 
                 await this._componentInteractionCreated.InvokeAsync(this, cea).ConfigureAwait(false);
             }
+            else if (interaction.Type is InteractionType.ModalSubmit)
+            {
+                var mea = new ModalSubmitEventArgs(interaction);
+
+                await this._modalSubmitted.InvokeAsync(this, mea).ConfigureAwait(false);
+            }
             else
             {
                 if (interaction.Data.Target.HasValue) // Context-Menu. //

--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -777,6 +777,17 @@ namespace DSharpPlus
         private AsyncEvent<DiscordClient, ComponentInteractionCreateEventArgs> _componentInteractionCreated;
 
         /// <summary>
+        /// Fired when a modal is submitted. If a modal is closed, this event is not fired.
+        /// </summary>
+        public event AsyncEventHandler<DiscordClient, ModalSubmitEventArgs> ModalSubmitted
+        {
+            add => this._modalSubmitted.Register(value);
+            remove => this._modalSubmitted.Unregister(value);
+        }
+
+        private AsyncEvent<DiscordClient, ModalSubmitEventArgs> _modalSubmitted;
+
+        /// <summary>
         /// Fired when a user uses a context menu.
         /// </summary>
         public event AsyncEventHandler<DiscordClient, ContextMenuInteractionCreateEventArgs> ContextMenuInteractionCreated

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -190,6 +190,7 @@ namespace DSharpPlus
             this._messagesBulkDeleted = new AsyncEvent<DiscordClient, MessageBulkDeleteEventArgs>("MESSAGE_BULK_DELETED", EventExecutionLimit, this.EventErrorHandler);
             this._interactionCreated = new AsyncEvent<DiscordClient, InteractionCreateEventArgs>("INTERACTION_CREATED", EventExecutionLimit, this.EventErrorHandler);
             this._componentInteractionCreated = new AsyncEvent<DiscordClient, ComponentInteractionCreateEventArgs>("COMPONENT_INTERACTED", EventExecutionLimit, this.EventErrorHandler);
+            this._modalSubmitted = new AsyncEvent<DiscordClient, ModalSubmitEventArgs>("MODAL_SUBMITTED", EventExecutionLimit, this.EventErrorHandler);
             this._contextMenuInteractionCreated = new AsyncEvent<DiscordClient, ContextMenuInteractionCreateEventArgs>("CONTEXT_MENU_INTERACTED", EventExecutionLimit, this.EventErrorHandler);
             this._typingStarted = new AsyncEvent<DiscordClient, TypingStartEventArgs>("TYPING_STARTED", EventExecutionLimit, this.EventErrorHandler);
             this._userSettingsUpdated = new AsyncEvent<DiscordClient, UserSettingsUpdateEventArgs>("USER_SETTINGS_UPDATED", EventExecutionLimit, this.EventErrorHandler);

--- a/DSharpPlus/Clients/DiscordShardedClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.Events.cs
@@ -762,6 +762,16 @@ namespace DSharpPlus
         private AsyncEvent<DiscordClient, ComponentInteractionCreateEventArgs> _componentInteractionCreated;
 
         /// <summary>
+        /// Fired when a modal is submitted. If a modal is closed, this event will not be fired.
+        /// </summary>
+        public event AsyncEventHandler<DiscordClient, ModalSubmitEventArgs> ModalSubmitted
+        {
+            add => this._modalSubmitted.Register(value);
+            remove => this._modalSubmitted.Unregister(value);
+        }
+        private AsyncEvent<DiscordClient, ModalSubmitEventArgs> _modalSubmitted;
+
+        /// <summary>
         /// Fired when a user uses a context menu.
         /// </summary>
         public event AsyncEventHandler<DiscordClient, ContextMenuInteractionCreateEventArgs> ContextMenuInteractionCreated
@@ -979,6 +989,9 @@ namespace DSharpPlus
 
         private Task Client_ComponentInteractionCreate(DiscordClient client, ComponentInteractionCreateEventArgs e)
             => this._componentInteractionCreated.InvokeAsync(client, e);
+
+        private Task Client_ModalSubmitted(DiscordClient client, ModalSubmitEventArgs e)
+            => this._modalSubmitted.InvokeAsync(client, e);
 
         private Task Client_ContextMenuInteractionCreate(DiscordClient client, ContextMenuInteractionCreateEventArgs e)
             => this._contextMenuInteractionCreated.InvokeAsync(client, e);

--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -472,6 +472,7 @@ namespace DSharpPlus
             this._messageBulkDeleted = new AsyncEvent<DiscordClient, MessageBulkDeleteEventArgs>("MESSAGE_BULK_DELETED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._interactionCreated = new AsyncEvent<DiscordClient, InteractionCreateEventArgs>("INTERACTION_CREATED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._componentInteractionCreated = new AsyncEvent<DiscordClient, ComponentInteractionCreateEventArgs>("COMPONENT_INTERACTED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
+            this._modalSubmitted = new AsyncEvent<DiscordClient, ModalSubmitEventArgs>("MODAL_SUBMITTED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._contextMenuInteractionCreated = new AsyncEvent<DiscordClient, ContextMenuInteractionCreateEventArgs>("CONTEXT_MENU_INTERACTED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._typingStarted = new AsyncEvent<DiscordClient, TypingStartEventArgs>("TYPING_STARTED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
             this._userSettingsUpdated = new AsyncEvent<DiscordClient, UserSettingsUpdateEventArgs>("USER_SETTINGS_UPDATED", DiscordClient.EventExecutionLimit, this.EventErrorHandler);
@@ -546,6 +547,7 @@ namespace DSharpPlus
             client.MessagesBulkDeleted += this.Client_MessageBulkDelete;
             client.InteractionCreated += this.Client_InteractionCreate;
             client.ComponentInteractionCreated += this.Client_ComponentInteractionCreate;
+            client.ModalSubmitted += this.Client_ModalSubmitted;
             client.ContextMenuInteractionCreated += this.Client_ContextMenuInteractionCreate;
             client.TypingStarted += this.Client_TypingStart;
             client.UserSettingsUpdated += this.Client_UserSettingsUpdate;
@@ -617,6 +619,7 @@ namespace DSharpPlus
             client.MessagesBulkDeleted -= this.Client_MessageBulkDelete;
             client.InteractionCreated -= this.Client_InteractionCreate;
             client.ComponentInteractionCreated -= this.Client_ComponentInteractionCreate;
+            client.ModalSubmitted -= this.Client_ModalSubmitted;
             client.ContextMenuInteractionCreated -= this.Client_ContextMenuInteractionCreate;
             client.TypingStarted -= this.Client_TypingStart;
             client.UserSettingsUpdated -= this.Client_UserSettingsUpdate;

--- a/DSharpPlus/Entities/Interaction/Components/DiscordModalInputComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordModalInputComponent.cs
@@ -48,10 +48,10 @@ namespace DSharpPlus.Entities
         public string Value { get; internal set; }
 
         /// <summary>
-        /// Optional minimum length for this input. Must be a positive integer, if set.
+        /// Optional minimum length for this input. Set to 0 for optional.
         /// </summary>
         [JsonProperty("min_length", NullValueHandling = NullValueHandling.Ignore)]
-        public int? MinimumLength { get; set; }
+        public int MinimumLength { get; set; }
 
         /// <summary>
         /// Optional maximum length for this input. Must be a positive integer, if set.
@@ -70,7 +70,7 @@ namespace DSharpPlus.Entities
             this.Type = ComponentType.FormInput;
         }
 
-        public DiscordModalInputComponent(string label, string customId, string placeholder = null, TextInputStyle style = TextInputStyle.Short, int? min_length = null, int? max_length = null)
+        public DiscordModalInputComponent(string label, string customId, string placeholder = null, TextInputStyle style = TextInputStyle.Short, int min_length = 0, int? max_length = null)
         {
             this.CustomId = customId;
             this.Type = ComponentType.FormInput;

--- a/DSharpPlus/Entities/Interaction/Components/DiscordModalInputComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordModalInputComponent.cs
@@ -42,13 +42,13 @@ namespace DSharpPlus.Entities
         public string Label { get; set; }
 
         /// <summary>
-        /// Readonly value for this input.
+        /// Pre-filled value for this input.
         /// </summary>
         [JsonProperty("value")]
-        public string Value { get; internal set; }
+        public string Value { get; set; }
 
         /// <summary>
-        /// Optional minimum length for this input. Set to 0 for optional.
+        /// Optional minimum length for this input.
         /// </summary>
         [JsonProperty("min_length", NullValueHandling = NullValueHandling.Ignore)]
         public int MinimumLength { get; set; }
@@ -58,6 +58,12 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("max_length", NullValueHandling = NullValueHandling.Ignore)]
         public int? MaximumLength { get; set; }
+
+        /// <summary>
+        /// Whether this input is required.
+        /// </summary>
+        [JsonProperty("required")]
+        public bool Required { get; set; }
 
         /// <summary>
         /// Style of this input.
@@ -70,7 +76,18 @@ namespace DSharpPlus.Entities
             this.Type = ComponentType.FormInput;
         }
 
-        public DiscordModalInputComponent(string label, string customId, string placeholder = null, TextInputStyle style = TextInputStyle.Short, int min_length = 0, int? max_length = null)
+        /// <summary>
+        /// Constructs a new text input field.
+        /// </summary>
+        /// <param name="label">The label for the field, placed above the input itself.</param>
+        /// <param name="customId">The ID of this field.</param>
+        /// <param name="placeholder">Placeholder text for the field.</param>
+        /// <param name="value">A pre-filled value for this field.</param>
+        /// <param name="required">Whether this field is required.</param>
+        /// <param name="style">The style of this field. A single-ling short, or multi-line paragraph.</param>
+        /// <param name="min_length">The minimum input length.</param>
+        /// <param name="max_length">The maximum input length. Must be greater than the minimum, if set.</param>
+        public DiscordModalInputComponent(string label, string customId, string placeholder = null, string value = null, bool required = true, TextInputStyle style = TextInputStyle.Short, int min_length = 0, int? max_length = null)
         {
             this.CustomId = customId;
             this.Type = ComponentType.FormInput;

--- a/DSharpPlus/Entities/Interaction/Components/DiscordModalInputComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordModalInputComponent.cs
@@ -27,7 +27,7 @@ namespace DSharpPlus.Entities
     /// <summary>
     /// A text-input field. Like selects, this can only be used once per action row.
     /// </summary>
-    public sealed class DiscordTextInputComponent : DiscordComponent
+    public sealed class DiscordModalInputComponent : DiscordComponent
     {
         /// <summary>
         /// Optional placeholder text for this input.
@@ -65,12 +65,12 @@ namespace DSharpPlus.Entities
         [JsonProperty("style")]
         public TextInputStyle Style { get; set; }
 
-        public DiscordTextInputComponent()
+        public DiscordModalInputComponent()
         {
             this.Type = ComponentType.FormInput;
         }
 
-        public DiscordTextInputComponent(string label, string customId, string placeholder = null, TextInputStyle style = TextInputStyle.Short, int? min_length = null, int? max_length = null)
+        public DiscordModalInputComponent(string label, string customId, string placeholder = null, TextInputStyle style = TextInputStyle.Short, int? min_length = null, int? max_length = null)
         {
             this.CustomId = customId;
             this.Type = ComponentType.FormInput;

--- a/DSharpPlus/Entities/Interaction/Components/DiscordTextInputComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordTextInputComponent.cs
@@ -1,0 +1,84 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2021 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Entities
+{
+    /// <summary>
+    /// A text-input field. Like selects, this can only be used once per action row.
+    /// </summary>
+    public sealed class DiscordTextInputComponent : DiscordComponent
+    {
+        /// <summary>
+        /// Optional placeholder text for this input.
+        /// </summary>
+        [JsonProperty("placeholder", NullValueHandling = NullValueHandling.Ignore)]
+        public string Placeholder { get; set; }
+
+        /// <summary>
+        /// Label text to put above this input.
+        /// </summary>
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
+        /// <summary>
+        /// Readonly value for this input.
+        /// </summary>
+        [JsonProperty("value")]
+        public string Value { get; internal set; }
+
+        /// <summary>
+        /// Optional minimum length for this input. Must be a positive integer, if set.
+        /// </summary>
+        [JsonProperty("min_length", NullValueHandling = NullValueHandling.Ignore)]
+        public int? MinimumLength { get; set; }
+
+        /// <summary>
+        /// Optional maximum length for this input. Must be a positive integer, if set.
+        /// </summary>
+        [JsonProperty("max_length", NullValueHandling = NullValueHandling.Ignore)]
+        public int? MaximumLength { get; set; }
+
+        /// <summary>
+        /// Style of this input.
+        /// </summary>
+        [JsonProperty("style")]
+        public TextInputStyle Style { get; set; }
+
+        public DiscordTextInputComponent()
+        {
+            this.Type = ComponentType.FormInput;
+        }
+
+        public DiscordTextInputComponent(string label, string customId, string placeholder = null, TextInputStyle style = TextInputStyle.Short, int? min_length = null, int? max_length = null)
+        {
+            this.CustomId = customId;
+            this.Type = ComponentType.FormInput;
+            this.Label = label;
+            this.Placeholder = placeholder;
+            this.MinimumLength = min_length;
+            this.MaximumLength = max_length;
+            this.Style = style;
+        }
+    }
+}

--- a/DSharpPlus/Entities/Interaction/Components/TextInputComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/TextInputComponent.cs
@@ -96,6 +96,7 @@ namespace DSharpPlus.Entities
             this.MinimumLength = min_length;
             this.MaximumLength = max_length;
             this.Style = style;
+            this.Value = value;
         }
     }
 }

--- a/DSharpPlus/Entities/Interaction/Components/TextInputComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/TextInputComponent.cs
@@ -27,7 +27,7 @@ namespace DSharpPlus.Entities
     /// <summary>
     /// A text-input field. Like selects, this can only be used once per action row.
     /// </summary>
-    public sealed class DiscordModalInputComponent : DiscordComponent
+    public sealed class TextInputComponent : DiscordComponent
     {
         /// <summary>
         /// Optional placeholder text for this input.
@@ -71,7 +71,7 @@ namespace DSharpPlus.Entities
         [JsonProperty("style")]
         public TextInputStyle Style { get; set; }
 
-        public DiscordModalInputComponent()
+        public TextInputComponent()
         {
             this.Type = ComponentType.FormInput;
         }
@@ -87,7 +87,7 @@ namespace DSharpPlus.Entities
         /// <param name="style">The style of this field. A single-ling short, or multi-line paragraph.</param>
         /// <param name="min_length">The minimum input length.</param>
         /// <param name="max_length">The maximum input length. Must be greater than the minimum, if set.</param>
-        public DiscordModalInputComponent(string label, string customId, string placeholder = null, string value = null, bool required = true, TextInputStyle style = TextInputStyle.Short, int min_length = 0, int? max_length = null)
+        public TextInputComponent(string label, string customId, string placeholder = null, string value = null, bool required = true, TextInputStyle style = TextInputStyle.Short, int min_length = 0, int? max_length = null)
         {
             this.CustomId = customId;
             this.Type = ComponentType.FormInput;

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
@@ -31,6 +31,12 @@ namespace DSharpPlus.Entities
         [JsonProperty("tts", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsTTS { get; internal set; }
 
+        [JsonProperty("custom_id", NullValueHandling = NullValueHandling.Ignore)]
+        public string CustomId { get; internal set; }
+
+        [JsonProperty("title", NullValueHandling = NullValueHandling.Ignore)]
+        public string Title { get; internal set; }
+
         [JsonProperty("content", NullValueHandling = NullValueHandling.Ignore)]
         public string Content { get; internal set; }
 

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionData.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionData.cs
@@ -51,10 +51,24 @@ namespace DSharpPlus.Entities
         public DiscordInteractionResolvedCollection Resolved { get; internal set; }
 
         /// <summary>
-        /// The Id of the component that invoked this interaction, if applicable.
+        /// The Id of the component that invoked this interaction, or the Id of the modal the interaction was spawned from.
         /// </summary>
         [JsonProperty("custom_id", NullValueHandling = NullValueHandling.Ignore)]
         public string CustomId { get; internal set; }
+
+        /// <summary>
+        /// The title of the modal, if applicable.
+        /// </summary>
+        [JsonProperty("title", NullValueHandling = NullValueHandling.Ignore)]
+        public string Title { get; internal set; }
+
+        /// <summary>
+        /// Components on this interaction. Only applies to modal interactions.
+        /// </summary>
+        public IReadOnlyList<DiscordActionRowComponent> Components => this._components;
+
+        [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
+        internal List<DiscordActionRowComponent> _components;
 
         /// <summary>
         /// The Id of the target. Applicable for context menus.

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -147,6 +147,34 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// If responding with a modal, sets the title of the modal.
+        /// </summary>
+        /// <param name="title"></param>
+        /// <returns></returns>
+        public DiscordInteractionResponseBuilder WithTitle(string title)
+        {
+            if (string.IsNullOrEmpty(title) || title.Length > 256)
+                throw new ArgumentException("Title must be between 1 and 256 characters.");
+
+            this.Title = title;
+            return this;
+        }
+
+        /// <summary>
+        /// If responding with a modal, sets the custom id for the modal.
+        /// </summary>
+        /// <param name="title"></param>
+        /// <returns></returns>
+        public DiscordInteractionResponseBuilder WithCustomId(string id)
+        {
+            if (string.IsNullOrEmpty(id) || id.Length > 100)
+                throw new ArgumentException("Custom ID must be between 1 and 100 characters.");
+
+            this.CustomId = id;
+            return this;
+        }
+
+        /// <summary>
         /// Appends a collection of components to the builder. Each call will append to a new row.
         /// </summary>
         /// <param name="components">The components to append. Up to five.</param>

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -46,6 +46,16 @@ namespace DSharpPlus.Entities
         public bool IsEphemeral { get; set; }
 
         /// <summary>
+        /// The custom id to send with this interaction response. Only applicable when creating a modal.
+        /// </summary>
+        public string CustomId { get; set; }
+
+        /// <summary>
+        /// The title to send with this interaction response. Only applicable
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
         /// Content of the message to send.
         /// </summary>
         public string Content

--- a/DSharpPlus/Enums/Interaction/ComponentType.cs
+++ b/DSharpPlus/Enums/Interaction/ComponentType.cs
@@ -38,6 +38,10 @@ namespace DSharpPlus
         /// <summary>
         /// A select menu.
         /// </summary>
-        Select = 3
+        Select = 3,
+        /// <summary>
+        /// An input field.
+        /// </summary>
+        FormInput = 4,
     }
 }

--- a/DSharpPlus/Enums/Interaction/InteractionType.cs
+++ b/DSharpPlus/Enums/Interaction/InteractionType.cs
@@ -47,5 +47,10 @@ namespace DSharpPlus
         /// An autocomplete field.
         /// </summary>
         AutoComplete = 4,
+
+        /// <summary>
+        /// A modal was submitted.
+        /// </summary>
+        ModalSubmit = 5
     }
 }

--- a/DSharpPlus/Enums/Interaction/TextInputStyle.cs
+++ b/DSharpPlus/Enums/Interaction/TextInputStyle.cs
@@ -20,47 +20,20 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
-
 namespace DSharpPlus
 {
     /// <summary>
-    /// Represents the type of interaction response
+    /// The style for a <see cref="DSharpPlus.Entities.DiscordTextInputComponent"/>
     /// </summary>
-    public enum InteractionResponseType
+    public enum TextInputStyle
     {
         /// <summary>
-        /// Acknowledges a Ping.
+        /// A short, single-line input
         /// </summary>
-        Pong = 1,
-
+        Short,
         /// <summary>
-        /// Responds to the interaction with a message.
+        /// A longer, multi-line input
         /// </summary>
-        ChannelMessageWithSource = 4,
-
-        /// <summary>
-        /// Acknowledges an interaction to edit to a response later. The user sees a "thinking" state.
-        /// </summary>
-        DeferredChannelMessageWithSource = 5,
-
-        /// <summary>
-        /// Acknowledges a component interaction to allow a response later.
-        /// </summary>
-        DeferredMessageUpdate = 6,
-
-        /// <summary>
-        /// Responds to a component interaction by editing the message it's attached to.
-        /// </summary>
-        UpdateMessage = 7,
-
-        /// <summary>
-        /// Responds to an auto-complete request.
-        /// </summary>
-        AutoCompleteResult = 8,
-
-        /// <summary>
-        /// Respond to an interaction with a modal popup.
-        /// </summary>
-        Modal = 9,
+        Paragraph
     }
 }

--- a/DSharpPlus/Enums/Interaction/TextInputStyle.cs
+++ b/DSharpPlus/Enums/Interaction/TextInputStyle.cs
@@ -25,7 +25,7 @@ using DSharpPlus.Entities;
 namespace DSharpPlus
 {
     /// <summary>
-    /// The style for a <see cref="DiscordModalInputComponent"/>
+    /// The style for a <see cref="TextInputComponent"/>
     /// </summary>
     public enum TextInputStyle
     {

--- a/DSharpPlus/EventArgs/Interaction/ModalSubmitEventArgs.cs
+++ b/DSharpPlus/EventArgs/Interaction/ModalSubmitEventArgs.cs
@@ -37,7 +37,7 @@ namespace DSharpPlus.EventArgs
         /// A dictionary of submitted fields, keyed on the custom id of the input component.
         /// </summary>
         [JsonIgnore]
-        public IReadOnlyDictionary<string, string> Values { get; internal set; }
+        public IReadOnlyDictionary<string, string> Values { get; }
 
         internal ModalSubmitEventArgs(DiscordInteraction interaction)
         {
@@ -46,7 +46,7 @@ namespace DSharpPlus.EventArgs
             var dict = new Dictionary<string, string>();
 
             foreach (var component in interaction.Data._components)
-                if (component.Components.First() is DiscordModalInputComponent input)
+                if (component.Components.First() is TextInputComponent input)
                     dict.Add(input.CustomId, input.Value);
 
             this.Values = dict;

--- a/DSharpPlus/EventArgs/Interaction/ModalSubmitEventArgs.cs
+++ b/DSharpPlus/EventArgs/Interaction/ModalSubmitEventArgs.cs
@@ -46,8 +46,10 @@ namespace DSharpPlus.EventArgs
             var dict = new Dictionary<string, string>();
 
             foreach (var component in interaction.Data._components)
-                if (component.Components.First() is DiscordTextInputComponent input)
+                if (component.Components.First() is DiscordModalInputComponent input)
                     dict.Add(input.CustomId, input.Value);
+
+            this.Values = dict;
         }
     }
 }

--- a/DSharpPlus/EventArgs/Interaction/ModalSubmitEventArgs.cs
+++ b/DSharpPlus/EventArgs/Interaction/ModalSubmitEventArgs.cs
@@ -20,47 +20,34 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using DSharpPlus.Entities;
+using Newtonsoft.Json;
 
-namespace DSharpPlus
+namespace DSharpPlus.EventArgs
 {
     /// <summary>
-    /// Represents the type of interaction response
+    /// Fired when a modal is submitted. Note that this event is fired only if the modal is submitted by the user, and not if the modal is closed.
     /// </summary>
-    public enum InteractionResponseType
+    public class ModalSubmitEventArgs : InteractionCreateEventArgs
     {
         /// <summary>
-        /// Acknowledges a Ping.
+        /// A dictionary of submitted fields, keyed on the custom id of the input component.
         /// </summary>
-        Pong = 1,
+        [JsonIgnore]
+        public IReadOnlyDictionary<string, string> Values { get; internal set; }
 
-        /// <summary>
-        /// Responds to the interaction with a message.
-        /// </summary>
-        ChannelMessageWithSource = 4,
+        internal ModalSubmitEventArgs(DiscordInteraction interaction)
+        {
+            this.Interaction = interaction;
 
-        /// <summary>
-        /// Acknowledges an interaction to edit to a response later. The user sees a "thinking" state.
-        /// </summary>
-        DeferredChannelMessageWithSource = 5,
+            var dict = new Dictionary<string, string>();
 
-        /// <summary>
-        /// Acknowledges a component interaction to allow a response later.
-        /// </summary>
-        DeferredMessageUpdate = 6,
-
-        /// <summary>
-        /// Responds to a component interaction by editing the message it's attached to.
-        /// </summary>
-        UpdateMessage = 7,
-
-        /// <summary>
-        /// Responds to an auto-complete request.
-        /// </summary>
-        AutoCompleteResult = 8,
-
-        /// <summary>
-        /// Respond to an interaction with a modal popup.
-        /// </summary>
-        Modal = 9,
+            foreach (var component in interaction.Data._components)
+                if (component.Components.First() is DiscordTextInputComponent input)
+                    dict.Add(input.CustomId, input.Value);
+        }
     }
 }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -3119,6 +3119,8 @@ namespace DSharpPlus.Net
                 Data = builder != null ? new DiscordInteractionApplicationCommandCallbackData
                 {
                     Content = builder.Content,
+                    Title = builder.Title,
+                    CustomId = builder.CustomId,
                     Embeds = builder.Embeds,
                     IsTTS = builder.IsTTS,
                     Mentions = new DiscordMentions(builder.Mentions ?? Mentions.All, builder.Mentions?.Any() ?? false),

--- a/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
@@ -48,6 +48,7 @@ namespace DSharpPlus.Net.Serialization
                 ComponentType.ActionRow => new DiscordActionRowComponent(),
                 ComponentType.Button => new DiscordButtonComponent(),
                 ComponentType.Select => new DiscordSelectComponent(),
+                ComponentType.FormInput => new DiscordModalInputComponent(),
                 _ => new DiscordComponent() { Type = type.Value }
             };
 

--- a/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
@@ -48,7 +48,7 @@ namespace DSharpPlus.Net.Serialization
                 ComponentType.ActionRow => new DiscordActionRowComponent(),
                 ComponentType.Button => new DiscordButtonComponent(),
                 ComponentType.Select => new DiscordSelectComponent(),
-                ComponentType.FormInput => new DiscordModalInputComponent(),
+                ComponentType.FormInput => new TextInputComponent(),
                 _ => new DiscordComponent() { Type = type.Value }
             };
 


### PR DESCRIPTION
# Summary
Adds support for Discord's new form input/modal interaction flow. 

# Details
This isn't even in a beta yet, so I'm unable to test. 

I've added the requisites of a new interaction type, event args, dispatch, etc.

# Changes proposed
```diff
+ Add new interaction resp type: Modal (9)
+ Add new interaction type: ModalSubmit (5)
+ Add Title and Description to DiscordInteractionResposneBuilder
+ Add Title and Description to REST payloads
+ Add new event args, with convience dictionary for pulling repsonse data
+ Add ModalSubmitted event to DiscordClient & DiscordShardedClient
```

# Notes
**This isn't even in beta, so testing will be postponed.**

Also I added a single itneractivity method, because you're probably better off just hooking an event handler, but meh.