### PR TITLE
Added mention of ChannelTypes Attribute

### DIFF
--- a/DSharpPlus.SlashCommands/README.md
+++ b/DSharpPlus.SlashCommands/README.md
@@ -107,7 +107,7 @@ Arguments must have the `Option` attribute, and can be of type:
 
 If you want to make them optional, you can assign a default value.
 
-You can also predefine some choices for the option. Choices only work for `string`, `long` or `double` arguments. THere are several ways to use them:
+You can also predefine some choices for the option. Custom choices only work for `string`, `long` or `double` arguments (for `DiscordChannel` arguments, `ChannelTypes` attribute can be used to limit the types of channels that can be chosen). There are several ways to use them:
 1. Using the `Choice` attribute. You can add multiple attributes to add multiple choices.
 2. You can define choices using enums. See the example below.
 3. You can use a `ChoiceProvider` to run code to get the choices from a database or similar. See the example below.


### PR DESCRIPTION
Added that the ChannelTypes attribute can be used to limit choices for DiscordChannel type option

# Summary
Added mention of ChannelTypes attribute in Readme

# Details
Added "(for `DiscordChannel` arguments, `ChannelTypes` attribute can be used to limit the types of channels that can be chosen)" to the ReadMe

# Changes proposed
* Documentation change for SlashCommands ReadMe

# Notes
There is probably a better way to word the description, but I think it should be mentioned in the docs because it is mentioned that choices can be defined only for other types