### PR TITLE
Fix broken slash commands group discord developer docs link

### DIFF
--- a/DSharpPlus.SlashCommands/README.md
+++ b/DSharpPlus.SlashCommands/README.md
@@ -169,7 +169,7 @@ public async Task ChoiceProviderCommand(InteractionContext ctx,
 ```
 
 ### Groups
-You can have slash commands in groups. Their structure is explained [here](https://discord.com/developers/docs/interactions/slash-commands#nested-subcommands-and-groups). You can simply mark your command class with the `[SlashCommandGroup]` attribute.
+You can have slash commands in groups. Their structure is explained [here](https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups). You can simply mark your command class with the `[SlashCommandGroup]` attribute.
 ```cs
 //for regular groups
 [SlashCommandGroup("group", "description")]

--- a/DSharpPlus.SlashCommands/README.md
+++ b/DSharpPlus.SlashCommands/README.md
@@ -107,7 +107,7 @@ Arguments must have the `Option` attribute, and can be of type:
 
 If you want to make them optional, you can assign a default value.
 
-You can also predefine some choices for the option. Choices only work for `string`, `long` or `double` arguments. THere are several ways to use them:
+You can also predefine some choices for the option. Custom choices only work for `string`, `long` or `double` arguments (for `DiscordChannel` arguments, `ChannelTypes` attribute can be used to limit the types of channels that can be chosen). There are several ways to use them:
 1. Using the `Choice` attribute. You can add multiple attributes to add multiple choices.
 2. You can define choices using enums. See the example below.
 3. You can use a `ChoiceProvider` to run code to get the choices from a database or similar. See the example below.


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Old link to the Discord developer docs for Slash Command Groups was broken

# Details
I replaced it with the new "application commands" link to the groups section

# Changes proposed
Just hyperlink was replaced
