### PR TITLE
Add Connected event and deprecate Ready in order to clarify usage

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -72,12 +72,22 @@ namespace DSharpPlus
         /// <summary>
         /// Fired when the client enters ready state.
         /// </summary>
+	[Obsolete("This event is being replaced with DiscordClient.Connected to clarify it's meaning. Please use this instead!")]
         public event AsyncEventHandler<DiscordClient, ReadyEventArgs> Ready
         {
             add => this._ready.Register(value);
             remove => this._ready.Unregister(value);
         }
         private AsyncEvent<DiscordClient, ReadyEventArgs> _ready;
+	
+	/// <summary>
+	/// Fired when the client enters ready state (connection established).
+	/// </summary>
+	public event AsyncEventHandler<DiscordClient, ReadyEventArgs> Connected
+	{
+	    add => this._ready.Register(value);
+	    remove => this._ready.Unregister(value);
+	}
 
         /// <summary>
         /// Fired whenever a session is resumed.


### PR DESCRIPTION
# Summary
Fixes #issue/Resolves #issue/Implements functionality. Short description of changes.
Rename Ready to Connected

# Details
You can put detailed description of the changes in here.
The Ready event is fired when the bot is connected to the websocket, not when the bot is fully ready (aka downloaded guilds etc).

# Changes proposed
Rename Ready event to Connected in a way that doesnt break semver

# Notes
Any additional notes go here.
This was quickly whipped up over an ssh session and untested.