### PR TITLE
Cleanup DiscordUser#GetAvatarUrl and add DiscordMember#GetGuildAvatarUrl

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -73,14 +73,13 @@ namespace DSharpPlus.Entities
         /// Gets the member's avatar for the current guild.
         /// </summary>
         [JsonIgnore]
-        public string GuildAvatarHash => this._avatarHash ?? this.User.AvatarHash;
+        public string GuildAvatarHash => this._avatarHash;
 
         /// <summary>
         /// Gets the members avatar url for the current guild.
         /// </summary>
         [JsonIgnore]
-        public string GuildAvatarUrl
-            => !string.IsNullOrWhiteSpace(this.GuildAvatarHash) ? (this.GuildAvatarHash.StartsWith("a_") ? $"https://cdn.discordapp.com{Endpoints.GUILDS}/{this._guild_id}{Endpoints.USERS}/{this.Id}{Endpoints.AVATARS}/{this.GuildAvatarHash}.gif?size=1024" : $"https://cdn.discordapp.com{Endpoints.GUILDS}/{this._guild_id}{Endpoints.USERS}/{this.Id}{Endpoints.AVATARS}/{this.GuildAvatarHash}.png?size=1024") : this.DefaultAvatarUrl;
+        public string GuildAvatarUrl => string.IsNullOrWhiteSpace(this.GuildAvatarHash) ? null : $"https://cdn.discordapp.com{Endpoints.GUILDS}/{this._guild_id}{Endpoints.USERS}/{this.Id}{Endpoints.AVATARS}/{this.GuildAvatarHash}.{(this.GuildAvatarHash.StartsWith("a_") ? "gif" : "png")}?size=1024";
 
         [JsonIgnore]
         internal string _avatarHash;
@@ -621,7 +620,8 @@ namespace DSharpPlus.Entities
                 _ => throw new ArgumentOutOfRangeException(nameof(imageFormat)),
             };
             var stringImageSize = imageSize.ToString(CultureInfo.InvariantCulture);
-            return $"https://cdn.discordapp.com/guilds/{this._guild_id}/users/{this.Id.ToString(CultureInfo.InvariantCulture)}/avatars/{this.GuildAvatarHash}.{stringImageFormat}?size={stringImageSize}";
+
+            return $"https://cdn.discordapp.com{Endpoints.GUILDS}/{this._guild_id}{Endpoints.USERS}/{this.Id}{Endpoints.AVATARS}/{this.GuildAvatarHash}.{stringImageFormat}?size={stringImageSize}";
         }
 
 

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -606,7 +606,7 @@ namespace DSharpPlus.Entities
                 throw new ArgumentOutOfRangeException("Image Size is not in between 16 and 4096: " + nameof(imageSize));
 
             // Checks to see if the image size is not a power of two.
-            if (imageSize is 0 && (imageSize & (imageSize - 1)) is not 0)
+            if (!(imageSize is not 0 && (imageSize & (imageSize - 1)) is 0))
                 throw new ArgumentOutOfRangeException("Image size is not a power of two: " + nameof(imageSize));
 
             // Get the string varients of the method parameters to use in the urls.

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -596,7 +596,7 @@ namespace DSharpPlus.Entities
         public string GetGuildAvatarUrl(ImageFormat imageFormat, ushort imageSize = 1024)
         {
             // Run this if statement before any others to prevent running the if statements twice.
-            if (string.IsNullOrWhiteSpace(this.AvatarHash))
+            if (string.IsNullOrWhiteSpace(this.GuildAvatarHash))
             {
                 return this.GetAvatarUrl(imageFormat, imageSize);
             }

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -596,7 +596,7 @@ namespace DSharpPlus.Entities
         public string GetGuildAvatarUrl(ImageFormat imageFormat, ushort imageSize = 1024)
         {
             // Run this if statement before any others to prevent running the if statements twice.
-            if (!string.IsNullOrWhiteSpace(this.AvatarHash))
+            if (string.IsNullOrWhiteSpace(this.AvatarHash))
             {
                 return this.GetAvatarUrl(imageFormat, imageSize);
             }
@@ -623,7 +623,7 @@ namespace DSharpPlus.Entities
                 _ => throw new ArgumentOutOfRangeException(nameof(imageFormat)),
             };
             var stringImageSize = imageSize.ToString(CultureInfo.InvariantCulture);
-            return $"https://cdn.discordapp.com/guilds/{this._guild_id}/users/{this.Id.ToString(CultureInfo.InvariantCulture)}/avatars/{this.AvatarHash}.{stringImageFormat}?size={stringImageSize}";
+            return $"https://cdn.discordapp.com/guilds/{this._guild_id}/users/{this.Id.ToString(CultureInfo.InvariantCulture)}/avatars/{this.GuildAvatarHash}.{stringImageFormat}?size={stringImageSize}";
         }
 
 

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -597,9 +597,7 @@ namespace DSharpPlus.Entities
         {
             // Run this if statement before any others to prevent running the if statements twice.
             if (string.IsNullOrWhiteSpace(this.GuildAvatarHash))
-            {
                 return this.GetAvatarUrl(imageFormat, imageSize);
-            }
 
             if (imageFormat == ImageFormat.Unknown)
                 throw new ArgumentException("You must specify valid image format.", nameof(imageFormat));
@@ -608,7 +606,7 @@ namespace DSharpPlus.Entities
             if (imageSize < 16 || imageSize > 4096)
                 throw new ArgumentOutOfRangeException("Image Size is not in between 16 and 4096: " + nameof(imageSize));
 
-            // Checks to see if the image size is a power of two.
+            // Checks to see if the image size is not a power of two.
             if (imageSize is 0 && (imageSize & (imageSize - 1)) is not 0)
                 throw new ArgumentOutOfRangeException("Image size is not a power of two: " + nameof(imageSize));
 

--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
+using DSharpPlus.Net;
 using DSharpPlus.Net.Abstractions;
 using Newtonsoft.Json;
 
@@ -237,13 +238,13 @@ namespace DSharpPlus.Entities
             if (!string.IsNullOrWhiteSpace(this.AvatarHash))
             {
                 var userId = this.Id.ToString(CultureInfo.InvariantCulture);
-                return $"https://cdn.discordapp.com/avatars/{userId}/{this.AvatarHash}.{stringImageFormat}?size={stringImageSize}";
+                return $"https://cdn.discordapp.com{Endpoints.AVATARS}/{userId}/{this.AvatarHash}.{stringImageFormat}?size={stringImageSize}";
             }
             else
             {
                 // https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints: In the case of the Default User Avatar endpoint, the value for `user_discriminator` in the path should be the user's discriminator `modulo 5—Test#1337` would be `1337 % 5`, which evaluates to 2.
                 var defaultAvatarType = (this.DiscriminatorInt % 5).ToString(CultureInfo.InvariantCulture);
-                return $"https://cdn.discordapp.com/embed/avatars/{defaultAvatarType}.{stringImageFormat}?size={stringImageSize}";
+                return $"https://cdn.discordapp.com/embed{Endpoints.AVATARS}/{defaultAvatarType}.{stringImageFormat}?size={stringImageSize}";
             }
         }
 

--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -218,8 +218,8 @@ namespace DSharpPlus.Entities
             if (imageSize < 16 || imageSize > 4096)
                 throw new ArgumentOutOfRangeException("Image Size is not in between 16 and 4096: " + nameof(imageSize));
 
-            // Checks to see if the image size is a power of two.
-            if (imageSize is 0 && (imageSize & (imageSize - 1)) is not 0)
+            // Checks to see if the image size is not a power of two.
+            if (!(imageSize is not 0 && (imageSize & (imageSize - 1)) is 0))
                 throw new ArgumentOutOfRangeException("Image size is not a power of two: " + nameof(imageSize));
 
             // Get the string varients of the method parameters to use in the urls.

--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Globalization;
 using System.Threading.Tasks;
 using DSharpPlus.Net.Abstractions;
@@ -205,41 +206,45 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the user's avatar URL, in requested format and size.
         /// </summary>
-        /// <param name="fmt">Format of the avatar to get.</param>
-        /// <param name="size">Maximum size of the avatar. Must be a power of two, minimum 16, maximum 2048.</param>
-        /// <returns>URL of the user's avatar.</returns>
-        public string GetAvatarUrl(ImageFormat fmt, ushort size = 1024)
+        /// <param name="imageFormat">The image format of the avatar to get.</param>
+        /// <param name="imageSize">The maximum size of the avatar. Must be a power of two, minimum 16, maximum 4096.</param>
+        /// <returns>The URL of the user's avatar.</returns>
+        public string GetAvatarUrl(ImageFormat imageFormat, ushort imageSize = 1024)
         {
-            if (fmt == ImageFormat.Unknown)
-                throw new ArgumentException("You must specify valid image format.", nameof(fmt));
+            if (imageFormat == ImageFormat.Unknown)
+                throw new ArgumentException("You must specify valid image format.", nameof(imageFormat));
 
-            if (size < 16 || size > 2048)
-                throw new ArgumentOutOfRangeException(nameof(size));
+            // Makes sure the image size is in between Discord's allowed range.
+            if (imageSize < 16 || imageSize > 4096)
+                throw new ArgumentOutOfRangeException("Image Size is not in between 16 and 4096: " + nameof(imageSize));
 
-            var log = Math.Log(size, 2);
-            if (log < 4 || log > 11 || log % 1 != 0)
-                throw new ArgumentOutOfRangeException(nameof(size));
+            // Checks to see if the image size is a power of two.
+            if (imageSize is 0 && (imageSize & (imageSize - 1)) is not 0)
+                throw new ArgumentOutOfRangeException("Image size is not a power of two: " + nameof(imageSize));
 
-            var sfmt = "";
-            sfmt = fmt switch
+            // Get the string varients of the method parameters to use in the urls.
+            var stringImageFormat = imageFormat switch
             {
                 ImageFormat.Gif => "gif",
                 ImageFormat.Jpeg => "jpg",
                 ImageFormat.Png => "png",
                 ImageFormat.WebP => "webp",
                 ImageFormat.Auto => !string.IsNullOrWhiteSpace(this.AvatarHash) ? (this.AvatarHash.StartsWith("a_") ? "gif" : "png") : "png",
-                _ => throw new ArgumentOutOfRangeException(nameof(fmt)),
+                _ => throw new ArgumentOutOfRangeException(nameof(imageFormat)),
             };
-            var ssize = size.ToString(CultureInfo.InvariantCulture);
+            var stringImageSize = imageSize.ToString(CultureInfo.InvariantCulture);
+
+            // If the avatar hash is set, get their avatar. If it isn't set, grab the default avatar calculated from their discriminator.
             if (!string.IsNullOrWhiteSpace(this.AvatarHash))
             {
-                var id = this.Id.ToString(CultureInfo.InvariantCulture);
-                return $"https://cdn.discordapp.com/avatars/{id}/{this.AvatarHash}.{sfmt}?size={ssize}";
+                var userId = this.Id.ToString(CultureInfo.InvariantCulture);
+                return $"https://cdn.discordapp.com/avatars/{userId}/{this.AvatarHash}.{stringImageFormat}?size={stringImageSize}";
             }
             else
             {
-                var type = (this.DiscriminatorInt % 5).ToString(CultureInfo.InvariantCulture);
-                return $"https://cdn.discordapp.com/embed/avatars/{type}.{sfmt}?size={ssize}";
+                // https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints: In the case of the Default User Avatar endpoint, the value for `user_discriminator` in the path should be the user's discriminator `modulo 5—Test#1337` would be `1337 % 5`, which evaluates to 2.
+                var defaultAvatarType = (this.DiscriminatorInt % 5).ToString(CultureInfo.InvariantCulture);
+                return $"https://cdn.discordapp.com/embed/avatars/{defaultAvatarType}.{stringImageFormat}?size={stringImageSize}";
             }
         }
 

--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Dynamic;
 using System.Globalization;
 using System.Threading.Tasks;
 using DSharpPlus.Net.Abstractions;


### PR DESCRIPTION
# Summary
Cleans up the DiscordUser#GetAvatarUrl method by renaming variables, adding code comments and using simplified logic. Adds DiscordMember#GetGuildAvatarUrl by copying DiscordUser#GetAvatarUrl with slight modifications, including falling back to DiscordUser#GetAvatarUrl when no `GuildAvatarHash` is set.

# Details
Additionally simplfies a few return if statements and fixes an XML doc.

Testing guild avatars:
```cs
using System.Threading.Tasks;
using DSharpPlus;
using DSharpPlus.Entities;
using DSharpPlus.SlashCommands;

namespace Tomoe.Commands
{
    public partial class Test : ApplicationCommandModule
    {
        [SlashCommand("guild_avatar_test", "Tests if D#+ can grab the members avatar at 4096px")]
        public static async Task GuildAvatarTest(InteractionContext context)
        {
            DiscordInteractionResponseBuilder messageBuilder = new();
            messageBuilder.AddEmbed(new DiscordEmbedBuilder()
            {
                Title = "Guild Avatar Test",
                Description = "This is a test of the member's guild avatar. If you see this, it means that D#+ can grab the member's guild avatar at 2048px.",
                ImageUrl = context.Member.GetGuildAvatarUrl(ImageFormat.Png, 2048)
            });

            messageBuilder.AddEmbed(new DiscordEmbedBuilder()
            {
                Title = "Guild Avatar Test",
                Description = "This is a test of the member's guild avatar. If you see this, it means D#+ can grab the member's guild avatar at 4096px.",
                ImageUrl = context.Member.GetGuildAvatarUrl(ImageFormat.Png, 4096)
            });

            await context.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, messageBuilder);
        }
    }
}
```
Testing guild avatars:
![image](https://user-images.githubusercontent.com/46751150/147863055-9271ec96-1ead-47ae-afda-92bd63a91909.png)

Testing user avatars:
```cs
using System.Threading.Tasks;
using DSharpPlus;
using DSharpPlus.Entities;
using DSharpPlus.SlashCommands;

namespace Tomoe.Commands
{
    public partial class Test : ApplicationCommandModule
    {
        [SlashCommand("user_avatar_test", "Tests if D#+ can grab the user's avatar at 4096px.")]
        public static async Task UserAvatarTest(InteractionContext context)
        {
            DiscordInteractionResponseBuilder messageBuilder = new();
            messageBuilder.AddEmbed(new DiscordEmbedBuilder()
            {
                Title = "User Avatar Test",
                Description = "This is a test of the user's avatar. If you see this, it means that D#+ can grab the user's avatar at 2048px.",
                ImageUrl = context.User.GetAvatarUrl(ImageFormat.Png, 2048)
            });

            messageBuilder.AddEmbed(new DiscordEmbedBuilder()
            {
                Title = "User Avatar Test",
                Description = "This is a test of the user's avatar. If you see this, it means D#+ can grab the user's avatar at 4096px.",
                ImageUrl = context.User.GetAvatarUrl(ImageFormat.Png, 4096)
            });

            await context.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource, messageBuilder);
        }
    }
}
```
![image](https://user-images.githubusercontent.com/46751150/147862895-240028c8-9da8-4683-ba0b-6c100ac1c286.png)

Closes #1146