### PR TITLE
Add GetThreadMemberAsync

### DIFF
--- a/DSharpPlus/Entities/Channel/Thread/DiscordThreadChannel.cs
+++ b/DSharpPlus/Entities/Channel/Thread/DiscordThreadChannel.cs
@@ -121,6 +121,11 @@ namespace DSharpPlus.Entities
             await this.Discord.ApiClient.RemoveThreadMemberAsync(this.Id, member.Id);
         }
 
+        /// <summary>
+        /// Returns a thread member object for the specified user if they are a member of the thread, returns a 404 response otherwise.
+        /// </summary>
+        /// <param name="member">The guild member to retrieve.</param>
+        /// <exception cref="NotFoundException">Thrown when a GuildMember has not joined the channel thread.</exception>
         public async Task<DiscordThreadChannelMember> GetThreadMemberAsync(DiscordMember member)
             => await this.Discord.ApiClient.GetThreadMemberAsync(this.Id, member.Id);
 

--- a/DSharpPlus/Entities/Channel/Thread/DiscordThreadChannel.cs
+++ b/DSharpPlus/Entities/Channel/Thread/DiscordThreadChannel.cs
@@ -121,8 +121,11 @@ namespace DSharpPlus.Entities
             await this.Discord.ApiClient.RemoveThreadMemberAsync(this.Id, member.Id);
         }
 
+        public async Task<DiscordThreadChannelMember> GetThreadMemberAsync(DiscordMember member)
+            => await this.Discord.ApiClient.GetThreadMemberAsync(this.Id, member.Id);
+
         #endregion
 
-        internal DiscordThreadChannel() {}
+        internal DiscordThreadChannel() { }
     }
 }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1189,7 +1189,7 @@ namespace DSharpPlus.Net
 
             var ret = JsonConvert.DeserializeObject<DiscordChannel>(res.Response);
 
-            if(ret.IsThread)
+            if (ret.IsThread)
                 ret = JsonConvert.DeserializeObject<DiscordThreadChannel>(res.Response);
 
             ret.Discord = this.Discord;
@@ -1297,7 +1297,7 @@ namespace DSharpPlus.Net
                 pld.MessageReference = new InternalDiscordMessageReference { MessageId = builder.ReplyId, FailIfNotExists = builder.FailOnInvalidReply };
 
             //if (builder.Mentions != null || builder.ReplyId != null)
-                pld.Mentions = new DiscordMentions(builder.Mentions ?? Mentions.All, builder.Mentions?.Any() ?? false, builder.MentionOnReply);
+            pld.Mentions = new DiscordMentions(builder.Mentions ?? Mentions.All, builder.Mentions?.Any() ?? false, builder.MentionOnReply);
 
             if (builder.Files.Count == 0)
             {
@@ -1820,6 +1820,17 @@ namespace DSharpPlus.Net
 
             var url = Utilities.GetApiUriFor(path);
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.DELETE, route);
+        }
+
+        internal async Task<DiscordThreadChannelMember> GetThreadMemberAsync(ulong channel_id, ulong user_id)
+        {
+            var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREAD_MEMBERS}/:user_id";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.POST, route, new { channel_id, user_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var response = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
+
+            return JsonConvert.DeserializeObject<DiscordThreadChannelMember>(response.Response);
         }
 
         internal Task AddThreadMemberAsync(ulong channel_id, ulong user_id)


### PR DESCRIPTION
Adds `GetThreadMemberAsync` to `DiscordThreadChannel` as per #825.

Testing:
```cs
namespace Tomoe.Commands.Test
{
    [Group("dsp_fix"), RequireOwner]
    public class Test : BaseCommandModule
    {
        [Command("get_thread_member"), Description("Test command.")]
        public async Task ByUser(CommandContext context, DiscordThreadChannel channel, DiscordMember member) => await context.RespondAsync($"{member.Mention} joined thread {channel.Mention} at {(await channel.GetThreadMemberAsync(member)).JoinTimeStamp.Humanize()}");
    }
}
```
![image](https://user-images.githubusercontent.com/46751150/149523647-8c72b176-781b-4661-9d09-139db5ec95e3.png)
