### PR TITLE
Fix DiscordGuild#ModifyAsync

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -305,9 +305,17 @@ namespace DSharpPlus
             else if (mdl.Splash.HasValue)
                 splashb64 = null;
 
+            var bannerb64 = Optional.FromNoValue<string>();
+
+            if (mdl.Banner.HasValue && mdl.Banner.Value != null)
+                using (var imgtool = new ImageTool(mdl.Banner.Value))
+                    bannerb64 = imgtool.GetBase64();
+            else if (mdl.Banner.HasValue)
+                bannerb64 = null;
+
             return await this.ApiClient.ModifyGuildAsync(guild_id, mdl.Name, mdl.Region.IfPresent(x => x.Id), mdl.VerificationLevel, mdl.DefaultMessageNotifications,
                 mdl.MfaLevel, mdl.ExplicitContentFilter, mdl.AfkChannel.IfPresent(x => x?.Id), mdl.AfkTimeout, iconb64, mdl.Owner.IfPresent(x => x.Id),
-                splashb64, mdl.SystemChannel.IfPresent(x => x?.Id), mdl.Banner, mdl.Description, mdl.DiscoverySplash, mdl.Features, mdl.PreferredLocale,
+                splashb64, mdl.SystemChannel.IfPresent(x => x?.Id), bannerb64, mdl.Description, mdl.DiscoverySplash, mdl.Features, mdl.PreferredLocale,
                 mdl.PublicUpdatesChannel.IfPresent(e => e?.Id), mdl.RulesChannel.IfPresent(e => e?.Id), mdl.SystemChannelFlags, mdl.AuditLogReason).ConfigureAwait(false);
         }
 

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -741,10 +741,12 @@ namespace DSharpPlus.Entities
         {
             var mdl = new GuildEditModel();
             action(mdl);
+
             if (mdl.AfkChannel.HasValue && mdl.AfkChannel.Value.Type != ChannelType.Voice)
                 throw new ArgumentException("AFK channel needs to be a voice channel.");
 
             var iconb64 = Optional.FromNoValue<string>();
+
             if (mdl.Icon.HasValue && mdl.Icon.Value != null)
                 using (var imgtool = new ImageTool(mdl.Icon.Value))
                     iconb64 = imgtool.GetBase64();
@@ -752,16 +754,28 @@ namespace DSharpPlus.Entities
                 iconb64 = null;
 
             var splashb64 = Optional.FromNoValue<string>();
+
             if (mdl.Splash.HasValue && mdl.Splash.Value != null)
                 using (var imgtool = new ImageTool(mdl.Splash.Value))
                     splashb64 = imgtool.GetBase64();
             else if (mdl.Splash.HasValue)
                 splashb64 = null;
 
+            var bannerb64 = Optional.FromNoValue<string>();
+
+            if (mdl.Splash.HasValue)
+            {
+                if (mdl.Splash.Value == null)
+                    bannerb64 = null;
+                else
+                    using (var imgtool = new ImageTool(mdl.Splash.Value))
+                        bannerb64 = imgtool.GetBase64();
+            }
+
             return await this.Discord.ApiClient.ModifyGuildAsync(this.Id, mdl.Name, mdl.Region.IfPresent(e => e.Id),
                 mdl.VerificationLevel, mdl.DefaultMessageNotifications, mdl.MfaLevel, mdl.ExplicitContentFilter,
                 mdl.AfkChannel.IfPresent(e => e?.Id), mdl.AfkTimeout, iconb64, mdl.Owner.IfPresent(e => e.Id), splashb64,
-                mdl.SystemChannel.IfPresent(e => e?.Id), mdl.Banner,
+                mdl.SystemChannel.IfPresent(e => e?.Id), bannerb64,
                 mdl.Description, mdl.DiscoverySplash, mdl.Features, mdl.PreferredLocale,
                 mdl.PublicUpdatesChannel.IfPresent(e => e?.Id), mdl.RulesChannel.IfPresent(e => e?.Id),
                 mdl.SystemChannelFlags, mdl.AuditLogReason).ConfigureAwait(false);

--- a/DSharpPlus/Entities/Optional.cs
+++ b/DSharpPlus/Entities/Optional.cs
@@ -96,6 +96,15 @@ namespace DSharpPlus.Entities
             this.HasValue = true;
         }
 
+
+        /// <summary>
+        /// Determines whether the optional has a value, and the value is non-null.
+        /// </summary>
+        /// <param name="value">The value contained within the optional.</param>
+        /// <returns>True if the value is set, and is not null, otherwise false.</returns>
+        public bool IsDefined(out T? value)
+            => (value = this._val) != null;
+
         /// <summary>
         /// Returns a string representation of this optional value.
         /// </summary>
@@ -185,7 +194,7 @@ namespace DSharpPlus.Entities
             if (!type.GetTypeInfo().ImplementedInterfaces.Contains(typeof(IOptional)))
                 return property;
 
-            // we cache the PropertyInfo object here (it's captured in closure). we don't have direct 
+            // we cache the PropertyInfo object here (it's captured in closure). we don't have direct
             // access to the property value so we have to reflect into it from the parent instance
             // we use UnderlyingName instead of PropertyName in case the C# name is different from the Json name.
             var declaringMember = property.DeclaringType.GetTypeInfo().DeclaredMembers

--- a/DSharpPlus/Net/Models/GuildEditModel.cs
+++ b/DSharpPlus/Net/Models/GuildEditModel.cs
@@ -122,7 +122,7 @@ namespace DSharpPlus.Net.Models
         /// <summary>
         /// The new banner of the guild
         /// </summary>
-        public Optional<string> Banner { get; set; }
+        public Optional<Stream> Banner { get; set; }
 
         /// <summary>
         /// The new system channel flags for the guild


### PR DESCRIPTION
Fixes DiscordGuild#ModifyAsync, which initally took a string, expecting an already-encoded version of the banner, instead of a stream, and converting it. Oops.