### PR TITLE
Add DateTimeOffset serializer

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -43,7 +43,7 @@ using Microsoft.Extensions.Logging;
 namespace DSharpPlus.CommandsNext
 {
     /// <summary>
-    /// This is the class which handles command registration, management, and execution. 
+    /// This is the class which handles command registration, management, and execution.
     /// </summary>
     public class CommandsNextExtension : BaseExtension, IDisposable
     {
@@ -796,7 +796,7 @@ namespace DSharpPlus.CommandsNext
                 IsTTS = false,
                 _attachments = new List<DiscordAttachment>(),
                 _embeds = new List<DiscordEmbed>(),
-                TimestampRaw = now.ToString("yyyy-MM-ddTHH:mm:sszzz"),
+                TimestampRaw = now,
                 _reactions = new List<DiscordReaction>()
             };
 
@@ -984,7 +984,7 @@ namespace DSharpPlus.CommandsNext
 
         #region Helpers
         /// <summary>
-        /// Gets the configuration-specific string comparer. This returns <see cref="StringComparer.Ordinal"/> or <see cref="StringComparer.OrdinalIgnoreCase"/>, 
+        /// Gets the configuration-specific string comparer. This returns <see cref="StringComparer.Ordinal"/> or <see cref="StringComparer.OrdinalIgnoreCase"/>,
         /// depending on whether <see cref="CommandsNextConfiguration.CaseSensitive"/> is set to <see langword="true"/> or <see langword="false"/>.
         /// </summary>
         /// <returns>A string comparer.</returns>

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -34,6 +34,7 @@ using DSharpPlus.Exceptions;
 using DSharpPlus.Lavalink.Entities;
 using DSharpPlus.Lavalink.EventArgs;
 using DSharpPlus.Net;
+using DSharpPlus.Net.Serialization;
 using DSharpPlus.Net.WebSocket;
 using Emzi0767.Utilities;
 using Microsoft.Extensions.Logging;
@@ -360,19 +361,19 @@ namespace DSharpPlus.Lavalink
             {
                 case "playerUpdate":
                     var gid = (ulong)jsonData["guildId"];
-                    var state = jsonData["state"].ToObject<LavalinkState>();
+                    var state = jsonData["state"].ToDiscordObject<LavalinkState>();
                     if (this._connectedGuilds.TryGetValue(gid, out var lvl))
                         await lvl.InternalUpdatePlayerStateAsync(state).ConfigureAwait(false);
                     break;
 
                 case "stats":
-                    var statsRaw = jsonData.ToObject<LavalinkStats>();
+                    var statsRaw = jsonData.ToDiscordObject<LavalinkStats>();
                     this.Statistics.Update(statsRaw);
                     await this._statsReceived.InvokeAsync(this, new StatisticsReceivedEventArgs(this.Statistics)).ConfigureAwait(false);
                     break;
 
                 case "event":
-                    var evtype = jsonData["type"].ToObject<EventType>();
+                    var evtype = jsonData["type"].ToDiscordObject<EventType>();
                     var guildId = (ulong)jsonData["guildId"];
                     switch (evtype)
                     {
@@ -419,7 +420,7 @@ namespace DSharpPlus.Lavalink
                             if (this._connectedGuilds.TryGetValue(guildId, out var lvl_ewsce))
                             {
                                 lvl_ewsce.VoiceWsDisconnectTcs.SetResult(true);
-                                await lvl_ewsce.InternalWebSocketClosedAsync(new WebSocketCloseEventArgs(jsonData["code"].ToObject<int>(), jsonData["reason"].ToString(), jsonData["byRemote"].ToObject<bool>())).ConfigureAwait(false);
+                                await lvl_ewsce.InternalWebSocketClosedAsync(new WebSocketCloseEventArgs(jsonData["code"].ToDiscordObject<int>(), jsonData["reason"].ToString(), jsonData["byRemote"].ToDiscordObject<bool>())).ConfigureAwait(false);
                             }
                             break;
                     }

--- a/DSharpPlus.Lavalink/LavalinkRestClient.cs
+++ b/DSharpPlus.Lavalink/LavalinkRestClient.cs
@@ -31,6 +31,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using DSharpPlus.Lavalink.Entities;
 using DSharpPlus.Net;
+using DSharpPlus.Net.Serialization;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -242,7 +243,7 @@ namespace DSharpPlus.Lavalink
                 var tracks = new List<LavalinkTrack>(jarr.Count);
                 foreach (var jt in jarr)
                 {
-                    var track = jt["info"].ToObject<LavalinkTrack>();
+                    var track = jt["info"].ToDiscordObject<LavalinkTrack>();
                     track.TrackString = jt["track"].ToString();
 
                     tracks.Add(track);
@@ -260,11 +261,11 @@ namespace DSharpPlus.Lavalink
                 // Lavalink 3.x
 
                 jarr = jo["tracks"] as JArray;
-                var loadInfo = jo.ToObject<LavalinkLoadResult>();
+                var loadInfo = jo.ToDiscordObject<LavalinkLoadResult>();
                 var tracks = new List<LavalinkTrack>(jarr.Count);
                 foreach (var jt in jarr)
                 {
-                    var track = jt["info"].ToObject<LavalinkTrack>();
+                    var track = jt["info"].ToDiscordObject<LavalinkTrack>();
                     track.TrackString = jt["track"].ToString();
 
                     tracks.Add(track);

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -35,6 +35,7 @@ using System.Threading.Tasks;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using DSharpPlus.Net;
+using DSharpPlus.Net.Serialization;
 using DSharpPlus.Net.Udp;
 using DSharpPlus.Net.WebSocket;
 using DSharpPlus.VoiceNext.Codec;
@@ -897,7 +898,7 @@ namespace DSharpPlus.VoiceNext
             {
                 case 2: // READY
                     this.Discord.Logger.LogTrace(VoiceNextEvents.VoiceDispatch, "Received READY (OP2)");
-                    var vrp = opp.ToObject<VoiceReadyPayload>();
+                    var vrp = opp.ToDiscordObject<VoiceReadyPayload>();
                     this.SSRC = vrp.SSRC;
                     this.UdpEndpoint = new ConnectionEndpoint(vrp.Address, vrp.Port);
                     // this is not the valid interval
@@ -909,7 +910,7 @@ namespace DSharpPlus.VoiceNext
 
                 case 4: // SESSION_DESCRIPTION
                     this.Discord.Logger.LogTrace(VoiceNextEvents.VoiceDispatch, "Received SESSION_DESCRIPTION (OP4)");
-                    var vsd = opp.ToObject<VoiceSessionDescriptionPayload>();
+                    var vsd = opp.ToDiscordObject<VoiceSessionDescriptionPayload>();
                     this.Key = vsd.SecretKey;
                     this.Sodium = new Sodium(this.Key.AsMemory());
                     await this.Stage2(vsd).ConfigureAwait(false);
@@ -919,7 +920,7 @@ namespace DSharpPlus.VoiceNext
                     // Don't spam OP5
                     // No longer spam, Discord supposedly doesn't send many of these
                     this.Discord.Logger.LogTrace(VoiceNextEvents.VoiceDispatch, "Received SPEAKING (OP5)");
-                    var spd = opp.ToObject<VoiceSpeakingPayload>();
+                    var spd = opp.ToDiscordObject<VoiceSpeakingPayload>();
                     var foundUserInCache = this.Discord.TryGetCachedUserInternal(spd.UserId.Value, out var resolvedUser);
                     var spk = new UserSpeakingEventArgs
                     {
@@ -958,7 +959,7 @@ namespace DSharpPlus.VoiceNext
                 case 8: // HELLO
                     // this sends a heartbeat interval that we need to use for heartbeating
                     this.Discord.Logger.LogTrace(VoiceNextEvents.VoiceDispatch, "Received HELLO (OP8)");
-                    this.HeartbeatInterval = opp["heartbeat_interval"].ToObject<int>();
+                    this.HeartbeatInterval = opp["heartbeat_interval"].ToDiscordObject<int>();
                     break;
 
                 case 9: // RESUMED
@@ -968,7 +969,7 @@ namespace DSharpPlus.VoiceNext
 
                 case 12: // CLIENT_CONNECTED
                     this.Discord.Logger.LogTrace(VoiceNextEvents.VoiceDispatch, "Received CLIENT_CONNECTED (OP12)");
-                    var ujpd = opp.ToObject<VoiceUserJoinPayload>();
+                    var ujpd = opp.ToDiscordObject<VoiceUserJoinPayload>();
                     var usrj = await this.Discord.GetUserAsync(ujpd.UserId).ConfigureAwait(false);
                     {
                         var opus = this.Opus.CreateDecoder();
@@ -986,7 +987,7 @@ namespace DSharpPlus.VoiceNext
 
                 case 13: // CLIENT_DISCONNECTED
                     this.Discord.Logger.LogTrace(VoiceNextEvents.VoiceDispatch, "Received CLIENT_DISCONNECTED (OP13)");
-                    var ulpd = opp.ToObject<VoiceUserLeavePayload>();
+                    var ulpd = opp.ToDiscordObject<VoiceUserLeavePayload>();
                     var txssrc = this.TransmittingSSRCs.FirstOrDefault(x => x.Value.Id == ulpd.UserId);
                     if (this.TransmittingSSRCs.ContainsKey(txssrc.Key))
                     {

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -76,7 +76,7 @@ namespace DSharpPlus
                 case "ready":
                     var glds = (JArray)dat["guilds"];
                     var dmcs = (JArray)dat["private_channels"];
-                    await this.OnReadyEventAsync(dat.ToObject<ReadyPayload>(), glds, dmcs).ConfigureAwait(false);
+                    await this.OnReadyEventAsync(dat.ToDiscordObject<ReadyPayload>(), glds, dmcs).ConfigureAwait(false);
                     break;
 
                 case "resumed":
@@ -88,17 +88,17 @@ namespace DSharpPlus
                 #region Channel
 
                 case "channel_create":
-                    chn = dat.ToObject<DiscordChannel>();
+                    chn = dat.ToDiscordObject<DiscordChannel>();
                     await this.OnChannelCreateEventAsync(chn).ConfigureAwait(false);
                     break;
 
                 case "channel_update":
-                    await this.OnChannelUpdateEventAsync(dat.ToObject<DiscordChannel>()).ConfigureAwait(false);
+                    await this.OnChannelUpdateEventAsync(dat.ToDiscordObject<DiscordChannel>()).ConfigureAwait(false);
                     break;
 
                 case "channel_delete":
-                    chn = dat.ToObject<DiscordChannel>();
-                    await this.OnChannelDeleteEventAsync(chn.IsPrivate ? dat.ToObject<DiscordDmChannel>() : chn).ConfigureAwait(false);
+                    chn = dat.ToDiscordObject<DiscordChannel>();
+                    await this.OnChannelDeleteEventAsync(chn.IsPrivate ? dat.ToDiscordObject<DiscordDmChannel>() : chn).ConfigureAwait(false);
                     break;
 
                 case "channel_pins_update":
@@ -112,15 +112,15 @@ namespace DSharpPlus
                 #region Scheduled Guild Events
 
                 case "guild_scheduled_event_create":
-                    var cevt = dat.ToObject<DiscordScheduledGuildEvent>();
+                    var cevt = dat.ToDiscordObject<DiscordScheduledGuildEvent>();
                     await this.OnScheduledGuildEventCreateEventAsync(cevt).ConfigureAwait(false);
                     break;
                 case "guild_scheduled_event_delete":
-                    var devt = dat.ToObject<DiscordScheduledGuildEvent>();
+                    var devt = dat.ToDiscordObject<DiscordScheduledGuildEvent>();
                     await this.OnScheduledGuildEventDeleteEventAsync(devt).ConfigureAwait(false);
                     break;
                 case "guild_scheduled_event_update":
-                    var uevt = dat.ToObject<DiscordScheduledGuildEvent>();
+                    var uevt = dat.ToDiscordObject<DiscordScheduledGuildEvent>();
                     await this.OnScheduledGuildEventUpdateEventAsync(uevt).ConfigureAwait(false);
                     break;
                 case "guild_scheduled_event_user_add":
@@ -153,12 +153,12 @@ namespace DSharpPlus
 
                 case "guild_sync":
                     gid = (ulong)dat["id"];
-                    await this.OnGuildSyncEventAsync(this._guilds[gid], (bool)dat["large"], (JArray)dat["members"], dat["presences"].ToObject<IEnumerable<DiscordPresence>>()).ConfigureAwait(false);
+                    await this.OnGuildSyncEventAsync(this._guilds[gid], (bool)dat["large"], (JArray)dat["members"], dat["presences"].ToDiscordObject<IEnumerable<DiscordPresence>>()).ConfigureAwait(false);
                     break;
 
                 case "guild_emojis_update":
                     gid = (ulong)dat["guild_id"];
-                    var ems = dat["emojis"].ToObject<IEnumerable<DiscordEmoji>>();
+                    var ems = dat["emojis"].ToDiscordObject<IEnumerable<DiscordEmoji>>();
                     await this.OnGuildEmojisUpdateEventAsync(this._guilds[gid], ems).ConfigureAwait(false);
                     break;
 
@@ -177,13 +177,13 @@ namespace DSharpPlus
                 #region Guild Ban
 
                 case "guild_ban_add":
-                    usr = dat["user"].ToObject<TransportUser>();
+                    usr = dat["user"].ToDiscordObject<TransportUser>();
                     gid = (ulong)dat["guild_id"];
                     await this.OnGuildBanAddEventAsync(usr, this._guilds[gid]).ConfigureAwait(false);
                     break;
 
                 case "guild_ban_remove":
-                    usr = dat["user"].ToObject<TransportUser>();
+                    usr = dat["user"].ToDiscordObject<TransportUser>();
                     gid = (ulong)dat["guild_id"];
                     await this.OnGuildBanRemoveEventAsync(usr, this._guilds[gid]).ConfigureAwait(false);
                     break;
@@ -194,12 +194,12 @@ namespace DSharpPlus
 
                 case "guild_member_add":
                     gid = (ulong)dat["guild_id"];
-                    await this.OnGuildMemberAddEventAsync(dat.ToObject<TransportMember>(), this._guilds[gid]).ConfigureAwait(false);
+                    await this.OnGuildMemberAddEventAsync(dat.ToDiscordObject<TransportMember>(), this._guilds[gid]).ConfigureAwait(false);
                     break;
 
                 case "guild_member_remove":
                     gid = (ulong)dat["guild_id"];
-                    usr = dat["user"].ToObject<TransportUser>();
+                    usr = dat["user"].ToDiscordObject<TransportUser>();
 
                     if (!this._guilds.ContainsKey(gid))
                     {
@@ -214,7 +214,7 @@ namespace DSharpPlus
 
                 case "guild_member_update":
                     gid = (ulong)dat["guild_id"];
-                    await this.OnGuildMemberUpdateEventAsync(dat.ToDiscordObject<TransportMember>(), this._guilds[gid], dat["roles"].ToObject<IEnumerable<ulong>>(), (string)dat["nick"], (bool?)dat["pending"], (DateTimeOffset?)dat["communication_disabled_until"]).ConfigureAwait(false);
+                    await this.OnGuildMemberUpdateEventAsync(dat.ToDiscordObject<TransportMember>(), this._guilds[gid], dat["roles"].ToDiscordObject<IEnumerable<ulong>>(), (string)dat["nick"], (bool?)dat["pending"], (DateTimeOffset?)dat["communication_disabled_until"]).ConfigureAwait(false);
                     break;
 
                 case "guild_members_chunk":
@@ -227,12 +227,12 @@ namespace DSharpPlus
 
                 case "guild_role_create":
                     gid = (ulong)dat["guild_id"];
-                    await this.OnGuildRoleCreateEventAsync(dat["role"].ToObject<DiscordRole>(), this._guilds[gid]).ConfigureAwait(false);
+                    await this.OnGuildRoleCreateEventAsync(dat["role"].ToDiscordObject<DiscordRole>(), this._guilds[gid]).ConfigureAwait(false);
                     break;
 
                 case "guild_role_update":
                     gid = (ulong)dat["guild_id"];
-                    await this.OnGuildRoleUpdateEventAsync(dat["role"].ToObject<DiscordRole>(), this._guilds[gid]).ConfigureAwait(false);
+                    await this.OnGuildRoleUpdateEventAsync(dat["role"].ToDiscordObject<DiscordRole>(), this._guilds[gid]).ConfigureAwait(false);
                     break;
 
                 case "guild_role_delete":
@@ -247,7 +247,7 @@ namespace DSharpPlus
                 case "invite_create":
                     gid = (ulong)dat["guild_id"];
                     cid = (ulong)dat["channel_id"];
-                    await this.OnInviteCreateEventAsync(cid, gid, dat.ToObject<DiscordInvite>()).ConfigureAwait(false);
+                    await this.OnInviteCreateEventAsync(cid, gid, dat.ToDiscordObject<DiscordInvite>()).ConfigureAwait(false);
                     break;
 
                 case "invite_delete":
@@ -270,44 +270,44 @@ namespace DSharpPlus
                     rawMbr = dat["member"];
 
                     if (rawMbr != null)
-                        mbr = rawMbr.ToObject<TransportMember>();
+                        mbr = rawMbr.ToDiscordObject<TransportMember>();
 
                     if (rawRefMsg != null && rawRefMsg.HasValues)
                     {
                         if (rawRefMsg.SelectToken("author") != null)
                         {
-                            refUsr = rawRefMsg.SelectToken("author").ToObject<TransportUser>();
+                            refUsr = rawRefMsg.SelectToken("author").ToDiscordObject<TransportUser>();
                         }
 
                         if (rawRefMsg.SelectToken("member") != null)
                         {
-                            refMbr = rawRefMsg.SelectToken("member").ToObject<TransportMember>();
+                            refMbr = rawRefMsg.SelectToken("member").ToDiscordObject<TransportMember>();
                         }
                     }
 
-                    await this.OnMessageCreateEventAsync(dat.ToDiscordObject<DiscordMessage>(), dat["author"].ToObject<TransportUser>(), mbr, refUsr, refMbr).ConfigureAwait(false);
+                    await this.OnMessageCreateEventAsync(dat.ToDiscordObject<DiscordMessage>(), dat["author"].ToDiscordObject<TransportUser>(), mbr, refUsr, refMbr).ConfigureAwait(false);
                     break;
 
                 case "message_update":
                     rawMbr = dat["member"];
 
                     if (rawMbr != null)
-                        mbr = rawMbr.ToObject<TransportMember>();
+                        mbr = rawMbr.ToDiscordObject<TransportMember>();
 
                     if (rawRefMsg != null && rawRefMsg.HasValues)
                     {
                         if (rawRefMsg.SelectToken("author") != null)
                         {
-                            refUsr = rawRefMsg.SelectToken("author").ToObject<TransportUser>();
+                            refUsr = rawRefMsg.SelectToken("author").ToDiscordObject<TransportUser>();
                         }
 
                         if (rawRefMsg.SelectToken("member") != null)
                         {
-                            refMbr = rawRefMsg.SelectToken("member").ToObject<TransportMember>();
+                            refMbr = rawRefMsg.SelectToken("member").ToDiscordObject<TransportMember>();
                         }
                     }
 
-                    await this.OnMessageUpdateEventAsync(dat.ToDiscordObject<DiscordMessage>(), dat["author"]?.ToObject<TransportUser>(), mbr, refUsr, refMbr).ConfigureAwait(false);
+                    await this.OnMessageUpdateEventAsync(dat.ToDiscordObject<DiscordMessage>(), dat["author"]?.ToDiscordObject<TransportUser>(), mbr, refUsr, refMbr).ConfigureAwait(false);
                     break;
 
                 // delete event does *not* include message object
@@ -316,7 +316,7 @@ namespace DSharpPlus
                     break;
 
                 case "message_delete_bulk":
-                    await this.OnMessageBulkDeleteEventAsync(dat["ids"].ToObject<ulong[]>(), (ulong)dat["channel_id"], (ulong?)dat["guild_id"]).ConfigureAwait(false);
+                    await this.OnMessageBulkDeleteEventAsync(dat["ids"].ToDiscordObject<ulong[]>(), (ulong)dat["channel_id"], (ulong?)dat["guild_id"]).ConfigureAwait(false);
                     break;
 
                 #endregion
@@ -327,13 +327,13 @@ namespace DSharpPlus
                     rawMbr = dat["member"];
 
                     if (rawMbr != null)
-                        mbr = rawMbr.ToObject<TransportMember>();
+                        mbr = rawMbr.ToDiscordObject<TransportMember>();
 
-                    await this.OnMessageReactionAddAsync((ulong)dat["user_id"], (ulong)dat["message_id"], (ulong)dat["channel_id"], (ulong?)dat["guild_id"], mbr, dat["emoji"].ToObject<DiscordEmoji>()).ConfigureAwait(false);
+                    await this.OnMessageReactionAddAsync((ulong)dat["user_id"], (ulong)dat["message_id"], (ulong)dat["channel_id"], (ulong?)dat["guild_id"], mbr, dat["emoji"].ToDiscordObject<DiscordEmoji>()).ConfigureAwait(false);
                     break;
 
                 case "message_reaction_remove":
-                    await this.OnMessageReactionRemoveAsync((ulong)dat["user_id"], (ulong)dat["message_id"], (ulong)dat["channel_id"], (ulong?)dat["guild_id"], dat["emoji"].ToObject<DiscordEmoji>()).ConfigureAwait(false);
+                    await this.OnMessageReactionRemoveAsync((ulong)dat["user_id"], (ulong)dat["message_id"], (ulong)dat["channel_id"], (ulong?)dat["guild_id"], dat["emoji"].ToDiscordObject<DiscordEmoji>()).ConfigureAwait(false);
                     break;
 
                 case "message_reaction_remove_all":
@@ -353,11 +353,11 @@ namespace DSharpPlus
                     break;
 
                 case "user_settings_update":
-                    await this.OnUserSettingsUpdateEventAsync(dat.ToObject<TransportUser>()).ConfigureAwait(false);
+                    await this.OnUserSettingsUpdateEventAsync(dat.ToDiscordObject<TransportUser>()).ConfigureAwait(false);
                     break;
 
                 case "user_update":
-                    await this.OnUserUpdateEventAsync(dat.ToObject<TransportUser>()).ConfigureAwait(false);
+                    await this.OnUserUpdateEventAsync(dat.ToDiscordObject<TransportUser>()).ConfigureAwait(false);
                     break;
 
                 #endregion
@@ -394,7 +394,7 @@ namespace DSharpPlus
 
                 case "thread_list_sync":
                     gid = (ulong)dat["guild_id"]; //get guild
-                    await this.OnThreadListSyncEventAsync(this._guilds[gid], dat["channel_ids"].ToDiscordObject<IReadOnlyList<ulong>>(), dat["threads"].ToObject<IReadOnlyList<DiscordThreadChannel>>(), dat["members"].ToObject<IReadOnlyList<DiscordThreadChannelMember>>()).ConfigureAwait(false);
+                    await this.OnThreadListSyncEventAsync(this._guilds[gid], dat["channel_ids"].ToDiscordObject<IReadOnlyList<ulong>>(), dat["threads"].ToDiscordObject<IReadOnlyList<DiscordThreadChannel>>(), dat["members"].ToDiscordObject<IReadOnlyList<DiscordThreadChannelMember>>()).ConfigureAwait(false);
                     break;
 
                 case "thread_member_update":
@@ -403,7 +403,7 @@ namespace DSharpPlus
 
                 case "thread_members_update":
                     gid = (ulong)dat["guild_id"];
-                    await this.OnThreadMembersUpdateEventAsync(this._guilds[gid], (ulong)dat["id"], dat["added_members"]?.ToObject<IReadOnlyList<DiscordThreadChannelMember>>(), dat["removed_member_ids"]?.ToObject<IReadOnlyList<ulong?>>(), (int)dat["member_count"]).ConfigureAwait(false);
+                    await this.OnThreadMembersUpdateEventAsync(this._guilds[gid], (ulong)dat["id"], dat["added_members"]?.ToDiscordObject<IReadOnlyList<DiscordThreadChannelMember>>(), dat["removed_member_ids"]?.ToDiscordObject<IReadOnlyList<ulong?>>(), (int)dat["member_count"]).ConfigureAwait(false);
                     break;
 
                 #endregion
@@ -416,12 +416,12 @@ namespace DSharpPlus
 
                     if (rawMbr != null)
                     {
-                        mbr = dat["member"].ToObject<TransportMember>();
+                        mbr = dat["member"].ToDiscordObject<TransportMember>();
                         usr = mbr.User;
                     }
                     else
                     {
-                        usr = dat["user"].ToObject<TransportUser>();
+                        usr = dat["user"].ToDiscordObject<TransportUser>();
                     }
 
                     cid = (ulong)dat["channel_id"];
@@ -429,23 +429,23 @@ namespace DSharpPlus
                     break;
 
                 case "application_command_create":
-                    await this.OnApplicationCommandCreateAsync(dat.ToObject<DiscordApplicationCommand>(), (ulong?)dat["guild_id"]).ConfigureAwait(false);
+                    await this.OnApplicationCommandCreateAsync(dat.ToDiscordObject<DiscordApplicationCommand>(), (ulong?)dat["guild_id"]).ConfigureAwait(false);
                     break;
 
                 case "application_command_update":
-                    await this.OnApplicationCommandUpdateAsync(dat.ToObject<DiscordApplicationCommand>(), (ulong?)dat["guild_id"]).ConfigureAwait(false);
+                    await this.OnApplicationCommandUpdateAsync(dat.ToDiscordObject<DiscordApplicationCommand>(), (ulong?)dat["guild_id"]).ConfigureAwait(false);
                     break;
 
                 case "application_command_delete":
-                    await this.OnApplicationCommandDeleteAsync(dat.ToObject<DiscordApplicationCommand>(), (ulong?)dat["guild_id"]).ConfigureAwait(false);
+                    await this.OnApplicationCommandDeleteAsync(dat.ToDiscordObject<DiscordApplicationCommand>(), (ulong?)dat["guild_id"]).ConfigureAwait(false);
                     break;
 
                 case "integration_create":
-                    await this.OnIntegrationCreateAsync(dat.ToObject<DiscordIntegration>(), (ulong)dat["guild_id"]).ConfigureAwait(false);
+                    await this.OnIntegrationCreateAsync(dat.ToDiscordObject<DiscordIntegration>(), (ulong)dat["guild_id"]).ConfigureAwait(false);
                     break;
 
                 case "integration_update":
-                    await this.OnIntegrationUpdateAsync(dat.ToObject<DiscordIntegration>(), (ulong)dat["guild_id"]).ConfigureAwait(false);
+                    await this.OnIntegrationUpdateAsync(dat.ToDiscordObject<DiscordIntegration>(), (ulong)dat["guild_id"]).ConfigureAwait(false);
                     break;
 
                 case "integration_delete":
@@ -457,15 +457,15 @@ namespace DSharpPlus
                 #region Stage Instance
 
                 case "stage_instance_create":
-                    await this.OnStageInstanceCreateAsync(dat.ToObject<DiscordStageInstance>()).ConfigureAwait(false);
+                    await this.OnStageInstanceCreateAsync(dat.ToDiscordObject<DiscordStageInstance>()).ConfigureAwait(false);
                     break;
 
                 case "stage_instance_update":
-                    await this.OnStageInstanceUpdateAsync(dat.ToObject<DiscordStageInstance>()).ConfigureAwait(false);
+                    await this.OnStageInstanceUpdateAsync(dat.ToDiscordObject<DiscordStageInstance>()).ConfigureAwait(false);
                     break;
 
                 case "stage_instance_delete":
-                    await this.OnStageInstanceDeleteAsync(dat.ToObject<DiscordStageInstance>()).ConfigureAwait(false);
+                    await this.OnStageInstanceDeleteAsync(dat.ToDiscordObject<DiscordStageInstance>()).ConfigureAwait(false);
                     break;
 
                 #endregion
@@ -483,7 +483,7 @@ namespace DSharpPlus
                     rawMbr = dat["member"];
 
                     if (rawMbr != null)
-                        mbr = rawMbr.ToObject<TransportMember>();
+                        mbr = rawMbr.ToDiscordObject<TransportMember>();
 
                     await this.OnTypingStartEventAsync((ulong)dat["user_id"], cid, this.InternalGetCachedChannel(cid), (ulong?)dat["guild_id"], Utilities.GetDateTimeOffset((long)dat["timestamp"]), mbr).ConfigureAwait(false);
                     break;
@@ -534,7 +534,7 @@ namespace DSharpPlus
             this._privateChannels.Clear();
             foreach (var rawChannel in rawDmChannels)
             {
-                var channel = rawChannel.ToObject<DiscordDmChannel>();
+                var channel = rawChannel.ToDiscordObject<DiscordDmChannel>();
 
                 channel.Discord = this;
 
@@ -542,7 +542,7 @@ namespace DSharpPlus
                 //    .Select(xtu => this.InternalGetCachedUser(xtu.Id) ?? new DiscordUser(xtu) { Discord = this })
                 //    .ToList();
 
-                var recips_raw = rawChannel["recipients"].ToObject<IEnumerable<TransportUser>>();
+                var recips_raw = rawChannel["recipients"].ToDiscordObject<IEnumerable<TransportUser>>();
                 var recipients = new List<DiscordUser>();
                 foreach (var xr in recips_raw)
                 {
@@ -604,7 +604,7 @@ namespace DSharpPlus
                 {
                     foreach (var xj in raw_members)
                     {
-                        var xtm = xj.ToObject<TransportMember>();
+                        var xtm = xj.ToDiscordObject<TransportMember>();
 
                         var xu = new DiscordUser(xtm.User) { Discord = this };
                         xu = this.UpdateUserCache(xu);
@@ -1292,7 +1292,7 @@ namespace DSharpPlus
             var mbrs = new HashSet<DiscordMember>();
             var pres = new HashSet<DiscordPresence>();
 
-            var members = dat["members"].ToObject<TransportMember[]>();
+            var members = dat["members"].ToDiscordObject<TransportMember[]>();
 
             var memCount = members.Count();
             for (var i = 0; i < memCount; i++)
@@ -1320,7 +1320,7 @@ namespace DSharpPlus
 
             if (dat["presences"] != null)
             {
-                var presences = dat["presences"].ToObject<DiscordPresence[]>();
+                var presences = dat["presences"].ToDiscordObject<DiscordPresence[]>();
 
                 var presCount = presences.Count();
                 for (var i = 0; i < presCount; i++)
@@ -1344,7 +1344,7 @@ namespace DSharpPlus
 
             if (dat["not_found"] != null)
             {
-                var nf = dat["not_found"].ToObject<ISet<ulong>>();
+                var nf = dat["not_found"].ToDiscordObject<ISet<ulong>>();
                 ea.NotFound = new ReadOnlySet<ulong>(nf);
             }
 
@@ -1451,7 +1451,7 @@ namespace DSharpPlus
 
             if (!guild._invites.TryRemove(dat["code"].ToString(), out var invite))
             {
-                invite = dat.ToObject<DiscordInvite>();
+                invite = dat.ToDiscordObject<DiscordInvite>();
                 invite.Discord = this;
             }
 
@@ -1837,7 +1837,7 @@ namespace DSharpPlus
                 };
             }
 
-            var partialEmoji = dat.ToObject<DiscordEmoji>();
+            var partialEmoji = dat.ToDiscordObject<DiscordEmoji>();
 
             if (!guild._emojis.TryGetValue(partialEmoji.Id, out var emoji))
             {
@@ -1874,7 +1874,7 @@ namespace DSharpPlus
             }
             else
             {
-                presence = rawPresence.ToObject<DiscordPresence>();
+                presence = rawPresence.ToDiscordObject<DiscordPresence>();
                 presence.Discord = this;
                 presence.Activity = new DiscordActivity(presence.RawActivity);
                 this._presences[presence.InternalUser.Id] = presence;
@@ -1992,7 +1992,7 @@ namespace DSharpPlus
             var uid = (ulong)raw["user_id"];
             var gld = this._guilds[gid];
 
-            var vstateNew = raw.ToObject<DiscordVoiceState>();
+            var vstateNew = raw.ToDiscordObject<DiscordVoiceState>();
             vstateNew.Discord = this;
 
             gld._voiceStates.TryRemove(uid, out var vstateOld);

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1543,7 +1543,7 @@ namespace DSharpPlus
                 oldmsg = new DiscordMessage(message);
 
                 guild = message.Channel?.Guild;
-                message.EditedTimestampRaw = event_message.EditedTimestampRaw;
+                message.EditedTimestamp = event_message.EditedTimestamp;
                 if (event_message.Content != null)
                     message.Content = event_message.Content;
                 message._embeds.Clear();

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -30,6 +30,7 @@ using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using DSharpPlus.Net;
 using DSharpPlus.Net.Abstractions;
+using DSharpPlus.Net.Serialization;
 using DSharpPlus.Net.WebSocket;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -242,7 +243,7 @@ namespace DSharpPlus
                     break;
 
                 case GatewayOpCode.Hello:
-                    await this.OnHelloAsync((payload.Data as JObject).ToObject<GatewayHello>()).ConfigureAwait(false);
+                    await this.OnHelloAsync((payload.Data as JObject).ToDiscordObject<GatewayHello>()).ConfigureAwait(false);
                     break;
 
                 case GatewayOpCode.HeartbeatAck:

--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -35,6 +35,7 @@ using System.Threading.Tasks;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using DSharpPlus.Net;
+using DSharpPlus.Net.Serialization;
 using Emzi0767.Utilities;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -289,7 +290,7 @@ namespace DSharpPlus
             timer.Start();
 
             var jo = JObject.Parse(await resp.Content.ReadAsStringAsync().ConfigureAwait(false));
-            var info = jo.ToObject<GatewayInfo>();
+            var info = jo.ToDiscordObject<GatewayInfo>();
 
             //There is a delay from parsing here.
             timer.Stop();

--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 using System;
+using System.IO;
 using System.Net;
 using DSharpPlus.Net.Udp;
 using DSharpPlus.Net.WebSocket;
@@ -102,8 +103,8 @@ namespace DSharpPlus
 
         /// <summary>
         /// <para>Sets the level of compression for WebSocket traffic.</para>
-        /// <para>Disabling this option will increase the amount of traffic sent via WebSocket. Setting <see cref="GatewayCompressionLevel.Payload"/> will enable compression for READY and GUILD_CREATE payloads. Setting <see cref="GatewayCompressionLevel.Stream"/> will enable compression for the entire WebSocket stream, drastically reducing amount of traffic.</para>
-        /// <para>Defaults to <see cref="GatewayCompressionLevel.Stream"/>.</para>
+        /// <para>Disabling this option will increase the amount of traffic sent via WebSocket. Setting <see cref="GatewayCompressionLevel.Payload"/> will enable compression for READY and GUILD_CREATE payloads. Setting <see cref="Stream"/> will enable compression for the entire WebSocket stream, drastically reducing amount of traffic.</para>
+        /// <para>Defaults to <see cref="Stream"/>.</para>
         /// </summary>
         public GatewayCompressionLevel GatewayCompressionLevel { internal get; set; } = GatewayCompressionLevel.Stream;
 

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -157,13 +157,8 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets when the last pinned message was pinned.
         /// </summary>
-        [JsonIgnore]
-        public DateTimeOffset? LastPinTimestamp
-            => !string.IsNullOrWhiteSpace(this.LastPinTimestampRaw) && DateTimeOffset.TryParse(this.LastPinTimestampRaw, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dto) ?
-                dto : null;
-
         [JsonProperty("last_pin_timestamp", NullValueHandling = NullValueHandling.Ignore)]
-        internal string LastPinTimestampRaw { get; set; }
+        public DateTimeOffset? LastPinTimestamp { get; internal set; }
 
         /// <summary>
         /// Gets this channel's mention string.

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -79,7 +79,7 @@ namespace DSharpPlus.Entities
             this.Author = other.Author;
             this.ChannelId = other.ChannelId;
             this.Content = other.Content;
-            this.EditedTimestampRaw = other.EditedTimestampRaw;
+            this.EditedTimestamp = other.EditedTimestamp;
             this.Id = other.Id;
             this.IsTTS = other.IsTTS;
             this.MessageType = other.MessageType;
@@ -130,30 +130,23 @@ namespace DSharpPlus.Entities
         /// Gets the message's creation timestamp.
         /// </summary>
         [JsonIgnore]
-        public DateTimeOffset Timestamp
-            => !string.IsNullOrWhiteSpace(this.TimestampRaw) && DateTimeOffset.TryParse(this.TimestampRaw, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dto) ?
-                dto : this.CreationTimestamp;
+        public DateTimeOffset Timestamp => this.TimestampRaw ?? this.CreationTimestamp;
 
         [JsonProperty("timestamp", NullValueHandling = NullValueHandling.Ignore)]
-        internal string TimestampRaw { get; set; }
+        internal DateTimeOffset? TimestampRaw { get; set; }
 
         /// <summary>
         /// Gets the message's edit timestamp. Will be null if the message was not edited.
         /// </summary>
-        [JsonIgnore]
-        public DateTimeOffset? EditedTimestamp
-            => !string.IsNullOrWhiteSpace(this.EditedTimestampRaw) && DateTimeOffset.TryParse(this.EditedTimestampRaw, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dto) ?
-                (DateTimeOffset?)dto : null;
-
         [JsonProperty("edited_timestamp", NullValueHandling = NullValueHandling.Ignore)]
-        internal string EditedTimestampRaw { get; set; }
+        public DateTimeOffset? EditedTimestamp { get; internal set; }
+
 
         /// <summary>
         /// Gets whether this message was edited.
         /// </summary>
         [JsonIgnore]
-        public bool IsEdited
-            => !string.IsNullOrWhiteSpace(this.EditedTimestampRaw);
+        public bool IsEdited => this.EditedTimestamp != null;
 
         /// <summary>
         /// Gets whether the message is a text-to-speech message.

--- a/DSharpPlus/Entities/Channel/Thread/DiscordThreadChannelMember.cs
+++ b/DSharpPlus/Entities/Channel/Thread/DiscordThreadChannelMember.cs
@@ -42,7 +42,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("id", NullValueHandling = NullValueHandling.Ignore)]
         public ulong ThreadId { get; set; }
-        
+
         /// <summary>
         /// Gets ID of the user.
         /// </summary>
@@ -52,13 +52,8 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets timestamp when the user joined the thread.
         /// </summary>
-        [JsonIgnore]
-        public DateTimeOffset? JoinTimeStamp
-            => !string.IsNullOrWhiteSpace(this.JoinTimeStampRaw) && DateTimeOffset.TryParse(this.JoinTimeStampRaw, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dto) ?
-                dto : null;
-
         [JsonProperty("join_timestamp", NullValueHandling = NullValueHandling.Ignore)]
-        internal string JoinTimeStampRaw { get; set; }
+        public DateTimeOffset? JoinTimeStamp { get; internal set; }
 
         [JsonProperty("flags", NullValueHandling = NullValueHandling.Ignore)]
         internal int UserFlags { get; set; }

--- a/DSharpPlus/Entities/Channel/Thread/DiscordThreadChannelMetadata.cs
+++ b/DSharpPlus/Entities/Channel/Thread/DiscordThreadChannelMetadata.cs
@@ -52,13 +52,8 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the time timestamp for when the thread's archive status was last changed.
         /// </summary>
-        [JsonIgnore]
-        public DateTimeOffset? ArchiveTimestamp
-            => !string.IsNullOrWhiteSpace(this.ArchiveTimestampRaw) && DateTimeOffset.TryParse(this.ArchiveTimestampRaw, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dto) ?
-                dto : null;
-
         [JsonProperty("archive_timestamp", NullValueHandling = NullValueHandling.Ignore)]
-        internal string ArchiveTimestampRaw { get; set; }
+        public DateTimeOffset? ArchiveTimestamp { get; internal set; }
 
         /// <summary>
         /// Gets whether this thread is locked or not.

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -1548,11 +1548,11 @@ namespace DSharpPlus.Entities
 
                                 case "permission_overwrites":
                                     var olds = xc.OldValues?.OfType<JObject>()
-                                        ?.Select(xjo => xjo.ToObject<DiscordOverwrite>())
+                                        ?.Select(xjo => xjo.ToDiscordObject<DiscordOverwrite>())
                                         ?.Select(xo => { xo.Discord = this.Discord; return xo; });
 
                                     var news = xc.NewValues?.OfType<JObject>()
-                                        ?.Select(xjo => xjo.ToObject<DiscordOverwrite>())
+                                        ?.Select(xjo => xjo.ToDiscordObject<DiscordOverwrite>())
                                         ?.Select(xo => { xo.Discord = this.Discord; return xo; });
 
                                     entrychn.OverwriteChange = new PropertyChange<IReadOnlyList<DiscordOverwrite>>

--- a/DSharpPlus/Net/Abstractions/AuditLogAbstractions.cs
+++ b/DSharpPlus/Net/Abstractions/AuditLogAbstractions.cs
@@ -23,6 +23,7 @@
 
 using System.Collections.Generic;
 using DSharpPlus.Entities;
+using DSharpPlus.Net.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -72,7 +73,7 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonIgnore]
         public IEnumerable<JObject> OldValues
-            => (this.OldValue as JArray)?.ToObject<IEnumerable<JObject>>();
+            => (this.OldValue as JArray)?.ToDiscordObject<IEnumerable<JObject>>();
 
         [JsonIgnore]
         public ulong OldValueUlong
@@ -88,7 +89,7 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonIgnore]
         public IEnumerable<JObject> NewValues
-            => (this.NewValue as JArray)?.ToObject<IEnumerable<JObject>>();
+            => (this.NewValue as JArray)?.ToDiscordObject<IEnumerable<JObject>>();
 
         [JsonIgnore]
         public ulong NewValueUlong

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -72,7 +72,7 @@ namespace DSharpPlus.Net
 
         private DiscordMessage PrepareMessage(JToken msg_raw)
         {
-            var author = msg_raw["author"].ToObject<TransportUser>();
+            var author = msg_raw["author"].ToDiscordObject<TransportUser>();
             var ret = msg_raw.ToDiscordObject<DiscordMessage>();
             ret.Discord = this.Discord;
 
@@ -81,7 +81,7 @@ namespace DSharpPlus.Net
             var referencedMsg = msg_raw["referenced_message"];
             if (ret.MessageType == MessageType.Reply && !string.IsNullOrWhiteSpace(referencedMsg?.ToString()))
             {
-                author = referencedMsg["author"].ToObject<TransportUser>();
+                author = referencedMsg["author"].ToDiscordObject<TransportUser>();
                 ret.ReferencedMessage.Discord = this.Discord;
                 this.PopulateMessage(author, ret.ReferencedMessage);
             }
@@ -184,7 +184,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path, BuildQueryString(querydict));
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
             var json = JArray.Parse(res.Response);
-            var tms = json.ToObject<IReadOnlyList<TransportMember>>();
+            var tms = json.ToDiscordObject<IReadOnlyList<TransportMember>>();
 
             var mbrs = new List<DiscordMember>();
             foreach (var xtm in tms)
@@ -207,7 +207,7 @@ namespace DSharpPlus.Net
             var res = await this.DoRequestAsync(this.Discord, bucket, uri, RestRequestMethod.GET, route).ConfigureAwait(false);
             var json = JObject.Parse(res.Response);
 
-            var ban = json.ToObject<DiscordBan>();
+            var ban = json.ToDiscordObject<DiscordBan>();
 
             if (!this.Discord.TryGetCachedUserInternal(ban.RawUser.Id, out var usr))
             {
@@ -1158,10 +1158,10 @@ namespace DSharpPlus.Net
                 .Select(j => (DiscordUser)
                         j
                         .SelectToken("member")?
-                        .ToObject<DiscordMember>() ??
+                        .ToDiscordObject<DiscordMember>() ??
                         j
                         .SelectToken("user")
-                        .ToObject<DiscordUser>())
+                        .ToDiscordObject<DiscordUser>())
                 .ToArray();
         }
 
@@ -2977,10 +2977,10 @@ namespace DSharpPlus.Net
             var emojis = new List<DiscordGuildEmoji>();
             foreach (var rawEmoji in emojisRaw)
             {
-                var xge = rawEmoji.ToObject<DiscordGuildEmoji>();
+                var xge = rawEmoji.ToDiscordObject<DiscordGuildEmoji>();
                 xge.Guild = gld;
 
-                var xtu = rawEmoji["user"]?.ToObject<TransportUser>();
+                var xtu = rawEmoji["user"]?.ToDiscordObject<TransportUser>();
                 if (xtu != null)
                 {
                     if (!users.ContainsKey(xtu.Id))
@@ -3009,10 +3009,10 @@ namespace DSharpPlus.Net
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
             var emoji_raw = JObject.Parse(res.Response);
-            var emoji = emoji_raw.ToObject<DiscordGuildEmoji>();
+            var emoji = emoji_raw.ToDiscordObject<DiscordGuildEmoji>();
             emoji.Guild = gld;
 
-            var xtu = emoji_raw["user"]?.ToObject<TransportUser>();
+            var xtu = emoji_raw["user"]?.ToDiscordObject<TransportUser>();
             if (xtu != null)
                 emoji.User = gld != null && gld.Members.TryGetValue(xtu.Id, out var member) ? member : new DiscordUser(xtu);
 
@@ -3041,10 +3041,10 @@ namespace DSharpPlus.Net
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
             var emoji_raw = JObject.Parse(res.Response);
-            var emoji = emoji_raw.ToObject<DiscordGuildEmoji>();
+            var emoji = emoji_raw.ToDiscordObject<DiscordGuildEmoji>();
             emoji.Guild = gld;
 
-            var xtu = emoji_raw["user"]?.ToObject<TransportUser>();
+            var xtu = emoji_raw["user"]?.ToDiscordObject<TransportUser>();
             emoji.User = xtu != null
                 ? gld != null && gld.Members.TryGetValue(xtu.Id, out var member) ? member : new DiscordUser(xtu)
                 : this.Discord.CurrentUser;
@@ -3073,10 +3073,10 @@ namespace DSharpPlus.Net
             this.Discord.Guilds.TryGetValue(guild_id, out var gld);
 
             var emoji_raw = JObject.Parse(res.Response);
-            var emoji = emoji_raw.ToObject<DiscordGuildEmoji>();
+            var emoji = emoji_raw.ToDiscordObject<DiscordGuildEmoji>();
             emoji.Guild = gld;
 
-            var xtu = emoji_raw["user"]?.ToObject<TransportUser>();
+            var xtu = emoji_raw["user"]?.ToDiscordObject<TransportUser>();
             if (xtu != null)
                 emoji.User = gld != null && gld.Members.TryGetValue(xtu.Id, out var member) ? member : new DiscordUser(xtu);
 
@@ -3539,7 +3539,7 @@ namespace DSharpPlus.Net
             var url = Utilities.GetApiUriFor(path);
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route, headers).ConfigureAwait(false);
 
-            var info = JObject.Parse(res.Response).ToObject<GatewayInfo>();
+            var info = JObject.Parse(res.Response).ToDiscordObject<GatewayInfo>();
             info.SessionBucket.ResetAfter = DateTimeOffset.UtcNow + TimeSpan.FromMilliseconds(info.SessionBucket.ResetAfterInternal);
             return info;
         }

--- a/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
@@ -38,7 +38,7 @@ namespace DSharpPlus.Net.Serialization
                 return null;
 
             var job = JObject.Load(reader);
-            var type = job["type"]?.ToObject<ComponentType>();
+            var type = job["type"]?.ToDiscordObject<ComponentType>();
 
             if (type == null)
                 throw new ArgumentException($"Value {reader} does not have a component type specifier");

--- a/DSharpPlus/Net/Serialization/DiscordJson.cs
+++ b/DSharpPlus/Net/Serialization/DiscordJson.cs
@@ -35,7 +35,9 @@ namespace DSharpPlus.Net.Serialization
     {
         private static readonly JsonSerializer _serializer = JsonSerializer.CreateDefault(new JsonSerializerSettings
         {
-            ContractResolver = new OptionalJsonContractResolver()
+            ContractResolver = new OptionalJsonContractResolver(),
+            DateParseHandling = DateParseHandling.None,
+            Converters = new[] { new ISO8601DateTimeOffsetJsonConverter() }
         });
 
         /// <summary>Serializes the specified object to a JSON string.</summary>

--- a/DSharpPlus/Net/Serialization/ISO8601DateTimeOffsetJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/ISO8601DateTimeOffsetJsonConverter.cs
@@ -1,0 +1,46 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+using System;
+using System.Globalization;
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Net.Serialization
+{
+    /// <summary>
+    /// Json converter for handling DateTimeOffset values.
+    /// </summary>
+    internal sealed class ISO8601DateTimeOffsetJsonConverter : JsonConverter<DateTimeOffset>
+    {
+        public override void WriteJson(JsonWriter writer, DateTimeOffset value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString("o", CultureInfo.InvariantCulture));
+        }
+
+        public override DateTimeOffset ReadJson(JsonReader reader, Type objectType, DateTimeOffset existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            var value = reader.ReadAsString();
+
+            return DateTimeOffset.TryParse("o", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dto) ? dto : default;
+        }
+    }
+}


### PR DESCRIPTION
# Summary
This PR aims to alleviate the issue of having to manually parse `DateTimeOffset`s (DTOs) everywhere.

# Changes proposed

- Added DTO serializer
- Remove `TimestmapRaw` where applicable, and slap JsonProperty attribute on DTO directly
- Ensure consistent use of .ToDiscordObject<T> to guaruntee proper deserialization
