### PR TITLE
Improve DuplicateCommandException message

### DIFF
--- a/DSharpPlus.CommandsNext/Exceptions/DuplicateCommandException.cs
+++ b/DSharpPlus.CommandsNext/Exceptions/DuplicateCommandException.cs
@@ -40,7 +40,7 @@ namespace DSharpPlus.CommandsNext.Exceptions
         /// </summary>
         /// <param name="name">Name of the command that was taken.</param>
         internal DuplicateCommandException(string name)
-            : base("A command with specified name already exists.")
+            : base($"A command or alias with the name '{name}' has already been registered.")
         {
             this.CommandName = name;
         }


### PR DESCRIPTION
# Summary
Improves the error message for DuplicateCommandException, allowing the faulty command to be identified in the debugger without needing to use extra error handling.
