### PR TITLE
Remove unnecessary string allocations.

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -43,7 +43,7 @@ using Microsoft.Extensions.Logging;
 namespace DSharpPlus.CommandsNext
 {
     /// <summary>
-    /// This is the class which handles command registration, management, and execution. 
+    /// This is the class which handles command registration, management, and execution.
     /// </summary>
     public class CommandsNextExtension : BaseExtension, IDisposable
     {
@@ -271,8 +271,7 @@ namespace DSharpPlus.CommandsNext
                 if (!ignoreCase)
                     return null;
 
-                next = next.ToLowerInvariant();
-                var cmdKvp = this.RegisteredCommands.FirstOrDefault(x => x.Key.ToLowerInvariant() == next);
+                var cmdKvp = this.RegisteredCommands.FirstOrDefault(x => x.Key.Equals(next, StringComparison.InvariantCultureIgnoreCase));
                 if (cmdKvp.Value == null)
                     return null;
 
@@ -293,15 +292,8 @@ namespace DSharpPlus.CommandsNext
                 if (next == null)
                     break;
 
-                if (ignoreCase)
-                {
-                    next = next.ToLowerInvariant();
-                    cmd = cm2.Children.FirstOrDefault(x => x.Name.ToLowerInvariant() == next || x.Aliases?.Any(xx => xx.ToLowerInvariant() == next) == true);
-                }
-                else
-                {
-                    cmd = cm2.Children.FirstOrDefault(x => x.Name == next || x.Aliases?.Contains(next) == true);
-                }
+                var comparison = ignoreCase ? StringComparison.InvariantCultureIgnoreCase : StringComparison.InvariantCulture;
+                cmd = cm2.Children.FirstOrDefault(x => x.Name.Equals(next, comparison) || x.Aliases?.Any(xx => xx.Equals(next, comparison)) == true);
 
                 if (cmd == null)
                 {
@@ -692,9 +684,12 @@ namespace DSharpPlus.CommandsNext
                             break;
                         }
 
-                        cmd = ctx.Config.CaseSensitive
-                            ? searchIn.FirstOrDefault(xc => xc.Name == c || (xc.Aliases != null && xc.Aliases.Contains(c)))
-                            : searchIn.FirstOrDefault(xc => xc.Name.ToLowerInvariant() == c.ToLowerInvariant() || (xc.Aliases != null && xc.Aliases.Select(xs => xs.ToLowerInvariant()).Contains(c.ToLowerInvariant())));
+                        var (comparison, comparer) = ctx.Config.CaseSensitive switch
+                        {
+                            true  => (StringComparison.InvariantCulture, StringComparer.InvariantCulture),
+                            false => (StringComparison.InvariantCultureIgnoreCase, StringComparer.InvariantCultureIgnoreCase)
+                        };
+                        cmd = searchIn.FirstOrDefault(xc => xc.Name.Equals(c, comparison) || (xc.Aliases != null && xc.Aliases.Contains(c, comparer)));
 
                         if (cmd == null)
                             break;
@@ -984,7 +979,7 @@ namespace DSharpPlus.CommandsNext
 
         #region Helpers
         /// <summary>
-        /// Gets the configuration-specific string comparer. This returns <see cref="StringComparer.Ordinal"/> or <see cref="StringComparer.OrdinalIgnoreCase"/>, 
+        /// Gets the configuration-specific string comparer. This returns <see cref="StringComparer.Ordinal"/> or <see cref="StringComparer.OrdinalIgnoreCase"/>,
         /// depending on whether <see cref="CommandsNextConfiguration.CaseSensitive"/> is set to <see langword="true"/> or <see langword="false"/>.
         /// </summary>
         /// <returns>A string comparer.</returns>

--- a/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
@@ -70,8 +70,9 @@ namespace DSharpPlus.CommandsNext.Converters
             var dv = di != -1 ? value.Substring(di + 1) : null;
 
             var us = ctx.Client.Guilds.Values
-                .SelectMany(xkvp => xkvp.Members.Values)
-                .Where(xm => (cs ? xm.Username : xm.Username.ToLowerInvariant()) == un && ((dv != null && xm.Discriminator == dv) || dv == null));
+                .SelectMany(xkvp => xkvp.Members.Values).Where(xm =>
+                    xm.Username.Equals(un, cs ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase) &&
+                    ((dv != null && xm.Discriminator == dv) || dv == null));
 
             var usr = us.FirstOrDefault();
             return usr != null ? Optional.FromValue<DiscordUser>(usr) : Optional.FromNoValue<DiscordUser>();
@@ -123,9 +124,10 @@ namespace DSharpPlus.CommandsNext.Converters
             var un = di != -1 ? value.Substring(0, di) : value;
             var dv = di != -1 ? value.Substring(di + 1) : null;
 
-            var us = ctx.Guild.Members.Values
-                .Where(xm => ((cs ? xm.Username : xm.Username.ToLowerInvariant()) == un && ((dv != null && xm.Discriminator == dv) || dv == null))
-                          || (cs ? xm.Nickname : xm.Nickname?.ToLowerInvariant()) == value);
+            var comparison = cs ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase;
+            var us = ctx.Guild.Members.Values.Where(xm =>
+                (xm.Username.Equals(un, comparison) &&
+                 ((dv != null && xm.Discriminator == dv) || dv == null)) || string.Equals(xm.Nickname, value, comparison));
 
             var mbr = us.FirstOrDefault();
             return mbr != null ? Optional.FromValue(mbr) : Optional.FromNoValue<DiscordMember>();
@@ -161,11 +163,10 @@ namespace DSharpPlus.CommandsNext.Converters
             }
 
             var cs = ctx.Config.CaseSensitive;
-            if (!cs)
-                value = value.ToLowerInvariant();
 
-            var chn = ctx.Guild?.Channels.Values.FirstOrDefault(xc => (cs ? xc.Name : xc.Name.ToLowerInvariant()) == value) ??
-            ctx.Guild?.Threads.Values.FirstOrDefault(xThread => (cs ? xThread.Name : xThread.Name.ToLowerInvariant()) == value);
+            var comparison = cs ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase;
+            var chn = ctx.Guild?.Channels.Values.FirstOrDefault(xc => xc.Name.Equals(value, comparison)) ??
+                      ctx.Guild?.Threads.Values.FirstOrDefault(xThread => xThread.Name.Equals(value, comparison));
 
             return chn != null ? Optional.FromValue(chn) : Optional.FromNoValue<DiscordChannel>();
         }
@@ -200,10 +201,9 @@ namespace DSharpPlus.CommandsNext.Converters
             }
 
             var cs = ctx.Config.CaseSensitive;
-            if (!cs)
-                value = value.ToLowerInvariant();
 
-            var thread = ctx.Guild?.Threads.Values.FirstOrDefault(xt => (cs ? xt.Name : xt.Name.ToLowerInvariant()) == value);
+            var thread = ctx.Guild?.Threads.Values.FirstOrDefault(xt =>
+                xt.Name.Equals(value, cs ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase));
 
             return thread != null ? Optional.FromValue(thread) : Optional.FromNoValue<DiscordThreadChannel>();
         }
@@ -243,10 +243,9 @@ namespace DSharpPlus.CommandsNext.Converters
             }
 
             var cs = ctx.Config.CaseSensitive;
-            if (!cs)
-                value = value.ToLowerInvariant();
 
-            var rol = ctx.Guild.Roles.Values.FirstOrDefault(xr => (cs ? xr.Name : xr.Name.ToLowerInvariant()) == value);
+            var rol = ctx.Guild.Roles.Values.FirstOrDefault(xr =>
+                xr.Name.Equals(value, cs ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase));
             return Task.FromResult(rol != null ? Optional.FromValue(rol) : Optional.FromNoValue<DiscordRole>());
         }
     }
@@ -263,10 +262,9 @@ namespace DSharpPlus.CommandsNext.Converters
             }
 
             var cs = ctx.Config.CaseSensitive;
-            if (!cs)
-                value = value?.ToLowerInvariant();
 
-            var gld = ctx.Client.Guilds.Values.FirstOrDefault(xg => (cs ? xg.Name : xg.Name.ToLowerInvariant()) == value);
+            var gld = ctx.Client.Guilds.Values.FirstOrDefault(xg =>
+                xg.Name.Equals(value, cs ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase));
             return Task.FromResult(gld != null ? Optional.FromValue(gld) : Optional.FromNoValue<DiscordGuild>());
         }
     }

--- a/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
@@ -127,7 +127,7 @@ namespace DSharpPlus.CommandsNext.Converters
             var comparison = cs ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase;
             var us = ctx.Guild.Members.Values.Where(xm =>
                 (xm.Username.Equals(un, comparison) &&
-                 ((dv != null && xm.Discriminator == dv) || dv == null)) || string.Equals(xm.Nickname, value, comparison));
+                 ((dv != null && xm.Discriminator == dv) || dv == null)) || value.Equals(xm.Nickname, comparison));
 
             var mbr = us.FirstOrDefault();
             return mbr != null ? Optional.FromValue(mbr) : Optional.FromNoValue<DiscordMember>();

--- a/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
@@ -62,8 +62,6 @@ namespace DSharpPlus.CommandsNext.Converters
             }
 
             var cs = ctx.Config.CaseSensitive;
-            if (!cs)
-                value = value.ToLowerInvariant();
 
             var di = value.IndexOf('#');
             var un = di != -1 ? value.Substring(0, di) : value;
@@ -117,8 +115,6 @@ namespace DSharpPlus.CommandsNext.Converters
                 return Optional.FromValue(searchResult.First());
 
             var cs = ctx.Config.CaseSensitive;
-            if (!cs)
-                value = value.ToLowerInvariant();
 
             var di = value.IndexOf('#');
             var un = di != -1 ? value.Substring(0, di) : value;

--- a/DSharpPlus.CommandsNext/Entities/CommandGroup.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandGroup.cs
@@ -58,9 +58,13 @@ namespace DSharpPlus.CommandsNext
 
             if (cn != null)
             {
-                var cmd = ctx.Config.CaseSensitive
-                    ? this.Children.FirstOrDefault(xc => xc.Name == cn || (xc.Aliases != null && xc.Aliases.Contains(cn)))
-                    : this.Children.FirstOrDefault(xc => xc.Name.ToLowerInvariant() == cn.ToLowerInvariant() || (xc.Aliases != null && xc.Aliases.Select(xs => xs.ToLowerInvariant()).Contains(cn.ToLowerInvariant())));
+                var (comparison, comparer) = ctx.Config.CaseSensitive switch
+                {
+                    true  => (StringComparison.InvariantCulture, StringComparer.InvariantCulture),
+                    false => (StringComparison.InvariantCultureIgnoreCase, StringComparer.InvariantCultureIgnoreCase)
+                };
+                var cmd = this.Children.FirstOrDefault(xc =>
+                    xc.Name.Equals(cn, comparison) || (xc.Aliases != null && xc.Aliases.Contains(cn, comparer)));
                 if (cmd != null)
                 {
                     // pass the execution on

--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -827,12 +827,13 @@ namespace DSharpPlus.SlashCommands
                 var parameter = parameters.ElementAt(i);
 
                 //Accounts for optional arguments without values given
-                if (parameter.IsOptional && (options == null ||
-                                             (!options?.Any(x => x.Name == parameter.GetCustomAttribute<OptionAttribute>().Name.ToLower()) ?? true)))
+                if (parameter.IsOptional && (!options?.Any(x =>
+                        x.Name.Equals(parameter.GetCustomAttribute<OptionAttribute>().Name, StringComparison.InvariantCultureIgnoreCase)) ?? true))
                     args.Add(parameter.DefaultValue);
                 else
                 {
-                    var option = options.Single(x => x.Name == parameter.GetCustomAttribute<OptionAttribute>().Name.ToLower());
+                    var option = options.Single(x =>
+                        x.Name.Equals(parameter.GetCustomAttribute<OptionAttribute>().Name, StringComparison.InvariantCultureIgnoreCase));
 
                     //Checks the type and casts/references resolved and adds the value to the list
                     //This can probably reference the slash command's type property that didn't exist when I wrote this and it could use a cleaner switch instead, but if it works it works

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -482,7 +482,7 @@ namespace DSharpPlus.Net
             }
 
             // check if global b1nzy
-            if (hs.TryGetValue("X-RateLimit-Global", out var isglobal) && isglobal.ToLowerInvariant() == "true")
+            if (hs.TryGetValue("X-RateLimit-Global", out var isglobal) && isglobal.Equals("true", StringComparison.InvariantCultureIgnoreCase))
             {
                 // global
                 global = true;
@@ -502,7 +502,7 @@ namespace DSharpPlus.Net
 
             var hs = response.Headers;
 
-            if (hs.TryGetValue("X-RateLimit-Global", out var isglobal) && isglobal.ToLowerInvariant() == "true")
+            if (hs.TryGetValue("X-RateLimit-Global", out var isglobal) && isglobal.Equals("true", StringComparison.InvariantCultureIgnoreCase))
             {
                 if (response.ResponseCode != 429)
                     this.FailInitialRateLimitTest(request, ratelimitTcs);


### PR DESCRIPTION
# Summary
Reduce unnecessary string allocations throughout library. Mostly its done via not calling `string.ToLowerInvariant()`  when comparing strings, and instead using `string.Equals` method with passing `StringComparison`/`StringComparer`. By doing this we will reduce allocations which will increase performance of the library.

# Risks
This PR somewhat increases complexity of code, so if you think that performance is less important than readability - feel free to close this PR.

# Notes
Maybe there are other places with "unnecessary string allocations", as all i've done is just search on Github with `ToLower`/`ToLowerInvariant`, and just patched places where possible, and if you think that those places need patching in this PR too - feel free to point them.