### PR TITLE
Fix GetEventsAsync not caching results

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -655,8 +655,15 @@ namespace DSharpPlus.Entities
         /// Gets the currently active or scheduled events in this guild.
         /// </summary>
         /// <returns>The active and scheduled events on the server, if any.</returns>
-        public Task<IReadOnlyList<DiscordScheduledGuildEvent>> GetEventsAsync()
-            => this.Discord.ApiClient.GetScheduledGuildEventsAsync(this.Id);
+        public async Task<IReadOnlyList<DiscordScheduledGuildEvent>> GetEventsAsync()
+        {
+            var events = await this.Discord.ApiClient.GetScheduledGuildEventsAsync(this.Id);
+
+            foreach (var @event in events)
+                this._scheduledEvents[@event.Id] = @event;
+
+            return events;
+        }
 
         /// <summary>
         /// Gets a list of users who are interested in this event.

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1078,7 +1078,7 @@ namespace DSharpPlus.Net
 
             var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.GET, route, new Dictionary<string, string>(), string.Empty).ConfigureAwait(false);
 
-            var ret = JsonConvert.DeserializeObject<IEnumerable<DiscordScheduledGuildEvent>>(res.Response).ToList();
+            var ret = DiscordJson.ToDiscordObject<IEnumerable<DiscordScheduledGuildEvent>>(res.Response).ToList();
 
             foreach (var xe in ret)
             {


### PR DESCRIPTION
Fixes an issue brought up by @Takato on Discord wherein they pointed out that `DiscordGuild#GetEventsAsync` did not cache events correctly. This is incorrect behavior and has been fixed.