### PR TITLE
Add missing method parameter to GetEventsAsync()

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -654,9 +654,10 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the currently active or scheduled events in this guild.
         /// </summary>
+        /// <param name="withUserCounts"></param>
         /// <returns>The active and scheduled events on the server, if any.</returns>
-        public Task<IReadOnlyList<DiscordScheduledGuildEvent>> GetEventsAsync()
-            => this.Discord.ApiClient.GetScheduledGuildEventsAsync(this.Id);
+        public Task<IReadOnlyList<DiscordScheduledGuildEvent>> GetEventsAsync(bool withUserCounts = false)
+            => this.Discord.ApiClient.GetScheduledGuildEventsAsync(this.Id, withUserCounts);
 
         /// <summary>
         /// Gets a list of users who are interested in this event.

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -654,7 +654,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the currently active or scheduled events in this guild.
         /// </summary>
-        /// <param name="withUserCounts"></param>
+        /// <param name="withUserCounts">Whether to include number of users subscribed to each event</param>
         /// <returns>The active and scheduled events on the server, if any.</returns>
         public Task<IReadOnlyList<DiscordScheduledGuildEvent>> GetEventsAsync(bool withUserCounts = false)
             => this.Discord.ApiClient.GetScheduledGuildEventsAsync(this.Id, withUserCounts);

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1072,7 +1072,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EVENTS}";
             var bucket = this.Rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var query = new Dictionary<string, string>() { { "with_counts", with_user_counts.ToString() } };
+            var query = new Dictionary<string, string>() { { "with_user_count", with_user_counts.ToString() } };
 
             var url = Utilities.GetApiUriFor(path, BuildQueryString(query));
 


### PR DESCRIPTION
# Summary
Adds a parameter for DiscordGuild.GetEventsAsync() method.


# Notes
As discussed here: [click](https://discord.com/channels/379378609942560770/379378610412191753/941461428928397352)
Prayed 3 times that nothing breaks, hope that was enough.