### PR TITLE
Fix guild's IconUrl

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -513,6 +513,9 @@ namespace DSharpPlus.Entities
         /// <returns>The URL of the guild's icon.</returns>
         public string GetIconUrl(ImageFormat imageFormat, ushort imageSize = 1024)
         {
+            
+            if (string.IsNullOrWhiteSpace(this.IconHash))
+                return null;
 
             if (imageFormat == ImageFormat.Unknown)
                 throw new ArgumentException("You must specify valid image format.", nameof(imageFormat));


### PR DESCRIPTION
# Summary
Fixes an issue with guild's icon URL format always being .jpg even if the icon is animated.
Adds a method to construct guild icon URL.

# Changes proposed

- Changed default icon format from jpg to png

-  Added a check in IconUrl property for animated icons.

-  Created a method for constructing icon URL with specified image format and size.