### PR TITLE
Fix broken DiscordMember guild avatars.

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -616,7 +616,7 @@ namespace DSharpPlus.Entities
                 ImageFormat.Jpeg => "jpg",
                 ImageFormat.Png => "png",
                 ImageFormat.WebP => "webp",
-                ImageFormat.Auto => !string.IsNullOrWhiteSpace(this.AvatarHash) ? (this.AvatarHash.StartsWith("a_") ? "gif" : "png") : "png",
+                ImageFormat.Auto => !string.IsNullOrWhiteSpace(this.GuildAvatarHash) ? (this.GuildAvatarHash.StartsWith("a_") ? "gif" : "png") : "png",
                 _ => throw new ArgumentOutOfRangeException(nameof(imageFormat)),
             };
             var stringImageSize = imageSize.ToString(CultureInfo.InvariantCulture);


### PR DESCRIPTION
# Summary
Fixes `GetGuildAvatarUrl()` method in `DiscordMember`

# Description
Noticed an issue with guild avatars not working when the user's avatar is animated. The reason for it was that `GetGuildAvatarUrl()` was checking user's avatar hash instead of guild avatar hash.

# Changes

- Replaced `AvatarHash` with `GuildAvatarHash` for `ImageFormat.Auto` switch case.