### PR TITLE
Fix PresenceEvent using old activity when new activities are empty

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1902,6 +1902,11 @@ namespace DSharpPlus
                     else
                         presence.Activity = new DiscordActivity(presence.RawActivity);
                 }
+                else
+                {
+                    presence.RawActivity = null;
+                    presence.Activity = null;
+                }
             }
 
             if (this.UserCache.TryGetValue(uid, out var usr))


### PR DESCRIPTION
# Summary
This fixes an issue where, in the presence event, `event.PresenceAfter.Activity` used the old activity, when the new activities are empty.

# Details
Ever since Discord begun sending multiple activities with arrays, DSharpPlus introduced a new `Activities` field for `DiscordPresence`, but have left the `Activity` field for compatibility & (presumably) convenience. This seems to have introduced been a few bugs & inconsistencies with `DiscordPresence`, where `Activities` had the correct data, whereas `Activity` had old/inconsistent data.

This PR fixes one case, in which, when a user no longer has any activities, `event.PresenceAfter.Activity` does not reflect this change, whereas `event.PresenceAfter.Activities` does, by being empty .

# Changes proposed
* Assign null to `presence.Activity` & `presence.RawActivity` if the Activities array is empty.

# Notes
I would advise changing the `DiscordPresence.Activity` field to a property that simply attempts accessing `DiscordPresence.Activities[0]`, so these inconsistencies caused by updating `Activities`, but not updating `Activity`, stop occurring.

https://github.com/DSharpPlus/DSharpPlus/blob/4cfca86031d08d09d374b5b5e9f1752b5e6cb8d6/DSharpPlus/Entities/User/DiscordPresence.cs#L53

Could be updated to:
```cs
public DiscordActivity Activity => this.Activities.Count > 0 ? this.Activities[0] : null;
```


