### PR TITLE
Add default value to AsEphemeral() parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ bld/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+
+# Visual Studio Code cache/options directory
+.vscode/
+
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -243,7 +243,7 @@ namespace DSharpPlus.Entities
         /// Sets the interaction response to be ephemeral.
         /// </summary>
         /// <param name="ephemeral">Ephemeral.</param>
-        public DiscordInteractionResponseBuilder AsEphemeral(bool ephemeral)
+        public DiscordInteractionResponseBuilder AsEphemeral(bool ephemeral = true)
         {
             this.IsEphemeral = ephemeral;
             return this;


### PR DESCRIPTION
# Summary
Addresses a small annoyance I always had with the `.AsEphemeral()` method.

# Details
The name `AsEphemeral` suggests that a certain response should be sent as an ephemeral message. Since the response builder defaults to not being ephemeral, and `AsEphemeral` takes a boolean argument, it felt appropriate to default the parameter to `true`. This should cause no breaking changes to currently existing code.

# Changes proposed
This
```cs
public DiscordInteractionResponseBuilder AsEphemeral(bool ephemeral = true)
```
In contrast to this
```cs
public DiscordInteractionResponseBuilder AsEphemeral(bool ephemeral)
```

# Notes
I've also added VSC's cache folder to `.gitignore`.