### PR TITLE
Add custom slash command argument converters

### DIFF
--- a/DSharpPlus.SlashCommands/Converters/CustomConverters.cs
+++ b/DSharpPlus.SlashCommands/Converters/CustomConverters.cs
@@ -33,32 +33,32 @@ namespace DSharpPlus.SlashCommands.Converters
     {
         public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.String;
 
+        private static Regex TimeSpanRegex { get; set; }
+
+        static TimespanConverter()
+        {
+#if NETSTANDARD1_3
+            TimeSpanRegex = new Regex(@"^(?<days>\d+d\s*)?(?<hours>\d{1,2}h\s*)?(?<minutes>\d{1,2}m\s*)?(?<seconds>\d{1,2}s\s*)?$", RegexOptions.ECMAScript);
+#else
+            TimeSpanRegex = new Regex(@"^(?<days>\d+d\s*)?(?<hours>\d{1,2}h\s*)?(?<minutes>\d{1,2}m\s*)?(?<seconds>\d{1,2}s\s*)?$", RegexOptions.ECMAScript | RegexOptions.Compiled);
+#endif
+        }
+
         public Task<TimeSpan?> Convert(DiscordInteractionDataOption value, InteractionContext context)
         {
-            var timeSpanRegex =
-                new Regex(@"^(?<days>\d+d\s*)?(?<hours>\d{1,2}h\s*)?(?<minutes>\d{1,2}m\s*)?(?<seconds>\d{1,2}s\s*)?$",
-                    RegexOptions.ECMAScript);
             if (value.Value.ToString() == "0")
-            {
                 return Task.FromResult((TimeSpan?)TimeSpan.Zero);
-            }
 
             if (int.TryParse(value.Value.ToString(), NumberStyles.Number, CultureInfo.InvariantCulture, out _))
-            {
                 return Task.FromResult((TimeSpan?)null);
-            }
 
             if (TimeSpan.TryParse(value.Value.ToString().ToLowerInvariant(), CultureInfo.InvariantCulture, out var result))
-            {
                 return Task.FromResult((TimeSpan?)result);
-            }
 
-            var gps = new string[] {"days", "hours", "minutes", "seconds"};
-            var mtc = timeSpanRegex.Match(value.Value.ToString());
+            var gps = new string[] { "days", "hours", "minutes", "seconds" };
+            var mtc = TimeSpanRegex.Match(value.Value.ToString().ToLowerInvariant());
             if (!mtc.Success)
-            {
                 return Task.FromResult((TimeSpan?)null);
-            }
 
             var d = 0;
             var h = 0;
@@ -69,11 +69,9 @@ namespace DSharpPlus.SlashCommands.Converters
                 var gpc = mtc.Groups[gp].Value;
                 if (string.IsNullOrWhiteSpace(gpc))
                     continue;
-                gpc = gpc.Trim();
 
                 var gpt = gpc[gpc.Length - 1];
-                int.TryParse(gpc.Substring(0, gpc.Length - 1), NumberStyles.Integer, CultureInfo.InvariantCulture,
-                    out var val);
+                int.TryParse(gpc.Substring(0, gpc.Length - 1), NumberStyles.Integer, CultureInfo.InvariantCulture, out var val);
                 switch (gpt)
                 {
                     case 'd':
@@ -93,7 +91,6 @@ namespace DSharpPlus.SlashCommands.Converters
                         break;
                 }
             }
-
             result = new TimeSpan(d, h, m, s);
             return Task.FromResult((TimeSpan?)result);
         }

--- a/DSharpPlus.SlashCommands/Converters/CustomConverters.cs
+++ b/DSharpPlus.SlashCommands/Converters/CustomConverters.cs
@@ -1,0 +1,113 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.SlashCommands.Converters
+{
+    public class TimespanConverter : ISlashArgumentConverter<TimeSpan?>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.String;
+
+        public Task<TimeSpan?> Convert(DiscordInteractionDataOption value, InteractionContext context)
+        {
+            var timeSpanRegex =
+                new Regex(@"^(?<days>\d+d\s*)?(?<hours>\d{1,2}h\s*)?(?<minutes>\d{1,2}m\s*)?(?<seconds>\d{1,2}s\s*)?$",
+                    RegexOptions.ECMAScript);
+            if (value.Value.ToString() == "0")
+            {
+                return Task.FromResult((TimeSpan?)TimeSpan.Zero);
+            }
+
+            if (int.TryParse(value.Value.ToString(), NumberStyles.Number, CultureInfo.InvariantCulture, out _))
+            {
+                return Task.FromResult((TimeSpan?)null);
+            }
+
+            if (TimeSpan.TryParse(value.Value.ToString().ToLowerInvariant(), CultureInfo.InvariantCulture, out var result))
+            {
+                return Task.FromResult((TimeSpan?)result);
+            }
+
+            var gps = new string[] {"days", "hours", "minutes", "seconds"};
+            var mtc = timeSpanRegex.Match(value.Value.ToString());
+            if (!mtc.Success)
+            {
+                return Task.FromResult((TimeSpan?)null);
+            }
+
+            var d = 0;
+            var h = 0;
+            var m = 0;
+            var s = 0;
+            foreach (var gp in gps)
+            {
+                var gpc = mtc.Groups[gp].Value;
+                if (string.IsNullOrWhiteSpace(gpc))
+                    continue;
+                gpc = gpc.Trim();
+
+                var gpt = gpc[gpc.Length - 1];
+                int.TryParse(gpc.Substring(0, gpc.Length - 1), NumberStyles.Integer, CultureInfo.InvariantCulture,
+                    out var val);
+                switch (gpt)
+                {
+                    case 'd':
+                        d = val;
+                        break;
+
+                    case 'h':
+                        h = val;
+                        break;
+
+                    case 'm':
+                        m = val;
+                        break;
+
+                    case 's':
+                        s = val;
+                        break;
+                }
+            }
+
+            result = new TimeSpan(d, h, m, s);
+            return Task.FromResult((TimeSpan?)result);
+        }
+    }
+
+    public class EmojiConverter : ISlashArgumentConverter<DiscordEmoji>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.String;
+
+        public Task<DiscordEmoji> Convert(DiscordInteractionDataOption value, InteractionContext context)
+        {
+            if (DiscordEmoji.TryFromUnicode(context.Client, value.Value.ToString(), out var emoji) || DiscordEmoji.TryFromName(context.Client, value.Value.ToString(), out emoji))
+                return Task.FromResult(emoji);
+            throw new ArgumentException("Error parsing emoji parameter.");
+        }
+    }
+}

--- a/DSharpPlus.SlashCommands/Converters/DefaultConverters.cs
+++ b/DSharpPlus.SlashCommands/Converters/DefaultConverters.cs
@@ -1,0 +1,159 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Threading.Tasks;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.SlashCommands.Converters
+{
+    public class StringConverter : ISlashArgumentConverter<string>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.String;
+
+        public Task<string> Convert(DiscordInteractionDataOption value, InteractionContext context)
+            => Task.FromResult(value.Value.ToString());
+    }
+
+    public class LongConverter : ISlashArgumentConverter<long>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Integer;
+
+        public Task<long> Convert(DiscordInteractionDataOption value, InteractionContext context)
+            => Task.FromResult((long)value.Value);
+    }
+
+    public class NullableLongConverter : ISlashArgumentConverter<long?>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Integer;
+
+        public Task<long?> Convert(DiscordInteractionDataOption value, InteractionContext context)
+            => Task.FromResult((long?)value.Value);
+    }
+
+    public class BoolConverter : ISlashArgumentConverter<bool>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Boolean;
+        public Task<bool> Convert(DiscordInteractionDataOption value, InteractionContext context)
+            => Task.FromResult((bool)value.Value);
+    }
+
+    public class NullableBoolConverter : ISlashArgumentConverter<bool?>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Boolean;
+        public Task<bool?> Convert(DiscordInteractionDataOption value, InteractionContext context)
+            => Task.FromResult((bool?)value.Value);
+    }
+
+    public class DoubleConverter : ISlashArgumentConverter<double>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Number;
+
+        public Task<double> Convert(DiscordInteractionDataOption value, InteractionContext context)
+            => Task.FromResult((double)value.Value);
+    }
+
+    public class NullableDoubleConverter : ISlashArgumentConverter<double?>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Number;
+
+        public Task<double?> Convert(DiscordInteractionDataOption value, InteractionContext context)
+            => Task.FromResult((double?)value.Value);
+    }
+
+    public class UserConverter : ISlashArgumentConverter<DiscordUser>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.User;
+
+        public async Task<DiscordUser> Convert(DiscordInteractionDataOption value, InteractionContext context)
+        {
+            //Checks through resolved
+            if (context.Interaction.Data.Resolved.Members != null &&
+                context.Interaction.Data.Resolved.Members.TryGetValue((ulong)value.Value, out var member))
+                return member;
+            if (context.Interaction.Data.Resolved.Users != null &&
+                     context.Interaction.Data.Resolved.Users.TryGetValue((ulong)value.Value, out var user))
+                return user;
+            return(await context.Client.GetUserAsync((ulong)value.Value));
+        }
+    }
+
+    public class ChannelConverter : ISlashArgumentConverter<DiscordChannel>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Channel;
+
+        public Task<DiscordChannel> Convert(DiscordInteractionDataOption value, InteractionContext context)
+        {
+            //Checks through resolved
+            if (context.Interaction.Data.Resolved.Channels != null &&
+                context.Interaction.Data.Resolved.Channels.TryGetValue((ulong)value.Value, out var channel))
+                return Task.FromResult(channel);
+            return Task.FromResult(context.Interaction.Guild.GetChannel((ulong)value.Value));
+        }
+    }
+
+    public class RoleConverter : ISlashArgumentConverter<DiscordRole>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Role;
+
+        public Task<DiscordRole> Convert(DiscordInteractionDataOption value, InteractionContext context)
+        {
+            //Checks through resolved
+            if (context.Interaction.Data.Resolved.Roles != null &&
+                context.Interaction.Data.Resolved.Roles.TryGetValue((ulong)value.Value, out var role))
+                return Task.FromResult(role);
+            return Task.FromResult(context.Interaction.Guild.GetRole((ulong)value.Value));
+        }
+    }
+
+    public class MentionableConverter : ISlashArgumentConverter<SnowflakeObject>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Mentionable;
+
+        public Task<SnowflakeObject> Convert(DiscordInteractionDataOption value, InteractionContext context)
+        {
+            if (context.Interaction.Data.Resolved.Roles != null && context.Interaction.Data.Resolved.Roles.TryGetValue((ulong)value.Value, out var role))
+                return Task.FromResult((SnowflakeObject)role);
+            if (context.Interaction.Data.Resolved.Members != null && context.Interaction.Data.Resolved.Members.TryGetValue((ulong)value.Value, out var member))
+                return Task.FromResult((SnowflakeObject)member);
+            if (context.Interaction.Data.Resolved.Users != null && context.Interaction.Data.Resolved.Users.TryGetValue((ulong)value.Value, out var user))
+                return Task.FromResult((SnowflakeObject)user);
+            throw new ArgumentException("Error resolving mentionable option.");
+        }
+    }
+
+    public class AttachmentConverter : ISlashArgumentConverter<DiscordAttachment>
+    {
+        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Attachment;
+        public Task<DiscordAttachment> Convert(DiscordInteractionDataOption value, InteractionContext context)
+        {
+            if (context.Interaction.Data.Resolved.Attachments?.ContainsKey((ulong)value.Value) ?? false)
+            {
+                var attachment = context.Interaction.Data.Resolved.Attachments[(ulong)value.Value];
+                return Task.FromResult(attachment);
+            }
+
+            throw new ArgumentException("Missing attachment in resolved data. This is an issue with Discord.");
+        }
+    }
+}

--- a/DSharpPlus.SlashCommands/Converters/DefaultConverters.cs
+++ b/DSharpPlus.SlashCommands/Converters/DefaultConverters.cs
@@ -124,9 +124,10 @@ namespace DSharpPlus.SlashCommands.Converters
         public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Attachment;
         public Task<DiscordAttachment> Convert(DiscordInteractionDataOption value, InteractionContext context)
         {
-            if (context.Interaction.Data.Resolved.Attachments?.ContainsKey((ulong)value.Value) ?? false)
+            var ulongValue = (ulong)value.Value;
+            if (context.Interaction.Data.Resolved.Attachments?.ContainsKey(ulongValue) ?? false)
             {
-                var attachment = context.Interaction.Data.Resolved.Attachments[(ulong)value.Value];
+                var attachment = context.Interaction.Data.Resolved.Attachments[ulongValue];
                 return Task.FromResult(attachment);
             }
 

--- a/DSharpPlus.SlashCommands/Converters/DefaultConverters.cs
+++ b/DSharpPlus.SlashCommands/Converters/DefaultConverters.cs
@@ -35,15 +35,7 @@ namespace DSharpPlus.SlashCommands.Converters
             => Task.FromResult(value.Value.ToString());
     }
 
-    public class LongConverter : ISlashArgumentConverter<long>
-    {
-        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Integer;
-
-        public Task<long> Convert(DiscordInteractionDataOption value, InteractionContext context)
-            => Task.FromResult((long)value.Value);
-    }
-
-    public class NullableLongConverter : ISlashArgumentConverter<long?>
+    public class LongConverter : ISlashArgumentConverter<long?>
     {
         public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Integer;
 
@@ -51,29 +43,14 @@ namespace DSharpPlus.SlashCommands.Converters
             => Task.FromResult((long?)value.Value);
     }
 
-    public class BoolConverter : ISlashArgumentConverter<bool>
-    {
-        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Boolean;
-        public Task<bool> Convert(DiscordInteractionDataOption value, InteractionContext context)
-            => Task.FromResult((bool)value.Value);
-    }
-
-    public class NullableBoolConverter : ISlashArgumentConverter<bool?>
+    public class BoolConverter : ISlashArgumentConverter<bool?>
     {
         public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Boolean;
         public Task<bool?> Convert(DiscordInteractionDataOption value, InteractionContext context)
             => Task.FromResult((bool?)value.Value);
     }
 
-    public class DoubleConverter : ISlashArgumentConverter<double>
-    {
-        public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Number;
-
-        public Task<double> Convert(DiscordInteractionDataOption value, InteractionContext context)
-            => Task.FromResult((double)value.Value);
-    }
-
-    public class NullableDoubleConverter : ISlashArgumentConverter<double?>
+    public class DoubleConverter : ISlashArgumentConverter<double?>
     {
         public ApplicationCommandOptionType OptionType { get; } = ApplicationCommandOptionType.Number;
 

--- a/DSharpPlus.SlashCommands/Converters/ISlashArgumentConverter.cs
+++ b/DSharpPlus.SlashCommands/Converters/ISlashArgumentConverter.cs
@@ -1,0 +1,53 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Threading.Tasks;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.SlashCommands.Converters
+{
+    /// <summary>
+    /// Argument converter abstract.
+    /// </summary>
+    public interface ISlashArgumentConverter
+    { }
+
+    /// <summary>
+    /// Represents a slash command converter for specific argument type.
+    /// </summary>
+    /// <typeparam name="T">Type for which the converter is to be registered.</typeparam>
+    public interface ISlashArgumentConverter<T> : ISlashArgumentConverter
+    {
+        /// <summary>
+        /// Slash command argument type that should be registered for this argument type.
+        /// </summary>
+        public ApplicationCommandOptionType OptionType { get; }
+
+        /// <summary>
+        /// Converts the raw value into the specified type.
+        /// </summary>
+        /// <param name="value">Value to convert.</param>
+        /// <param name="context">Context in which the value will be converted.</param>
+        public Task<T> Convert(DiscordInteractionDataOption value, InteractionContext context);
+    }
+}


### PR DESCRIPTION
# Summary
Adds the ability for slash command users to define their own argument converters. Also moves all the default converters to the same system.

# Details
Uses a similar system to how it works in commandsnext. This greatly cleans up the slashcommandsextension.cs file, and makes a distinction between the converters for the default values and the converters for timespan and discordemoji which aren't parsed by discord.