### PR TITLE
Adds role ID support to RequireRolesAttribute

### DIFF
--- a/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
@@ -95,8 +95,7 @@ namespace DSharpPlus.CommandsNext.Attributes
             if (ctx.Guild == null || ctx.Member == null)
                 return Task.FromResult(false);
 
-            if (((this.CheckMode & RoleCheckMode.MatchNames) != 0 && (this.CheckMode & RoleCheckMode.MatchIds) == 0)
-                || this.RoleIds.Count == 0)
+            if ((this.CheckMode.HasValue(RoleCheckMode.MatchNames) && !this.CheckMode.HasValue(RoleCheckMode.MatchIds)) || this.RoleIds.Count == 0)
             {
                 var roleNames = ctx.Member.Roles.Select(xr => xr.Name);
                 var roleNameCount = roleNames.Count();
@@ -111,8 +110,7 @@ namespace DSharpPlus.CommandsNext.Attributes
                     _ => Task.FromResult(intersectCount > 0),
                 };
             }
-            else if (((this.CheckMode & RoleCheckMode.MatchIds) != 0 && (this.CheckMode & RoleCheckMode.MatchNames) == 0)
-                || this.RoleNames.Count == 0)
+            else if ((!this.CheckMode.HasValue(RoleCheckMode.MatchNames) && this.CheckMode.HasValue(RoleCheckMode.MatchIds)) || this.RoleNames.Count == 0)
             {
                 var roleIds = ctx.Member.RoleIds;
                 var roleIdCount = roleIds.Count();

--- a/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
@@ -95,7 +95,8 @@ namespace DSharpPlus.CommandsNext.Attributes
             if (ctx.Guild == null || ctx.Member == null)
                 return Task.FromResult(false);
 
-            if ((this.CheckMode.HasValue(RoleCheckMode.MatchNames) && !this.CheckMode.HasValue(RoleCheckMode.MatchIds)) || this.RoleIds.Count == 0)
+            if (((this.CheckMode & RoleCheckMode.MatchNames) != 0 && (this.CheckMode & RoleCheckMode.MatchIds) == 0)
+                || this.RoleIds.Count == 0)
             {
                 var roleNames = ctx.Member.Roles.Select(xr => xr.Name);
                 var roleNameCount = roleNames.Count();
@@ -110,7 +111,8 @@ namespace DSharpPlus.CommandsNext.Attributes
                     _ => Task.FromResult(intersectCount > 0),
                 };
             }
-            else if ((!this.CheckMode.HasValue(RoleCheckMode.MatchNames) && this.CheckMode.HasValue(RoleCheckMode.MatchIds)) || this.RoleNames.Count == 0)
+            else if (((this.CheckMode & RoleCheckMode.MatchIds) != 0 && (this.CheckMode & RoleCheckMode.MatchNames) == 0)
+                || this.RoleNames.Count == 0)
             {
                 var roleIds = ctx.Member.RoleIds;
                 var roleIdCount = roleIds.Count();

--- a/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
@@ -95,8 +95,7 @@ namespace DSharpPlus.CommandsNext.Attributes
             if (ctx.Guild == null || ctx.Member == null)
                 return Task.FromResult(false);
 
-            if (((this.CheckMode & RoleCheckMode.MatchNames) != 0 && (this.CheckMode & RoleCheckMode.MatchIds) == 0)
-                || this.RoleIds.Count == 0)
+            if ((this.CheckMode.HasFlag(RoleCheckMode.MatchNames) && !this.CheckMode.HasFlag(RoleCheckMode.MatchIds)) || this.RoleIds.Count == 0)
             {
                 var roleNames = ctx.Member.Roles.Select(xr => xr.Name);
                 var roleNameCount = roleNames.Count();
@@ -111,8 +110,7 @@ namespace DSharpPlus.CommandsNext.Attributes
                     _ => Task.FromResult(intersectCount > 0),
                 };
             }
-            else if (((this.CheckMode & RoleCheckMode.MatchIds) != 0 && (this.CheckMode & RoleCheckMode.MatchNames) == 0)
-                || this.RoleNames.Count == 0)
+            else if ((!this.CheckMode.HasFlag(RoleCheckMode.MatchNames) && this.CheckMode.HasFlag(RoleCheckMode.MatchIds)) || this.RoleNames.Count == 0)
             {
                 var roleIds = ctx.Member.RoleIds;
                 var roleIdCount = roleIds.Count();


### PR DESCRIPTION
# Summary

Allow RequireRoleAttribute to match against IDs

# Details

This allows RequireRoleAttribute to match against IDs, retaining the capability to match against role names.

This commit breaks some unintended use cases such as manually casting an integer to RoleCheckMode, but it should not break any intended use cases for the attribute