### PR TITLE
Fixed user object not being grabbed from cache

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1657,7 +1657,11 @@ namespace DSharpPlus
 
             emoji.Discord = this;
 
-            var usr = this.UpdateUser(new DiscordUser { Id = userId, Discord = this }, guildId, guild, mbr);
+            DiscordUser usr = null!;
+            if (!this.TryGetCachedUserInternal(userId, out usr))
+            {
+                usr = this.UpdateUser(new DiscordUser { Id = userId, Discord = this }, guildId, guild, mbr);
+            }
 
             if (channel == null)
             {


### PR DESCRIPTION
Fixes the `MessageReactionAddEventArgs.User` property being set to default (+id).
Before:
![image](https://user-images.githubusercontent.com/46751150/156954030-e7394eba-4223-40f1-a738-94d356a42da7.png)
After:
![image](https://user-images.githubusercontent.com/46751150/156953968-084fb156-5c9f-4722-bff5-63a2d45bd38b.png)