### PR TITLE
Fixed WaitForModalAsync() and added overload

### DIFF
--- a/DSharpPlus.Interactivity/EventHandling/ModalEventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ModalEventWaiter.cs
@@ -1,0 +1,96 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using ConcurrentCollections;
+using DSharpPlus.EventArgs;
+using Microsoft.Extensions.Logging;
+
+namespace DSharpPlus.Interactivity.EventHandling
+{
+    /// <summary>
+    /// Modal version of <see cref="EventWaiter{T}"/>
+    /// </summary>
+    internal class ModalEventWaiter : IDisposable
+    {
+        private DiscordClient Client { get;}
+
+        /// <summary>
+        /// Collection of <see cref = "ModalMatchRequest"/> representing requests to wait for modals.
+        /// </summary>
+        private ConcurrentHashSet<ModalMatchRequest> MatchRequests { get; } = new();
+
+        public ModalEventWaiter(DiscordClient client)
+        {
+            this.Client = client;
+            this.Client.ModalSubmitted += this.Handle; //registering Handle event to be fired upon ModalSubmitted
+        }
+
+        /// <summary>
+        /// Waits for a specified <see cref="ModalMatchRequest"/>'s predicate to be fufilled.
+        /// </summary>
+        /// <param name="request">The request to wait for a match.</param>
+        /// <returns>The returned args, or null if it timed out.</returns>
+        public async Task<ModalSubmitEventArgs> WaitForMatchAsync(ModalMatchRequest request)
+        {
+            this.MatchRequests.Add(request);
+
+            try
+            {
+                return await request.Tcs.Task.ConfigureAwait(false); // awaits request until completeion or cancellation
+            }
+            catch(Exception e)
+            {
+                this.Client.Logger.LogError(InteractivityEvents.InteractivityWaitError, e, "An exception was thrown while waiting for a modal.");
+                return null;
+            }
+            finally
+            {
+                this.MatchRequests.TryRemove(request);
+            }
+        }
+
+        /// <summary>
+        /// Is called whenever <see cref="ModalSubmitEventArgs"/> is fired. Checks to see submitted modal matches any of the current requests.
+        /// </summary>
+        /// <param name="args">The <see cref="ModalSubmitEventArgs"/> to match.</param>
+        /// <returns>A task that represents matching the requests.</returns>
+        private Task Handle(DiscordClient _, ModalSubmitEventArgs args)
+        {
+            foreach(var req in this.MatchRequests.ToArray()) // ToArray to get a copy of the collection that won't be modified during iteration
+            {
+                if(req.ModalId == args.Interaction.Data.CustomId && req.IsMatch(args)) // will catch all matches
+                    req.Tcs.TrySetResult(args);
+            }
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            this.MatchRequests.Clear();
+            this.Client.ModalSubmitted -= this.Handle;
+        }
+    }
+}

--- a/DSharpPlus.Interactivity/EventHandling/ModalEventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ModalEventWaiter.cs
@@ -35,7 +35,7 @@ namespace DSharpPlus.Interactivity.EventHandling
     /// </summary>
     internal class ModalEventWaiter : IDisposable
     {
-        private DiscordClient Client { get;}
+        private DiscordClient Client { get; }
 
         /// <summary>
         /// Collection of <see cref = "ModalMatchRequest"/> representing requests to wait for modals.
@@ -61,7 +61,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             {
                 return await request.Tcs.Task.ConfigureAwait(false); // awaits request until completeion or cancellation
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 this.Client.Logger.LogError(InteractivityEvents.InteractivityWaitError, e, "An exception was thrown while waiting for a modal.");
                 return null;
@@ -75,13 +75,14 @@ namespace DSharpPlus.Interactivity.EventHandling
         /// <summary>
         /// Is called whenever <see cref="ModalSubmitEventArgs"/> is fired. Checks to see submitted modal matches any of the current requests.
         /// </summary>
+        /// <param name="_"></param>
         /// <param name="args">The <see cref="ModalSubmitEventArgs"/> to match.</param>
         /// <returns>A task that represents matching the requests.</returns>
         private Task Handle(DiscordClient _, ModalSubmitEventArgs args)
         {
-            foreach(var req in this.MatchRequests.ToArray()) // ToArray to get a copy of the collection that won't be modified during iteration
+            foreach (var req in this.MatchRequests.ToArray()) // ToArray to get a copy of the collection that won't be modified during iteration
             {
-                if(req.ModalId == args.Interaction.Data.CustomId && req.IsMatch(args)) // will catch all matches
+                if (req.ModalId == args.Interaction.Data.CustomId && req.IsMatch(args)) // will catch all matches
                     req.Tcs.TrySetResult(args);
             }
             return Task.CompletedTask;

--- a/DSharpPlus.Interactivity/EventHandling/Requests/ModalMatchRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/ModalMatchRequest.cs
@@ -55,7 +55,7 @@ namespace DSharpPlus.Interactivity.EventHandling
             this.ModalId = modal_id;
             this.Predicate = predicate;
             this.Cancellation = cancellation;
-            this.Cancellation.Register(() => this.Tcs.TrySetResult(null)); // "TrySetCancelled would probably be better but I digress" - Velvet //
+            this.Cancellation.Register(() => this.Tcs.TrySetResult(null)); // "TrySetCancelled would probably be better but I digress" - Velvet // "TrySetCancelled throws an exception when you await the task, actually" - Velvet, 2022
         }
 
         /// <summary>

--- a/DSharpPlus.Interactivity/EventHandling/Requests/ModalMatchRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/ModalMatchRequest.cs
@@ -1,0 +1,69 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DSharpPlus.EventArgs;
+
+namespace DSharpPlus.Interactivity.EventHandling
+{
+    /// <summary>
+    /// Represents a match request for a modal of the given Id and predicate.
+    /// </summary>
+    internal class ModalMatchRequest
+    {
+        /// <summary>
+        /// The custom Id of the modal.
+        /// </summary>
+        public string ModalId { get; }
+
+        /// <summary>
+        /// The completion source that represents the result of the match.
+        /// </summary>
+        public TaskCompletionSource<ModalSubmitEventArgs> Tcs { get; private set; } = new();
+
+        protected CancellationToken Cancellation { get; }
+
+        /// <summary>
+        /// The predicate/criteria that this match will be fulfilled under.
+        /// </summary>
+        protected Func<ModalSubmitEventArgs, bool> Predicate { get; }
+
+        public ModalMatchRequest(string modal_id, Func<ModalSubmitEventArgs, bool> predicate, CancellationToken cancellation)
+        {
+            this.ModalId = modal_id;
+            this.Predicate = predicate;
+            this.Cancellation = cancellation;
+            this.Cancellation.Register(() => this.Tcs.TrySetResult(null)); // "TrySetCancelled would probably be better but I digress" - Velvet //
+        }
+
+        /// <summary>
+        /// Checks whether the <see cref="ModalSubmitEventArgs"/> matches the predicate criteria.
+        /// </summary>
+        /// <param name="args">The <see cref="ModalSubmitEventArgs"/> to check.</param>
+        /// <returns>Whether the <see cref="ModalSubmitEventArgs"/> matches the predicate.</returns>
+        public bool IsMatch(ModalSubmitEventArgs args)
+            => this.Predicate(args);
+    }
+}

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -55,6 +55,8 @@ namespace DSharpPlus.Interactivity
 
         private ComponentEventWaiter ComponentEventWaiter;
 
+        private ModalEventWaiter ModalEventWaiter;
+
         private ReactionCollector ReactionCollector;
 
         private Poller Poller;
@@ -81,6 +83,7 @@ namespace DSharpPlus.Interactivity
             this.Paginator = new Paginator(this.Client);
             this._compPaginator = new(this.Client, this.Config);
             this.ComponentEventWaiter = new(this.Client, this.Config);
+            this.ModalEventWaiter = new(this.Client);
 
         }
 
@@ -115,12 +118,63 @@ namespace DSharpPlus.Interactivity
         }
 
         /// <summary>
-        /// Waits for a user to submit a modal.
+        /// Waits for a modal with the specified id to be submitted.
         /// </summary>
-        /// <param name="modal_id">The id of the modal to wait for.</param>
+        /// <param name="modal_id">The id of the modal to wait for. Should be unique to avoid issues.</param>
         /// <param name="timeoutOverride">Override the timeout period in <see cref="InteractivityConfiguration"/>.</param>
+        /// <returns>A <see cref="InteractivityResult{ModalSubmitEventArgs}"/> with a modal if the interactivity did not time out.</returns>
         public Task<InteractivityResult<ModalSubmitEventArgs>> WaitForModalAsync(string modal_id, TimeSpan? timeoutOverride = null)
-            => this.WaitForEventArgsAsync<ModalSubmitEventArgs>(m => m.Interaction.Data.CustomId == modal_id, timeoutOverride);
+            => this.WaitForModalAsync(modal_id, this.GetCancellationToken(timeoutOverride));
+
+        /// <summary>
+        /// Waits for a modal with the specified id to be submitted.
+        /// </summary>
+        /// <param name="modal_id">The id of the modal to wait for. Should be unique to avoid issues.</param>
+        /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
+        /// <returns>A <see cref="InteractivityResult{ModalSubmitEventArgs}"/> with a modal if the interactivity did not time out.</returns>
+        public async Task<InteractivityResult<ModalSubmitEventArgs>> WaitForModalAsync(string modal_id, CancellationToken token)
+        {
+            if (string.IsNullOrEmpty(modal_id) || modal_id.Length > 100)
+                throw new ArgumentException("Custom ID must be between 1 and 100 characters.");
+
+            var matchRequest = new ModalMatchRequest(modal_id,
+                    c => c.Interaction.Type == InteractionType.ModalSubmit &&
+                    c.Interaction.Data.CustomId == modal_id, cancellation: token);
+            var result = await this.ModalEventWaiter.WaitForMatchAsync(matchRequest).ConfigureAwait(false);
+
+            return new(result is null, result);
+        }
+
+        /// <summary>
+        /// Waits for a modal with the specificed custom id to be submitted by the given user.
+        /// </summary>
+        /// <param name="modal_id">The id of the modal to wait for. Should be unique to avoid issues.</param>
+        /// <param name="user">The user to wait for the modal from.</param>
+        /// <param name="timeoutOverride">Override the timeout period in <see cref="InteractivityConfiguration"/>.</param>
+        /// <returns>A <see cref="InteractivityResult{ModalSubmitEventArgs}"/> with a modal if the interactivity did not time out.</returns>
+        public Task<InteractivityResult<ModalSubmitEventArgs>> WaitForModalAsync(string modal_id, DiscordUser user, TimeSpan? timeoutOverride = null)
+            => this.WaitForModalAsync(modal_id, user, this.GetCancellationToken(timeoutOverride));
+
+        /// <summary>
+        /// Waits for a modal with the specificed custom id to be submitted by the given user.
+        /// </summary>
+        /// <param name="modal_id">The id of the modal to wait for. Should be unique to avoid issues.</param>
+        /// <param name="user">The user to wait for the modal from.</param>
+        /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
+        /// <returns>A <see cref="InteractivityResult{ModalSubmitEventArgs}"/> with a modal if the interactivity did not time out.</returns>
+        public async Task<InteractivityResult<ModalSubmitEventArgs>> WaitForModalAsync(string modal_id, DiscordUser user, CancellationToken token)
+        {
+            if (string.IsNullOrEmpty(modal_id) || modal_id.Length > 100)
+                throw new ArgumentException("Custom ID must be between 1 and 100 characters.");
+
+            var matchRequest = new ModalMatchRequest(modal_id,
+                    c => c.Interaction.Type == InteractionType.ModalSubmit &&
+                    c.Interaction.Data.CustomId == modal_id &&
+                    c.Interaction.User.Id == user.Id, cancellation: token);
+            var result = await this.ModalEventWaiter.WaitForMatchAsync(matchRequest).ConfigureAwait(false);
+
+            return new(result is null, result);
+        }
 
         /// <summary>
         /// Waits for any button in the specified collection to be pressed.
@@ -604,7 +658,7 @@ namespace DSharpPlus.Interactivity
         {
             var timeout = timeoutoverride ?? this.Config.Timeout;
 
-            using var waiter = new EventWaiter<T>(this.Client);
+            var waiter = new EventWaiter<T>(this.Client);
             var res = await waiter.WaitForMatch(new MatchRequest<T>(predicate, timeout)).ConfigureAwait(false);
             return new InteractivityResult<T>(res == null, res);
         }

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -138,8 +138,7 @@ namespace DSharpPlus.Interactivity
                 throw new ArgumentException("Custom ID must be between 1 and 100 characters.");
 
             var matchRequest = new ModalMatchRequest(modal_id,
-                    c => c.Interaction.Type == InteractionType.ModalSubmit &&
-                    c.Interaction.Data.CustomId == modal_id, cancellation: token);
+                    c => c.Interaction.Data.CustomId == modal_id, cancellation: token);
             var result = await this.ModalEventWaiter.WaitForMatchAsync(matchRequest).ConfigureAwait(false);
 
             return new(result is null, result);
@@ -168,8 +167,7 @@ namespace DSharpPlus.Interactivity
                 throw new ArgumentException("Custom ID must be between 1 and 100 characters.");
 
             var matchRequest = new ModalMatchRequest(modal_id,
-                    c => c.Interaction.Type == InteractionType.ModalSubmit &&
-                    c.Interaction.Data.CustomId == modal_id &&
+                    c => c.Interaction.Data.CustomId == modal_id &&
                     c.Interaction.User.Id == user.Id, cancellation: token);
             var result = await this.ModalEventWaiter.WaitForMatchAsync(matchRequest).ConfigureAwait(false);
 

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -184,7 +184,9 @@ namespace DSharpPlus.Test
 
         private async Task Discord_ModalSubmitted(DiscordClient sender, ModalSubmitEventArgs e)
         {
-            await e.Interaction.CreateResponseAsync(InteractionResponseType.UpdateMessage, new DiscordInteractionResponseBuilder().WithContent("Thank you!"));
+            bool testWaitForModal = true;
+            if(!testWaitForModal)
+                await e.Interaction.CreateResponseAsync(InteractionResponseType.UpdateMessage, new DiscordInteractionResponseBuilder().WithContent("Thank you!"));
 
             this.Discord.Logger.LogInformation("Got callback from user {User}, {Modal}", e.Interaction.User, e.Values);
         }


### PR DESCRIPTION
# Summary
Created an event handler dedicated for modals so that `WaitForModalAsync()` will no longer result in an internal NRE. Also added overloads.

# Changes
- Created ModalEventWaiter class.
- Created ModalMatchRequest class.
- Added three new overloads for `WaitForModalAsync()`, taking a mix of user, Timespan? and CancellationToken parameters.

@VelvetThePanda @OoLunar Thank you both for the help. o7