### PR TITLE
Fixed role icons

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordRole.cs
+++ b/DSharpPlus/Entities/Guild/DiscordRole.cs
@@ -169,7 +169,7 @@ namespace DSharpPlus.Entities
             var mdl = new RoleEditModel();
             action(mdl);
 
-            return this.ModifyAsync(mdl.Name, mdl.Permissions, mdl.Color, mdl.Hoist, mdl.Mentionable, mdl.AuditLogReason);
+            return this.ModifyAsync(mdl.Name, mdl.Permissions, mdl.Color, mdl.Hoist, mdl.Mentionable, mdl.AuditLogReason, mdl.Icon, mdl.Emoji);
         }
 
         /// <summary>


### PR DESCRIPTION
When implementing role icons, everything was correctly added except we forgot to pass the role icon and role emoji arguments to the api client. This lead to role icons not being updated.