### PR TITLE
Fix updating banner in DiscordGuild.ModifyAsync

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -556,10 +556,10 @@ namespace DSharpPlus
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public async Task<DiscordGuild> GetGuildAsync(ulong id, bool? withCounts = null)
         {
-            //if (this._guilds.TryGetValue(id, out var guild) && (!withCounts.HasValue || !withCounts.Value))
-            //    return guild;
+            if (this._guilds.TryGetValue(id, out var guild) && (!withCounts.HasValue || !withCounts.Value))
+                return guild;
 
-            DiscordGuild guild = await this.ApiClient.GetGuildAsync(id, withCounts).ConfigureAwait(false);
+            guild = await this.ApiClient.GetGuildAsync(id, withCounts).ConfigureAwait(false);
             var channels = await this.ApiClient.GetGuildChannelsAsync(guild.Id).ConfigureAwait(false);
             foreach (var channel in channels) guild._channels[channel.Id] = channel;
 

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -824,12 +824,12 @@ namespace DSharpPlus.Entities
 
             var bannerb64 = Optional.FromNoValue<string>();
 
-            if (mdl.Splash.HasValue)
+            if (mdl.Banner.HasValue)
             {
-                if (mdl.Splash.Value == null)
+                if (mdl.Banner.Value == null)
                     bannerb64 = null;
                 else
-                    using (var imgtool = new ImageTool(mdl.Splash.Value))
+                    using (var imgtool = new ImageTool(mdl.Banner.Value))
                         bannerb64 = imgtool.GetBase64();
             }
 


### PR DESCRIPTION
Previously when `mdl.Banner` held a value, copy and pasted code checked if `mdl.Splash` held a value instead. This meant the banner was only updated if the splash held a value.