### PR TITLE
Fix updating banner in DiscordGuild.ModifyAsync

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -823,12 +823,12 @@ namespace DSharpPlus.Entities
 
             var bannerb64 = Optional.FromNoValue<string>();
 
-            if (mdl.Splash.HasValue)
+            if (mdl.Banner.HasValue)
             {
-                if (mdl.Splash.Value == null)
+                if (mdl.Banner.Value == null)
                     bannerb64 = null;
                 else
-                    using (var imgtool = new ImageTool(mdl.Splash.Value))
+                    using (var imgtool = new ImageTool(mdl.Banner.Value))
                         bannerb64 = imgtool.GetBase64();
             }
 


### PR DESCRIPTION
Previously when `mdl.Banner` held a value, copy and pasted code checked if `mdl.Splash` held a value instead. This meant the banner was only updated if the splash held a value.

Closes #1238 due to broken Git history