### PR TITLE
[ci-skip] Switch to self-hosted actions runner

### DIFF
--- a/.github/workflows/publish_nightly.yml
+++ b/.github/workflows/publish_nightly.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish_nightly:
-    runs-on: "ubuntu-latest"
+    runs-on: "self-hosted"
     if: "!contains(toJSON(github.event.commits.*.message), '[ci-skip]')"
     steps:
       - name: "Checkout"

--- a/.github/workflows/publish_nightly.yml
+++ b/.github/workflows/publish_nightly.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish_nightly:
     runs-on: "self-hosted"
-    if: "!contains(toJSON(github.event.commits.*.message), '[ci-skip]')"
+    if: "!contains(format('{0} {1}', github.event.head_commit.message, github.event.pull_request.title), '[ci-skip]')"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish_release:
     runs-on: "self-hosted"
-    if: "!contains(toJSON(github.event.commits.*.message), '[ci-skip]')"
+    if: "!contains(format('{0} {1}', github.event.head_commit.message, github.event.pull_request.title), '[ci-skip]')"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish_release:
-    runs-on: "ubuntu-latest"
+    runs-on: "self-hosted"
     if: "!contains(toJSON(github.event.commits.*.message), '[ci-skip]')"
     steps:
       - name: "Checkout"

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   build_pr:
-    runs-on: "ubuntu-latest"
+    runs-on: "self-hosted"
     if: "!contains(toJSON(github.event.commits.*.message), '[ci-skip]')"
     steps:
       - name: "Checkout"

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   build_pr:
     runs-on: "self-hosted"
-    if: "!contains(toJSON(github.event.commits.*.message), '[ci-skip]')"
+    if: "!contains(format('{0} {1}', github.event.head_commit.message, github.event.pull_request.title), '[ci-skip]')"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"


### PR DESCRIPTION
In an attempt to prevent 10 minute wait-times like we've had previously, switching to a self-hosted github actions runner allows us to immediately execute our actions. Currently the self-hosted runner is on my server, however it can easily be switched provided the person who's switching it knows what they're doing. I usually reboot my server about 3 times a month, however the reboot time usually takes less than 2 minutes.