### PR TITLE
Enable nullable annotations for CNext

### DIFF
--- a/DSharpPlus.CommandsNext/Attributes/CommandAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/CommandAttribute.cs
@@ -35,7 +35,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <summary>
         /// Gets the name of this command.
         /// </summary>
-        public string Name { get; }
+        public string? Name { get; }
 
         /// <summary>
         /// Marks this method as a command, using the method's name as command name.

--- a/DSharpPlus.CommandsNext/Attributes/CooldownAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/CooldownAttribute.cs
@@ -89,7 +89,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         public TimeSpan GetRemainingCooldown(CommandContext ctx)
         {
             var bucket = this.GetBucket(ctx);
-            if (bucket == null)
+            if (bucket is null)
                 return TimeSpan.Zero;
 
             return bucket.RemainingUses > 0 ? TimeSpan.Zero : bucket.ResetsAt - DateTimeOffset.UtcNow;
@@ -281,7 +281,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// </summary>
         /// <param name="obj">Object to compare to.</param>
         /// <returns>Whether the object is equal to this <see cref="CommandCooldownBucket"/>.</returns>
-        public override bool Equals(object obj) => this.Equals(obj as CommandCooldownBucket);
+        public override bool Equals(object obj) => obj is CommandCooldownBucket cooldownBucket && this.Equals(cooldownBucket);
 
         /// <summary>
         /// Checks whether this <see cref="CommandCooldownBucket"/> is equal to another <see cref="CommandCooldownBucket"/>.

--- a/DSharpPlus.CommandsNext/Attributes/GroupAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/GroupAttribute.cs
@@ -35,7 +35,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <summary>
         /// Gets the name of this group.
         /// </summary>
-        public string Name { get; }
+        public string? Name { get; }
 
         /// <summary>
         /// Marks this class as a command group, using the class' name as group name.

--- a/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/RequireRolesAttribute.cs
@@ -110,9 +110,9 @@ namespace DSharpPlus.CommandsNext.Attributes
             }
         }
 
-        private bool MatchRoles<T>(IReadOnlyList<T> present, IEnumerable<T> passed, IEqualityComparer<T> comparer = null)
+        private bool MatchRoles<T>(IReadOnlyList<T> present, IEnumerable<T> passed, IEqualityComparer<T>? comparer = null)
         {
-            var intersect = passed.Intersect(present, comparer);
+            var intersect = passed.Intersect(present, comparer ?? EqualityComparer<T>.Default);
 
             return this.CheckMode switch
             {

--- a/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
@@ -54,13 +54,13 @@ namespace DSharpPlus.CommandsNext
         /// <para>Sets the string prefixes used for commands.</para>
         /// <para>Defaults to no value (disabled).</para>
         /// </summary>
-        public IEnumerable<string> StringPrefixes { internal get; set; }
+        public IEnumerable<string> StringPrefixes { internal get; set; } = Enumerable.Empty<string>();
 
         /// <summary>
         /// <para>Sets the custom prefix resolver used for commands.</para>
         /// <para>Defaults to none (disabled).</para>
         /// </summary>
-        public PrefixResolverDelegate PrefixResolver { internal get; set; } = null;
+        public PrefixResolverDelegate? PrefixResolver { internal get; set; } = null;
 
         /// <summary>
         /// <para>Sets whether to allow mentioning the bot to be used as command prefix.</para>
@@ -98,7 +98,7 @@ namespace DSharpPlus.CommandsNext
         /// <para>Only applicable if default help is enabled.</para>
         /// <para>Defaults to null.</para>
         /// </summary>
-        public IEnumerable<CheckBaseAttribute> DefaultHelpChecks { internal get; set; } = null;
+        public IEnumerable<CheckBaseAttribute> DefaultHelpChecks { internal get; set; } = Enumerable.Empty<CheckBaseAttribute>();
 
         /// <summary>
         /// <para>Sets whether commands sent via direct messages should be processed.</para>
@@ -158,7 +158,7 @@ namespace DSharpPlus.CommandsNext
             this.IgnoreExtraArguments = other.IgnoreExtraArguments;
             this.UseDefaultCommandHandler = other.UseDefaultCommandHandler;
             this.Services = other.Services;
-            this.StringPrefixes = other.StringPrefixes?.ToArray();
+            this.StringPrefixes = other.StringPrefixes.ToArray();
             this.DmHelp = other.DmHelp;
             this.DefaultParserCulture = other.DefaultParserCulture;
             this.CommandExecutor = other.CommandExecutor;

--- a/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
@@ -85,7 +85,7 @@ namespace DSharpPlus.CommandsNext
         }
 
         //internal static string ExtractNextArgument(string str, out string remainder)
-        internal static string ExtractNextArgument(this string str, ref int startPos)
+        internal static string? ExtractNextArgument(this string str, ref int startPos)
         {
             if (string.IsNullOrWhiteSpace(str))
                 return null;
@@ -195,7 +195,7 @@ namespace DSharpPlus.CommandsNext
             var command = ctx.Command;
             var overload = ctx.Overload;
 
-            var args = new object[overload.Arguments.Count + 2];
+            var args = new object?[overload.Arguments.Count + 2];
             args[1] = ctx;
             var rawArgumentList = new List<string>(overload.Arguments.Count);
 
@@ -226,7 +226,7 @@ namespace DSharpPlus.CommandsNext
                             break;
 
                         argValue = argString.Substring(foundAt).Trim();
-                        argValue = argValue == "" ? null : argValue;
+                        argValue = argValue == "" ? string.Empty : argValue;
                         foundAt = argString.Length;
 
                         rawArgumentList.Add(argValue);
@@ -236,16 +236,16 @@ namespace DSharpPlus.CommandsNext
                 else
                 {
                     argValue = ExtractNextArgument(argString, ref foundAt);
-                    rawArgumentList.Add(argValue);
+                    rawArgumentList.Add(argValue ?? string.Empty);
                 }
 
                 if (argValue == null && !arg.IsOptional && !arg.IsCatchAll)
                     return new ArgumentBindingResult(new ArgumentException("Not enough arguments supplied to the command."));
                 else if (argValue == null)
-                    rawArgumentList.Add(null);
+                    rawArgumentList.Add(string.Empty);
             }
 
-            if (!ignoreSurplus && foundAt < argString.Length)
+            if (!ignoreSurplus && foundAt < (argString ?? string.Empty).Length)
                 return new ArgumentBindingResult(new ArgumentException("Too many arguments were supplied to this command."));
 
             for (var i = 0; i < overload.Arguments.Count; i++)
@@ -321,7 +321,8 @@ namespace DSharpPlus.CommandsNext
 
         internal static bool IsCommandCandidate(this MethodInfo method, out ParameterInfo[] parameters)
         {
-            parameters = null;
+            parameters = Array.Empty<ParameterInfo>();
+
             // check if exists
             if (method == null)
                 return false;

--- a/DSharpPlus.CommandsNext/Converters/ArgumentBindingResult.cs
+++ b/DSharpPlus.CommandsNext/Converters/ArgumentBindingResult.cs
@@ -29,11 +29,11 @@ namespace DSharpPlus.CommandsNext.Converters
     public struct ArgumentBindingResult
     {
         public bool IsSuccessful { get; }
-        public object[] Converted { get; }
+        public object?[] Converted { get; }
         public IReadOnlyList<string> Raw { get; }
-        public Exception Reason { get; }
+        public Exception? Reason { get; }
 
-        public ArgumentBindingResult(object[] converted, IReadOnlyList<string> raw)
+        public ArgumentBindingResult(object?[] converted, IReadOnlyList<string> raw)
         {
             this.IsSuccessful = true;
             this.Reason = null;
@@ -45,8 +45,8 @@ namespace DSharpPlus.CommandsNext.Converters
         {
             this.IsSuccessful = false;
             this.Reason = ex;
-            this.Converted = null;
-            this.Raw = null;
+            this.Converted = Array.Empty<object>();
+            this.Raw = Array.Empty<string>();
         }
     }
 }

--- a/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
+++ b/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
@@ -35,7 +35,7 @@ namespace DSharpPlus.CommandsNext.Converters
     public class DefaultHelpFormatter : BaseHelpFormatter
     {
         public DiscordEmbedBuilder EmbedBuilder { get; }
-        private Command Command { get; set; }
+        private Command? Command { get; set; }
 
         /// <summary>
         /// Creates a new default help formatter.
@@ -63,10 +63,10 @@ namespace DSharpPlus.CommandsNext.Converters
             if (command is CommandGroup cgroup && cgroup.IsExecutableWithoutSubcommands)
                 this.EmbedBuilder.WithDescription($"{this.EmbedBuilder.Description}\n\nThis group can be executed as a standalone command.");
 
-            if (command.Aliases?.Any() == true)
+            if (command.Aliases.Count > 0)
                 this.EmbedBuilder.AddField("Aliases", string.Join(", ", command.Aliases.Select(Formatter.InlineCode)), false);
 
-            if (command.Overloads?.Any() == true)
+            if (command.Overloads.Count > 0)
             {
                 var sb = new StringBuilder();
 
@@ -98,7 +98,7 @@ namespace DSharpPlus.CommandsNext.Converters
         /// <returns>This help formatter.</returns>
         public override BaseHelpFormatter WithSubcommands(IEnumerable<Command> subcommands)
         {
-            this.EmbedBuilder.AddField(this.Command != null ? "Subcommands" : "Commands", string.Join(", ", subcommands.Select(x => Formatter.InlineCode(x.Name))), false);
+            this.EmbedBuilder.AddField(this.Command is not null ? "Subcommands" : "Commands", string.Join(", ", subcommands.Select(x => Formatter.InlineCode(x.Name))), false);
 
             return this;
         }
@@ -109,7 +109,7 @@ namespace DSharpPlus.CommandsNext.Converters
         /// <returns>Data for the help message.</returns>
         public override CommandHelpMessage Build()
         {
-            if (this.Command == null)
+            if (this.Command is null)
                 this.EmbedBuilder.WithDescription("Listing all top-level commands and groups. Specify a command to see more information.");
 
             return new CommandHelpMessage(embed: this.EmbedBuilder.Build());

--- a/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
+++ b/DSharpPlus.CommandsNext/Converters/EntityConverters.cs
@@ -181,19 +181,19 @@ namespace DSharpPlus.CommandsNext.Converters
 #endif
         }
 
-        async Task<Optional<DiscordThreadChannel>> IArgumentConverter<DiscordThreadChannel>.ConvertAsync(string value, CommandContext ctx)
+        Task<Optional<DiscordThreadChannel>> IArgumentConverter<DiscordThreadChannel>.ConvertAsync(string value, CommandContext ctx)
         {
             if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var threadId))
             {
                 var result = ctx.Client.InternalGetCachedThread(threadId);
-                return result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordThreadChannel>();
+                return Task.FromResult(result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordThreadChannel>());
             }
 
             var m = ThreadRegex.Match(value);
             if (m.Success && ulong.TryParse(m.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out threadId))
             {
                 var result = ctx.Client.InternalGetCachedThread(threadId);
-                return result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordThreadChannel>();
+                return Task.FromResult(result != null ? Optional.FromValue(result) : Optional.FromNoValue<DiscordThreadChannel>());
             }
 
             var cs = ctx.Config.CaseSensitive;
@@ -201,7 +201,7 @@ namespace DSharpPlus.CommandsNext.Converters
             var thread = ctx.Guild?.Threads.Values.FirstOrDefault(xt =>
                 xt.Name.Equals(value, cs ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase));
 
-            return thread != null ? Optional.FromValue(thread) : Optional.FromNoValue<DiscordThreadChannel>();
+            return Task.FromResult(thread != null ? Optional.FromValue(thread) : Optional.FromNoValue<DiscordThreadChannel>());
         }
     }
 

--- a/DSharpPlus.CommandsNext/Converters/HelpFormatterFactory.cs
+++ b/DSharpPlus.CommandsNext/Converters/HelpFormatterFactory.cs
@@ -21,18 +21,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DSharpPlus.CommandsNext.Converters
 {
     internal class HelpFormatterFactory
     {
-        private ObjectFactory Factory { get; set; }
+        private ObjectFactory Factory { get; set; } = null!;
 
         public HelpFormatterFactory() { }
 
         public void SetFormatterType<T>() where T : BaseHelpFormatter => this.Factory = ActivatorUtilities.CreateFactory(typeof(T), new[] { typeof(CommandContext) });
 
-        public BaseHelpFormatter Create(CommandContext ctx) => this.Factory(ctx.Services, new object[] { ctx }) as BaseHelpFormatter;
+        public BaseHelpFormatter Create(CommandContext ctx)
+            => this.Factory is null
+                ? throw new InvalidOperationException($"A formatter type must be set with the {nameof(this.SetFormatterType)} method.")
+                : (BaseHelpFormatter)this.Factory(ctx.Services, new object[] { ctx });
     }
 }

--- a/DSharpPlus.CommandsNext/Converters/NullableConverter.cs
+++ b/DSharpPlus.CommandsNext/Converters/NullableConverter.cs
@@ -39,7 +39,7 @@ namespace DSharpPlus.CommandsNext.Converters
 
             if (ctx.CommandsNext.ArgumentConverters.TryGetValue(typeof(T), out var cv))
             {
-                var cvx = cv as IArgumentConverter<T>;
+                var cvx = (IArgumentConverter<T>)cv;
                 var val = await cvx.ConvertAsync(value, ctx).ConfigureAwait(false);
                 return val.HasValue ? Optional.FromValue<Nullable<T>>(val.Value) : Optional.FromNoValue<Nullable<T>>();
             }

--- a/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
+++ b/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
@@ -8,6 +8,8 @@
     <RootNamespace>DSharpPlus.CommandsNext</RootNamespace>
     <OutputType>Library</OutputType>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/DSharpPlus.CommandsNext/Entities/Builders/CommandBuilder.cs
+++ b/DSharpPlus.CommandsNext/Entities/Builders/CommandBuilder.cs
@@ -39,7 +39,7 @@ namespace DSharpPlus.CommandsNext.Builders
         /// <summary>
         /// Gets the name set for this command.
         /// </summary>
-        public string Name { get; private set; }
+        public string Name { get; private set; } = null!;
 
         /// <summary>
         /// Gets the aliases set for this command.
@@ -50,7 +50,7 @@ namespace DSharpPlus.CommandsNext.Builders
         /// <summary>
         /// Gets the description set for this command.
         /// </summary>
-        public string Description { get; private set; }
+        public string? Description { get; private set; }
 
         /// <summary>
         /// Gets whether this command will be hidden or not.
@@ -73,7 +73,7 @@ namespace DSharpPlus.CommandsNext.Builders
         /// <summary>
         /// Gets the module on which this command is to be defined.
         /// </summary>
-        public ICommandModule Module { get; }
+        public ICommandModule? Module { get; }
 
         /// <summary>
         /// Gets custom attributes defined on this command.
@@ -92,7 +92,7 @@ namespace DSharpPlus.CommandsNext.Builders
         /// Creates a new command builder.
         /// </summary>
         /// <param name="module">Module on which this command is to be defined.</param>
-        public CommandBuilder(ICommandModule module)
+        public CommandBuilder(ICommandModule? module)
         {
             this.AliasList = new List<string>();
             this.Aliases = new ReadOnlyCollection<string>(this.AliasList);
@@ -261,11 +261,14 @@ namespace DSharpPlus.CommandsNext.Builders
             return this;
         }
 
-        internal virtual Command Build(CommandGroup parent)
+        internal virtual Command Build(CommandGroup? parent)
         {
             var cmd = new Command
             {
-                Name = this.Name,
+                Name = string.IsNullOrWhiteSpace(this.Name)
+                    ? throw new InvalidOperationException($"Cannot build a command with an invalid name. Use the method {nameof(this.WithName)} to set a valid name.")
+                    : this.Name,
+
                 Description = this.Description,
                 Aliases = this.Aliases,
                 ExecutionChecks = this.ExecutionChecks,

--- a/DSharpPlus.CommandsNext/Entities/Builders/CommandGroupBuilder.cs
+++ b/DSharpPlus.CommandsNext/Entities/Builders/CommandGroupBuilder.cs
@@ -50,7 +50,7 @@ namespace DSharpPlus.CommandsNext.Builders
         /// Creates a new command group builder.
         /// </summary>
         /// <param name="module">Module on which this group is to be defined.</param>
-        public CommandGroupBuilder(ICommandModule module)
+        public CommandGroupBuilder(ICommandModule? module)
             : base(module)
         {
             this.ChildrenList = new List<CommandBuilder>();
@@ -68,7 +68,7 @@ namespace DSharpPlus.CommandsNext.Builders
             return this;
         }
 
-        internal override Command Build(CommandGroup parent)
+        internal override Command Build(CommandGroup? parent)
         {
             var cmd = new CommandGroup
             {

--- a/DSharpPlus.CommandsNext/Entities/Builders/CommandModuleBuilder.cs
+++ b/DSharpPlus.CommandsNext/Entities/Builders/CommandModuleBuilder.cs
@@ -35,7 +35,7 @@ namespace DSharpPlus.CommandsNext.Builders
         /// <summary>
         /// Gets the type this build will construct a module out of.
         /// </summary>
-        public Type Type { get; private set; }
+        public Type Type { get; private set; } = null!;
 
         /// <summary>
         /// Gets the lifespan for the built module.
@@ -75,6 +75,9 @@ namespace DSharpPlus.CommandsNext.Builders
 
         internal ICommandModule Build(IServiceProvider services)
         {
+            if (this.Type is null)
+                throw new InvalidOperationException($"A command module cannot be built without a module type, please use the {nameof(this.WithType)} method to set a type.");
+
             return this.Lifespan switch
             {
                 ModuleLifespan.Singleton => new SingletonCommandModule(this.Type, services),

--- a/DSharpPlus.CommandsNext/Entities/Builders/CommandOverloadBuilder.cs
+++ b/DSharpPlus.CommandsNext/Entities/Builders/CommandOverloadBuilder.cs
@@ -46,7 +46,7 @@ namespace DSharpPlus.CommandsNext.Builders
         /// <summary>
         /// Gets the collection of arguments this overload takes.
         /// </summary>
-        public IReadOnlyList<CommandArgument> Arguments { get; }
+        public IReadOnlyList<CommandArgument> Arguments { get; } = Array.Empty<CommandArgument>();
 
         /// <summary>
         /// Gets this overload's priority when picking a suitable one for execution.
@@ -58,7 +58,7 @@ namespace DSharpPlus.CommandsNext.Builders
         /// </summary>
         public Delegate Callable { get; set; }
 
-        private object InvocationTarget { get; }
+        private object? InvocationTarget { get; }
 
         /// <summary>
         /// Creates a new command overload builder from specified method.
@@ -76,7 +76,7 @@ namespace DSharpPlus.CommandsNext.Builders
             : this(method.GetMethodInfo(), method.Target)
         { }
 
-        private CommandOverloadBuilder(MethodInfo method, object target)
+        private CommandOverloadBuilder(MethodInfo method, object? target)
         {
             if (!method.IsCommandCandidate(out var prms))
                 throw new ArgumentException("Specified method is not suitable for a command.", nameof(method));

--- a/DSharpPlus.CommandsNext/Entities/Command.cs
+++ b/DSharpPlus.CommandsNext/Entities/Command.cs
@@ -38,28 +38,28 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Gets this command's name.
         /// </summary>
-        public string Name { get; internal set; }
+        public string Name { get; internal set; } = string.Empty;
 
         /// <summary>
         /// Gets this command's qualified name (i.e. one that includes all module names).
         /// </summary>
         public string QualifiedName
-            => this.Parent != null ? string.Concat(this.Parent.QualifiedName, " ", this.Name) : this.Name;
+            => this.Parent is not null ? string.Concat(this.Parent.QualifiedName, " ", this.Name) : this.Name;
 
         /// <summary>
         /// Gets this command's aliases.
         /// </summary>
-        public IReadOnlyList<string> Aliases { get; internal set; }
+        public IReadOnlyList<string> Aliases { get; internal set; } = Array.Empty<string>();
 
         /// <summary>
         /// Gets this command's parent module, if any.
         /// </summary>
-        public CommandGroup Parent { get; internal set; }
+        public CommandGroup? Parent { get; internal set; }
 
         /// <summary>
         /// Gets this command's description.
         /// </summary>
-        public string Description { get; internal set; }
+        public string? Description { get; internal set; }
 
         /// <summary>
         /// Gets whether this command is hidden.
@@ -69,22 +69,22 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Gets a collection of pre-execution checks for this command.
         /// </summary>
-        public IReadOnlyList<CheckBaseAttribute> ExecutionChecks { get; internal set; }
+        public IReadOnlyList<CheckBaseAttribute> ExecutionChecks { get; internal set; } = Array.Empty<CheckBaseAttribute>();
 
         /// <summary>
         /// Gets a collection of this command's overloads.
         /// </summary>
-        public IReadOnlyList<CommandOverload> Overloads { get; internal set; }
+        public IReadOnlyList<CommandOverload> Overloads { get; internal set; } = Array.Empty<CommandOverload>();
 
         /// <summary>
         /// Gets the module in which this command is defined.
         /// </summary>
-        public ICommandModule Module { get; internal set; }
+        public ICommandModule? Module { get; internal set; }
 
         /// <summary>
         /// Gets the custom attributes defined on this command.
         /// </summary>
-        public IReadOnlyList<Attribute> CustomAttributes { get; internal set; }
+        public IReadOnlyList<Attribute> CustomAttributes { get; internal set; } = Array.Empty<Attribute>();
 
         internal Command() { }
 
@@ -153,7 +153,7 @@ namespace DSharpPlus.CommandsNext
         public async Task<IEnumerable<CheckBaseAttribute>> RunChecksAsync(CommandContext ctx, bool help)
         {
             var fchecks = new List<CheckBaseAttribute>();
-            if (this.ExecutionChecks != null && this.ExecutionChecks.Any())
+            if (this.ExecutionChecks.Any())
                 foreach (var ec in this.ExecutionChecks)
                     if (!await ec.ExecuteCheckAsync(ctx, help).ConfigureAwait(false))
                         fchecks.Add(ec);

--- a/DSharpPlus.CommandsNext/Entities/CommandArgument.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandArgument.cs
@@ -31,12 +31,12 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Gets this argument's name.
         /// </summary>
-        public string Name { get; internal set; }
+        public string Name { get; internal set; } = string.Empty;
 
         /// <summary>
         /// Gets this argument's type.
         /// </summary>
-        public Type Type { get; internal set; }
+        public Type Type { get; internal set; } = null!;
 
         /// <summary>
         /// Gets or sets whether this argument is an array argument.
@@ -51,7 +51,7 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Gets this argument's default value.
         /// </summary>
-        public object DefaultValue { get; internal set; }
+        public object? DefaultValue { get; internal set; }
 
         /// <summary>
         /// Gets whether this argument catches all remaining arguments.
@@ -61,11 +61,11 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Gets this argument's description.
         /// </summary>
-        public string Description { get; internal set; }
+        public string? Description { get; internal set; }
 
         /// <summary>
         /// Gets the custom attributes attached to this argument.
         /// </summary>
-        public IReadOnlyCollection<Attribute> CustomAttributes { get; internal set; }
+        public IReadOnlyCollection<Attribute> CustomAttributes { get; internal set; } = Array.Empty<Attribute>();
     }
 }

--- a/DSharpPlus.CommandsNext/Entities/CommandGroup.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandGroup.cs
@@ -37,12 +37,12 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Gets all the commands that belong to this module.
         /// </summary>
-        public IReadOnlyList<Command> Children { get; internal set; }
+        public IReadOnlyList<Command> Children { get; internal set; } = Array.Empty<Command>();
 
         /// <summary>
         /// Gets whether this command is executable without subcommands.
         /// </summary>
-        public bool IsExecutableWithoutSubcommands => this.Overloads?.Any() == true;
+        public bool IsExecutableWithoutSubcommands => this.Overloads.Count > 0;
 
         internal CommandGroup() : base() { }
 
@@ -64,8 +64,8 @@ namespace DSharpPlus.CommandsNext
                     false => (StringComparison.InvariantCultureIgnoreCase, StringComparer.InvariantCultureIgnoreCase)
                 };
                 var cmd = this.Children.FirstOrDefault(xc =>
-                    xc.Name.Equals(cn, comparison) || (xc.Aliases != null && xc.Aliases.Contains(cn, comparer)));
-                if (cmd != null)
+                    xc.Name.Equals(cn, comparison) || xc.Aliases.Contains(cn, comparer));
+                if (cmd is not null)
                 {
                     // pass the execution on
                     var xctx = new CommandContext

--- a/DSharpPlus.CommandsNext/Entities/CommandHelpMessage.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandHelpMessage.cs
@@ -33,19 +33,19 @@ namespace DSharpPlus.CommandsNext.Entities
         /// <summary>
         /// Gets the contents of the help message.
         /// </summary>
-        public string Content { get; }
+        public string? Content { get; }
 
         /// <summary>
         /// Gets the embed attached to the help message.
         /// </summary>
-        public DiscordEmbed Embed { get; }
+        public DiscordEmbed? Embed { get; }
 
         /// <summary>
         /// Creates a new instance of a help message.
         /// </summary>
         /// <param name="content">Contents of the message.</param>
         /// <param name="embed">Embed to attach to the message.</param>
-        public CommandHelpMessage(string content = null, DiscordEmbed embed = null)
+        public CommandHelpMessage(string? content = null, DiscordEmbed? embed = null)
         {
             this.Content = content;
             this.Embed = embed;

--- a/DSharpPlus.CommandsNext/Entities/CommandModule.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandModule.cs
@@ -68,7 +68,7 @@ namespace DSharpPlus.CommandsNext.Entities
         /// <param name="services">Services to instantiate the module with.</param>
         /// <returns>Created module.</returns>
         public BaseCommandModule GetInstance(IServiceProvider services)
-            => this.ModuleType.CreateInstance(services) as BaseCommandModule;
+            => (BaseCommandModule)this.ModuleType.CreateInstance(services);
     }
 
     /// <summary>
@@ -94,7 +94,7 @@ namespace DSharpPlus.CommandsNext.Entities
         internal SingletonCommandModule(Type t, IServiceProvider services)
         {
             this.ModuleType = t;
-            this.Instance = t.CreateInstance(services) as BaseCommandModule;
+            this.Instance = (BaseCommandModule)t.CreateInstance(services);
         }
 
         /// <summary>

--- a/DSharpPlus.CommandsNext/Entities/CommandOverload.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandOverload.cs
@@ -34,7 +34,7 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Gets this command overload's arguments.
         /// </summary>
-        public IReadOnlyList<CommandArgument> Arguments { get; internal set; }
+        public IReadOnlyList<CommandArgument> Arguments { get; internal set; } = Array.Empty<CommandArgument>();
 
         /// <summary>
         /// Gets this command overload's priority.
@@ -44,9 +44,9 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Gets this command overload's delegate.
         /// </summary>
-        internal Delegate Callable { get; set; }
+        internal Delegate Callable { get; set; } = null!;
 
-        internal object InvocationTarget { get; set; }
+        internal object? InvocationTarget { get; set; }
 
         internal CommandOverload() { }
     }

--- a/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandContext.cs
@@ -39,12 +39,12 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Gets the client which received the message.
         /// </summary>
-        public DiscordClient Client { get; internal set; }
+        public DiscordClient Client { get; internal set; } = null!;
 
         /// <summary>
         /// Gets the message that triggered the execution.
         /// </summary>
-        public DiscordMessage Message { get; internal set; }
+        public DiscordMessage Message { get; internal set; } = null!;
 
         /// <summary>
         /// Gets the channel in which the execution was triggered,
@@ -67,53 +67,53 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Gets the member who triggered the execution. This property is null for commands sent over direct messages.
         /// </summary>
-        public DiscordMember Member
+        public DiscordMember? Member
             => this._lazyMember.Value;
 
-        private readonly Lazy<DiscordMember> _lazyMember;
+        private readonly Lazy<DiscordMember?> _lazyMember;
 
         /// <summary>
         /// Gets the CommandsNext service instance that handled this command.
         /// </summary>
-        public CommandsNextExtension CommandsNext { get; internal set; }
+        public CommandsNextExtension CommandsNext { get; internal set; } = null!;
 
         /// <summary>
         /// Gets the service provider for this CNext instance.
         /// </summary>
-        public IServiceProvider Services { get; internal set; }
+        public IServiceProvider Services { get; internal set; } = null!;
 
         /// <summary>
         /// Gets the command that is being executed.
         /// </summary>
-        public Command Command { get; internal set; }
+        public Command? Command { get; internal set; }
 
         /// <summary>
         /// Gets the overload of the command that is being executed.
         /// </summary>
-        public CommandOverload Overload { get; internal set; }
+        public CommandOverload Overload { get; internal set; } = null!;
 
         /// <summary>
         /// Gets the list of raw arguments passed to the command.
         /// </summary>
-        public IReadOnlyList<string> RawArguments { get; internal set; }
+        public IReadOnlyList<string> RawArguments { get; internal set; } = Array.Empty<string>();
 
         /// <summary>
         /// Gets the raw string from which the arguments were extracted.
         /// </summary>
-        public string RawArgumentString { get; internal set; }
+        public string RawArgumentString { get; internal set; } = string.Empty;
 
         /// <summary>
         /// Gets the prefix used to invoke the command.
         /// </summary>
-        public string Prefix { get; internal set; }
+        public string Prefix { get; internal set; } = string.Empty;
 
-        internal CommandsNextConfiguration Config { get; set; }
+        internal CommandsNextConfiguration Config { get; set; } = null!;
 
         internal ServiceContext ServiceScopeContext { get; set; }
 
         internal CommandContext()
         {
-            this._lazyMember = new Lazy<DiscordMember>(() => this.Guild != null && this.Guild.Members.TryGetValue(this.User.Id, out var member) ? member : this.Guild?.GetMemberAsync(this.User.Id).ConfigureAwait(false).GetAwaiter().GetResult());
+            this._lazyMember = new Lazy<DiscordMember?>(() => this.Guild is not null && this.Guild.Members.TryGetValue(this.User.Id, out var member) ? member : this.Guild?.GetMemberAsync(this.User.Id).ConfigureAwait(false).GetAwaiter().GetResult());
         }
 
         /// <summary>

--- a/DSharpPlus.CommandsNext/EventArgs/CommandErrorEventArgs.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandErrorEventArgs.cs
@@ -30,6 +30,6 @@ namespace DSharpPlus.CommandsNext
     /// </summary>
     public class CommandErrorEventArgs : CommandEventArgs
     {
-        public Exception Exception { get; internal set; }
+        public Exception Exception { get; internal set; } = null!;
     }
 }

--- a/DSharpPlus.CommandsNext/EventArgs/CommandEventArgs.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandEventArgs.cs
@@ -33,12 +33,12 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Gets the context in which the command was executed.
         /// </summary>
-        public CommandContext Context { get; internal set; }
+        public CommandContext Context { get; internal set; } = null!;
 
         /// <summary>
         /// Gets the command that was executed.
         /// </summary>
         public Command Command
-            => this.Context.Command;
+            => this.Context.Command!;
     }
 }

--- a/DSharpPlus.CommandsNext/Exceptions/InvalidOverloadException.cs
+++ b/DSharpPlus.CommandsNext/Exceptions/InvalidOverloadException.cs
@@ -39,7 +39,7 @@ namespace DSharpPlus.CommandsNext.Exceptions
         /// <summary>
         /// Gets or sets the argument that caused the problem. This can be null.
         /// </summary>
-        public ParameterInfo Parameter { get; }
+        public ParameterInfo? Parameter { get; }
 
         /// <summary>
         /// Creates a new <see cref="InvalidOverloadException"/>.
@@ -47,7 +47,7 @@ namespace DSharpPlus.CommandsNext.Exceptions
         /// <param name="message">Exception message.</param>
         /// <param name="method">Method that caused the problem.</param>
         /// <param name="parameter">Method argument that caused the problem.</param>
-        public InvalidOverloadException(string message, MethodInfo method, ParameterInfo parameter)
+        public InvalidOverloadException(string message, MethodInfo method, ParameterInfo? parameter)
             : base(message)
         {
             this.Method = method;

--- a/DSharpPlus.Test/TestBotHelpFormatter.cs
+++ b/DSharpPlus.Test/TestBotHelpFormatter.cs
@@ -44,10 +44,10 @@ namespace DSharpPlus.Test
         {
             this.Content.Append(command.Description ?? "No description provided.").Append("\n\n");
 
-            if (command.Aliases?.Any() == true)
+            if (command.Aliases.Count > 0)
                 this.Content.Append("Aliases: ").Append(string.Join(", ", command.Aliases)).Append("\n\n");
 
-            if (command.Overloads?.Any() == true)
+            if (command.Overloads.Count > 0)
             {
                 var sb = new StringBuilder();
 


### PR DESCRIPTION
# Summary
This pull requests enables nullable annotations on CNext's csproj file.

# Details
`<Nullable>enable</Nullable>` and `<WarningsAsErrors>Nullable</WarningsAsErrors>` were added to CNext's project file. Changes then were made to the project to either correct or silence the warnings. Some hidden bugs were fixed along the way.

I tried my best to keep the current API as is. Some collections had `null` as their default state, which is considered "surprising behavior" by most developers. Now they default to being empty and code that checked for nulls was changed accordingly.

I've run some of the commands from [DSharpPlus.Test](https://github.com/DSharpPlus/DSharpPlus/tree/master/DSharpPlus.Test) and everything seems to be in order.

# Notes
Is someone currently doing work on [DSharpPlus.SlashCommands](https://github.com/DSharpPlus/DSharpPlus/tree/master/DSharpPlus.SlashCommands)? Cuz I'm planning to do the same there next.