### PR TITLE
Make mentions optional in ApiClient.EditMessageAsync

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -539,7 +539,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task ModifyEmbedSuppressionAsync(bool hideEmbeds)
-            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, default, default, this.GetMentions(), default, Array.Empty<DiscordMessageFile>(), hideEmbeds ? MessageFlags.SuppressedEmbeds : null, default);
+            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, default, default, default, default, Array.Empty<DiscordMessageFile>(), hideEmbeds ? MessageFlags.SuppressedEmbeds : null, default);
 
         /// <summary>
         /// Deletes the message.

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1440,7 +1440,7 @@ namespace DSharpPlus.Net
             return ret;
         }
 
-        internal async Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, Optional<string> content, Optional<IEnumerable<DiscordEmbed>> embeds, IEnumerable<IMention> mentions, IReadOnlyList<DiscordActionRowComponent> components, IReadOnlyCollection<DiscordMessageFile> files, MessageFlags? flags, IEnumerable<DiscordAttachment> attachments)
+        internal async Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, Optional<string> content, Optional<IEnumerable<DiscordEmbed>> embeds, Optional<IEnumerable<IMention>> mentions, IReadOnlyList<DiscordActionRowComponent> components, IReadOnlyCollection<DiscordMessageFile> files, MessageFlags? flags, IEnumerable<DiscordAttachment> attachments)
         {
             if (embeds.HasValue && embeds.Value != null)
                 foreach (var embed in embeds.Value)
@@ -1458,7 +1458,7 @@ namespace DSharpPlus.Net
                 Attachments = attachments
             };
 
-            pld.Mentions = new DiscordMentions(mentions ?? Mentions.None, false, mentions?.OfType<RepliedUserMention>().Any() ?? false);
+            pld.Mentions = mentions.HasValue ? new DiscordMentions(mentions.Value ?? Mentions.None, false, mentions.Value?.OfType<RepliedUserMention>().Any() ?? false) : null;
 
             var values = new Dictionary<string, string>
             {


### PR DESCRIPTION
Also doen't set the `mentions` parameter in ModifyEmbedSuppressionAsync

# Summary
Fixes an issue where `ModifyEmbedSuppressionAsync` was not working on messages authored by other users, by making the `mentions` parameter in `Discord.ApiClient.EditMessageAsync` be optional and not setting it in `ModifyEmbedSuppressionAsync`.

# Details

Currently, trying to call `ModifyEmbedSuppressionAsync` on a message that is not authored by the bot fails, since the code tries to send an `allowed_mentions` property in the payload, causing Discord to reject the edit:

```
[2022-03-27 17:27:29 +01:00] [124 /REST ↑      ] [Trace] {"allowed_mentions":{"parse":[],"replied_user":false},"flags":4}
[2022-03-27 17:27:29 +01:00] [123 /REST ↓      ] [Trace] {"message": "Cannot edit a message authored by another user", "code": 50005}
```

This change resolves that issue by making that allowed_mentions property optional, and not setting it for the call that `ModifyEmbedSuppressionAsync` uses:
```
[2022-03-27 18:24:04 +01:00] [124 /REST ↑      ] [Trace] {"flags":4}
```
Which causes the embed supression to now succeed.

This *shouldn't* break anything else still using the property, since the property will still function as intended if given.

# Notes
I did some basic testing to ensure this doesn't break anything else, however I can't guarentee having checked every single case or possibility. 

I don't know why this property wasn't optional to begin with when the others were, so if there was a legitimate reason then please keep that in mind.