### PR TITLE
Fixed default parameters not working properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Credentials for the DSharpPlus.Test bot
+DSharpPlus.Test/config.json

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -871,12 +871,12 @@ namespace DSharpPlus.CommandsNext
         /// <param name="ctx">Context in which to convert to.</param>
         /// <param name="type">Type to convert to.</param>
         /// <returns>Converted object.</returns>
-        public async Task<object> ConvertArgument(string value, CommandContext ctx, Type type)
+        public async Task<object> ConvertArgument(string? value, CommandContext ctx, Type type)
         {
             var m = this.ConvertGeneric.MakeGenericMethod(type);
             try
             {
-                return await ((Task<object>)m.Invoke(this, new object[] { value, ctx })).ConfigureAwait(false);
+                return await ((Task<object>)m.Invoke(this, new object?[] { value, ctx })).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is TargetInvocationException or InvalidCastException)
             {

--- a/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
@@ -189,7 +189,7 @@ namespace DSharpPlus.CommandsNext
 
             return s.Remove(li - ll + 1, ll);
         }
-
+        
         internal static async Task<ArgumentBindingResult> BindArgumentsAsync(CommandContext ctx, bool ignoreSurplus)
         {
             var command = ctx.Command;
@@ -197,14 +197,14 @@ namespace DSharpPlus.CommandsNext
 
             var args = new object?[overload.Arguments.Count + 2];
             args[1] = ctx;
-            var rawArgumentList = new List<string>(overload.Arguments.Count);
-
+            var rawArgumentList = new List<string?>(overload.Arguments.Count);
             var argString = ctx.RawArgumentString;
             var foundAt = 0;
-            var argValue = "";
+
             for (var i = 0; i < overload.Arguments.Count; i++)
             {
                 var arg = overload.Arguments[i];
+                var argValue = string.Empty;
                 if (arg.IsCatchAll)
                 {
                     if (arg.IsArray)
@@ -226,7 +226,7 @@ namespace DSharpPlus.CommandsNext
                             break;
 
                         argValue = argString.Substring(foundAt).Trim();
-                        argValue = argValue == "" ? string.Empty : argValue;
+                        argValue = argValue == "" ? null : argValue;
                         foundAt = argString.Length;
 
                         rawArgumentList.Add(argValue);
@@ -236,16 +236,16 @@ namespace DSharpPlus.CommandsNext
                 else
                 {
                     argValue = ExtractNextArgument(argString, ref foundAt);
-                    rawArgumentList.Add(argValue ?? string.Empty);
+                    rawArgumentList.Add(argValue);
                 }
 
                 if (argValue == null && !arg.IsOptional && !arg.IsCatchAll)
                     return new ArgumentBindingResult(new ArgumentException("Not enough arguments supplied to the command."));
                 else if (argValue == null)
-                    rawArgumentList.Add(string.Empty);
+                    rawArgumentList.Add(null);
             }
 
-            if (!ignoreSurplus && foundAt < (argString ?? string.Empty).Length)
+            if (!ignoreSurplus && foundAt < (argString?.Length ?? 0))
                 return new ArgumentBindingResult(new ArgumentException("Too many arguments were supplied to this command."));
 
             for (var i = 0; i < overload.Arguments.Count; i++)
@@ -284,7 +284,7 @@ namespace DSharpPlus.CommandsNext
                 }
             }
 
-            return new ArgumentBindingResult(args, rawArgumentList);
+            return new ArgumentBindingResult(args, rawArgumentList.Where(x => x is not null).OfType<string>().ToArray());
         }
 
         internal static bool IsModuleCandidateType(this Type type)


### PR DESCRIPTION
# Summary
Fixes weird behavior with command default parameters.

# Details
`ConvertArgument` actually expects null input values, changes were made accordingly.

# Notes
My bad, this bug was introduced in my [previous PR](https://github.com/DSharpPlus/DSharpPlus/pull/1246). Hopefully that's the first and last issue caused by it.