### PR TITLE
Fixed Interaction Member deserialization

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -214,6 +214,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets this member's username.
         /// </summary>
+        [JsonIgnore]
         public override string Username
         {
             get => this.User.Username;
@@ -223,6 +224,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the member's 4-digit discriminator.
         /// </summary>
+        [JsonIgnore]
         public override string Discriminator
         {
             get => this.User.Discriminator;
@@ -258,6 +260,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets whether the member is a bot.
         /// </summary>
+        [JsonIgnore]
         public override bool IsBot
         {
             get => this.User.IsBot;
@@ -268,6 +271,7 @@ namespace DSharpPlus.Entities
         /// Gets the member's email address.
         /// <para>This is only present in OAuth.</para>
         /// </summary>
+        [JsonIgnore]
         public override string Email
         {
             get => this.User.Email;
@@ -277,6 +281,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets whether the member has multi-factor authentication enabled.
         /// </summary>
+        [JsonIgnore]
         public override bool? MfaEnabled
         {
             get => this.User.MfaEnabled;
@@ -287,6 +292,7 @@ namespace DSharpPlus.Entities
         /// Gets whether the member is verified.
         /// <para>This is only present in OAuth.</para>
         /// </summary>
+        [JsonIgnore]
         public override bool? Verified
         {
             get => this.User.Verified;
@@ -296,6 +302,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the member's chosen language
         /// </summary>
+        [JsonIgnore]
         public override string Locale
         {
             get => this.User.Locale;
@@ -305,6 +312,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the user's flags.
         /// </summary>
+        [JsonIgnore]
         public override UserFlags? OAuthFlags
         {
             get => this.User.OAuthFlags;
@@ -314,6 +322,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the member's flags for OAuth.
         /// </summary>
+        [JsonIgnore]
         public override UserFlags? Flags
         {
             get => this.User.Flags;


### PR DESCRIPTION
# Summary
Fixes NRE on interactions with member arguments due to change in Discord's member payloads. Also applied this change to similar properties to avoid future pitfalls.

# Details
Inherited and overridden members from DiscordUser have been marked as JsonIgnore on DiscordMember and will no longer be deserialized for the latter. These properties cannot be successfully deserialized as the User is not set and the Discord spec does not provide them through payloads anyway.
