### PR TITLE
Fix CNext Stack Overflow

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -353,10 +353,10 @@ namespace DSharpPlus.Entities
                 reference.Guild = client._guilds.TryGetValue(guildId.Value, out var g)
                     ? g
                     : new DiscordGuild
-                {
-                    Id = guildId.Value,
-                    Discord = client
-                };
+                    {
+                        Id = guildId.Value,
+                        Discord = client
+                    };
 
             var channel = client.InternalGetCachedChannel(channelId.Value);
 
@@ -397,7 +397,7 @@ namespace DSharpPlus.Entities
             var mentions = new List<IMention>();
 
             if (this.ReferencedMessage != null && this._mentionedUsers.Contains(this.ReferencedMessage.Author))
-               mentions.Add(new RepliedUserMention()); // Return null to allow all mentions
+                mentions.Add(new RepliedUserMention()); // Return null to allow all mentions
 
             if (this._mentionedUsers?.Any() ?? false)
                 mentions.AddRange(this._mentionedUsers.Select(m => (IMention)new UserMention(m)));
@@ -420,10 +420,35 @@ namespace DSharpPlus.Entities
             {
                 foreach (var usr in this._mentionedUsers)
                 {
-                    usr.Discord = this.Discord;
-                    this.Discord.UpdateUserCache(usr);
+                    var member = usr as DiscordMember;
+                    if (member != null)
+                    {
+                        this.Discord.UpdateUserCache(new DiscordUser()
+                        {
+                            Id = member.Id,
+                            Username = member.Username,
+                            Discriminator = member.Discriminator,
+                            AvatarHash = member.AvatarHash,
+                            _bannerColor = member._bannerColor,
+                            BannerHash = member.BannerHash,
+                            IsBot = member.IsBot,
+                            MfaEnabled = member.MfaEnabled,
+                            Verified = member.Verified,
+                            Email = member.Email,
+                            PremiumType = member.PremiumType,
+                            Locale = member.Locale,
+                            Flags = member.Flags,
+                            OAuthFlags = member.OAuthFlags,
+                            Discord = this.Discord
+                        });
+                    }
+                    else
+                    {
+                        usr.Discord = this.Discord;
+                        this.Discord.UpdateUserCache(usr);
+                    }
 
-                    mentionedUsers.Add(guild._members.TryGetValue(usr.Id, out var member) ? member : usr);
+                    mentionedUsers.Add(member ?? (guild._members.TryGetValue(usr.Id, out var cachedMember) ? cachedMember : usr));
                 }
             }
             if (!string.IsNullOrWhiteSpace(this.Content))
@@ -464,7 +489,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> ModifyAsync(Optional<DiscordEmbed> embed = default)
-            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, default, embed.HasValue ? new[] {embed.Value} : Array.Empty<DiscordEmbed>(), this.GetMentions(), default, Array.Empty<DiscordMessageFile>(), null, default);
+            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, default, embed.HasValue ? new[] { embed.Value } : Array.Empty<DiscordEmbed>(), this.GetMentions(), default, Array.Empty<DiscordMessageFile>(), null, default);
 
         /// <summary>
         /// Edits the message.
@@ -477,7 +502,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> ModifyAsync(Optional<string> content, Optional<DiscordEmbed> embed = default)
-            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, embed.HasValue ? new[] {embed.Value} : Array.Empty<DiscordEmbed>(), this.GetMentions(), default, Array.Empty<DiscordMessageFile>(), null, default);
+            => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, embed.HasValue ? new[] { embed.Value } : Array.Empty<DiscordEmbed>(), this.GetMentions(), default, Array.Empty<DiscordMessageFile>(), null, default);
 
         /// <summary>
         /// Edits the message.


### PR DESCRIPTION
# Summary
Fixes a recursive SO caused by editing a DiscordMessage that has mentions in it.

# Details
When a user edits a message on Discord, the `DiscordMessage.PopulateMentions` called by `OnMessageUpdateEventAsync` would cache `DiscordMember`'s cast as `DiscordUser`, thus causing a Stack Overflow when attempting to access the `DiscordMember.User` property from the global user cache. As explained simply by @Quahu:

> `DiscordMember` has a `User` property which accesses the global user cache. All the global properties like `Username` will use the `User` property, the idea here is to save memory between different members sharing the same global user data. The problem in your library is that somewhere in the event handling code you're adding the `DiscordMember` instance to the user cache, this causes a stack overflow when the member keeps retrieving itself from the global user cache.
Essentially it should be like this
`DiscordMember` -> `DiscordUser` -> `Username`
but right now it's
`DiscordMember` -> `DiscordMember` -> `DiscordMember`...

# Changes proposed
Construct a DiscordUser from DiscordMember using the properties copied from `DiscordUser(TransportUser user)`, and cache the newly created `DiscordUser` instead of `DiscordMember`.

# Notes
Tested by editing a message with mentions, which was the original cause of the SO.