### PR TITLE
Throw an exception on startup if GroupCommand overloads are registered

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -489,8 +489,19 @@ namespace DSharpPlus.CommandsNext
                         foreach (var chk in inheritedChecks)
                             groupBuilder.WithExecutionCheck(chk);
 
-                        foreach (var mi in ti.DeclaredMethods.Where(x => x.IsCommandCandidate(out _) && x.GetCustomAttribute<GroupCommandAttribute>() != null))
-                            groupBuilder.WithOverload(new CommandOverloadBuilder(mi));
+                        if (ti.DeclaredMethods.Any(x => x.IsCommandCandidate(out _) && x.GetCustomAttribute<GroupCommandAttribute>() != null))
+                        {
+                            var groupCommandOverloads =
+                                ti.DeclaredMethods.Where(x => x.IsCommandCandidate(out _) && x.GetCustomAttribute<GroupCommandAttribute>() != null);
+
+                            // overloads don't work for group commands, so throw on startup instead of at runtime.
+                            if(groupCommandOverloads.Count() > 1)
+                            {
+                                throw new InvalidOverloadException("GroupCommands cannot be overloaded", groupCommandOverloads.First());
+                            }
+
+                            groupBuilder.WithOverload(new CommandOverloadBuilder(groupCommandOverloads.First()));
+                        }
                         break;
 
                     case AliasesAttribute a:

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -497,7 +497,7 @@ namespace DSharpPlus.CommandsNext
                             // overloads don't work for group commands, so throw on startup instead of at runtime.
                             if(groupCommandOverloads.Count() > 1)
                             {
-                                throw new InvalidOverloadException("GroupCommands cannot be overloaded", groupCommandOverloads.First());
+                                throw new InvalidOverloadException($"Commands marked with [{nameof(GroupCommandAttribute)}] cannot be overloaded", groupCommandOverloads.First());
                             }
 
                             groupBuilder.WithOverload(new CommandOverloadBuilder(groupCommandOverloads.First()));

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -489,13 +489,13 @@ namespace DSharpPlus.CommandsNext
                         foreach (var chk in inheritedChecks)
                             groupBuilder.WithExecutionCheck(chk);
 
-                        var gcan = ti.DeclaredMethods.Where(x => x.IsCommandCandidate(out _) && x.GetCustomAttribute<GroupCommandAttribute>() != null).ToArray();
+                        var groupCandidates = ti.DeclaredMethods.Where(x => x.IsCommandCandidate(out _) && x.GetCustomAttribute<GroupCommandAttribute>() != null).ToArray();
 
-                        _ = gcan.Length switch
+                        _ = groupCandidates.Length switch
                         {
                             0 => null,
-                            1 => groupBuilder.WithOverload(new CommandOverloadBuilder(gcan[0])),
-                            _ => throw new InvalidOverloadException($"Commands marked with [{nameof(GroupCommandAttribute)}] cannot be overloaded", gcan[0])
+                            1 => groupBuilder.WithOverload(new CommandOverloadBuilder(groupCandidates[0])),
+                            _ => throw new InvalidOverloadException($"Commands marked with [{nameof(GroupCommandAttribute)}] cannot be overloaded", groupCandidates[0])
                         };
                         break;
 

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -489,19 +489,14 @@ namespace DSharpPlus.CommandsNext
                         foreach (var chk in inheritedChecks)
                             groupBuilder.WithExecutionCheck(chk);
 
-                        if (ti.DeclaredMethods.Any(x => x.IsCommandCandidate(out _) && x.GetCustomAttribute<GroupCommandAttribute>() != null))
+                        var gcan = ti.DeclaredMethods.Where(x => x.IsCommandCandidate(out _) && x.GetCustomAttribute<GroupCommandAttribute>() != null).ToArray();
+
+                        _ = gcan.Length switch
                         {
-                            var groupCommandOverloads =
-                                ti.DeclaredMethods.Where(x => x.IsCommandCandidate(out _) && x.GetCustomAttribute<GroupCommandAttribute>() != null);
-
-                            // overloads don't work for group commands, so throw on startup instead of at runtime.
-                            if(groupCommandOverloads.Count() > 1)
-                            {
-                                throw new InvalidOverloadException($"Commands marked with [{nameof(GroupCommandAttribute)}] cannot be overloaded", groupCommandOverloads.First());
-                            }
-
-                            groupBuilder.WithOverload(new CommandOverloadBuilder(groupCommandOverloads.First()));
-                        }
+                            0 => null,
+                            1 => groupBuilder.WithOverload(new CommandOverloadBuilder(gcan[0])),
+                            _ => throw new InvalidOverloadException($"Commands marked with [{nameof(GroupCommandAttribute)}] cannot be overloaded", gcan[0])
+                        };
                         break;
 
                     case AliasesAttribute a:


### PR DESCRIPTION
Previously, the library would allow GroupCommand overloads at startup, but at runtime they would fail to execute, throwing an `ArgumentException` with the message "Could not find a suitable overload for the command."

This PR moves the check to startup command registration instead and alerts the user with a clear error message.

fixes #910 