### PR TITLE
Fixed InvalidCastException for User Property in MessageReactionAddEventArgs

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1657,6 +1657,10 @@ namespace DSharpPlus
             {
                 usr = this.UpdateUser(new DiscordUser { Id = userId, Discord = this }, guildId, guild, mbr);
             }
+            else
+            {
+                usr = this.UpdateUser(usr, guild?.Id, guild, mbr);
+            }
 
             if (channel == null)
             {


### PR DESCRIPTION
# Summary
This PR aims to fix #1263 brought up by @oliverbooth. The user property on `MessageReactionAddEventArgs` could not be cast to a DiscordMember, even if the reaction was done in a guild.

# Details
For some reason, the user object returned by `TryGetCachedUserInternal` was not of underlying type DiscordMember, which was causing the error. The hotfix is to call `UpdateUser` on the object, which will create a DiscordMember from the transport user [Message Reaction Add](https://discord.com/developers/docs/topics/gateway#message-reaction-add) sends. 

# Notes
I am not aware of other events that will have a similar issue and my time to go comb through them is limited. Although I will try to fix any other occurrences that other people are able to find. The underlying problem is probably also caused by a cache issue elsewhere.