### PR TITLE
Fixed incorrect nullability for Command in CommandEventArgs

### DIFF
--- a/DSharpPlus.CommandsNext/EventArgs/CommandEventArgs.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandEventArgs.cs
@@ -38,7 +38,7 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Gets the command that was executed.
         /// </summary>
-        public Command Command
-            => this.Context.Command!;
+        public Command? Command
+            => this.Context.Command;
     }
 }

--- a/DSharpPlus.CommandsNext/EventArgs/CommandExecutionEventArgs.cs
+++ b/DSharpPlus.CommandsNext/EventArgs/CommandExecutionEventArgs.cs
@@ -28,5 +28,10 @@ namespace DSharpPlus.CommandsNext
     /// </summary>
     public class CommandExecutionEventArgs : CommandEventArgs
     {
+        /// <summary>
+        /// Gets the command that was executed.
+        /// </summary>
+        public new Command Command
+            => this.Context.Command!;
     }
 }


### PR DESCRIPTION
# Summary
Fixes incorrect nullability for `Command` in `CommandEventArgs` introduced in #1246.

# Details
`Command` can still be null generally, for example when the command was not found.
However `Command!` is correct when the command was executed successfully in `CommandExecutionEventArgs`.

# Changes proposed
Make `Command` nullable in `CommandEventArgs` and hide property with non-null `Command` in `CommandExecutionEventArgs`.

# Notes
Optionally could also remove `Command` from `CommandEventArgs` entirely and put their `Command`/`Command?` versions into `CommandExecutionEventArgs` and `CommandErrorEventArgs` directly.

Change also matches null checks in `TestBot.cs`: https://github.com/DSharpPlus/DSharpPlus/blob/a293857de5d9aa4d6140b4a780e9837d969b49fa/DSharpPlus.Test/TestBot.cs#L272 and https://github.com/DSharpPlus/DSharpPlus/blob/a293857de5d9aa4d6140b4a780e9837d969b49fa/DSharpPlus.Test/TestBot.cs#L285