### PR TITLE
Added Guild Connection Created/Remove Events to Lavalink Extension

### DIFF
--- a/DSharpPlus.Lavalink/EventArgs/GuildConnectionCreatedEventArgs - Copy.cs
+++ b/DSharpPlus.Lavalink/EventArgs/GuildConnectionCreatedEventArgs - Copy.cs
@@ -1,0 +1,34 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Emzi0767.Utilities;
+
+namespace DSharpPlus.Lavalink.EventArgs
+{
+    /// <summary>
+    /// Represents arguments for guild connection created event.
+    /// </summary>
+    public sealed class GuildConnectionCreatedEventArgs : AsyncEventArgs
+    {
+    }
+}

--- a/DSharpPlus.Lavalink/EventArgs/GuildConnectionRemovedEventArgs.cs
+++ b/DSharpPlus.Lavalink/EventArgs/GuildConnectionRemovedEventArgs.cs
@@ -1,0 +1,34 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using Emzi0767.Utilities;
+
+namespace DSharpPlus.Lavalink.EventArgs
+{
+    /// <summary>
+    /// Represents arguments for guild connection created event.
+    /// </summary>
+    public sealed class GuildConnectionRemovedEventArgs : AsyncEventArgs
+    {
+    }
+}

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -219,7 +219,7 @@ namespace DSharpPlus.Lavalink
             this._playbackFinished = new AsyncEvent<LavalinkGuildConnection, TrackFinishEventArgs>("LAVALINK_PLAYBACK_FINISHED", TimeSpan.Zero, this.Discord.EventErrorHandler);
             this._trackStuck = new AsyncEvent<LavalinkGuildConnection, TrackStuckEventArgs>("LAVALINK_TRACK_STUCK", TimeSpan.Zero, this.Discord.EventErrorHandler);
             this._trackException = new AsyncEvent<LavalinkGuildConnection, TrackExceptionEventArgs>("LAVALINK_TRACK_EXCEPTION", TimeSpan.Zero, this.Discord.EventErrorHandler);
-            this._guildConnectionCreated = new AsyncEvent<LavalinkGuildConnection, AsyncEventArgs>("LAVALINK_GUILD_CONNECTION_CREATED", TimeSpan.Zero, this.Discord.EventErrorHandler); ;
+            this._guildConnectionCreated = new AsyncEvent<LavalinkGuildConnection, AsyncEventArgs>("LAVALINK_GUILD_CONNECTION_CREATED", TimeSpan.Zero, this.Discord.EventErrorHandler);
             this._guildConnectionRemoved = new AsyncEvent<LavalinkGuildConnection, AsyncEventArgs>("LAVALINK_GUILD_CONNECTION_REMOVED", TimeSpan.Zero, this.Discord.EventErrorHandler);
 
             this.VoiceServerUpdates = new ConcurrentDictionary<ulong, TaskCompletionSource<VoiceServerUpdateEventArgs>>();

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -142,7 +142,7 @@ namespace DSharpPlus.Lavalink
         private readonly AsyncEvent<LavalinkGuildConnection, AsyncEventArgs> _guildConnectionCreated;
 
         /// <summary>
-        /// Triggered whenever a new guild connection is removed.
+        /// Triggered whenever a guild connection is removed.
         /// </summary>
         public event AsyncEventHandler<LavalinkGuildConnection, AsyncEventArgs> GuildConnectionRemoved
         {

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -134,22 +134,22 @@ namespace DSharpPlus.Lavalink
         /// <summary>
         /// Triggered whenever a new guild connection is created.
         /// </summary>
-        public event AsyncEventHandler<LavalinkGuildConnection, AsyncEventArgs> GuildConnectionCreated
+        public event AsyncEventHandler<LavalinkGuildConnection, GuildConnectionCreatedEventArgs> GuildConnectionCreated
         {
             add { this._guildConnectionCreated.Register(value); }
             remove { this._guildConnectionCreated.Unregister(value); }
         }
-        private readonly AsyncEvent<LavalinkGuildConnection, AsyncEventArgs> _guildConnectionCreated;
+        private readonly AsyncEvent<LavalinkGuildConnection, GuildConnectionCreatedEventArgs> _guildConnectionCreated;
 
         /// <summary>
         /// Triggered whenever a guild connection is removed.
         /// </summary>
-        public event AsyncEventHandler<LavalinkGuildConnection, AsyncEventArgs> GuildConnectionRemoved
+        public event AsyncEventHandler<LavalinkGuildConnection, GuildConnectionRemovedEventArgs> GuildConnectionRemoved
         {
             add { this._guildConnectionRemoved.Register(value); }
             remove { this._guildConnectionRemoved.Unregister(value); }
         }
-        private readonly AsyncEvent<LavalinkGuildConnection, AsyncEventArgs> _guildConnectionRemoved;
+        private readonly AsyncEvent<LavalinkGuildConnection, GuildConnectionRemovedEventArgs> _guildConnectionRemoved;
 
         /// <summary>
         /// Gets the remote endpoint of this Lavalink node connection.
@@ -219,8 +219,8 @@ namespace DSharpPlus.Lavalink
             this._playbackFinished = new AsyncEvent<LavalinkGuildConnection, TrackFinishEventArgs>("LAVALINK_PLAYBACK_FINISHED", TimeSpan.Zero, this.Discord.EventErrorHandler);
             this._trackStuck = new AsyncEvent<LavalinkGuildConnection, TrackStuckEventArgs>("LAVALINK_TRACK_STUCK", TimeSpan.Zero, this.Discord.EventErrorHandler);
             this._trackException = new AsyncEvent<LavalinkGuildConnection, TrackExceptionEventArgs>("LAVALINK_TRACK_EXCEPTION", TimeSpan.Zero, this.Discord.EventErrorHandler);
-            this._guildConnectionCreated = new AsyncEvent<LavalinkGuildConnection, AsyncEventArgs>("LAVALINK_GUILD_CONNECTION_CREATED", TimeSpan.Zero, this.Discord.EventErrorHandler);
-            this._guildConnectionRemoved = new AsyncEvent<LavalinkGuildConnection, AsyncEventArgs>("LAVALINK_GUILD_CONNECTION_REMOVED", TimeSpan.Zero, this.Discord.EventErrorHandler);
+            this._guildConnectionCreated = new AsyncEvent<LavalinkGuildConnection, GuildConnectionCreatedEventArgs>("LAVALINK_GUILD_CONNECTION_CREATED", TimeSpan.Zero, this.Discord.EventErrorHandler);
+            this._guildConnectionRemoved = new AsyncEvent<LavalinkGuildConnection, GuildConnectionRemovedEventArgs>("LAVALINK_GUILD_CONNECTION_REMOVED", TimeSpan.Zero, this.Discord.EventErrorHandler);
 
             this.VoiceServerUpdates = new ConcurrentDictionary<ulong, TaskCompletionSource<VoiceServerUpdateEventArgs>>();
             this.VoiceStateUpdates = new ConcurrentDictionary<ulong, TaskCompletionSource<VoiceStateUpdateEventArgs>>();
@@ -352,7 +352,7 @@ namespace DSharpPlus.Lavalink
             con.TrackStuck += (s, e) => this._trackStuck.InvokeAsync(s, e);
             con.TrackException += (s, e) => this._trackException.InvokeAsync(s, e);
             this._connectedGuilds[channel.Guild.Id] = con;
-            await _guildConnectionCreated.InvokeAsync(con, new AsyncEventArgs());
+            await _guildConnectionCreated.InvokeAsync(con, new GuildConnectionCreatedEventArgs());
 
             return con;
         }
@@ -478,7 +478,7 @@ namespace DSharpPlus.Lavalink
                 {
                     await kvp.Value.SendVoiceUpdateAsync().ConfigureAwait(false);
                     _ = this._connectedGuilds.TryRemove(kvp.Key, out var con);
-                    await _guildConnectionRemoved.InvokeAsync(con, new AsyncEventArgs());
+                    await _guildConnectionRemoved.InvokeAsync(con, new GuildConnectionRemovedEventArgs());
                 }
                 this.NodeDisconnected?.Invoke(this);
                 await this._disconnected.InvokeAsync(this, new NodeDisconnectedEventArgs(this, false)).ConfigureAwait(false);
@@ -500,7 +500,7 @@ namespace DSharpPlus.Lavalink
         private async void Con_ChannelDisconnected(LavalinkGuildConnection con)
         {
             this._connectedGuilds.TryRemove(con.GuildId, out con);
-            await _guildConnectionRemoved.InvokeAsync(con, new AsyncEventArgs());
+            await _guildConnectionRemoved.InvokeAsync(con, new GuildConnectionRemovedEventArgs());
         }
 
         private Task Discord_VoiceStateUpdated(DiscordClient client, VoiceStateUpdateEventArgs e)
@@ -527,7 +527,7 @@ namespace DSharpPlus.Lavalink
 
                         await lvlgc.DisconnectInternalAsync(false, true).ConfigureAwait(false);
                         _ = this._connectedGuilds.TryRemove(gld.Id, out var con);
-                        await _guildConnectionRemoved.InvokeAsync(con, new AsyncEventArgs());
+                        await _guildConnectionRemoved.InvokeAsync(con, new GuildConnectionRemovedEventArgs());
                     });
                 }
 

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -132,6 +132,26 @@ namespace DSharpPlus.Lavalink
         private readonly AsyncEvent<LavalinkGuildConnection, TrackExceptionEventArgs> _trackException;
 
         /// <summary>
+        /// Triggered whenever a new guild connection is created.
+        /// </summary>
+        public event AsyncEventHandler<LavalinkGuildConnection, AsyncEventArgs> GuildConnectionCreated
+        {
+            add { this._guildConnectionCreated.Register(value); }
+            remove { this._guildConnectionCreated.Unregister(value); }
+        }
+        private readonly AsyncEvent<LavalinkGuildConnection, AsyncEventArgs> _guildConnectionCreated;
+
+        /// <summary>
+        /// Triggered whenever a new guild connection is removed.
+        /// </summary>
+        public event AsyncEventHandler<LavalinkGuildConnection, AsyncEventArgs> GuildConnectionRemoved
+        {
+            add { this._guildConnectionRemoved.Register(value); }
+            remove { this._guildConnectionRemoved.Unregister(value); }
+        }
+        private readonly AsyncEvent<LavalinkGuildConnection, AsyncEventArgs> _guildConnectionRemoved;
+
+        /// <summary>
         /// Gets the remote endpoint of this Lavalink node connection.
         /// </summary>
         public ConnectionEndpoint NodeEndpoint => this.Configuration.SocketEndpoint;
@@ -199,6 +219,8 @@ namespace DSharpPlus.Lavalink
             this._playbackFinished = new AsyncEvent<LavalinkGuildConnection, TrackFinishEventArgs>("LAVALINK_PLAYBACK_FINISHED", TimeSpan.Zero, this.Discord.EventErrorHandler);
             this._trackStuck = new AsyncEvent<LavalinkGuildConnection, TrackStuckEventArgs>("LAVALINK_TRACK_STUCK", TimeSpan.Zero, this.Discord.EventErrorHandler);
             this._trackException = new AsyncEvent<LavalinkGuildConnection, TrackExceptionEventArgs>("LAVALINK_TRACK_EXCEPTION", TimeSpan.Zero, this.Discord.EventErrorHandler);
+            this._guildConnectionCreated = new AsyncEvent<LavalinkGuildConnection, AsyncEventArgs>("LAVALINK_GUILD_CONNECTION_CREATED", TimeSpan.Zero, this.Discord.EventErrorHandler); ;
+            this._guildConnectionRemoved = new AsyncEvent<LavalinkGuildConnection, AsyncEventArgs>("LAVALINK_GUILD_CONNECTION_REMOVED", TimeSpan.Zero, this.Discord.EventErrorHandler);
 
             this.VoiceServerUpdates = new ConcurrentDictionary<ulong, TaskCompletionSource<VoiceServerUpdateEventArgs>>();
             this.VoiceStateUpdates = new ConcurrentDictionary<ulong, TaskCompletionSource<VoiceStateUpdateEventArgs>>();
@@ -330,6 +352,7 @@ namespace DSharpPlus.Lavalink
             con.TrackStuck += (s, e) => this._trackStuck.InvokeAsync(s, e);
             con.TrackException += (s, e) => this._trackException.InvokeAsync(s, e);
             this._connectedGuilds[channel.Guild.Id] = con;
+            await _guildConnectionCreated.InvokeAsync(con, new AsyncEventArgs());
 
             return con;
         }
@@ -454,7 +477,8 @@ namespace DSharpPlus.Lavalink
                 foreach (var kvp in this._connectedGuilds)
                 {
                     await kvp.Value.SendVoiceUpdateAsync().ConfigureAwait(false);
-                    _ = this._connectedGuilds.TryRemove(kvp.Key, out _);
+                    _ = this._connectedGuilds.TryRemove(kvp.Key, out var con);
+                    await _guildConnectionRemoved.InvokeAsync(con, new AsyncEventArgs());
                 }
                 this.NodeDisconnected?.Invoke(this);
                 await this._disconnected.InvokeAsync(this, new NodeDisconnectedEventArgs(this, false)).ConfigureAwait(false);
@@ -473,8 +497,11 @@ namespace DSharpPlus.Lavalink
                 await this.SendPayloadAsync(new LavalinkConfigureResume(this.Configuration.ResumeKey, this.Configuration.ResumeTimeout)).ConfigureAwait(false);
         }
 
-        private void Con_ChannelDisconnected(LavalinkGuildConnection con)
-            => this._connectedGuilds.TryRemove(con.GuildId, out _);
+        private async void Con_ChannelDisconnected(LavalinkGuildConnection con)
+        {
+            this._connectedGuilds.TryRemove(con.GuildId, out con);
+            await _guildConnectionRemoved.InvokeAsync(con, new AsyncEventArgs());
+        }
 
         private Task Discord_VoiceStateUpdated(DiscordClient client, VoiceStateUpdateEventArgs e)
         {
@@ -499,7 +526,8 @@ namespace DSharpPlus.Lavalink
                         _ = await Task.WhenAny(delayTask, tcs).ConfigureAwait(false);
 
                         await lvlgc.DisconnectInternalAsync(false, true).ConfigureAwait(false);
-                        _ = this._connectedGuilds.TryRemove(gld.Id, out _);
+                        _ = this._connectedGuilds.TryRemove(gld.Id, out var con);
+                        await _guildConnectionRemoved.InvokeAsync(con, new AsyncEventArgs());
                     });
                 }
 


### PR DESCRIPTION
# Summary
Provides useful events for the creation and removal of LavalinkGuildConnections which provides a useful and meaningful way to track the creation and removal of connections without having to manage multiple events which may or may not be synced or fired for this purpose.

# Details
Since the LavalinkGuildConnection is sealed, alongside most of the classes in the Lavalink addition, it's difficult to track the creation and removal of these connections for the purposes of extending its functionality (for example, adding a built-in queue system, or adding music "players" in addition to that which Lavalink provides, or tracking other additional data). I'm sure there are other use cases for this change as well, it's simply a useful event since there is no consistent event for this purpose anyways (removal occurs in multiple places).

# Changes proposed
* Added LavalinkNodeConnection#GuildConnectionCreated event
* Added LavalinkNodeConnection#GuildConnectionRemoved event
* Modified LavalinkNodeConnection#Con_ChannelDisconnected to be an async method

# Notes
This is my first time contributing and I'm not particularly familiar with the affects/results of async methods. If there is anything I should change regarding this, please let me know, I'd be ready and willing to change it! I tried to follow the contributor guidelines best I could.

I have tested this in an implementation and it works great.

I was not sure what type of version bump would be needed for this, particularly due to the change on line 500. I think since this is internal it would be a patch or minor? But I'd rather a common contributor make the change they'd feel this best fits :)