### PR TITLE
ratelimiting skeleton

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,6 +35,11 @@ dotnet_diagnostic.IDE0005.severity = error
 # Yell at people when they don't include the file header template
 dotnet_diagnostic.IDE0073.severity = error
 
+# shut IDEs up about file scoped namespaces and java-style using directives 
+# while there is authoritative style rule found in here
+dotnet_diagnostic.IDE0065.severity = none
+dotnet_diagnostic.IDE0161.severity = none
+
 # this. preferences
 dotnet_style_qualification_for_field = false:error
 dotnet_style_qualification_for_property = false:error

--- a/DSharpPlus.Core/DSharpPlus.Core.csproj
+++ b/DSharpPlus.Core/DSharpPlus.Core.csproj
@@ -13,6 +13,11 @@
         <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, webhooks</PackageTags>
     </PropertyGroup>
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     </ItemGroup>
 </Project>

--- a/DSharpPlus.Core/DiscordClient.cs
+++ b/DSharpPlus.Core/DiscordClient.cs
@@ -1,0 +1,124 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// this is a stub, intended to demonstrate how to set up the rest client rather than
+// act as a working client
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using DSharpPlus.Core.Rest;
+using DSharpPlus.Core.Rest.Ratelimiting;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Polly;
+using Polly.Contrib.WaitAndRetry;
+
+namespace DSharpPlus.Core
+{
+
+    public class DiscordClient
+    {
+        // unfortunately, we need those two.
+        public IServiceCollection ServiceCollection { get; private set; }
+
+        public ServiceProvider Services { get; private set; }
+
+        // this is what we end up using after init has completed.
+        public RestClient RestClient { get; private set; }
+
+        // again, one second
+        private static readonly TimeSpan oneSecond = TimeSpan.FromSeconds(1);
+
+        public DiscordClient(IServiceCollection serviceCollection)
+        {
+            ServiceCollection = serviceCollection;
+
+            // we need to register the rest client via DI to make sure everything works.
+            ServiceCollection
+                .AddSingleton<RestClient>()
+                .AddMemoryCache();
+
+            Services = serviceCollection.BuildServiceProvider();
+
+            #region set up policies, retrying etc. this should be moved to a separate method.
+            PollyRatelimitingPolicy ratelimiter = new();
+
+            // these values are arbitrary and should be configurable. they specify how much time should elapse between retries,
+            // and how often we should retry. the algorithm creates an exponentially increasing list of delays, with the first one
+            // being based on 0.5 seconds here.
+            IEnumerable<TimeSpan> retryDelay = Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(0.5), 10);
+
+            ServiceCollection.AddHttpClient<RestClient>()
+                .ConfigureHttpClient((services, httpClient) =>
+                {
+                    httpClient.BaseAddress = new("https://discord.com/api/v9"); // or whatever, ideally have this in a constant
+                    httpClient.DefaultRequestHeaders.UserAgent.Add(new("DSharpPlus", "v5")); // again, constants
+                })
+                // register our ratelimiter
+                .AddTransientHttpErrorPolicy(policy => policy.WaitAndRetryAsync(retryDelay).WrapAsync(ratelimiter))
+
+                // register our retrying
+                .AddPolicyHandler
+                (
+                    // only retry 429 in addition to the already specified 5xx and 408
+                    Policy.HandleResult<HttpResponseMessage>(result => result.StatusCode == HttpStatusCode.TooManyRequests)
+                        .WaitAndRetryAsync(retryCount: 1, // retry once. another arbitrary number.
+                        sleepDurationProvider: (_, response, _) =>
+                        {
+                            HttpResponseMessage message = response.Result;
+
+                            if (message.Headers.GetValues("X-RateLimit-Scope").SingleOrDefault() == "shared")
+                            {
+                                throw new HttpRequestException("Shared ratelimit hit, not retrying request."); // this should be our own exception type
+                            }
+
+                            else if (message == default)
+                            {
+                                return oneSecond;
+                            }
+#pragma warning disable IDE0046 // shut up about ternaries
+                            else if (message.Headers.RetryAfter == null || message.Headers.RetryAfter.Delta == null)
+#pragma warning restore IDE0046
+                            {
+                                return oneSecond;
+                            }
+                            else 
+                            { 
+                                return message.Headers.RetryAfter.Delta.Value; 
+                            }
+                        },
+                        onRetryAsync: (_, _, _, _) => Task.CompletedTask)
+                );
+            #endregion
+
+            // get the final rest client instance via DI.
+            RestClient = Services.GetRequiredService<RestClient>();
+        }
+    }
+}

--- a/DSharpPlus.Core/Rest/IRestRequest.cs
+++ b/DSharpPlus.Core/Rest/IRestRequest.cs
@@ -1,0 +1,39 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Net.Http;
+
+using Polly;
+
+namespace DSharpPlus.Core.Rest
+{
+    // another stub.
+    public interface IRestRequest
+    {
+        // the actual request goes here
+
+        public Context Context { get; }
+
+        public HttpRequestMessage Build();
+    }
+}

--- a/DSharpPlus.Core/Rest/IRestRequest.cs
+++ b/DSharpPlus.Core/Rest/IRestRequest.cs
@@ -32,6 +32,16 @@ namespace DSharpPlus.Core.Rest
     {
         // the actual request goes here
 
+
+        // this needs to be populated by the API client. it needs to have a MemoryCache for the entire API client
+        // storing ratelimits, specify whether the request should be subject to the global limit and
+        // store the endpoint this request is made to. Major route parameters (guild id, channel id, webhook id)
+        // should be sent here as number, minor route parameters (message id, for instance) as a global constant representing
+        // them, like ":message_id".
+        // cache needs to be passed with the key `cache`
+        // request/ratelimiting needs to be passed with the key `subject-to-global-limit`
+        // endpoint needs to be passed with the key `endpoint`
+        // of course, these are all changeable in PollyRatelimitingPolicy.cs
         public Context Context { get; }
 
         public HttpRequestMessage Build();

--- a/DSharpPlus.Core/Rest/Ratelimiting/PollyRatelimitingPolicy.cs
+++ b/DSharpPlus.Core/Rest/Ratelimiting/PollyRatelimitingPolicy.cs
@@ -1,0 +1,172 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.Caching.Memory;
+
+using Polly;
+
+namespace DSharpPlus.Core.Rest.Ratelimiting
+{
+    // main ratelimit handler
+    internal class PollyRatelimitingPolicy : AsyncPolicy<HttpResponseMessage>
+    {
+        // keeps track of endpoint -> bucket hash mapping
+        private readonly ConcurrentDictionary<string, string> endpointBuckets;
+
+        // global ratelimit bucket of 50 requests per second
+        private readonly RatelimitBucket globalBucket;
+
+        // one second, we use this a lot so don't reallocate every time
+        private static readonly TimeSpan oneSecond = TimeSpan.FromSeconds(1);
+
+        public PollyRatelimitingPolicy()
+        {
+            globalBucket = new(50, 50, DateTimeOffset.UtcNow + oneSecond, "global");
+            endpointBuckets = new();
+        }
+
+        // the main policy.
+        protected override async Task<HttpResponseMessage> ImplementationAsync(
+            Func<Context, CancellationToken, Task<HttpResponseMessage>> action,
+            Context context,
+            CancellationToken cancellationToken,
+            bool continueOnCapturedContext)
+        {
+            // ensure a valid endpoint was passed
+            if (!context.TryGetValue("endpoint", out object endpointRaw) || endpointRaw is not string endpoint)
+            {
+                throw new InvalidOperationException("No endpoint passed.");
+            }
+
+            // ensure a valid cache was passed. the cache mostly serves as an alternative to v4's "BucketCleanerTask",
+            // which, in its static manner, would hardly work with the very DI-focused architecture of Polly and Polly policies.
+            if (!context.TryGetValue("cache", out object cacheRaw) || cacheRaw is not IMemoryCache cache)
+            {
+                throw new InvalidOperationException("No cache passed.");
+            }
+
+            // avoid having to create multiple of these. execution time should be reasonably fast.
+            DateTimeOffset instant = DateTimeOffset.UtcNow;
+
+            // some endpoints are exempt from the global limit, account for them.
+            bool subjectToGlobalLimit = true;
+
+            // this is our unique identifier for each active bucket.
+            string bucketHash;
+
+            // make sure to reflect context-passed exemption
+            if (context.TryGetValue("subject-to-global-limit", out object globallyLimitedRaw) && globallyLimitedRaw is bool globallyLimited)
+            {
+                subjectToGlobalLimit = globallyLimited;
+            }
+
+            // the following logic applies only to globally ratelimited requests.
+            if (subjectToGlobalLimit)
+            {
+                // if the bucket is already expired, reset it. technically we could save a bit of time by goto-ing out of the
+                // if clause entirely if this check succeeds, since we are then guaranteed the request will be allowed.
+                if (globalBucket.ResetTime < instant)
+                {
+                    globalBucket.ResetBucket(instant + oneSecond);
+                }
+
+                if (!globalBucket.AllowNextRequest())
+                {
+                    HttpResponseMessage response = new(HttpStatusCode.TooManyRequests);
+
+                    response.Headers.RetryAfter = new(globalBucket.ResetTime - instant);
+
+                    // allow users to figure out whether the 429 showing up in their debug windows was thrown by Discord or
+                    // an internal DSharpPlus response. also specify what bucket denied the request.
+                    response.Headers.Add("X-DSharpPlus-Preemptive-Ratelimit", "global");
+
+                    // pretend this was a discord api call and return the response.
+                    return response;
+                }
+            }
+
+            // if we don't already have this bucket cached, set the hash to our endpoint for now. 
+            // this will later be used to identify a newly called bucket.
+            bucketHash = endpointBuckets.TryGetValue(endpoint, out string? nullableBucketHash)
+                ? nullableBucketHash
+                : endpoint;
+
+            // get the cached ratelimit bucket. if it doesn't exist, we are guaranteed our request will be allowed
+            // as it will be the first request to this bucket, which never 429s.
+            if (cache.TryGetValue(bucketHash, out RatelimitBucket? cachedBucket) || !cachedBucket!.AllowNextRequest())
+            {
+                HttpResponseMessage response = new(HttpStatusCode.TooManyRequests);
+
+                response.Headers.RetryAfter = new(cachedBucket!.ResetTime - instant);
+
+                // allow users to figure out whether the 429 showing up in their debug windows was thrown by Discord or
+                // an internal DSharpPlus response. also specify what bucket denied the request.
+                response.Headers.Add("X-DSharpPlus-Preemptive-Ratelimit", "endpoint");
+
+                // pretend this was a discord api call and return the response.
+                return response;
+            }
+
+            // actually make our api call now. we can remove the ConfigureAwait call or always pass false if we want.
+            HttpResponseMessage discordResponse = await action(context, cancellationToken).ConfigureAwait(continueOnCapturedContext);
+
+            // try extracting a new ratelimit bucket from this, even if we already had one cached.
+            // discord can decide to change the limit on us, in which case we need a new bucket with a new hash.
+            if(!RatelimitBucket.TryExtractRatelimitBucket(discordResponse.Headers, out RatelimitBucket? extractedBucket))
+            {
+                return discordResponse;
+            }
+
+            if(extractedBucket.Hash == null)
+            {
+                // make sure we dont end up with chaotic state first
+                endpointBuckets.TryRemove(endpoint, out _);
+                cache.Set(endpoint, extractedBucket, extractedBucket.ResetTime + oneSecond);
+
+                return discordResponse;
+            }
+
+            // wow, everything went well. update the ratelimit bucket and return
+
+            endpointBuckets.AddOrUpdate(endpoint, extractedBucket.Hash, (_, _) => extractedBucket.Hash);
+
+            // expire one second after the bucket expires, to avoid race conditions.
+            cache.Set(endpoint, extractedBucket, extractedBucket.ResetTime + oneSecond);
+
+            // remove potential stale data
+            if(extractedBucket.Hash != bucketHash)
+            {
+                cache.Remove(bucketHash);
+            }
+
+            return discordResponse;
+        }
+    }
+}

--- a/DSharpPlus.Core/Rest/Ratelimiting/RatelimitBucket.cs
+++ b/DSharpPlus.Core/Rest/Ratelimiting/RatelimitBucket.cs
@@ -1,0 +1,142 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Core.Rest.Ratelimiting
+{
+    using System;
+using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using System.Net.Http.Headers;
+    using System.Threading;
+
+    // keeps track of one single ratelimit for us
+    internal record RatelimitBucket
+    {
+        // default values for if we cant rely on discord
+        private const string UnlimitedRatelimitIdentifier = "unlimited";
+        private const int DefaultLimit = 1;
+        private const int DefaultRemaining = 0;
+        private static readonly DateTimeOffset discordEpoch = new(2015, 0, 0, 0, 0, 0, new());
+
+        // lock
+        private readonly object __lock = new();
+
+        // the limit for this bucket. this should never change without the hash also changing and us therefore creating a new bucket.
+        public int Limit { get; } = DefaultLimit;
+
+#pragma warning disable CS0420 // yes, we are passing ref which makes the reference non-volatile, but you're supposed to use the API like that
+        public int Remaining
+        {
+            get => Volatile.Read(ref _remaining);
+            set => Volatile.Write(ref _remaining, value);
+        }
+#pragma warning restore CS0420
+
+        private volatile int _remaining = DefaultRemaining;
+
+        // this can and will wildly change
+        public DateTimeOffset ResetTime { get; private set; } = discordEpoch;
+
+        // and this is what we use to keep track of buckets
+        public string Hash { get; } = UnlimitedRatelimitIdentifier;
+
+        #region Constructing
+
+        public RatelimitBucket(int limit, int remaining, DateTimeOffset resetTime, string? hash)
+        {
+            Limit = limit;
+            Remaining = remaining;
+            ResetTime = resetTime;
+            Hash = hash ?? UnlimitedRatelimitIdentifier;
+        }
+
+        public static bool TryExtractRatelimitBucket(HttpResponseHeaders headers,
+            
+            [NotNullWhen(true)]
+            out RatelimitBucket? bucket)
+        {
+            bucket = null;
+
+            try
+            {
+                // these three headers are critical for us. if they don't exist, assume no valid ratelimit is passed
+                // and abort the operation, indicating that no ratelimit was extracted successfully.
+
+                if (!headers.TryGetValues("X-RateLimit-Limit", out IEnumerable<string>? limitRaw)
+                || !headers.TryGetValues("X-RateLimit-Remaining", out IEnumerable<string>? remainingRaw)
+                || !headers.TryGetValues("X-RateLimit-Reset", out IEnumerable<string>? ratelimitResetRaw))
+                {
+                    return false;
+                }
+
+                // again, these headers are critical. if they don't hold valid values, abort as well.
+
+                if (!int.TryParse(limitRaw.SingleOrDefault(), out int limit)
+                    || !int.TryParse(remainingRaw.SingleOrDefault(), out int remaining)
+                    || !double.TryParse(ratelimitResetRaw.SingleOrDefault(), out double ratelimitReset))
+                {
+                    return false;
+                }
+
+                string? hash = headers.GetValues("X-RateLimit-Name").SingleOrDefault();
+                DateTimeOffset resetTime = DateTimeOffset.UnixEpoch + TimeSpan.FromSeconds(ratelimitReset);
+
+                bucket = new(limit, remaining, resetTime, hash);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        #endregion
+
+        public void ResetBucket(DateTimeOffset nextResetTime)
+        {
+            if(nextResetTime < ResetTime)
+            {
+                throw new ArgumentOutOfRangeException("The next ratelimit bucket expiration cannot be in the past.");
+            }
+
+            lock (__lock)
+            {
+                Remaining = Limit;
+                ResetTime = nextResetTime;
+            }
+        }
+
+        public bool AllowNextRequest()
+        {
+            if(Remaining <= 0)
+            {
+                // if the bucket should have reset by now, allow it anyway
+                return ResetTime < DateTimeOffset.UtcNow;
+            }
+
+            Remaining--;
+            return true;        
+        }
+    }
+}

--- a/DSharpPlus.Core/Rest/Ratelimiting/RatelimitBucket.cs
+++ b/DSharpPlus.Core/Rest/Ratelimiting/RatelimitBucket.cs
@@ -117,7 +117,7 @@ using System.Collections.Generic;
         {
             if(nextResetTime < ResetTime)
             {
-                throw new ArgumentOutOfRangeException("The next ratelimit bucket expiration cannot be in the past.");
+                throw new ArgumentOutOfRangeException(nameof(nextResetTime), "The next ratelimit bucket expiration cannot be in the past.");
             }
 
             lock (__lock)

--- a/DSharpPlus.Core/Rest/RestClient.cs
+++ b/DSharpPlus.Core/Rest/RestClient.cs
@@ -1,0 +1,50 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace DSharpPlus.Core.Rest
+{
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    using Polly;
+
+    // another stub, just like DiscordClient.
+    public class RestClient
+    {
+        private readonly HttpClient client;
+
+        public RestClient(HttpClient client) 
+            => this.client = client;
+
+        public async Task<HttpResponseMessage> MakeRequestAsync(IRestRequest request)
+        {
+            HttpRequestMessage message = request.Build();
+
+            // this way our execution policy knows what we're doing
+            message.SetPolicyExecutionContext(request.Context);
+
+            // we should be handling errors etc here, but again, this is a stub to show the concept rather than a final implementation.
+            return await client.SendAsync(message);
+        }
+    }
+}


### PR DESCRIPTION
The only seriously, finally proposed changes are `DSharpPlus.Core.csproj`, `PollyRatelimitingPolicy.cs` and `RatelimitBucket.cs`. The editorconfig served as a temporary measure, as explained in the code comment, and the remaining three files (`IRestRequest.cs`, `RestClient.cs` and `DiscordClient.cs` demonstrate how the ratelimiter is used, as opposed to being a final implementation proposal.