### PR TITLE
Use .png for APNG stickers

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageSticker.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageSticker.cs
@@ -126,8 +126,7 @@ namespace DSharpPlus.Entities
 
         private string GetFileTypeExtension() => this.FormatType switch
         {
-            StickerFormat.PNG => ".png",
-            StickerFormat.APNG => ".apng",
+            StickerFormat.PNG or StickerFormat.APNG => ".png",
             StickerFormat.LOTTIE => ".json",
             _ => ".png"
         };


### PR DESCRIPTION
# Summary
Replaces a presumed erroneous `.apng` in `DiscordMessageSticker.GetFileTypeExtension` with `.png`

# Details
Currently when you try to fetch the `.StickerUrl` for an animated PNG (APNG) sticker, it returns a URL ending in `.apng`

For example: https://cdn.discordapp.com/stickers/916487734858752010.apng

This URL does not work, the file is not present on Discord's CDN.

Replacing it with a `.png` however, resolves this: https://cdn.discordapp.com/stickers/916487734858752010.png 

This is the same URL that the Discord client uses, and is presumably the correct one for an APNG file.

# Changes proposed
* Use `.png` for `StickerFormat.APNG` as well as `StickerFormat.PNG`, in `DiscordMessageSticker.GetFileTypeExtension`

# Notes
As always when someone goes around changing established values so make things work, you should make sure it doesn't break anything else. I have done this to the best of my knowledge, and checked all types of stickers still return their appropriate values.

I also don't know why there's a switch statement there at this point when only one value is different from the default of `.png`, but I thought I would prefer fixing the immediate issue to rewriting chunks to fit my beliefs.