### PR TITLE
Fix incorrect value for MessageActivityType.JoinRequest

### DIFF
--- a/DSharpPlus/Enums/Message/MessageActivityType.cs
+++ b/DSharpPlus/Enums/Message/MessageActivityType.cs
@@ -46,6 +46,6 @@ namespace DSharpPlus
         /// <summary>
         /// Allows the user to request to join.
         /// </summary>
-        JoinRequest = 4
+        JoinRequest = 5
     }
 }


### PR DESCRIPTION
`MessageActivityType.JoinRequest` was incorrectly set to 4 when the `MessageActivityType` enumeration was created; the documentation says it should be *5*.

Fixes #1281