### PR TITLE
[ci-skip] Remove misinformation

### DIFF
--- a/docs/articles/advanced_topics/buttons.md
+++ b/docs/articles/advanced_topics/buttons.md
@@ -161,7 +161,7 @@ client.ComponentInteractionCreated += async (s, e) =>
             .WithContent("No more buttons for you >:)"));
 }
 ```
-This will update the message, and without the infamous <sub>(edited)</sub> next to it. Nice.
+This will update the message, and remove all the buttons. Nice.
 
 
 # Interactivity


### PR DESCRIPTION
# Summary
Removes the old line that confuses everyone who tries to use buttons

# Details
Discord has since declared that "It was a bug and not an intended feature" - velvet, 18/04/2022

# Changes proposed
* one line about the (edited) in the interaction responses