### PR TITLE
V5 deserialization tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 obj/
 .vscode
 .vs
+DSharpPlus.Test/TestResults/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "discord-payloads"]
+	path = discord-payloads
+	url = https://github.com/discord-payloads/discord-payloads

--- a/DSharpPlus.Core/Attributes/DiscordGatewayEventName.cs
+++ b/DSharpPlus.Core/Attributes/DiscordGatewayEventName.cs
@@ -21,34 +21,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using DSharpPlus.Core.Attributes;
-using DSharpPlus.Core.Entities;
-using Newtonsoft.Json;
+using System;
 
-namespace DSharpPlus.Core.Gateway.Payloads
+namespace DSharpPlus.Core.Attributes
 {
-    /// <summary>
-    /// Sent when an integration is deleted.
-    /// </summary>
-    [DiscordGatewayEventName("INTEGRATION_DELETE")]
-    public sealed record DiscordGuildIntegrationDeletePayload
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+    public sealed class DiscordGatewayEventNameAttribute : Attribute
     {
-        /// <summary>
-        /// The integration id.
-        /// </summary>
-        [JsonProperty("id", NullValueHandling = NullValueHandling.Ignore)]
-        public DiscordSnowflake Id { get; init; } = null!;
+        public string[] Names { get; }
 
-        /// <summary>
-        /// The id of the guild.
-        /// </summary>
-        [JsonProperty("guild_id", NullValueHandling = NullValueHandling.Ignore)]
-        public DiscordSnowflake GuildId { get; init; } = null!;
-
-        /// <summary>
-        /// The id of the bot/OAuth2 application for this discord integration.
-        /// </summary>
-        [JsonProperty("application_id", NullValueHandling = NullValueHandling.Ignore)]
-        public Optional<DiscordSnowflake> ApplicationId { get; init; }
+        public DiscordGatewayEventNameAttribute(params string[] names) => Names = names;
     }
 }

--- a/DSharpPlus.Core/Attributes/DiscordGatewayPayloadAttribute.cs
+++ b/DSharpPlus.Core/Attributes/DiscordGatewayPayloadAttribute.cs
@@ -22,14 +22,32 @@
 // SOFTWARE.
 
 using System;
+using System.Diagnostics;
 
 namespace DSharpPlus.Core.Attributes
 {
+    /// <summary>
+    /// Associates a payload with one or more gateway events.
+    /// </summary>
+    [DebuggerDisplay("Gateway Payloads: {GetDebuggerDisplay()}")]
     [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
-    public sealed class DiscordGatewayEventNameAttribute : Attribute
+    public sealed class DiscordGatewayPayloadAttribute : Attribute
     {
+        /// <summary>
+        /// The payloads that this record is associated with. Names should be in SCREAMING_SNAKE_CASE. See https://discord.com/developers/docs/topics/gateway#commands-and-events for possible values.
+        /// </summary>
         public string[] Names { get; }
 
-        public DiscordGatewayEventNameAttribute(params string[] names) => Names = names;
+        /// <summary>
+        /// The payloads that this record is associated with. Names should be in SCREAMING_SNAKE_CASE. See https://discord.com/developers/docs/topics/gateway#commands-and-events for possible values.
+        /// </summary>
+        /// <param name="names">The gateway event names to associate the record with.</param>
+        public DiscordGatewayPayloadAttribute(params string[] names) => Names = names;
+
+        /// <summary>
+        /// Returns the names of the gateway payloads associated with this record. Not truly required, but nice to have when debugging.
+        /// </summary>
+        /// <returns>A `, ` delimited string of associated gateway event names.</returns>
+        private string GetDebuggerDisplay() => string.Join(", ", Names);
     }
 }

--- a/DSharpPlus.Core/DSharpPlus.Core.csproj
+++ b/DSharpPlus.Core/DSharpPlus.Core.csproj
@@ -7,12 +7,12 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
     <PropertyGroup>
-        <PackageId>DSharpPlus</PackageId>
+        <PackageId>DSharpPlus.Core</PackageId>
         <Authors>Naamloos, afroraydude, DrCreo, Death, TiaqoY0, Axiom, Emzi0767, IDoEverything, Velvet, DSharpPlus contributors</Authors>
         <Description>A C# API for Discord based off DiscordSharp, but rewritten to fit the API standards.</Description>
         <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, webhooks</PackageTags>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 </Project>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordChannelPinsUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordChannelPinsUpdatePayload.cs
@@ -31,7 +31,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a message is pinned or unpinned in a text channel. This is not sent when a pinned message is deleted.
     /// </summary>
-    [DiscordGatewayEventName("CHANNEL_PINS_UPDATE")]
+    [DiscordGatewayPayload("CHANNEL_PINS_UPDATE")]
     public sealed record DiscordChannelPinsUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordChannelPinsUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordChannelPinsUpdatePayload.cs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 using System;
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -30,6 +31,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a message is pinned or unpinned in a text channel. This is not sent when a pinned message is deleted.
     /// </summary>
+    [DiscordGatewayEventName("CHANNEL_PINS_UPDATE")]
     public sealed record DiscordChannelPinsUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildBanAddPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildBanAddPayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user is banned from a guild.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_BAN_ADD")]
     public sealed record DiscordGuildBanAddPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildBanAddPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildBanAddPayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user is banned from a guild.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_BAN_ADD")]
+    [DiscordGatewayPayload("GUILD_BAN_ADD")]
     public sealed record DiscordGuildBanAddPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildBanRemovePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildBanRemovePayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user is unbanned from a guild.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_BAN_REMOVE")]
     public sealed record DiscordGuildBanRemovePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildBanRemovePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildBanRemovePayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user is unbanned from a guild.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_BAN_REMOVE")]
+    [DiscordGatewayPayload("GUILD_BAN_REMOVE")]
     public sealed record DiscordGuildBanRemovePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildEmojisUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildEmojisUpdatePayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a guild's emojis have been updated.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_EMOJIS_UPDATE")]
+    [DiscordGatewayPayload("GUILD_EMOJIS_UPDATE")]
     public sealed record DiscordGuildEmojisUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildEmojisUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildEmojisUpdatePayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a guild's emojis have been updated.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_EMOJIS_UPDATE")]
     public sealed record DiscordGuildEmojisUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildIntegrationDeletePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildIntegrationDeletePayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when an integration is deleted.
     /// </summary>
-    [DiscordGatewayEventName("INTEGRATION_DELETE")]
+    [DiscordGatewayPayload("INTEGRATION_DELETE")]
     public sealed record DiscordGuildIntegrationDeletePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildIntegrationsUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildIntegrationsUpdatePayload.cs
@@ -21,11 +21,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Gateway.Payloads
 {
+    [DiscordGatewayEventName("GUILD_INTEGRATIONS_UPDATE")]
     public sealed record DiscordGuildIntegrationsUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildIntegrationsUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildIntegrationsUpdatePayload.cs
@@ -27,7 +27,7 @@ using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Gateway.Payloads
 {
-    [DiscordGatewayEventName("GUILD_INTEGRATIONS_UPDATE")]
+    [DiscordGatewayPayload("GUILD_INTEGRATIONS_UPDATE")]
     public sealed record DiscordGuildIntegrationsUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildMemberRemovePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildMemberRemovePayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway
     /// <summary>
     /// Sent when a user is removed from a guild (leave/kick/ban).
     /// </summary>
-    [DiscordGatewayEventName("GUILD_MEMBER_REMOVE")]
+    [DiscordGatewayPayload("GUILD_MEMBER_REMOVE")]
     public sealed record DiscordGuildMemberRemovePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildMemberRemovePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildMemberRemovePayload.cs
@@ -25,20 +25,14 @@ using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
-namespace DSharpPlus.Core.Gateway.Payloads
+namespace DSharpPlus.Core.Gateway
 {
     /// <summary>
-    /// Sent when an integration is deleted.
+    /// Sent when a user is removed from a guild (leave/kick/ban).
     /// </summary>
-    [DiscordGatewayEventName("INTEGRATION_DELETE")]
-    public sealed record DiscordGuildIntegrationDeletePayload
+    [DiscordGatewayEventName("GUILD_MEMBER_REMOVE")]
+    public sealed record DiscordGuildMemberRemovePayload
     {
-        /// <summary>
-        /// The integration id.
-        /// </summary>
-        [JsonProperty("id", NullValueHandling = NullValueHandling.Ignore)]
-        public DiscordSnowflake Id { get; init; } = null!;
-
         /// <summary>
         /// The id of the guild.
         /// </summary>
@@ -46,9 +40,9 @@ namespace DSharpPlus.Core.Gateway.Payloads
         public DiscordSnowflake GuildId { get; init; } = null!;
 
         /// <summary>
-        /// The id of the bot/OAuth2 application for this discord integration.
+        /// The user who was removed.
         /// </summary>
-        [JsonProperty("application_id", NullValueHandling = NullValueHandling.Ignore)]
-        public Optional<DiscordSnowflake> ApplicationId { get; init; }
+        [JsonProperty("user", NullValueHandling = NullValueHandling.Ignore)]
+        public DiscordUser User { get; init; } = null!;
     }
 }

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildMemberUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildMemberUpdatePayload.cs
@@ -31,7 +31,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a guild member is updated. This will also fire when the user object of a guild member changes.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_MEMBER_UPDATE")]
+    [DiscordGatewayPayload("GUILD_MEMBER_UPDATE")]
     public sealed record DiscordGuildMemberUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildMemberUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildMemberUpdatePayload.cs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 using System;
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -30,6 +31,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a guild member is updated. This will also fire when the user object of a guild member changes.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_MEMBER_UPDATE")]
     public sealed record DiscordGuildMemberUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildMembersChunkPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildMembersChunkPayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent in response to Guild Request Members. You can use the chunk_index and chunk_count to calculate how many chunks are left for your request.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_MEMBERS_CHUNK")]
     public sealed record DiscordGuildMembersChunkPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildMembersChunkPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildMembersChunkPayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent in response to Guild Request Members. You can use the chunk_index and chunk_count to calculate how many chunks are left for your request.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_MEMBERS_CHUNK")]
+    [DiscordGatewayPayload("GUILD_MEMBERS_CHUNK")]
     public sealed record DiscordGuildMembersChunkPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildRoleCreatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildRoleCreatePayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a guild role is created.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_ROLE_CREATE")]
+    [DiscordGatewayPayload("GUILD_ROLE_CREATE")]
     public sealed record DiscordGuildRoleCreatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildRoleCreatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildRoleCreatePayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a guild role is created.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_ROLE_CREATE")]
     public sealed record DiscordGuildRoleCreatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildRoleDeletePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildRoleDeletePayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a guild role is deleted.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_ROLE_DELETE")]
+    [DiscordGatewayPayload("GUILD_ROLE_DELETE")]
     public sealed record DiscordGuildRoleDeletePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildRoleDeletePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildRoleDeletePayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a guild role is deleted.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_ROLE_DELETE")]
     public sealed record DiscordGuildRoleDeletePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildRoleUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildRoleUpdatePayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a guild role is updated.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_ROLE_UPDATE")]
     public sealed record DiscordGuildRoleUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildRoleUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildRoleUpdatePayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a guild role is updated.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_ROLE_UPDATE")]
+    [DiscordGatewayPayload("GUILD_ROLE_UPDATE")]
     public sealed record DiscordGuildRoleUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildScheduledEventUserAddPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildScheduledEventUserAddPayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user has subscribed to a guild scheduled event.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_SCHEDULED_EVENT_USER_ADD")]
+    [DiscordGatewayPayload("GUILD_SCHEDULED_EVENT_USER_ADD")]
     public sealed record DiscordGuildScheduledEventUserAddPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildScheduledEventUserAddPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildScheduledEventUserAddPayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user has subscribed to a guild scheduled event.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_SCHEDULED_EVENT_USER_ADD")]
     public sealed record DiscordGuildScheduledEventUserAddPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildScheduledEventUserRemovePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildScheduledEventUserRemovePayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user has unsubscribed from a guild scheduled event.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_SCHEDULED_EVENT_USER_REMOVE")]
     public sealed record DiscordGuildScheduledEventUserRemovePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildScheduledEventUserRemovePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildScheduledEventUserRemovePayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user has unsubscribed from a guild scheduled event.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_SCHEDULED_EVENT_USER_REMOVE")]
+    [DiscordGatewayPayload("GUILD_SCHEDULED_EVENT_USER_REMOVE")]
     public sealed record DiscordGuildScheduledEventUserRemovePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildStickersUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildStickersUpdatePayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a guild's emojis have been updated.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_STICKERS_UPDATE")]
     public sealed record DiscordGuildStickersUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildStickersUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordGuildStickersUpdatePayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a guild's emojis have been updated.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_STICKERS_UPDATE")]
+    [DiscordGatewayPayload("GUILD_STICKERS_UPDATE")]
     public sealed record DiscordGuildStickersUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordHelloPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordHelloPayload.cs
@@ -29,7 +29,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent on connection to the websocket. Defines the heartbeat interval that the client should heartbeat to.
     /// </summary>
-    [DiscordGatewayEventName("HELLO")]
+    [DiscordGatewayPayload("HELLO")]
     public sealed record DiscordHelloPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordHelloPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordHelloPayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Gateway.Payloads
@@ -28,6 +29,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent on connection to the websocket. Defines the heartbeat interval that the client should heartbeat to.
     /// </summary>
+    [DiscordGatewayEventName("HELLO")]
     public sealed record DiscordHelloPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordInviteCreatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordInviteCreatePayload.cs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 using System;
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using DSharpPlus.Core.Enums;
 using Newtonsoft.Json;
@@ -31,6 +32,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a new invite to a channel is created.
     /// </summary>
+    [DiscordGatewayEventName("INVITE_CREATE")]
     public sealed record DiscordInviteCreatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordInviteCreatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordInviteCreatePayload.cs
@@ -32,7 +32,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a new invite to a channel is created.
     /// </summary>
-    [DiscordGatewayEventName("INVITE_CREATE")]
+    [DiscordGatewayPayload("INVITE_CREATE")]
     public sealed record DiscordInviteCreatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordInviteDeletePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordInviteDeletePayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when an invite is deleted.
     /// </summary>
+    [DiscordGatewayEventName("INVITE_DELETE")]
     public sealed record DiscordInviteDeletePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordInviteDeletePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordInviteDeletePayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when an invite is deleted.
     /// </summary>
-    [DiscordGatewayEventName("INVITE_DELETE")]
+    [DiscordGatewayPayload("INVITE_DELETE")]
     public sealed record DiscordInviteDeletePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageDeleteBulkPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageDeleteBulkPayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when multiple messages are deleted at once.
     /// </summary>
-    [DiscordGatewayEventName("MESSAGE_DELETE_BULK")]
+    [DiscordGatewayPayload("MESSAGE_DELETE_BULK")]
     public sealed record DiscordMessageDeleteBulkPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageDeleteBulkPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageDeleteBulkPayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when multiple messages are deleted at once.
     /// </summary>
+    [DiscordGatewayEventName("MESSAGE_DELETE_BULK")]
     public sealed record DiscordMessageDeleteBulkPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageDeletePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageDeletePayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a message is deleted.
     /// </summary>
+    [DiscordGatewayEventName("MESSAGE_DELETE")]
     public sealed record DiscordMessageDeletePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageDeletePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageDeletePayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a message is deleted.
     /// </summary>
-    [DiscordGatewayEventName("MESSAGE_DELETE")]
+    [DiscordGatewayPayload("MESSAGE_DELETE")]
     public sealed record DiscordMessageDeletePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionAddPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionAddPayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user adds a reaction to a message.
     /// </summary>
-    [DiscordGatewayEventName("MESSAGE_REACTION_ADD")]
+    [DiscordGatewayPayload("MESSAGE_REACTION_ADD")]
     public sealed record DiscordMessageReactionAddPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionAddPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionAddPayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user adds a reaction to a message.
     /// </summary>
+    [DiscordGatewayEventName("MESSAGE_REACTION_ADD")]
     public sealed record DiscordMessageReactionAddPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionRemoveAllPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionRemoveAllPayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user explicitly removes all reactions from a message.
     /// </summary>
-    [DiscordGatewayEventName("MESSAGE_REACTION_REMOVE_ALL")]
+    [DiscordGatewayPayload("MESSAGE_REACTION_REMOVE_ALL")]
     public sealed record DiscordMessageReactionRemoveAllPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionRemoveAllPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionRemoveAllPayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user explicitly removes all reactions from a message.
     /// </summary>
+    [DiscordGatewayEventName("MESSAGE_REACTION_REMOVE_ALL")]
     public sealed record DiscordMessageReactionRemoveAllPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionRemoveEmojiPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionRemoveEmojiPayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a bot removes all instances of a given emoji from the reactions of a message.
     /// </summary>
-    [DiscordGatewayEventName("MESSAGE_REACTION_REMOVE_EMOJI")]
+    [DiscordGatewayPayload("MESSAGE_REACTION_REMOVE_EMOJI")]
     public sealed record DiscordMessageReactionRemoveEmojiPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionRemoveEmojiPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionRemoveEmojiPayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a bot removes all instances of a given emoji from the reactions of a message.
     /// </summary>
+    [DiscordGatewayEventName("MESSAGE_REACTION_REMOVE_EMOJI")]
     public sealed record DiscordMessageReactionRemoveEmojiPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionRemovePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionRemovePayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user removes a reaction from a message.
     /// </summary>
-    [DiscordGatewayEventName("MESSAGE_REACTION_REMOVE")]
+    [DiscordGatewayPayload("MESSAGE_REACTION_REMOVE")]
     public sealed record DiscordMessageReactionRemovePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionRemovePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordMessageReactionRemovePayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user removes a reaction from a message.
     /// </summary>
+    [DiscordGatewayEventName("MESSAGE_REACTION_REMOVE")]
     public sealed record DiscordMessageReactionRemovePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordReadyPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordReadyPayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// The ready event is dispatched when a client has completed the initial handshake with the gateway (for new sessions). The ready event can be the largest and most complex event the gateway will send, as it contains all the state required for a client to begin interacting with the rest of the platform.
     /// </summary>
+    [DiscordGatewayEventName("READY")]
     public sealed record DiscordReadyPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordReadyPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordReadyPayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// The ready event is dispatched when a client has completed the initial handshake with the gateway (for new sessions). The ready event can be the largest and most complex event the gateway will send, as it contains all the state required for a client to begin interacting with the rest of the platform.
     /// </summary>
-    [DiscordGatewayEventName("READY")]
+    [DiscordGatewayPayload("READY")]
     public sealed record DiscordReadyPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordThreadListSyncPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordThreadListSyncPayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when the current user gains access to a channel.
     /// </summary>
+    [DiscordGatewayEventName("THREAD_LIST_SYNC")]
     public sealed record DiscordThreadListSyncPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordThreadListSyncPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordThreadListSyncPayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when the current user gains access to a channel.
     /// </summary>
-    [DiscordGatewayEventName("THREAD_LIST_SYNC")]
+    [DiscordGatewayPayload("THREAD_LIST_SYNC")]
     public sealed record DiscordThreadListSyncPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordThreadMembersUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordThreadMembersUpdatePayload.cs
@@ -33,7 +33,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <remarks>
     /// In this gateway event, the thread member objects will also include the <see cref="DiscordGuildMember"/> and nullable <see cref="DiscordUpdatePresencePayload"/> for each added thread member.
     /// </remarks>
-    [DiscordGatewayEventName("THREAD_MEMBERS_UPDATE")]
+    [DiscordGatewayPayload("THREAD_MEMBERS_UPDATE")]
     public sealed record DiscordThreadMembersUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordThreadMembersUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordThreadMembersUpdatePayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -32,6 +33,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <remarks>
     /// In this gateway event, the thread member objects will also include the <see cref="DiscordGuildMember"/> and nullable <see cref="DiscordUpdatePresencePayload"/> for each added thread member.
     /// </remarks>
+    [DiscordGatewayEventName("THREAD_MEMBERS_UPDATE")]
     public sealed record DiscordThreadMembersUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordTypingStartPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordTypingStartPayload.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user starts typing in a channel.
     /// </summary>
-    [DiscordGatewayEventName("TYPING_START")]
+    [DiscordGatewayPayload("TYPING_START")]
     public sealed record DiscordTypingStartPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordTypingStartPayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordTypingStartPayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// Sent when a user starts typing in a channel.
     /// </summary>
+    [DiscordGatewayEventName("TYPING_START")]
     public sealed record DiscordTypingStartPayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordUpdatePresencePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordUpdatePresencePayload.cs
@@ -31,7 +31,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// A user's presence is their current state on a guild. This event is sent when a user's presence or info, such as name or avatar, is updated.
     /// </summary>
-    [DiscordGatewayEventName("PRESENCE_UPDATE")]
+    [DiscordGatewayPayload("PRESENCE_UPDATE")]
     public sealed record DiscordUpdatePresencePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordUpdatePresencePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordUpdatePresencePayload.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using DSharpPlus.Core.Enums;
 using Newtonsoft.Json;
@@ -30,6 +31,7 @@ namespace DSharpPlus.Core.Gateway.Payloads
     /// <summary>
     /// A user's presence is their current state on a guild. This event is sent when a user's presence or info, such as name or avatar, is updated.
     /// </summary>
+    [DiscordGatewayEventName("PRESENCE_UPDATE")]
     public sealed record DiscordUpdatePresencePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordVoiceServerUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordVoiceServerUpdatePayload.cs
@@ -21,11 +21,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Gateway.Payloads
 {
+    [DiscordGatewayEventName("VOICE_SERVER_UPDATE")]
     public sealed record DiscordVoiceServerUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordVoiceServerUpdatePayload.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordVoiceServerUpdatePayload.cs
@@ -27,7 +27,7 @@ using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Gateway.Payloads
 {
-    [DiscordGatewayEventName("VOICE_SERVER_UPDATE")]
+    [DiscordGatewayPayload("VOICE_SERVER_UPDATE")]
     public sealed record DiscordVoiceServerUpdatePayload
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordWebhooksUpdate.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordWebhooksUpdate.cs
@@ -21,11 +21,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Entities;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Gateway.Payloads
 {
+    [DiscordGatewayEventName("WEBHOOKS_UPDATE")]
     public sealed record DiscordWebhookUpdate
     {
         /// <summary>

--- a/DSharpPlus.Core/GatewayEntities/Payloads/DiscordWebhooksUpdate.cs
+++ b/DSharpPlus.Core/GatewayEntities/Payloads/DiscordWebhooksUpdate.cs
@@ -27,7 +27,7 @@ using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Gateway.Payloads
 {
-    [DiscordGatewayEventName("WEBHOOKS_UPDATE")]
+    [DiscordGatewayPayload("WEBHOOKS_UPDATE")]
     public sealed record DiscordWebhookUpdate
     {
         /// <summary>

--- a/DSharpPlus.Core/JsonConverters/DiscordSnowflakeConverter.cs
+++ b/DSharpPlus.Core/JsonConverters/DiscordSnowflakeConverter.cs
@@ -27,7 +27,7 @@ using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.JsonConverters
 {
-    internal class DiscordSnowflakeConverter : JsonConverter<DiscordSnowflake>
+    public class DiscordSnowflakeConverter : JsonConverter<DiscordSnowflake>
     {
         public override DiscordSnowflake? ReadJson(JsonReader reader, Type objectType, DiscordSnowflake? existingValue, bool hasExistingValue, JsonSerializer serializer) => reader.TokenType == JsonToken.Null
             ? null

--- a/DSharpPlus.Core/RestEntities/Channel/DiscordChannel.cs
+++ b/DSharpPlus.Core/RestEntities/Channel/DiscordChannel.cs
@@ -31,7 +31,7 @@ namespace DSharpPlus.Core.Entities
     /// <summary>
     /// Represents a guild or DM channel within Discord.
     /// </summary>
-    [DiscordGatewayEventName("CHANNEL_CREATE", "CHANNEL_UPDATE", "CHANNEL_DELETE", "THREAD_CREATE", "THREAD_UPDATE", "THREAD_DELETE")]
+    [DiscordGatewayPayload("CHANNEL_CREATE", "CHANNEL_UPDATE", "CHANNEL_DELETE", "THREAD_CREATE", "THREAD_UPDATE", "THREAD_DELETE")]
     public sealed record DiscordChannel
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Channel/DiscordChannel.cs
+++ b/DSharpPlus.Core/RestEntities/Channel/DiscordChannel.cs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 using System;
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Enums;
 using Newtonsoft.Json;
 
@@ -30,6 +31,7 @@ namespace DSharpPlus.Core.Entities
     /// <summary>
     /// Represents a guild or DM channel within Discord.
     /// </summary>
+    [DiscordGatewayEventName("CHANNEL_CREATE", "CHANNEL_UPDATE", "CHANNEL_DELETE", "THREAD_CREATE", "THREAD_UPDATE", "THREAD_DELETE")]
     public sealed record DiscordChannel
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Guild/DiscordGuild.cs
+++ b/DSharpPlus.Core/RestEntities/Guild/DiscordGuild.cs
@@ -32,7 +32,7 @@ namespace DSharpPlus.Core.Entities
     /// <summary>
     /// Guilds in Discord represent an isolated collection of users and channels, and are often referred to as "servers" in the UI.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_CREATE", "GUILD_UPDATE", "GUILD_DELETE")]
+    [DiscordGatewayPayload("GUILD_CREATE", "GUILD_UPDATE", "GUILD_DELETE")]
     public sealed record DiscordGuild
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Guild/DiscordGuild.cs
+++ b/DSharpPlus.Core/RestEntities/Guild/DiscordGuild.cs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 using System;
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Enums;
 using DSharpPlus.Core.Gateway.Payloads;
 using Newtonsoft.Json;
@@ -31,6 +32,7 @@ namespace DSharpPlus.Core.Entities
     /// <summary>
     /// Guilds in Discord represent an isolated collection of users and channels, and are often referred to as "servers" in the UI.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_CREATE", "GUILD_UPDATE", "GUILD_DELETE")]
     public sealed record DiscordGuild
     {
         /// <summary>
@@ -307,7 +309,7 @@ namespace DSharpPlus.Core.Entities
         /// <summary>
         /// The approximate number of non-offline members in this guild, returned from the <c>GET /guilds/:id</c> endpoint when <c>with_counts</c> is true.
         /// </summary>
-        [JsonProperty("approximate_member_count", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("approximate_presence_count", NullValueHandling = NullValueHandling.Ignore)]
         public Optional<int> ApproximatePresenceCount { get; init; }
 
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Guild/DiscordGuildMember.cs
+++ b/DSharpPlus.Core/RestEntities/Guild/DiscordGuildMember.cs
@@ -31,7 +31,7 @@ namespace DSharpPlus.Core.Entities
     /// <summary>
     /// Represents a member of a guild. Implements a <see href="https://discord.com/developers/docs/resources/guild#guild-member-object">Discord Guild Member</see>.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_MEMBER_ADD")]
+    [DiscordGatewayPayload("GUILD_MEMBER_ADD")]
     public sealed record DiscordGuildMember
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Guild/DiscordGuildMember.cs
+++ b/DSharpPlus.Core/RestEntities/Guild/DiscordGuildMember.cs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 using System;
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Enums;
 using Newtonsoft.Json;
 
@@ -30,6 +31,7 @@ namespace DSharpPlus.Core.Entities
     /// <summary>
     /// Represents a member of a guild. Implements a <see href="https://discord.com/developers/docs/resources/guild#guild-member-object">Discord Guild Member</see>.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_MEMBER_ADD")]
     public sealed record DiscordGuildMember
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Guild/DiscordStageInstance.cs
+++ b/DSharpPlus.Core/RestEntities/Guild/DiscordStageInstance.cs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 using System;
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Enums;
 using Newtonsoft.Json;
 
@@ -30,6 +31,7 @@ namespace DSharpPlus.Core.Entities
     /// <summary>
     /// A Stage Instance holds information about a live stage.
     /// </summary>
+    [DiscordGatewayEventName("STAGE_INSTANCE_CREATE", "STAGE_INSTANCE_UPDATE", "STAGE_INSTANCE_DELETE")]
     public sealed record DiscordStageInstance
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Guild/DiscordStageInstance.cs
+++ b/DSharpPlus.Core/RestEntities/Guild/DiscordStageInstance.cs
@@ -31,7 +31,7 @@ namespace DSharpPlus.Core.Entities
     /// <summary>
     /// A Stage Instance holds information about a live stage.
     /// </summary>
-    [DiscordGatewayEventName("STAGE_INSTANCE_CREATE", "STAGE_INSTANCE_UPDATE", "STAGE_INSTANCE_DELETE")]
+    [DiscordGatewayPayload("STAGE_INSTANCE_CREATE", "STAGE_INSTANCE_UPDATE", "STAGE_INSTANCE_DELETE")]
     public sealed record DiscordStageInstance
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Guild/DiscordThreadMember.cs
+++ b/DSharpPlus.Core/RestEntities/Guild/DiscordThreadMember.cs
@@ -33,7 +33,7 @@ namespace DSharpPlus.Core.Entities
     /// <remarks>
     /// The <see cref="Id"/> and <see cref="UserId"/> fields are omitted on the member sent within each thread in the <c>GUILD_CREATE</c> event
     /// </remarks>
-    [DiscordGatewayEventName("THREAD_MEMBER_UPDATE")]
+    [DiscordGatewayPayload("THREAD_MEMBER_UPDATE")]
     public sealed record DiscordThreadMember
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Guild/DiscordThreadMember.cs
+++ b/DSharpPlus.Core/RestEntities/Guild/DiscordThreadMember.cs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 using System;
+using DSharpPlus.Core.Attributes;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Entities
@@ -32,6 +33,7 @@ namespace DSharpPlus.Core.Entities
     /// <remarks>
     /// The <see cref="Id"/> and <see cref="UserId"/> fields are omitted on the member sent within each thread in the <c>GUILD_CREATE</c> event
     /// </remarks>
+    [DiscordGatewayEventName("THREAD_MEMBER_UPDATE")]
     public sealed record DiscordThreadMember
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Guild/ScheduledEvent/DiscordGuildScheduledEvent.cs
+++ b/DSharpPlus.Core/RestEntities/Guild/ScheduledEvent/DiscordGuildScheduledEvent.cs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 using System;
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Enums;
 using Newtonsoft.Json;
 
@@ -30,6 +31,7 @@ namespace DSharpPlus.Core.Entities
     /// <summary>
     /// A representation of a scheduled event in a guild.
     /// </summary>
+    [DiscordGatewayEventName("GUILD_SCHEDULED_EVENT_CREATE", "GUILD_SCHEDULED_EVENT_UPDATE", "GUILD_SCHEDULED_EVENT_DELETE")]
     public sealed record DiscordGuildScheduledEvent
     {
         /// <summary>
@@ -80,19 +82,19 @@ namespace DSharpPlus.Core.Entities
         /// <summary>
         /// The time the scheduled event will end, required if <see cref="EntityType"/> is <see cref="DiscordGuildScheduledEventEntityType.External"/>.
         /// </summary>
-        [JsonProperty("scheduled_start_time", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("scheduled_end_time", NullValueHandling = NullValueHandling.Ignore)]
         public DateTimeOffset? ScheduledEndTime { get; init; }
 
         /// <summary>
         /// The privacy level of the scheduled event.
         /// </summary>
-        [JsonProperty("scheduled_end_time", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("privacy_level", NullValueHandling = NullValueHandling.Ignore)]
         public DiscordGuildScheduledEventPrivacyLevel PrivacyLevel { get; init; }
 
         /// <summary>
         /// The status of the scheduled event.
         /// </summary>
-        [JsonProperty("privacy_level", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("status", NullValueHandling = NullValueHandling.Ignore)]
         public DiscordGuildScheduledEventStatus Status { get; init; }
 
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Guild/ScheduledEvent/DiscordGuildScheduledEvent.cs
+++ b/DSharpPlus.Core/RestEntities/Guild/ScheduledEvent/DiscordGuildScheduledEvent.cs
@@ -31,7 +31,7 @@ namespace DSharpPlus.Core.Entities
     /// <summary>
     /// A representation of a scheduled event in a guild.
     /// </summary>
-    [DiscordGatewayEventName("GUILD_SCHEDULED_EVENT_CREATE", "GUILD_SCHEDULED_EVENT_UPDATE", "GUILD_SCHEDULED_EVENT_DELETE")]
+    [DiscordGatewayPayload("GUILD_SCHEDULED_EVENT_CREATE", "GUILD_SCHEDULED_EVENT_UPDATE", "GUILD_SCHEDULED_EVENT_DELETE")]
     public sealed record DiscordGuildScheduledEvent
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Integration/DiscordIntegration.cs
+++ b/DSharpPlus.Core/RestEntities/Integration/DiscordIntegration.cs
@@ -28,7 +28,7 @@ using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Entities
 {
-    [DiscordGatewayEventName("INTEGRATION_CREATE", "INTEGRATION_UPDATE")]
+    [DiscordGatewayPayload("INTEGRATION_CREATE", "INTEGRATION_UPDATE")]
     public sealed record DiscordIntegration
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Integration/DiscordIntegration.cs
+++ b/DSharpPlus.Core/RestEntities/Integration/DiscordIntegration.cs
@@ -22,11 +22,13 @@
 // SOFTWARE.
 
 using System;
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Enums;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Entities
 {
+    [DiscordGatewayEventName("INTEGRATION_CREATE", "INTEGRATION_UPDATE")]
     public sealed record DiscordIntegration
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Interaction/DiscordInteraction.cs
+++ b/DSharpPlus.Core/RestEntities/Interaction/DiscordInteraction.cs
@@ -27,7 +27,7 @@ using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Entities
 {
-    [DiscordGatewayEventName("INTERACTION_CREATE")]
+    [DiscordGatewayPayload("INTERACTION_CREATE")]
     public sealed record DiscordInteraction
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Interaction/DiscordInteraction.cs
+++ b/DSharpPlus.Core/RestEntities/Interaction/DiscordInteraction.cs
@@ -21,11 +21,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Enums;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Entities
 {
+    [DiscordGatewayEventName("INTERACTION_CREATE")]
     public sealed record DiscordInteraction
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Message/DiscordMessage.cs
+++ b/DSharpPlus.Core/RestEntities/Message/DiscordMessage.cs
@@ -22,11 +22,13 @@
 // SOFTWARE.
 
 using System;
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Enums;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Entities
 {
+    [DiscordGatewayEventName("MESSAGE_CREATE", "MESSAGE_UPDATE")]
     public sealed record DiscordMessage
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/Message/DiscordMessage.cs
+++ b/DSharpPlus.Core/RestEntities/Message/DiscordMessage.cs
@@ -28,7 +28,7 @@ using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Entities
 {
-    [DiscordGatewayEventName("MESSAGE_CREATE", "MESSAGE_UPDATE")]
+    [DiscordGatewayPayload("MESSAGE_CREATE", "MESSAGE_UPDATE")]
     public sealed record DiscordMessage
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/User/DiscordUser.cs
+++ b/DSharpPlus.Core/RestEntities/User/DiscordUser.cs
@@ -30,7 +30,7 @@ namespace DSharpPlus.Core.Entities
     /// <summary>
     /// Implements a <see href="https://discord.com/developers/docs/resources/user#user-object-user-structure">Discord User</see>.
     /// </summary>
-    [DiscordGatewayEventName("USER_UPDATE")]
+    [DiscordGatewayPayload("USER_UPDATE")]
     public sealed record DiscordUser
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/User/DiscordUser.cs
+++ b/DSharpPlus.Core/RestEntities/User/DiscordUser.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Enums;
 using Newtonsoft.Json;
 
@@ -29,6 +30,7 @@ namespace DSharpPlus.Core.Entities
     /// <summary>
     /// Implements a <see href="https://discord.com/developers/docs/resources/user#user-object-user-structure">Discord User</see>.
     /// </summary>
+    [DiscordGatewayEventName("USER_UPDATE")]
     public sealed record DiscordUser
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/User/DiscordVoiceState.cs
+++ b/DSharpPlus.Core/RestEntities/User/DiscordVoiceState.cs
@@ -22,10 +22,12 @@
 // SOFTWARE.
 
 using System;
+using DSharpPlus.Core.Attributes;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Entities
 {
+    [DiscordGatewayEventName("VOICE_STATE_UPDATE")]
     public sealed record DiscordVoiceState
     {
         /// <summary>

--- a/DSharpPlus.Core/RestEntities/User/DiscordVoiceState.cs
+++ b/DSharpPlus.Core/RestEntities/User/DiscordVoiceState.cs
@@ -27,7 +27,7 @@ using Newtonsoft.Json;
 
 namespace DSharpPlus.Core.Entities
 {
-    [DiscordGatewayEventName("VOICE_STATE_UPDATE")]
+    [DiscordGatewayPayload("VOICE_STATE_UPDATE")]
     public sealed record DiscordVoiceState
     {
         /// <summary>

--- a/DSharpPlus.Test/DSharpPlus.Test.csproj
+++ b/DSharpPlus.Test/DSharpPlus.Test.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <AssemblyName>DSharpPlus.Test</AssemblyName>
+        <RootNamespace>DSharpPlus.Test</RootNamespace>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+    <PropertyGroup>
+        <PackageId>DSharpPlus.Test</PackageId>
+        <Authors>Naamloos, afroraydude, DrCreo, Death, TiaqoY0, Axiom, Emzi0767, IDoEverything, Velvet, DSharpPlus contributors</Authors>
+        <Description>A C# API for Discord based off DiscordSharp, but rewritten to fit the API standards.</Description>
+        <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, webhooks</PackageTags>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="../DSharpPlus.Core/DSharpPlus.Core.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="2.2.9" />
+        <PackageReference Include="MSTest.TestFramework" Version="2.2.9" />
+    </ItemGroup>
+</Project>

--- a/DSharpPlus.Test/Serialization/Core/TestPayloadSerialization.cs
+++ b/DSharpPlus.Test/Serialization/Core/TestPayloadSerialization.cs
@@ -1,0 +1,96 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using DSharpPlus.Core.Attributes;
+using DSharpPlus.Core.Gateway.Payloads;
+using DSharpPlus.Core.JsonConverters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace DSharpPlus.Test.Serialization.Core
+{
+    [TestClass]
+    public class TestPayloadSerialization
+    {
+        [TestMethod]
+        public void TestPayloadSerializationAsync()
+        {
+            Dictionary<string, string> serialized = new();
+            Dictionary<string, Type?> payloadMap = new() {
+                { "HEARTBEAT", typeof(int?) },
+                { "RECONNECT", null },
+            };
+
+            foreach (Type type in typeof(DiscordReadyPayload).Assembly.GetExportedTypes())
+            {
+                DiscordGatewayEventNameAttribute? eventName = type.GetCustomAttribute<DiscordGatewayEventNameAttribute>();
+                if (eventName == null)
+                {
+                    continue;
+                }
+
+                foreach (string name in eventName.Names)
+                {
+                    payloadMap.Add(name, type);
+                }
+            }
+
+            JsonSerializer jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings() { Converters = new List<JsonConverter>() { new DiscordSnowflakeConverter(), new OptionalConverter() } });
+            string filePath = "../../../../discord-payloads"; // This should be fine as long as we use the dotnet command instead of moving the executable and executing it.
+            foreach (string file in Directory.GetFiles(Path.Join(Environment.CurrentDirectory, filePath), "*.json", new EnumerationOptions() { RecurseSubdirectories = true }))
+            {
+                string json = File.ReadAllText(file);
+                JObject jObject = JObject.Parse(json);
+                if (!jObject.TryGetValue("t", out JToken? t) || t == null)
+                {
+                    throw new InvalidDataException($"Unable to find property 't' in file {file}");
+                }
+
+                string eventName = t.Value<string>()!;
+                if (!payloadMap.TryGetValue(eventName, out Type? payloadType) || payloadType == null)
+                {
+                    throw new InvalidOperationException($"No payload type found for event {eventName}!");
+                }
+
+                try
+                {
+                    using TextReader reader = File.OpenText(file);
+                    object serializedObject = jsonSerializer.Deserialize(reader, payloadType)!;
+                    serialized.Add(file, payloadType.Name);
+                }
+                catch (Exception error)
+                {
+                    Console.WriteLine($"Error on {file} ({payloadType.FullName}): {error.Message}");
+                }
+            }
+
+            Console.WriteLine($"Serialized {serialized.Keys.Count}/{payloadMap.Keys.Count} payloads!");
+            Assert.IsTrue(serialized.Keys.Count == Directory.GetFiles(Path.Join(Environment.CurrentDirectory, filePath), "*.json", new EnumerationOptions() { RecurseSubdirectories = true }).Length);
+        }
+    }
+}

--- a/DSharpPlus.Test/Serialization/Core/TestPayloadSerialization.cs
+++ b/DSharpPlus.Test/Serialization/Core/TestPayloadSerialization.cs
@@ -27,7 +27,6 @@ using System.IO;
 using System.Reflection;
 using DSharpPlus.Core.Attributes;
 using DSharpPlus.Core.Gateway.Payloads;
-using DSharpPlus.Core.JsonConverters;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -40,37 +39,45 @@ namespace DSharpPlus.Test.Serialization.Core
         [TestMethod]
         public void TestPayloadSerializationAsync()
         {
-            Dictionary<string, string> serialized = new();
             Dictionary<string, Type?> payloadMap = new() {
-                { "HEARTBEAT", typeof(int?) },
-                { "RECONNECT", null },
+                { "HEARTBEAT", typeof(int?) }, // Doesn't include fields, only returns an int? which is null on first heartbeat.
+                { "RECONNECT", null }, // Reconnect doesn't have a payload.
             };
 
+            // Retrieve all gateway payloads. Some payloads are entities, some are custom classes. All payloads have the `DiscordGatewayPayloadAttribute`, so we can use reflection to grab them.
             foreach (Type type in typeof(DiscordReadyPayload).Assembly.GetExportedTypes())
             {
-                DiscordGatewayEventNameAttribute? eventName = type.GetCustomAttribute<DiscordGatewayEventNameAttribute>();
+                // Skip non-payload types
+                DiscordGatewayPayloadAttribute? eventName = type.GetCustomAttribute<DiscordGatewayPayloadAttribute>();
                 if (eventName == null)
                 {
                     continue;
                 }
 
+                // Some entities can represent multiple payloads, so we add the entity by payload name instead of by type.
                 foreach (string name in eventName.Names)
                 {
                     payloadMap.Add(name, type);
                 }
             }
 
-            JsonSerializer jsonSerializer = JsonSerializer.Create(new JsonSerializerSettings() { Converters = new List<JsonConverter>() { new DiscordSnowflakeConverter(), new OptionalConverter() } });
-            string filePath = "../../../../discord-payloads"; // This should be fine as long as we use the dotnet command instead of moving the executable and executing it.
-            foreach (string file in Directory.GetFiles(Path.Join(Environment.CurrentDirectory, filePath), "*.json", new EnumerationOptions() { RecurseSubdirectories = true }))
+            Dictionary<string, string> serializedPayloads = new();
+            JsonSerializer jsonSerializer = JsonSerializer.Create();
+
+            // Using Path.GetFullPath should be fine as long as we use the `dotnet test` command instead of moving the executable and executing it.
+            string[] files = Directory.GetFiles(Path.GetFullPath("../../../../discord-payloads", Environment.CurrentDirectory), "*.json", new EnumerationOptions() { RecurseSubdirectories = true });
+            foreach (string file in files)
             {
                 string json = File.ReadAllText(file);
                 JObject jObject = JObject.Parse(json);
+
+                // If the `t` (payload type) field is not present, it's invalid data. This should only happen when discord-payloads includes rest payloads, and tests should be modified to include them in a separate method.
                 if (!jObject.TryGetValue("t", out JToken? t) || t == null)
                 {
                     throw new InvalidDataException($"Unable to find property 't' in file {file}");
                 }
 
+                // Attempt to see if the payload type is in the payload map. If it isn't, it's a new payload and we should include it within the next few commits.
                 string eventName = t.Value<string>()!;
                 if (!payloadMap.TryGetValue(eventName, out Type? payloadType) || payloadType == null)
                 {
@@ -79,18 +86,20 @@ namespace DSharpPlus.Test.Serialization.Core
 
                 try
                 {
-                    using TextReader reader = File.OpenText(file);
-                    object serializedObject = jsonSerializer.Deserialize(reader, payloadType)!;
-                    serialized.Add(file, payloadType.Name);
+                    using TextReader stringReader = new StringReader(json);
+                    object serializedObject = jsonSerializer.Deserialize(stringReader, payloadType)!;
+
+                    // If the above method doesn't throw, then the payload has serialized correctly.
+                    serializedPayloads.Add(file, payloadType.Name);
                 }
                 catch (Exception error)
                 {
-                    Console.WriteLine($"Error on {file} ({payloadType.FullName}): {error.Message}");
+                    Console.WriteLine($"Error on {payloadType.FullName} ({file}): {error.Message}");
                 }
             }
 
-            Console.WriteLine($"Serialized {serialized.Keys.Count}/{payloadMap.Keys.Count} payloads!");
-            Assert.IsTrue(serialized.Keys.Count == Directory.GetFiles(Path.Join(Environment.CurrentDirectory, filePath), "*.json", new EnumerationOptions() { RecurseSubdirectories = true }).Length);
+            Console.WriteLine($"Serialized {serializedPayloads.Keys.Count}/{files.Length} payloads!");
+            Assert.IsTrue(serializedPayloads.Keys.Count == files.Length);
         }
     }
 }

--- a/DSharpPlus.sln
+++ b/DSharpPlus.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DSharpPlus.Core", "DSharpPlus.Core\DSharpPlus.Core.csproj", "{F1C54B08-EE46-43E1-B7A6-CB8B77084898}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DSharpPlus.Test", "DSharpPlus.Test\DSharpPlus.Test.csproj", "{103F6DDB-CCF0-45A8-A8A7-039FF098CE0A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{F1C54B08-EE46-43E1-B7A6-CB8B77084898}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F1C54B08-EE46-43E1-B7A6-CB8B77084898}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F1C54B08-EE46-43E1-B7A6-CB8B77084898}.Release|Any CPU.Build.0 = Release|Any CPU
+		{103F6DDB-CCF0-45A8-A8A7-039FF098CE0A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{103F6DDB-CCF0-45A8-A8A7-039FF098CE0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{103F6DDB-CCF0-45A8-A8A7-039FF098CE0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{103F6DDB-CCF0-45A8-A8A7-039FF098CE0A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
# Summary
Utilizing https://github.com/discord-payloads/discord-payloads, we can test our gateway entities by deserializing the payloads provided. We did obtain permission to do so from @Victorsitou.

# Changes proposed
- Added https://github.com/discord-payloads/discord-payloads as a submodule
- Added `DSharpPlus.Test`
- Allows `dotnet test` to be utilized on new commits.