### PR TITLE
Add an option to bypass cache in GetMemberAsync and others

### DIFF
--- a/DSharpPlus/Entities/Application/DiscordApplication.cs
+++ b/DSharpPlus/Entities/Application/DiscordApplication.cs
@@ -148,11 +148,11 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Retrieves this application's assets.
         /// </summary>
-        /// <param name="useCacheIfPossible">True to return cached assets if possible, false to always retrieve fresh assets from Discord.</param>
+        /// <param name="updateCache">Whether to always make a REST request and update the cached assets.</param>
         /// <returns>This application's assets.</returns>
-        public async Task<IReadOnlyList<DiscordApplicationAsset>> GetAssetsAsync(bool useCacheIfPossible = true)
+        public async Task<IReadOnlyList<DiscordApplicationAsset>> GetAssetsAsync(bool updateCache = false)
         {
-            if (!useCacheIfPossible || this.Assets == null)
+            if (updateCache || this.Assets == null)
                 this.Assets = await this.Discord.ApiClient.GetApplicationAssetsAsync(this).ConfigureAwait(false);
 
             return this.Assets;

--- a/DSharpPlus/Entities/Application/DiscordApplication.cs
+++ b/DSharpPlus/Entities/Application/DiscordApplication.cs
@@ -150,7 +150,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="useCacheIfPossible">True to return cached assets if possible, false to always retrieve fresh assets from Discord.</param>
         /// <returns>This application's assets.</returns>
-        public async Task<IReadOnlyList<DiscordApplicationAsset>> GetAssetsAsync(bool useCacheIfPossible = false)
+        public async Task<IReadOnlyList<DiscordApplicationAsset>> GetAssetsAsync(bool useCacheIfPossible = true)
         {
             if (!useCacheIfPossible || this.Assets == null)
                 this.Assets = await this.Discord.ApiClient.GetApplicationAssetsAsync(this).ConfigureAwait(false);

--- a/DSharpPlus/Entities/Application/DiscordApplication.cs
+++ b/DSharpPlus/Entities/Application/DiscordApplication.cs
@@ -148,10 +148,11 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Retrieves this application's assets.
         /// </summary>
+        /// <param name="useCacheIfPossible">True to return cached assets if possible, false to always retrieve fresh assets from Discord.</param>
         /// <returns>This application's assets.</returns>
-        public async Task<IReadOnlyList<DiscordApplicationAsset>> GetAssetsAsync()
+        public async Task<IReadOnlyList<DiscordApplicationAsset>> GetAssetsAsync(bool useCacheIfPossible = false)
         {
-            if (this.Assets == null)
+            if (!useCacheIfPossible || this.Assets == null)
                 this.Assets = await this.Discord.ApiClient.GetApplicationAssetsAsync(this).ConfigureAwait(false);
 
             return this.Assets;
@@ -186,7 +187,7 @@ namespace DSharpPlus.Entities
 
             foreach(var v in scopes)
                 scopeBuilder.Append(" ").Append(this.TranslateOAuthScope(v));
-            
+
 
             var queryBuilder = new QueryUriBuilder("https://discord.com/oauth2/authorize")
                 .AddParameter("client_id", this.Id.ToString(CultureInfo.InvariantCulture))

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -405,14 +405,17 @@ namespace DSharpPlus.Entities
         /// Returns a specific message
         /// </summary>
         /// <param name="id">The id of the message</param>
+        /// <param name="useCacheIfPossible">True to return a cached object if possible, false to always retrieve a fresh object from Discord.</param>
         /// <returns></returns>
         /// <exception cref="UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.ReadMessageHistory"/> permission.</exception>
         /// <exception cref="NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public async Task<DiscordMessage> GetMessageAsync(ulong id)
+        /// <remarks>Cached message objects will not be returned if <see cref="DiscordConfiguration.MessageCacheSize"/> is set to zero, if the client does not have the <see cref="DiscordIntents.GuildMessages"/> or <see cref="DiscordIntents.DirectMessages"/> intents, or if the discord client is a <see cref="DiscordShardedClient"/>.</remarks>
+        public async Task<DiscordMessage> GetMessageAsync(ulong id, bool useCacheIfPossible = true)
         {
-            return this.Discord.Configuration.MessageCacheSize > 0
+            return useCacheIfPossible
+                && this.Discord.Configuration.MessageCacheSize > 0
                 && this.Discord is DiscordClient dc
                 && dc.MessageCache != null
                 && dc.MessageCache.TryGet(xm => xm.Id == id && xm.ChannelId == this.Id, out var msg)

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -405,16 +405,16 @@ namespace DSharpPlus.Entities
         /// Returns a specific message
         /// </summary>
         /// <param name="id">The id of the message</param>
-        /// <param name="useCacheIfPossible">True to return a cached object if possible, false to always retrieve a fresh object from Discord.</param>
+        /// <param name="skipCache">Whether to always make a REST request.</param>
         /// <returns></returns>
         /// <exception cref="UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.ReadMessageHistory"/> permission.</exception>
         /// <exception cref="NotFoundException">Thrown when the channel does not exist.</exception>
         /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
         /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         /// <remarks>Cached message objects will not be returned if <see cref="DiscordConfiguration.MessageCacheSize"/> is set to zero, if the client does not have the <see cref="DiscordIntents.GuildMessages"/> or <see cref="DiscordIntents.DirectMessages"/> intents, or if the discord client is a <see cref="DiscordShardedClient"/>.</remarks>
-        public async Task<DiscordMessage> GetMessageAsync(ulong id, bool useCacheIfPossible = true)
+        public async Task<DiscordMessage> GetMessageAsync(ulong id, bool skipCache = false)
         {
-            return useCacheIfPossible
+            return !skipCache
                 && this.Discord.Configuration.MessageCacheSize > 0
                 && this.Discord is DiscordClient dc
                 && dc.MessageCache != null

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -1253,12 +1253,12 @@ namespace DSharpPlus.Entities
         /// Gets a member of this guild by their user ID.
         /// </summary>
         /// <param name="userId">ID of the member to get.</param>
-        /// <param name="useCacheIfPossible">True to return a cached object if one is present, false to always retrieve a fresh object from Discord.</param>
+        /// <param name="updateCache">Whether to always make a REST request and update the member cache.</param>
         /// <returns>The requested member.</returns>
         /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public async Task<DiscordMember> GetMemberAsync(ulong userId, bool useCacheIfPossible = true)
+        public async Task<DiscordMember> GetMemberAsync(ulong userId, bool updateCache = false)
         {
-            if (useCacheIfPossible && this._members != null && this._members.TryGetValue(userId, out var mbr))
+            if (!updateCache && this._members != null && this._members.TryGetValue(userId, out var mbr))
                 return mbr;
 
             mbr = await this.Discord.ApiClient.GetGuildMemberAsync(this.Id, userId).ConfigureAwait(false);

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -1253,11 +1253,12 @@ namespace DSharpPlus.Entities
         /// Gets a member of this guild by their user ID.
         /// </summary>
         /// <param name="userId">ID of the member to get.</param>
+        /// <param name="useCacheIfPossible">True to return a cached object if one is present, false to always retrieve a fresh object from Discord.</param>
         /// <returns>The requested member.</returns>
         /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-        public async Task<DiscordMember> GetMemberAsync(ulong userId)
+        public async Task<DiscordMember> GetMemberAsync(ulong userId, bool useCacheIfPossible = true)
         {
-            if (this._members != null && this._members.TryGetValue(userId, out var mbr))
+            if (useCacheIfPossible && this._members != null && this._members.TryGetValue(userId, out var mbr))
                 return mbr;
 
             mbr = await this.Discord.ApiClient.GetGuildMemberAsync(this.Id, userId).ConfigureAwait(false);


### PR DESCRIPTION
Closes #1296.

# Summary
Some entities have methods that can return either a cached object or call the API. For all these methods I added an optional parameter to bypass the cache and retrieve a fresh object from Discord. This lets you avoid caching-related problems.

# Notes
Let me know if this commit screwed up any line endings, git told me it replaced crlf with lf, despite being on linux.
