### PR TITLE
Removed Three/Seven Day Thread Archive Checks 

### DIFF
--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -1042,8 +1042,6 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Threads can only be created within text or news channels.");
             else if (message.ChannelId != this.Id)
                 throw new ArgumentException("You must use a message from this channel to create a thread.");
-            else if ((archiveAfter == AutoArchiveDuration.ThreeDays && !this.Guild.Features.Contains("THREE_DAY_THREAD_ARCHIVE")) || (archiveAfter == AutoArchiveDuration.Week && !this.Guild.Features.Contains("SEVEN_DAY_THREAD_ARCHIVE")))
-                throw new ArgumentException("This archive duration requires the guild to be boosted or have these archive durations enabled."); //are guild features always cached?
 
             return this.Discord.ApiClient.CreateThreadFromMessageAsync(this.Id, message.Id, name, archiveAfter, reason);
         }
@@ -1067,8 +1065,6 @@ namespace DSharpPlus.Entities
                 throw new InvalidOperationException("News threads can only be created within a news channels.");
             else if (threadType != ChannelType.PublicThread && threadType != ChannelType.PrivateThread && threadType != ChannelType.NewsThread)
                 throw new ArgumentException("Given channel type for creating a thread is not a valid type of thread.");
-            else if ((archiveAfter == AutoArchiveDuration.ThreeDays && !this.Guild.Features.Contains("THREE_DAY_THREAD_ARCHIVE")) || (archiveAfter == AutoArchiveDuration.Week && !this.Guild.Features.Contains("SEVEN_DAY_THREAD_ARCHIVE")))
-                throw new ArgumentException("This archive duration requires the guild to be boosted or have these archive durations enabled.");
             else if (threadType == ChannelType.PrivateThread && !this.Guild.Features.Contains("PRIVATE_THREADS"))
                 throw new ArgumentException("This guild cannot create private threads.");
 


### PR DESCRIPTION
# Summary
This was brought up to my attention by @JulianusIV and @VelvetThePanda that thread creation would just... silently bork. This is because [thread archive durations are no longer boost locked](https://github.com/discord/discord-api-docs/pull/4825). 

# Details
This removes the checks for the three and seven day archive for creating a thread in DiscordChannel. The functions on DiscordMessage do not check for it currently. I have done marginal testing on this and it does not entirely break.

# Notes
I have left the private thread creation check in there, as I am reasonably sure it still requires boost levels to actually create a private thread.