### PR TITLE
Add missing audit log action types and fields

### DIFF
--- a/DSharpPlus/Entities/DiscordAuditLogObjects.cs
+++ b/DSharpPlus/Entities/DiscordAuditLogObjects.cs
@@ -285,6 +285,11 @@ namespace DSharpPlus.Entities
         /// </summary>
         public PropertyChange<bool?> DeafenChange { get; internal set; }
 
+        /// <summary>
+        /// Gets the change in a user's timeout status
+        /// </summary>
+        public PropertyChange<System.DateTime?> TimeoutChange { get; internal set; }
+
         internal DiscordAuditLogMemberUpdateEntry() { }
     }
 
@@ -399,6 +404,11 @@ namespace DSharpPlus.Entities
         /// Gets the description of webhook's avatar change.
         /// </summary>
         public PropertyChange<string> AvatarHashChange { get; internal set; }
+
+        /// <summary>
+        /// Gets the change in application ID.
+        /// </summary>
+        public PropertyChange<ulong?> ApplicationIdChange { get; internal set; }
 
         internal DiscordAuditLogWebhookEntry() { }
     }
@@ -559,6 +569,103 @@ namespace DSharpPlus.Entities
         /// </summary>
         public PropertyChange<int?> ExpireBehavior { get; internal set; }
     }
+
+    public sealed class DiscordAuditLogGuildScheduledEventEntry : DiscordAuditLogEntry
+    {
+        /// <summary>
+        /// Gets a change in the event's name
+        /// </summary>
+        public PropertyChange<string?> Name { get; internal set; }
+
+        /// <summary>
+        /// Gets the target event. Note that this will only have the ID specified if it is not cached.
+        /// </summary>
+        public DiscordScheduledGuildEvent Target { get; internal set; }
+
+        /// <summary>
+        /// Gets the channel the event was changed to.
+        /// </summary>
+        public PropertyChange<DiscordChannel?> Channel { get; internal set; }
+
+        /// <summary>
+        /// Gets the description change of the event.
+        /// </summary>
+        public PropertyChange<string?> Description { get; internal set; }
+
+        /// <summary>
+        /// Gets the change of type for the event.
+        /// </summary>
+        public PropertyChange<ScheduledGuildEventType?> Type { get; internal set; }
+
+        /// <summary>
+        /// Gets the change in image hash.
+        /// </summary>
+        public PropertyChange<string?> ImageHash { get; internal set; }
+
+        /// <summary>
+        /// Gets the change in event location, if it's an external event.
+        /// </summary>
+        public PropertyChange<string?> Location { get; internal set; }
+
+        /// <summary>
+        /// Gets change in privacy level.
+        /// </summary>
+        public PropertyChange<ScheduledGuildEventPrivacyLevel?> PrivacyLevel { get; internal set; }
+
+        /// <summary>
+        /// Gets the change in status.
+        /// </summary>
+        public PropertyChange<ScheduledGuildEventStatus?> Status { get; internal set; }
+
+        public DiscordAuditLogGuildScheduledEventEntry() { }
+    }
+
+    public sealed class DiscordAuditLogThreadEventEntry : DiscordAuditLogEntry
+    {
+        /// <summary>
+        /// Gets the target thread.
+        /// </summary>
+        public DiscordThreadChannel Target { get; internal set; }
+
+        /// <summary>
+        /// Gets a change in the thread's name.
+        /// </summary>
+        public PropertyChange<string?> Name { get; internal set; }
+
+        /// <summary>
+        /// Gets a change in channel type.
+        /// </summary>
+        public PropertyChange<ChannelType?> Type { get; internal set; }
+
+        /// <summary>
+        /// Gets a change in the thread's archived status.
+        /// </summary>
+        public PropertyChange<bool?> Archived { get; internal set; }
+
+        /// <summary>
+        /// Gets a change in the thread's auto archive duration.
+        /// </summary>
+        public PropertyChange<int?> AutoArchiveDuration { get; internal set; }
+
+        /// <summary>
+        /// Gets a change in the threads invitibility
+        /// </summary>
+        public PropertyChange<bool?> Invitable { get; internal set; }
+
+        /// <summary>
+        /// Gets a change in the thread's locked status
+        /// </summary>
+        public PropertyChange<bool?> Locked { get; internal set; }
+
+        /// <summary>
+        /// Gets a change in the thread's slowmode setting
+        /// </summary>
+        public PropertyChange<int?> PerUserRateLimit { get; internal set; }
+
+        internal DiscordAuditLogThreadEventEntry() { }
+
+    }
+
 
     /// <summary>
     /// Indicates audit log action category.
@@ -782,5 +889,35 @@ namespace DSharpPlus.Entities
         /// Indicates that an sticker was deleted.
         /// </summary>
         StickerDelete = 92,
+
+        /// <summary>
+        /// Indicates that a guild event was created.
+        /// </summary>
+        GuildScheduledEventCreate = 100,
+
+        /// <summary>
+        /// Indicates that a guild event was updated.
+        /// </summary>
+        GuildScheduledEventUpdate = 101,
+
+        /// <summary>
+        /// Indicates that a guild event was deleted.
+        /// </summary>
+        GuildScheduledEventDelete = 102,
+
+        /// <summary>
+        /// Indicates that a thread was created.
+        /// </summary>
+        ThreadCreate = 110,
+
+        /// <summary>
+        /// Indicates that a thread was updated.
+        /// </summary>
+        ThreadUpdate = 111,
+
+        /// <summary>
+        /// Indicates that a thread was deleted.
+        /// </summary>
+        ThreadDelete = 112
     }
 }

--- a/DSharpPlus/Entities/DiscordAuditLogObjects.cs
+++ b/DSharpPlus/Entities/DiscordAuditLogObjects.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
 using System.Collections.Generic;
 
 namespace DSharpPlus.Entities

--- a/DSharpPlus/Entities/DiscordAuditLogObjects.cs
+++ b/DSharpPlus/Entities/DiscordAuditLogObjects.cs
@@ -289,7 +289,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the change in a user's timeout status
         /// </summary>
-        public PropertyChange<System.DateTime?> TimeoutChange { get; internal set; }
+        public PropertyChange<DateTime?> TimeoutChange { get; internal set; }
 
         internal DiscordAuditLogMemberUpdateEntry() { }
     }

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -1444,8 +1444,13 @@ namespace DSharpPlus.Entities
                 .GroupBy(xh => xh.Id)
                 .Select(xgh => xgh.First());
 
-            var ams = amr.Select(xau => (this._members != null && this._members.TryGetValue(xau.Id, out var member)) ? member : new DiscordMember { Discord = this.Discord, Id = xau.Id, _guild_id = this.Id });
-            var amd = ams.ToDictionary(xm => xm.Id, xm => xm);
+            var eve = alrs.SelectMany(xr => xr.Events)
+                .GroupBy(xa => xa.Id)
+                .Select(xu => xu.First());
+
+            var Thr = alrs.SelectMany(xr => xr.Threads)
+                .GroupBy(xa => xa.Id)
+                .Select(xu => xu.First());
 
             Dictionary<ulong, DiscordWebhook> ahd = null;
             if (ahr.Any())
@@ -1456,6 +1461,26 @@ namespace DSharpPlus.Entities
                 var amh = ahr.Select(xah => whs.TryGetValue(xah.Id, out var webhook) ? webhook : new DiscordWebhook { Discord = this.Discord, Name = xah.Name, Id = xah.Id, AvatarHash = xah.AvatarHash, ChannelId = xah.ChannelId, GuildId = xah.GuildId, Token = xah.Token });
                 ahd = amh.ToDictionary(xh => xh.Id, xh => xh);
             }
+
+            Dictionary<ulong, DiscordScheduledGuildEvent> events = null;
+            if (eve.Any())
+            {
+                var evh = await this.GetEventsAsync().ConfigureAwait(false);
+                var evb = evh.ToDictionary(xr => xr.Id, xr => xr);
+
+                var evf = eve.Select(xa => evb.TryGetValue(xa.Id, out var Event) ? Event : new DiscordScheduledGuildEvent { Discord = this.Discord, Name = xa.Name, Id = xa.Id, ChannelId = xa.ChannelId, GuildId = xa.GuildId, Creator = xa.Creator, Description = xa.Description, EndTime = xa.EndTime, Metadata = xa.Metadata, PrivacyLevel = xa.PrivacyLevel, StartTime = xa.StartTime, Status = xa.Status, Type = xa.Type, UserCount = xa.UserCount});
+                events = evf.ToDictionary(xb => xb.Id, xb => xb);
+            }
+
+            Dictionary<ulong, DiscordThreadChannel> threads = null;
+            if (Thr.Any())
+            {
+                var thb = Thr.Select(xr => xr ?? new DiscordThreadChannel{ Discord = this.Discord, Id = xr.Id, Name = xr.Name, GuildId = xr.GuildId});
+                threads = thb.ToDictionary(xa => xa.Id, xa => xa);
+            }
+
+            var ams = amr.Select(xau => (this._members != null && this._members.TryGetValue(xau.Id, out var member)) ? member : new DiscordMember { Discord = this.Discord, Id = xau.Id, _guild_id = this.Id });
+            var amd = ams.ToDictionary(xm => xm.Id, xm => xm);
 
             var acs = alrs.SelectMany(xa => xa.Entries).OrderByDescending(xa => xa.Id);
             var entries = new List<DiscordAuditLogEntry>();
@@ -1799,6 +1824,14 @@ namespace DSharpPlus.Entities
                                     };
                                     break;
 
+                                case "communication_disabled_until":
+                                    entrymbu.TimeoutChange = new PropertyChange<DateTime?>
+                                    {
+                                        Before = xc.OldValue != null ? (DateTime)xc.OldValue : null,
+                                        After = xc.NewValue != null ? (DateTime)xc.NewValue : null
+                                    };
+                                    break;
+
                                 case "$add":
                                     entrymbu.AddedRoles = new ReadOnlyCollection<DiscordRole>(xc.NewValues.Select(xo => (ulong)xo["id"]).Select(this.GetRole).ToList());
                                     break;
@@ -2050,6 +2083,15 @@ namespace DSharpPlus.Entities
                                     };
                                     break;
 
+                                case "application_id": //No idea what this is or does and can't test it so /shrug I guess this probably works
+                                    entrywhk.ApplicationIdChange = new PropertyChange<ulong?>
+                                    {
+                                        Before = xc.OldValue != null ? xc.OldValueUlong : null,
+                                        After = xc.NewValue != null ? xc.NewValueUlong : null
+                                    };
+                                    break;
+
+
                                 default:
                                     this.Discord.Logger.LogWarning(LoggerEvents.AuditLog, "Unknown key in webhook update: {Key} - this should be reported to library developers", xc.Key);
                                     break;
@@ -2297,6 +2339,167 @@ namespace DSharpPlus.Entities
 
                                 default:
                                     this.Discord.Logger.LogWarning(LoggerEvents.AuditLog, "Unknown key in integration update: {Key} - this should be reported to library developers", xc.Key);
+                                    break;
+                            }
+                        }
+                        break;
+
+                    case AuditLogActionType.GuildScheduledEventCreate:
+                    case AuditLogActionType.GuildScheduledEventDelete:
+                    case AuditLogActionType.GuildScheduledEventUpdate:
+                        entry = new DiscordAuditLogGuildScheduledEventEntry()
+                        {
+                            Target = events.TryGetValue(xac.TargetId.Value, out var ta) ? ta : new DiscordScheduledGuildEvent() { Id = xac.TargetId.Value, Discord = this.Discord },
+                        };
+
+                        var evententry = entry as DiscordAuditLogGuildScheduledEventEntry;
+                        foreach (var xc in xac.Changes)
+                        {
+                            switch (xc.Key.ToLowerInvariant())
+                            {
+                                case "name":
+                                    evententry.Name = new PropertyChange<string?>
+                                    {
+                                        Before = xc.OldValue != null ? xc.OldValueString : null,
+                                        After = xc.NewValue != null ? xc.NewValueString : null
+                                    };
+                                    break;
+                                case "channel_id":
+                                    ulong.TryParse(xc.NewValue as string, NumberStyles.Integer, CultureInfo.InvariantCulture, out t1);
+                                    ulong.TryParse(xc.OldValue as string, NumberStyles.Integer, CultureInfo.InvariantCulture, out t2);
+                                    evententry.Channel = new PropertyChange<DiscordChannel?>
+                                    {
+                                        Before = this.GetChannel(t2) ?? new DiscordChannel { Id = t2, Discord = this.Discord, GuildId = this.Id },
+                                        After = this.GetChannel(t1) ?? new DiscordChannel { Id = t1, Discord = this.Discord, GuildId = this.Id }
+                                    };
+                                    break;
+
+                                case "description":
+                                    evententry.Description = new PropertyChange<string?>
+                                    {
+                                        Before = xc.OldValue != null ? xc.OldValueString : null,
+                                        After = xc.NewValue != null ? xc.NewValueString : null
+                                    };
+                                    break;
+
+                                case "entity_type":
+                                    evententry.Type = new PropertyChange<ScheduledGuildEventType?>
+                                    {
+                                        Before = xc.OldValue != null ? (ScheduledGuildEventType)(long)xc.OldValue : null,
+                                        After = xc.NewValue != null ? (ScheduledGuildEventType)(long)xc.NewValue : null
+                                    };
+                                    break;
+
+                                case "image_hash":
+                                    evententry.ImageHash = new PropertyChange<string?>
+                                    {
+                                        Before = (string?)xc.OldValue,
+                                        After = (string?)xc.NewValue
+                                    };
+                                    break;
+
+                                case "location":
+                                    evententry.Location = new PropertyChange<string?>
+                                    {
+                                        Before = (string?)xc.OldValue,
+                                        After = (string?)xc.NewValue
+                                    };
+                                    break;
+
+                                case "privacy_level":
+                                    evententry.PrivacyLevel = new PropertyChange<ScheduledGuildEventPrivacyLevel?>
+                                    {
+                                        Before = xc.OldValue != null ? (ScheduledGuildEventPrivacyLevel)(long)xc.OldValue : null,
+                                        After = xc.NewValue != null ? (ScheduledGuildEventPrivacyLevel)(long)xc.NewValue : null
+                                    };
+                                    break;
+
+                                case "status":
+                                    evententry.Status = new PropertyChange<ScheduledGuildEventStatus?>
+                                    {
+                                        Before = xc.OldValue != null ? (ScheduledGuildEventStatus)(long)xc.OldValue : null,
+                                        After = xc.NewValue != null ? (ScheduledGuildEventStatus)(long)xc.NewValue : null
+                                    };
+                                    break;
+
+                                default:
+                                    this.Discord.Logger.LogWarning(LoggerEvents.AuditLog, "Unknown key in scheduled event update: {Key} - this should be reported to library developers", xc.Key);
+                                    break;
+                            }
+                        }
+                        break;
+
+                    case AuditLogActionType.ThreadCreate:
+                    case AuditLogActionType.ThreadDelete:
+                    case AuditLogActionType.ThreadUpdate:
+                        entry = new DiscordAuditLogThreadEventEntry()
+                        {
+                            Target = this.Threads.TryGetValue(xac.TargetId.Value, out var channel) ? channel : new DiscordThreadChannel() { Id = xac.TargetId.Value, Discord = this.Discord },
+                        };
+
+                        var threadentry = entry as DiscordAuditLogThreadEventEntry;
+                        foreach(var xc in xac.Changes)
+                        {
+                            switch(xc.Key.ToLowerInvariant())
+                            {
+                                case "name":
+                                    threadentry.Name = new PropertyChange<string?>
+                                    {
+                                        Before = xc.OldValue != null ? xc.OldValueString : null,
+                                        After = xc.NewValue != null ? xc.NewValueString : null
+                                    };
+                                    break;
+
+                                case "type":
+                                    threadentry.Type = new PropertyChange<ChannelType?>
+                                    {
+                                        Before = xc.OldValue != null ? (ChannelType)xc.OldValueLong : null,
+                                        After = xc.NewValue != null ? (ChannelType)xc.NewValueLong : null
+                                    };
+                                    break;
+
+                                case "archived":
+                                    threadentry.Archived = new PropertyChange<bool?>
+                                    {
+                                        Before = xc.OldValue != null ? xc.OldValueBool : null,
+                                        After = xc.NewValue != null ? xc.NewValueBool : null
+                                    };
+                                    break;
+
+                                case "auto_archive_duration":
+                                    threadentry.AutoArchiveDuration = new PropertyChange<int?>
+                                    {
+                                        Before = xc.OldValue != null ? (int)xc.OldValueLong : null,
+                                        After = xc.NewValue != null ? (int)xc.NewValueLong : null
+                                    };
+                                    break;
+
+                                case "invitable":
+                                    threadentry.Invitable = new PropertyChange<bool?>
+                                    {
+                                        Before = xc.OldValue != null ? xc.OldValueBool : null,
+                                        After = xc.NewValue != null ? xc.NewValueBool : null
+                                    };
+                                    break;
+
+                                case "locked":
+                                    threadentry.Locked = new PropertyChange<bool?>
+                                    {
+                                        Before = xc.OldValue != null ? xc.OldValueBool : null,
+                                        After = xc.NewValue != null ? xc.NewValueBool : null
+                                    };
+                                    break;
+
+                                case "rate_limit_per_user":
+                                    threadentry.PerUserRateLimit = new PropertyChange<int?>
+                                    {
+                                        Before = xc.OldValue != null ? (int)xc.OldValueLong : null,
+                                        After = xc.NewValue != null ? (int)xc.NewValueLong : null
+                                    };
+                                    break;
+
+                                default:
+                                    this.Discord.Logger.LogWarning(LoggerEvents.AuditLog, "Unknown key in thread update: {Key} - this should be reported to library developers", xc.Key);
                                     break;
                             }
                         }

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -1448,7 +1448,7 @@ namespace DSharpPlus.Entities
                 .GroupBy(xa => xa.Id)
                 .Select(xu => xu.First());
 
-            var Thr = alrs.SelectMany(xr => xr.Threads)
+            var thr = alrs.SelectMany(xr => xr.Threads)
                 .GroupBy(xa => xa.Id)
                 .Select(xu => xu.First());
 
@@ -1465,17 +1465,15 @@ namespace DSharpPlus.Entities
             Dictionary<ulong, DiscordScheduledGuildEvent> events = null;
             if (eve.Any())
             {
-                var evh = await this.GetEventsAsync().ConfigureAwait(false);
-                var evb = evh.ToDictionary(xr => xr.Id, xr => xr);
-
+                var evb = this._scheduledEvents;
                 var evf = eve.Select(xa => evb.TryGetValue(xa.Id, out var Event) ? Event : new DiscordScheduledGuildEvent { Discord = this.Discord, Name = xa.Name, Id = xa.Id, ChannelId = xa.ChannelId, GuildId = xa.GuildId, Creator = xa.Creator, Description = xa.Description, EndTime = xa.EndTime, Metadata = xa.Metadata, PrivacyLevel = xa.PrivacyLevel, StartTime = xa.StartTime, Status = xa.Status, Type = xa.Type, UserCount = xa.UserCount});
                 events = evf.ToDictionary(xb => xb.Id, xb => xb);
             }
 
             Dictionary<ulong, DiscordThreadChannel> threads = null;
-            if (Thr.Any())
+            if (thr.Any())
             {
-                var thb = Thr.Select(xr => xr ?? new DiscordThreadChannel{ Discord = this.Discord, Id = xr.Id, Name = xr.Name, GuildId = xr.GuildId});
+                var thb = thr.Select(xr => xr ?? new DiscordThreadChannel{ Discord = this.Discord, Id = xr.Id, Name = xr.Name, GuildId = xr.GuildId});
                 threads = thb.ToDictionary(xa => xa.Id, xa => xa);
             }
 

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -2081,11 +2081,11 @@ namespace DSharpPlus.Entities
                                     };
                                     break;
 
-                                case "application_id": //No idea what this is or does and can't test it so /shrug I guess this probably works
+                                case "application_id": //Why the fuck does discord send this as a string if it's supposed to be a snowflake
                                     entrywhk.ApplicationIdChange = new PropertyChange<ulong?>
                                     {
-                                        Before = xc.OldValue != null ? xc.OldValueUlong : null,
-                                        After = xc.NewValue != null ? xc.NewValueUlong : null
+                                        Before = xc.OldValue != null ? Convert.ToUInt64(xc.OldValueString) : null,
+                                        After = xc.NewValue != null ? Convert.ToUInt64(xc.NewValueString) : null
                                     };
                                     break;
 

--- a/DSharpPlus/Net/Abstractions/AuditLogAbstractions.cs
+++ b/DSharpPlus/Net/Abstractions/AuditLogAbstractions.cs
@@ -83,6 +83,15 @@ namespace DSharpPlus.Net.Abstractions
         public string OldValueString
             => (string)this.OldValue;
 
+        [JsonIgnore]
+        public bool OldValueBool
+            => (bool)this.OldValue;
+
+        [JsonIgnore]
+        public long OldValueLong
+            => (long)this.OldValue;
+
+
         // this can be a string or an array
         [JsonProperty("new_value")]
         public object NewValue { get; set; }
@@ -98,6 +107,14 @@ namespace DSharpPlus.Net.Abstractions
         [JsonIgnore]
         public string NewValueString
             => (string)this.NewValue;
+
+        [JsonIgnore]
+        public bool NewValueBool
+            => (bool)this.NewValue;
+
+        [JsonIgnore]
+        public long NewValueLong
+            => (long)this.NewValue;
 
         [JsonProperty("key")]
         public string Key { get; set; }
@@ -161,5 +178,14 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("audit_log_entries")]
         public IEnumerable<AuditLogAction> Entries { get; set; }
+
+        [JsonProperty("guild_scheduled_events")]
+        public IEnumerable<DiscordScheduledGuildEvent> Events { get; set; }
+
+        [JsonProperty("integrations")]
+        public IEnumerable<DiscordIntegration> Integrations { get; set; }
+
+        [JsonProperty("threads")]
+        public IEnumerable<DiscordThreadChannel> Threads { get; set; }
     }
 }


### PR DESCRIPTION
# Summary
Fixes #1298 

# Details
This adds the support for the audit log action types
- GUILD_SCHEDULED_EVENT_CREATE
- GUILD_SCHEDULED_EVENT_UPDATE
- GUILD_SCHEDULED_EVENT_DELETE
- THREAD_CREATE
- THREAD_UPDATE
- THREAD_DELETE

Along with the associated types
- `DiscordAuditLogGuildScheduledEventEntry`
- `DiscordAuditLogThreadEventEntry`

As well as two missing keys for 
- Member update: `communication_disabled_until`
- Webhook update: `application_id`

# Notes
~~I don't have a way to test the webhook update auditlog key so if anyone could test that, it would be good.~~

There's also `APPLICATION_COMMAND_PERMISSION_UPDATE` that I didn't implement with this because I am not touching that shit with a ten foot pole