### PR TITLE
Revert #1261

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -489,14 +489,8 @@ namespace DSharpPlus.CommandsNext
                         foreach (var chk in inheritedChecks)
                             groupBuilder.WithExecutionCheck(chk);
 
-                        var groupCandidates = ti.DeclaredMethods.Where(x => x.IsCommandCandidate(out _) && x.GetCustomAttribute<GroupCommandAttribute>() != null).ToArray();
-
-                        _ = groupCandidates.Length switch
-                        {
-                            0 => null,
-                            1 => groupBuilder.WithOverload(new CommandOverloadBuilder(groupCandidates[0])),
-                            _ => throw new InvalidOverloadException($"Commands marked with [{nameof(GroupCommandAttribute)}] cannot be overloaded", groupCandidates[0])
-                        };
+                        foreach (var mi in ti.DeclaredMethods.Where(x => x.IsCommandCandidate(out _) && x.GetCustomAttribute<GroupCommandAttribute>() != null))
+                            groupBuilder.WithOverload(new CommandOverloadBuilder(mi));
                         break;
 
                     case AliasesAttribute a:


### PR DESCRIPTION
The underlying issue does not occur every time, this exception is thrown every time. A lot of code depends on this apparently random factor. 

The issue itself appears to lie far deeper, and fixing it once and for all will take time. Therefore, for now, this bandaid should be removed to keep existing code working when updating to 4.3.0 nightlies; even though nightlies make no guarantees in regards to breaking changes, this would block a potential 4.3.0 release.

A comprehensive fix for this issue will likely entail changing the core concept of group commands as they are right now, and of overloads as they are right now. Further work will be required to ensure 4.2 -> future compatibility.