### PR TITLE
Implemented PATCH /guilds/:guild_id/roles (untested)

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -842,6 +842,25 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// Batch modifies the role order in the guild.
+        /// </summary>
+        /// <param name="roles">A dictionary of guild roles indexed by their new role positions.</param>
+        /// <param name="reason">An optional Audit log reason on why this action was done.</param>
+        /// <returns>A list of all the current guild roles ordered in their new role positions.</returns>
+        public async Task<IReadOnlyList<DiscordRole>> ModifyRolePositionsAsync(IDictionary<int, DiscordRole> roles, string reason = null)
+        {
+            if (roles.Count == 0)
+                throw new ArgumentException("Roles cannot be empty.", nameof(roles));
+
+            // Sort the roles by position and create skeleton roles for the payload.
+            var returnedRoles = await this.Discord.ApiClient.ModifyGuildRolePositionsAsync(this.Id, roles.Select(x => new RestGuildRoleReorderPayload() { RoleId = x.Value.Id, Position = x.Key }), reason).ConfigureAwait(false);
+
+            // Update the cache as the endpoint returns all roles in the order they were sent.
+            this._roles = new(returnedRoles.Select(x => new KeyValuePair<ulong, DiscordRole>(x.Id, x)));
+            return returnedRoles;
+        }
+
+        /// <summary>
         /// Bans a specified member from this guild.
         /// </summary>
         /// <param name="member">Member to ban.</param>
@@ -2436,9 +2455,9 @@ namespace DSharpPlus.Entities
                         };
 
                         var threadentry = entry as DiscordAuditLogThreadEventEntry;
-                        foreach(var xc in xac.Changes)
+                        foreach (var xc in xac.Changes)
                         {
-                            switch(xc.Key.ToLowerInvariant())
+                            switch (xc.Key.ToLowerInvariant())
                             {
                                 case "name":
                                     threadentry.Name = new PropertyChange<string?>

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -509,6 +509,28 @@ namespace DSharpPlus.Net
             return this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld));
         }
 
+        internal async Task<DiscordRole[]> ModifyGuildRolePositionsAsync(ulong guild_id, IEnumerable<RestGuildRoleReorderPayload> newRolePositions, string reason)
+        {
+            var headers = Utilities.GetBaseHeaders();
+            if (!string.IsNullOrWhiteSpace(reason))
+                headers[REASON_HEADER_NAME] = reason;
+
+            var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.ROLES}";
+            var bucket = this.Rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
+
+            var url = Utilities.GetApiUriFor(path);
+            var res = await this.DoRequestAsync(this.Discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(newRolePositions)).ConfigureAwait(false);
+
+            var ret = JsonConvert.DeserializeObject<DiscordRole[]>(res.Response);
+            foreach (var r in ret)
+            {
+                r.Discord = this.Discord;
+                r._guild_id = guild_id;
+            }
+
+            return ret;
+        }
+
         internal async Task<AuditLog> GetAuditLogsAsync(ulong guild_id, int limit, ulong? after, ulong? before, ulong? responsible, int? action_type)
         {
             var urlparams = new Dictionary<string, string>


### PR DESCRIPTION
Implements editing the entire role position list in one API request. Your rate limits may now rest.

Untested.