### PR TITLE
Added Client-Name header to Lavalink connection.

### DIFF
--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -250,6 +250,7 @@ namespace DSharpPlus.Lavalink
             this.WebSocket.AddDefaultHeader("Authorization", this.Configuration.Password);
             this.WebSocket.AddDefaultHeader("Num-Shards", this.Discord.ShardCount.ToString(CultureInfo.InvariantCulture));
             this.WebSocket.AddDefaultHeader("User-Id", this.Discord.CurrentUser.Id.ToString(CultureInfo.InvariantCulture));
+            this.WebSocket.AddDefaultHeader("Client-Name", "DSharpPlus.Lavalink");
             if (this.Configuration.ResumeKey != null)
                 this.WebSocket.AddDefaultHeader("Resume-Key", this.Configuration.ResumeKey);
 


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Added Client-Name in Websocket's headers

# Details
Currently dev branch of lavalink has check for `Client-Name` Header in Websocket connection. It may be required later.