### PR TITLE
Implement smart quote handling in CommandsNext (#1268)

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
@@ -79,7 +79,7 @@ namespace DSharpPlus.CommandsNext
         /// <para>Sets whether to enable default help command.</para>
         /// <para>Disabling this will allow you to make your own help command.</para>
         /// <para>
-        /// Modifying default help can be achieved via custom help formatters (see <see cref="BaseHelpFormatter"/> and <see cref="CommandsNextExtension.SetHelpFormatter{T}()"/> for more details). 
+        /// Modifying default help can be achieved via custom help formatters (see <see cref="BaseHelpFormatter"/> and <see cref="CommandsNextExtension.SetHelpFormatter{T}()"/> for more details).
         /// It is recommended to use help formatter instead of disabling help.
         /// </para>
         /// <para>Defaults to true.</para>
@@ -120,6 +120,12 @@ namespace DSharpPlus.CommandsNext
         public bool IgnoreExtraArguments { internal get; set; } = false;
 
         /// <summary>
+        /// <para>Sets the quotation marks on parameters, used to interpret spaces as part of a single argument.</para>
+        /// <para>Defaults to a collection of <c>"</c>, <c>'</c>, <c>«</c>, <c>»</c>, <c>‘</c>, <c>“</c>, <c>„</c> and <c>‟</c>.</para>
+        /// </summary>
+        public IEnumerable<char> QuotationMarks { internal get; set; } = new[] { '"', '\'', '«', '»', '‘', '“', '„', '‟' };
+
+        /// <summary>
         /// <para>Gets or sets whether to automatically enable handling commands.</para>
         /// <para>If this is set to false, you will need to manually handle each incoming message and pass it to CommandsNext.</para>
         /// <para>Defaults to true.</para>
@@ -156,6 +162,7 @@ namespace DSharpPlus.CommandsNext
             this.EnableDms = other.EnableDms;
             this.EnableMentionPrefix = other.EnableMentionPrefix;
             this.IgnoreExtraArguments = other.IgnoreExtraArguments;
+            this.QuotationMarks = other.QuotationMarks;
             this.UseDefaultCommandHandler = other.UseDefaultCommandHandler;
             this.Services = other.Services;
             this.StringPrefixes = other.StringPrefixes.ToArray();

--- a/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
@@ -121,9 +121,9 @@ namespace DSharpPlus.CommandsNext
 
         /// <summary>
         /// <para>Sets the quotation marks on parameters, used to interpret spaces as part of a single argument.</para>
-        /// <para>Defaults to a collection of <c>"</c>, <c>'</c>, <c>«</c>, <c>»</c>, <c>‘</c>, <c>“</c>, <c>„</c> and <c>‟</c>.</para>
+        /// <para>Defaults to a collection of <c>"</c>, <c>«</c>, <c>»</c>, <c>‘</c>, <c>“</c>, <c>„</c> and <c>‟</c>.</para>
         /// </summary>
-        public IEnumerable<char> QuotationMarks { internal get; set; } = new[] { '"', '\'', '«', '»', '‘', '“', '„', '‟' };
+        public IEnumerable<char> QuotationMarks { internal get; set; } = new[] { '"', '«', '»', '‘', '“', '„', '‟' };
 
         /// <summary>
         /// <para>Gets or sets whether to automatically enable handling commands.</para>

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -237,7 +237,7 @@ namespace DSharpPlus.CommandsNext
             var cnt = e.Message.Content.Substring(mpos);
 
             var __ = 0;
-            var fname = cnt.ExtractNextArgument(ref __);
+            var fname = cnt.ExtractNextArgument(ref __, this.Config.QuotationMarks);
 
             var cmd = this.FindCommand(cnt, out var args);
             var ctx = this.CreateContext(e.Message, pfx, cmd, args);
@@ -263,7 +263,7 @@ namespace DSharpPlus.CommandsNext
 
             var ignoreCase = !this.Config.CaseSensitive;
             var pos = 0;
-            var next = commandString.ExtractNextArgument(ref pos);
+            var next = commandString.ExtractNextArgument(ref pos, this.Config.QuotationMarks);
             if (next is null)
                 return null;
 
@@ -289,7 +289,7 @@ namespace DSharpPlus.CommandsNext
             {
                 var cm2 = cmd as CommandGroup;
                 var oldPos = pos;
-                next = commandString.ExtractNextArgument(ref pos);
+                next = commandString.ExtractNextArgument(ref pos, this.Config.QuotationMarks);
                 if (next is null)
                     break;
 

--- a/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
@@ -85,7 +85,7 @@ namespace DSharpPlus.CommandsNext
         }
 
         //internal static string ExtractNextArgument(string str, out string remainder)
-        internal static string? ExtractNextArgument(this string str, ref int startPos, IEnumerable<char> _quoteChars)
+        internal static string? ExtractNextArgument(this string str, ref int startPos, IEnumerable<char> quoteChars)
         {
             if (string.IsNullOrWhiteSpace(str))
                 return null;
@@ -114,7 +114,7 @@ namespace DSharpPlus.CommandsNext
                     if (!inEscape && !inBacktick && !inTripleBacktick)
                     {
                         inEscape = true;
-                        if (str.IndexOf("\\`", i) == i || _quoteChars.Any(c => str.IndexOf($"\\{c}", i) == i) || str.IndexOf("\\\\", i) == i || (str.Length >= i && char.IsWhiteSpace(str[i + 1])))
+                        if (str.IndexOf("\\`", i) == i || quoteChars.Any(c => str.IndexOf($"\\{c}", i) == i) || str.IndexOf("\\\\", i) == i || (str.Length >= i && char.IsWhiteSpace(str[i + 1])))
                             removeIndices.Add(i - startPosition);
                         i++;
                     }
@@ -146,7 +146,7 @@ namespace DSharpPlus.CommandsNext
                         inBacktick = true;
                 }
 
-                if (_quoteChars.Contains(str[i]) && !inEscape && !inBacktick && !inTripleBacktick)
+                if (quoteChars.Contains(str[i]) && !inEscape && !inBacktick && !inTripleBacktick)
                 {
                     removeIndices.Add(i - startPosition);
 

--- a/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
@@ -42,6 +42,7 @@ namespace DSharpPlus.CommandsNext
     public static class CommandsNextUtilities
     {
         private static Regex UserRegex { get; } = new Regex(@"<@\!?(\d+?)> ", RegexOptions.ECMAScript);
+        private static IReadOnlyCollection<char> _quoteChars { get; } = new[] { '"', '\'', '«', '»', '‘', '“', '„', '‟' };
 
         /// <summary>
         /// Checks whether the message has a specified string prefix.
@@ -114,7 +115,7 @@ namespace DSharpPlus.CommandsNext
                     if (!inEscape && !inBacktick && !inTripleBacktick)
                     {
                         inEscape = true;
-                        if (str.IndexOf("\\`", i) == i || str.IndexOf("\\\"", i) == i || str.IndexOf("\\\\", i) == i || (str.Length >= i && char.IsWhiteSpace(str[i + 1])))
+                        if (str.IndexOf("\\`", i) == i || _quoteChars.Any(c => str.IndexOf($"\\{c}", i) == i) || str.IndexOf("\\\\", i) == i || (str.Length >= i && char.IsWhiteSpace(str[i + 1])))
                             removeIndices.Add(i - startPosition);
                         i++;
                     }
@@ -146,7 +147,7 @@ namespace DSharpPlus.CommandsNext
                         inBacktick = true;
                 }
 
-                if (str[i] == '"' && !inEscape && !inBacktick && !inTripleBacktick)
+                if (_quoteChars.Contains(str[i]) && !inEscape && !inBacktick && !inTripleBacktick)
                 {
                     removeIndices.Add(i - startPosition);
 

--- a/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
@@ -42,7 +42,6 @@ namespace DSharpPlus.CommandsNext
     public static class CommandsNextUtilities
     {
         private static Regex UserRegex { get; } = new Regex(@"<@\!?(\d+?)> ", RegexOptions.ECMAScript);
-        private static IReadOnlyCollection<char> _quoteChars { get; } = new[] { '"', '\'', '«', '»', '‘', '“', '„', '‟' };
 
         /// <summary>
         /// Checks whether the message has a specified string prefix.
@@ -86,7 +85,7 @@ namespace DSharpPlus.CommandsNext
         }
 
         //internal static string ExtractNextArgument(string str, out string remainder)
-        internal static string? ExtractNextArgument(this string str, ref int startPos)
+        internal static string? ExtractNextArgument(this string str, ref int startPos, IEnumerable<char> _quoteChars)
         {
             if (string.IsNullOrWhiteSpace(str))
                 return null;
@@ -212,7 +211,7 @@ namespace DSharpPlus.CommandsNext
                     {
                         while (true)
                         {
-                            argValue = ExtractNextArgument(argString, ref foundAt);
+                            argValue = ExtractNextArgument(argString, ref foundAt, ctx.Config.QuotationMarks);
                             if (argValue == null)
                                 break;
 
@@ -236,7 +235,7 @@ namespace DSharpPlus.CommandsNext
                 }
                 else
                 {
-                    argValue = ExtractNextArgument(argString, ref foundAt);
+                    argValue = ExtractNextArgument(argString, ref foundAt, ctx.Config.QuotationMarks);
                     rawArgumentList.Add(argValue);
                 }
 

--- a/DSharpPlus.CommandsNext/Entities/CommandGroup.cs
+++ b/DSharpPlus.CommandsNext/Entities/CommandGroup.cs
@@ -54,7 +54,7 @@ namespace DSharpPlus.CommandsNext
         public override async Task<CommandResult> ExecuteAsync(CommandContext ctx)
         {
             var findpos = 0;
-            var cn = CommandsNextUtilities.ExtractNextArgument(ctx.RawArgumentString, ref findpos);
+            var cn = CommandsNextUtilities.ExtractNextArgument(ctx.RawArgumentString, ref findpos, ctx.Config.QuotationMarks);
 
             if (cn != null)
             {


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Fixes #1268 by checking for multiple kinds of quotes, instead of just `"`.

# Details
A (configurable) collection of quotation marks such as `"`, `'`, `«` and `»` are available in the CNextConfiguration, and passed to the CommandsNextUtilities, as it is responsible for extracting the arguments in a command. Checks related to quotes have been modified to be using the collection.

# Changes proposed
* Added a CNextConfiguration of quotation characters, with a default of a couple of common quotation characters.
* Modified the quote checks to use the collection.

# Notes
This might not be too performant...