### PR TITLE
Fixed Mentions in Updated Messages

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1524,7 +1524,7 @@ namespace DSharpPlus
             DiscordMessage oldmsg = null;
             if (this.Configuration.MessageCacheSize == 0
                 || this.MessageCache == null
-                || !this.MessageCache.TryGet(xm => xm.Id == event_message.Id && xm.ChannelId == event_message.ChannelId, out message))
+                || !this.MessageCache.TryGet(xm => xm.Id == event_message.Id && xm.ChannelId == event_message.ChannelId, out message)) // previous message was not in cache 
             {
                 message = event_message;
                 this.PopulateMessageReactionsAndCache(message, author, member);
@@ -1537,10 +1537,11 @@ namespace DSharpPlus
                     message.ReferencedMessage.PopulateMentions();
                 }
             }
-            else
+            else // previous message was fetched in cache 
             {
                 oldmsg = new DiscordMessage(message);
 
+                // cached message is updated with information from the event message 
                 guild = message.Channel?.Guild;
                 message.EditedTimestamp = event_message.EditedTimestamp;
                 if (event_message.Content != null)
@@ -1551,6 +1552,15 @@ namespace DSharpPlus
                 message._attachments.AddRange(event_message._attachments);
                 message.Pinned = event_message.Pinned;
                 message.IsTTS = event_message.IsTTS;
+
+                // Mentions
+                message._mentionedUsers.Clear();
+                message._mentionedUsers.AddRange(event_message._mentionedUsers ?? new());
+                message._mentionedRoles.Clear();
+                message._mentionedRoles.AddRange(event_message._mentionedRoles ?? new());
+                message._mentionedChannels.Clear();
+                message._mentionedChannels.AddRange(event_message._mentionedChannels ?? new());
+                message.MentionEveryone = event_message.MentionEveryone;
             }
 
             message.PopulateMentions();


### PR DESCRIPTION
# Summary
This bug was brought up by Link#8313 in the Discord. Under some conditions an updated message would not properly reflect the json sent by Discord when it came to mentions. 

This happened whenever a message was cached, as the returned message would not use the mention data sent by Discord. If a message was not cached, or the message cache was disabled, then the message returned was simply the updated message from Discord and would have correct mentions. 

Note that other properties that can change in an update can also suffer this same fate if the data is not accessed. Obviously. (Also note I did not test other properties, but I did test this PR.)

# Changes
- Message returned by `OnMessageUpdateEventAsync()` now copies it's mentions from the data Discord sends.
- Some extra comments because I get ~~paid~~ nothing by the line.

Test code used: 
```
private async Task Discord_MessageUpdated(DiscordClient sender, MessageUpdateEventArgs args)
{
    StringBuilder builder = new();
    builder.AppendLine($"Message.MentionedUsers.Count    : {args.Message.MentionedUsers.Count}");
    builder.AppendLine($"Message.MentionedChannels.Count : {args.Message.MentionedChannels.Count}");
    builder.AppendLine($"Message.MentionedRoles.Count    : {args.Message.MentionedRoles.Count}");
    builder.AppendLine($"Message.MentionEveryone.Count   : {args.Message.MentionEveryone}");

    await args.Channel.SendMessageAsync(new DiscordMessageBuilder().WithContent(builder.ToString()).WithReply(args.Message.Id));
}
```
"Definitely a user error" - @OoLunar 
