### PR TITLE
Improve XML documentation for DiscordClient.Ready

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -70,8 +70,12 @@ namespace DSharpPlus
         private AsyncEvent<DiscordClient, SocketCloseEventArgs> _socketClosed;
 
         /// <summary>
-        /// Fired when the client enters ready state.
+        /// Fired when this client has successfully completed its handshake with the websocket gateway.
         /// </summary>
+        /// <remarks>
+        /// <i><see cref="Guilds"/> will not be populated when this event is fired.</i><br/>
+        /// See also: <see cref="GuildAvailable"/>, <see cref="GuildDownloadCompleted"/>
+        /// </remarks>
         public event AsyncEventHandler<DiscordClient, ReadyEventArgs> Ready
         {
             add => this._ready.Register(value);


### PR DESCRIPTION
# Summary
I clarified what the `READY` event signifies and added a note informing the user that the guild cache is not populated when the event is fired.

# Notes
Sorry it took so long hope u guys like it 👍 