### PR TITLE
Refactored `DiscordMessage.PopulateMentions` and `DiscordClient.OnMessageUpdateEventAsync`

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
@@ -38,15 +39,6 @@ namespace DSharpPlus.Entities
     {
         internal DiscordMessage()
         {
-            this._attachmentsLazy = new Lazy<IReadOnlyList<DiscordAttachment>>(() => new ReadOnlyCollection<DiscordAttachment>(this._attachments));
-            this._embedsLazy = new Lazy<IReadOnlyList<DiscordEmbed>>(() => new ReadOnlyCollection<DiscordEmbed>(this._embeds));
-            this._mentionedChannelsLazy = new Lazy<IReadOnlyList<DiscordChannel>>(() => this._mentionedChannels != null
-                    ? new ReadOnlyCollection<DiscordChannel>(this._mentionedChannels)
-                    : Array.Empty<DiscordChannel>());
-            this._mentionedRolesLazy = new Lazy<IReadOnlyList<DiscordRole>>(() => this._mentionedRoles != null ? new ReadOnlyCollection<DiscordRole>(this._mentionedRoles) : Array.Empty<DiscordRole>());
-            this._mentionedUsersLazy = new Lazy<IReadOnlyList<DiscordUser>>(() => new ReadOnlyCollection<DiscordUser>(this._mentionedUsers));
-            this._reactionsLazy = new Lazy<IReadOnlyList<DiscordReaction>>(() => new ReadOnlyCollection<DiscordReaction>(this._reactions));
-            this._stickersLazy = new Lazy<IReadOnlyList<DiscordMessageSticker>>(() => new ReadOnlyCollection<DiscordMessageSticker>(this._stickers));
             this._jumpLink = new Lazy<Uri>(() =>
             {
                 var gid = this.Channel is DiscordDmChannel ? "@me" : this.Channel.GuildId.Value.ToString(CultureInfo.InvariantCulture);
@@ -107,7 +99,6 @@ namespace DSharpPlus.Entities
         [JsonProperty("channel_id", NullValueHandling = NullValueHandling.Ignore)]
         public ulong ChannelId { get; internal set; }
 
-
         /// <summary>
         /// Gets the components this message was sent with.
         /// </summary>
@@ -141,7 +132,6 @@ namespace DSharpPlus.Entities
         [JsonProperty("edited_timestamp", NullValueHandling = NullValueHandling.Ignore)]
         public DateTimeOffset? EditedTimestamp { get; internal set; }
 
-
         /// <summary>
         /// Gets whether this message was edited.
         /// </summary>
@@ -165,13 +155,13 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordUser> MentionedUsers
-            => this._mentionedUsersLazy.Value;
+            => this._mentionedUsers.AsReadOnly();
 
+        /// <remarks>
+        /// If copying from a different source (such as <see cref="EventArgs.MessageUpdateEventArgs" />) and pairing with <see cref="PopulateMentions" />, take extra care to ensure that this property is copied as well so that new user mentions can be cached.
+        /// </remarks>
         [JsonProperty("mentions", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordUser> _mentionedUsers;
-
-        [JsonIgnore]
-        internal readonly Lazy<IReadOnlyList<DiscordUser>> _mentionedUsersLazy;
 
         // TODO this will probably throw an exception in DMs since it tries to wrap around a null List...
         // this is probably low priority but need to find out a clean way to solve it...
@@ -180,7 +170,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordRole> MentionedRoles
-            => this._mentionedRolesLazy.Value;
+            => this._mentionedRoles.AsReadOnly();
 
         [JsonIgnore]
         internal List<DiscordRole> _mentionedRoles;
@@ -188,56 +178,45 @@ namespace DSharpPlus.Entities
         [JsonProperty("mention_roles")]
         internal List<ulong> _mentionedRoleIds;
 
-        [JsonIgnore]
-        private readonly Lazy<IReadOnlyList<DiscordRole>> _mentionedRolesLazy;
-
         /// <summary>
         /// Gets channels mentioned by this message.
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordChannel> MentionedChannels
-            => this._mentionedChannelsLazy.Value;
+            => this._mentionedChannels.AsReadOnly();
 
         [JsonIgnore]
         internal List<DiscordChannel> _mentionedChannels;
-        [JsonIgnore]
-        private readonly Lazy<IReadOnlyList<DiscordChannel>> _mentionedChannelsLazy;
 
         /// <summary>
         /// Gets files attached to this message.
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordAttachment> Attachments
-            => this._attachmentsLazy.Value;
+            => this._attachments.AsReadOnly();
 
         [JsonProperty("attachments", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordAttachment> _attachments = new();
-        [JsonIgnore]
-        private readonly Lazy<IReadOnlyList<DiscordAttachment>> _attachmentsLazy;
 
         /// <summary>
         /// Gets embeds attached to this message.
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordEmbed> Embeds
-            => this._embedsLazy.Value;
+            => this._embeds.AsReadOnly();
 
         [JsonProperty("embeds", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordEmbed> _embeds = new();
-        [JsonIgnore]
-        private readonly Lazy<IReadOnlyList<DiscordEmbed>> _embedsLazy;
 
         /// <summary>
         /// Gets reactions used on this message.
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordReaction> Reactions
-            => this._reactionsLazy.Value;
+            => this._reactions.AsReadOnly();
 
         [JsonProperty("reactions", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordReaction> _reactions = new();
-        [JsonIgnore]
-        private readonly Lazy<IReadOnlyList<DiscordReaction>> _reactionsLazy;
 
         /*
         /// <summary>
@@ -312,12 +291,10 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordMessageSticker> Stickers
-            => this._stickersLazy.Value;
+            => this._stickers.AsReadOnly();
 
         [JsonProperty("sticker_items", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordMessageSticker> _stickers = new();
-        [JsonIgnore]
-        private readonly Lazy<IReadOnlyList<DiscordMessageSticker>> _stickersLazy;
 
         [JsonProperty("guild_id", NullValueHandling = NullValueHandling.Ignore)]
         internal ulong? GuildId { get; set; }
@@ -410,61 +387,129 @@ namespace DSharpPlus.Entities
 
         internal void PopulateMentions()
         {
+            if (this.Content == null)
+            {
+                // Nothing to cache, I think
+                return;
+            }
+
             var guild = this.Channel?.Guild;
             this._mentionedUsers ??= new List<DiscordUser>();
             this._mentionedRoles ??= new List<DiscordRole>();
             this._mentionedChannels ??= new List<DiscordChannel>();
 
-            var mentionedUsers = new HashSet<DiscordUser>(new DiscordUserComparer());
             if (guild != null)
             {
-                foreach (var usr in this._mentionedUsers)
+                foreach (var mentionedUser in this._mentionedUsers)
                 {
-                    var member = usr as DiscordMember;
-                    if (member != null)
+                    // Prevent StackOverflowException
+                    // https://github.com/DSharpPlus/DSharpPlus/pull/1257
+                    if (mentionedUser is DiscordMember mentionedMember)
                     {
                         this.Discord.UpdateUserCache(new DiscordUser()
                         {
-                            Id = member.Id,
-                            Username = member.Username,
-                            Discriminator = member.Discriminator,
-                            AvatarHash = member.AvatarHash,
-                            _bannerColor = member._bannerColor,
-                            BannerHash = member.BannerHash,
-                            IsBot = member.IsBot,
-                            MfaEnabled = member.MfaEnabled,
-                            Verified = member.Verified,
-                            Email = member.Email,
-                            PremiumType = member.PremiumType,
-                            Locale = member.Locale,
-                            Flags = member.Flags,
-                            OAuthFlags = member.OAuthFlags,
+                            Id = mentionedMember.Id,
+                            Username = mentionedMember.Username,
+                            Discriminator = mentionedMember.Discriminator,
+                            AvatarHash = mentionedMember.AvatarHash,
+                            _bannerColor = mentionedMember._bannerColor,
+                            BannerHash = mentionedMember.BannerHash,
+                            IsBot = mentionedMember.IsBot,
+                            MfaEnabled = mentionedMember.MfaEnabled,
+                            Verified = mentionedMember.Verified,
+                            Email = mentionedMember.Email,
+                            PremiumType = mentionedMember.PremiumType,
+                            Locale = mentionedMember.Locale,
+                            Flags = mentionedMember.Flags,
+                            OAuthFlags = mentionedMember.OAuthFlags,
                             Discord = this.Discord
                         });
                     }
                     else
                     {
-                        usr.Discord = this.Discord;
-                        this.Discord.UpdateUserCache(usr);
+                        mentionedUser.Discord = this.Discord;
+                        this.Discord.UpdateUserCache(mentionedUser);
+                    }
+                }
+            }
+
+            // This is meant to stop having to Regex the same string multiple times.
+            // Yes, I'm using it as an exercise. Shush.
+            StringBuilder snowflakeBuilder = new(20);
+            for (int stringIndex = 0, snowflakeIndex; stringIndex < this.Content.Length; stringIndex++)
+            {
+                // Parse channel mentions. DOESN'T include mentions to other DM channels or channels from different guilds that the bot MAY be in.
+                if (guild != null && this.Content[stringIndex] == '#' && this.Content[stringIndex - 1] == '<')
+                {
+                    // Reset the snowflake index from other mentions AND increment the string index before snowflakeIndex assignment to skip the '#' character.
+                    snowflakeIndex = ++stringIndex;
+
+                    // While the snowflake index is less than 20 (ulong.MaxValue.ToString().Length).
+                    // While the snowflake index is less than the length of the string.
+                    // While the snowflake index isn't on the end of a mention.
+                    while (snowflakeIndex < stringIndex + 20 && snowflakeIndex < this.Content.Length && this.Content[snowflakeIndex] != '>')
+                    {
+                        // Append the current character to a StringBuilder.
+                        snowflakeBuilder.Append(this.Content[snowflakeIndex]);
+
+                        // Advance to the next character.
+                        snowflakeIndex++;
                     }
 
-                    mentionedUsers.Add(member ?? (guild._members.TryGetValue(usr.Id, out var cachedMember) ? cachedMember : usr));
-                }
-            }
-            if (!string.IsNullOrWhiteSpace(this.Content))
-            {
-                //uncomment if this breaks
-                //mentionedUsers.UnionWith(Utilities.GetUserMentions(this).Select(this.Discord.GetCachedOrEmptyUserInternal));
+                    // Try to parse the snowflake as a number
+                    if (ulong.TryParse(snowflakeBuilder.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var channelId)
+                        // Try to fetch the channel from the current guild.
+                        && guild._channels.TryGetValue(channelId, out var channel)
+                        // Make sure we're not adding duplicates.
+                        && !this._mentionedChannels.Contains(channel))
+                    {
+                        // Add the mentioned channel.
+                        this._mentionedChannels.Add(channel);
+                    }
 
-                if (guild != null)
+                    // Clear the StringBuilder so other mentions can be parsed.
+                    snowflakeBuilder.Clear();
+                }
+                // If we're at the start of a user or role mention
+                else if (this.Content[stringIndex] == '@' && this.Content[stringIndex - 1] == '<')
                 {
-                    //uncomment if this breaks
-                    //this._mentionedRoles = this._mentionedRoles.Union(Utilities.GetRoleMentions(this).Select(xid => guild.GetRole(xid))).ToList();
-                    this._mentionedRoles = this._mentionedRoles.Union(this._mentionedRoleIds.Select(xid => guild.GetRole(xid))).ToList();
-                    this._mentionedChannels = this._mentionedChannels.Union(Utilities.GetChannelMentions(this).Select(xid => guild.GetChannel(xid))).ToList();
+                    // If the next character isn't out of bounds and is a '&' (role)
+                    var isRole =  this.Content.Length > stringIndex + 1 && this.Content[stringIndex + 1] == '&';
+                    // If the next character isn't out of bounds and is a '!' (outdated nick mention, mostly unused)
+                    var isNickname = this.Content.Length > stringIndex + 1 && this.Content[stringIndex + 1] == '!';
+
+                    // If it's a role or nick mention, skip 2 characters (@& or &!), otherwise skip 1 (@)
+                    stringIndex += isRole || isNickname ? 2 : 1;
+                    snowflakeIndex = stringIndex;
+
+                    while (snowflakeIndex < stringIndex + 20 && snowflakeIndex < this.Content.Length && this.Content[snowflakeIndex] != '>')
+                    {
+                        snowflakeBuilder.Append(this.Content[snowflakeIndex]);
+                        snowflakeIndex++;
+                    }
+
+                    // Make sure we have ourselves a valid snowflake.
+                    if (ulong.TryParse(snowflakeBuilder.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var userOrRoleId))
+                    {
+                        if (isRole && guild._roles.TryGetValue(userOrRoleId, out var role) && !this._mentionedRoles.Contains(role))
+                        {
+                            this._mentionedRoles.Add(role);
+                        }
+                        // Try to add a member casted to a user to the mentioned users.
+                        else if (guild._members.TryGetValue(userOrRoleId, out var member) && !this._mentionedUsers.Contains(member))
+                        {
+                            this._mentionedUsers.Add(member);
+                        }
+                        // Try to get the user from the cache.
+                        else if (this.Discord.TryGetCachedUserInternal(userOrRoleId, out var user) && !this._mentionedUsers.Contains(user))
+                        {
+                            this._mentionedUsers.Add(user);
+                        }
+                    }
+
+                    snowflakeBuilder.Clear();
                 }
             }
-            this._mentionedUsers = mentionedUsers.ToList();
         }
 
         /// <summary>
@@ -516,7 +561,6 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> ModifyAsync(Optional<string> content, Optional<IEnumerable<DiscordEmbed>> embeds = default)
             => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, embeds, this.GetMentions(), default, Array.Empty<DiscordMessageFile>(), null, default);
-
 
         /// <summary>
         /// Edits the message.


### PR DESCRIPTION
DiscordMessage.PopulateMentions:
- This was refactored for a multitude of reasons, the main motivation being that it's regexed three times over. The new text manipulation logic iterates over the message once, caching new users and adding mentioned users/roles IF they're not already present.

DiscordClient.OnMessageUpdateEventAsync:
- Generally just dirty code that needed cleaning up. Also updates a few properties that weren't previously updated.

DiscordMessage:
- Removed all Lazy properties except for JumpLink. These Lazy properties can be updated anytime, however, `Lazy<>` is not run every time the property is accessed, meaning the new updated backing values are never reflected in public properties.

# Tested?
All of you were laughing at my pain in #dev-text, don't act innocent. Did any of you offer a helping hand? I think NOT.

# Notes
Specifically asking for @ExaInsanity's review on `DiscordMessage.PopulateMentions`