### PR TITLE
Fix #1331

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1042,7 +1042,7 @@ namespace DSharpPlus
                 foreach (var kvp in gld._threads ??= new()) oldGuild._threads[kvp.Key] = kvp.Value;
                 foreach (var kvp in gld._emojis ??= new()) oldGuild._emojis[kvp.Key] = kvp.Value;
                 foreach (var kvp in gld._roles ??= new()) oldGuild._roles[kvp.Key] = kvp.Value;
-                //new ConcurrentDictionary<ulong, DiscordVoiceState>()
+                                                      //new ConcurrentDictionary<ulong, DiscordVoiceState>()
                 foreach (var kvp in gld._voiceStates ??= new()) oldGuild._voiceStates[kvp.Key] = kvp.Value;
                 foreach (var kvp in gld._members ??= new()) oldGuild._members[kvp.Key] = kvp.Value;
             }
@@ -1514,68 +1514,66 @@ namespace DSharpPlus
             await this._messageCreated.InvokeAsync(this, ea).ConfigureAwait(false);
         }
 
-        internal async Task OnMessageUpdateEventAsync(DiscordMessage updatedMessage, TransportUser author, TransportMember member, TransportUser referenceAuthor, TransportMember referenceMember)
+        internal async Task OnMessageUpdateEventAsync(DiscordMessage message, TransportUser author, TransportMember member, TransportUser referenceAuthor, TransportMember referenceMember)
         {
-            updatedMessage.Discord = this;
-            DiscordMessage outdatedMessage = null;
+            DiscordGuild guild;
 
-            // If the user has cache disabled or the message wasn't found in the cache.
-            if (this.Configuration.MessageCacheSize == 0 || this.MessageCache == null || !this.MessageCache.TryGet(cacheMessage => cacheMessage.Id == updatedMessage.Id && cacheMessage.ChannelId == updatedMessage.ChannelId, out var cachedMessage))
+            message.Discord = this;
+            var event_message = message;
+
+            DiscordMessage oldmsg = null;
+            if (this.Configuration.MessageCacheSize == 0
+                || this.MessageCache == null
+                || !this.MessageCache.TryGet(xm => xm.Id == event_message.Id && xm.ChannelId == event_message.ChannelId, out message)) // previous message was not in cache 
             {
-                // MessageUpdate event doesn't share reactions. So we update the reactions on the message and put the message in the cache.
-                // Should be two separate methods imo but that's out of scope for this PR.
-                this.PopulateMessageReactionsAndCache(updatedMessage, author, member);
+                message = event_message;
+                this.PopulateMessageReactionsAndCache(message, author, member);
+                guild = message.Channel?.Guild;
 
-                if (updatedMessage.ReferencedMessage != null)
+                if (message.ReferencedMessage != null)
                 {
-                    // Do the same with the referenced message.
-                    updatedMessage.ReferencedMessage.Discord = this;
-                    this.PopulateMessageReactionsAndCache(updatedMessage.ReferencedMessage, referenceAuthor, referenceMember);
-
-                    // Make sure the referenced message has the correct mentions.
-                    updatedMessage.ReferencedMessage.PopulateMentions();
+                    message.ReferencedMessage.Discord = this;
+                    this.PopulateMessageReactionsAndCache(message.ReferencedMessage, referenceAuthor, referenceMember);
+                    message.ReferencedMessage.PopulateMentions();
                 }
             }
-            // The message was found in cache, now we need to update the cached message.
-            else
+            else // previous message was fetched in cache 
             {
-                // Create a copy of the cached message for the Before event argument.
-                outdatedMessage = new DiscordMessage(cachedMessage);
+                oldmsg = new DiscordMessage(message);
 
-                // Update the properties
-                if (updatedMessage.Content != null)
-                {
-                    cachedMessage.Content = updatedMessage.Content;
-                }
+                // cached message is updated with information from the event message 
+                guild = message.Channel?.Guild;
+                message.EditedTimestamp = event_message.EditedTimestamp;
+                if (event_message.Content != null)
+                    message.Content = event_message.Content;
+                message._embeds.Clear();
+                message._embeds.AddRange(event_message._embeds);
+                message._attachments.Clear();
+                message._attachments.AddRange(event_message._attachments);
+                message.Pinned = event_message.Pinned;
+                message.IsTTS = event_message.IsTTS;
 
-                cachedMessage.EditedTimestamp = updatedMessage.EditedTimestamp;
-                cachedMessage.MentionEveryone = updatedMessage.MentionEveryone;
-                cachedMessage._attachments = updatedMessage._attachments ?? new();
-                cachedMessage._embeds = updatedMessage._embeds ?? new();
-                cachedMessage.Pinned = updatedMessage.Pinned;
-                cachedMessage.Activity = updatedMessage.Activity;
-                cachedMessage.Flags = updatedMessage.Flags;
-                cachedMessage.Components = updatedMessage.Components;
-                cachedMessage._stickers = updatedMessage._stickers ?? new();
-                // Copy this over so that users in the new mentions are cached as well.
-                cachedMessage._mentionedUsers = updatedMessage._mentionedUsers ?? new();
-
-                updatedMessage = cachedMessage;
+                // Mentions
+                message._mentionedUsers.Clear();
+                message._mentionedUsers.AddRange(event_message._mentionedUsers ?? new());
+                message._mentionedRoles.Clear();
+                message._mentionedRoles.AddRange(event_message._mentionedRoles ?? new());
+                message._mentionedChannels.Clear();
+                message._mentionedChannels.AddRange(event_message._mentionedChannels ?? new());
+                message.MentionEveryone = event_message.MentionEveryone;
             }
 
-            // Content is getting updated regardless if the message was updated or not.
-            updatedMessage.PopulateMentions();
+            message.PopulateMentions();
 
-            var eventArgs = new MessageUpdateEventArgs()
+            var ea = new MessageUpdateEventArgs
             {
-                Message = updatedMessage,
-                MessageBefore = outdatedMessage,
-                MentionedChannels = (updatedMessage._mentionedChannels ?? new()).AsReadOnly(),
-                MentionedRoles = (updatedMessage._mentionedRoles ?? new()).AsReadOnly(),
-                MentionedUsers = (updatedMessage._mentionedUsers ?? new()).AsReadOnly()
+                Message = message,
+                MessageBefore = oldmsg,
+                MentionedUsers = new ReadOnlyCollection<DiscordUser>(message._mentionedUsers),
+                MentionedRoles = message._mentionedRoles != null ? new ReadOnlyCollection<DiscordRole>(message._mentionedRoles) : null,
+                MentionedChannels = message._mentionedChannels != null ? new ReadOnlyCollection<DiscordChannel>(message._mentionedChannels) : null
             };
-
-            await this._messageUpdated.InvokeAsync(this, eventArgs).ConfigureAwait(false);
+            await this._messageUpdated.InvokeAsync(this, ea).ConfigureAwait(false);
         }
 
         internal async Task OnMessageDeleteEventAsync(ulong messageId, ulong channelId, ulong? guildId)

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -38,15 +38,6 @@ namespace DSharpPlus.Entities
     {
         internal DiscordMessage()
         {
-            this._attachmentsLazy = new Lazy<IReadOnlyList<DiscordAttachment>>(() => new ReadOnlyCollection<DiscordAttachment>(this._attachments));
-            this._embedsLazy = new Lazy<IReadOnlyList<DiscordEmbed>>(() => new ReadOnlyCollection<DiscordEmbed>(this._embeds));
-            this._mentionedChannelsLazy = new Lazy<IReadOnlyList<DiscordChannel>>(() => this._mentionedChannels != null
-                    ? new ReadOnlyCollection<DiscordChannel>(this._mentionedChannels)
-                    : Array.Empty<DiscordChannel>());
-            this._mentionedRolesLazy = new Lazy<IReadOnlyList<DiscordRole>>(() => this._mentionedRoles != null ? new ReadOnlyCollection<DiscordRole>(this._mentionedRoles) : Array.Empty<DiscordRole>());
-            this._mentionedUsersLazy = new Lazy<IReadOnlyList<DiscordUser>>(() => new ReadOnlyCollection<DiscordUser>(this._mentionedUsers));
-            this._reactionsLazy = new Lazy<IReadOnlyList<DiscordReaction>>(() => new ReadOnlyCollection<DiscordReaction>(this._reactions));
-            this._stickersLazy = new Lazy<IReadOnlyList<DiscordMessageSticker>>(() => new ReadOnlyCollection<DiscordMessageSticker>(this._stickers));
             this._jumpLink = new Lazy<Uri>(() =>
             {
                 var gid = this.Channel is DiscordDmChannel ? "@me" : this.Channel.GuildId.Value.ToString(CultureInfo.InvariantCulture);
@@ -107,7 +98,6 @@ namespace DSharpPlus.Entities
         [JsonProperty("channel_id", NullValueHandling = NullValueHandling.Ignore)]
         public ulong ChannelId { get; internal set; }
 
-
         /// <summary>
         /// Gets the components this message was sent with.
         /// </summary>
@@ -141,7 +131,6 @@ namespace DSharpPlus.Entities
         [JsonProperty("edited_timestamp", NullValueHandling = NullValueHandling.Ignore)]
         public DateTimeOffset? EditedTimestamp { get; internal set; }
 
-
         /// <summary>
         /// Gets whether this message was edited.
         /// </summary>
@@ -165,13 +154,10 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordUser> MentionedUsers
-            => this._mentionedUsersLazy.Value;
+            => this._mentionedUsers;
 
         [JsonProperty("mentions", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordUser> _mentionedUsers;
-
-        [JsonIgnore]
-        internal readonly Lazy<IReadOnlyList<DiscordUser>> _mentionedUsersLazy;
 
         // TODO this will probably throw an exception in DMs since it tries to wrap around a null List...
         // this is probably low priority but need to find out a clean way to solve it...
@@ -180,7 +166,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordRole> MentionedRoles
-            => this._mentionedRolesLazy.Value;
+            => this._mentionedRoles;
 
         [JsonIgnore]
         internal List<DiscordRole> _mentionedRoles;
@@ -188,56 +174,45 @@ namespace DSharpPlus.Entities
         [JsonProperty("mention_roles")]
         internal List<ulong> _mentionedRoleIds;
 
-        [JsonIgnore]
-        private readonly Lazy<IReadOnlyList<DiscordRole>> _mentionedRolesLazy;
-
         /// <summary>
         /// Gets channels mentioned by this message.
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordChannel> MentionedChannels
-            => this._mentionedChannelsLazy.Value;
+            => this._mentionedChannels;
 
         [JsonIgnore]
         internal List<DiscordChannel> _mentionedChannels;
-        [JsonIgnore]
-        private readonly Lazy<IReadOnlyList<DiscordChannel>> _mentionedChannelsLazy;
 
         /// <summary>
         /// Gets files attached to this message.
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordAttachment> Attachments
-            => this._attachmentsLazy.Value;
+            => this._attachments;
 
         [JsonProperty("attachments", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordAttachment> _attachments = new();
-        [JsonIgnore]
-        private readonly Lazy<IReadOnlyList<DiscordAttachment>> _attachmentsLazy;
 
         /// <summary>
         /// Gets embeds attached to this message.
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordEmbed> Embeds
-            => this._embedsLazy.Value;
+            => this._embeds;
 
         [JsonProperty("embeds", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordEmbed> _embeds = new();
-        [JsonIgnore]
-        private readonly Lazy<IReadOnlyList<DiscordEmbed>> _embedsLazy;
 
         /// <summary>
         /// Gets reactions used on this message.
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordReaction> Reactions
-            => this._reactionsLazy.Value;
+            => this._reactions;
 
         [JsonProperty("reactions", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordReaction> _reactions = new();
-        [JsonIgnore]
-        private readonly Lazy<IReadOnlyList<DiscordReaction>> _reactionsLazy;
 
         /*
         /// <summary>
@@ -312,12 +287,10 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordMessageSticker> Stickers
-            => this._stickersLazy.Value;
+            => this._stickers;
 
         [JsonProperty("sticker_items", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordMessageSticker> _stickers = new();
-        [JsonIgnore]
-        private readonly Lazy<IReadOnlyList<DiscordMessageSticker>> _stickersLazy;
 
         [JsonProperty("guild_id", NullValueHandling = NullValueHandling.Ignore)]
         internal ulong? GuildId { get; set; }
@@ -516,7 +489,6 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> ModifyAsync(Optional<string> content, Optional<IEnumerable<DiscordEmbed>> embeds = default)
             => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, embeds, this.GetMentions(), default, Array.Empty<DiscordMessageFile>(), null, default);
-
 
         /// <summary>
         /// Edits the message.

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -26,7 +26,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
@@ -39,6 +38,15 @@ namespace DSharpPlus.Entities
     {
         internal DiscordMessage()
         {
+            this._attachmentsLazy = new Lazy<IReadOnlyList<DiscordAttachment>>(() => new ReadOnlyCollection<DiscordAttachment>(this._attachments));
+            this._embedsLazy = new Lazy<IReadOnlyList<DiscordEmbed>>(() => new ReadOnlyCollection<DiscordEmbed>(this._embeds));
+            this._mentionedChannelsLazy = new Lazy<IReadOnlyList<DiscordChannel>>(() => this._mentionedChannels != null
+                    ? new ReadOnlyCollection<DiscordChannel>(this._mentionedChannels)
+                    : Array.Empty<DiscordChannel>());
+            this._mentionedRolesLazy = new Lazy<IReadOnlyList<DiscordRole>>(() => this._mentionedRoles != null ? new ReadOnlyCollection<DiscordRole>(this._mentionedRoles) : Array.Empty<DiscordRole>());
+            this._mentionedUsersLazy = new Lazy<IReadOnlyList<DiscordUser>>(() => new ReadOnlyCollection<DiscordUser>(this._mentionedUsers));
+            this._reactionsLazy = new Lazy<IReadOnlyList<DiscordReaction>>(() => new ReadOnlyCollection<DiscordReaction>(this._reactions));
+            this._stickersLazy = new Lazy<IReadOnlyList<DiscordMessageSticker>>(() => new ReadOnlyCollection<DiscordMessageSticker>(this._stickers));
             this._jumpLink = new Lazy<Uri>(() =>
             {
                 var gid = this.Channel is DiscordDmChannel ? "@me" : this.Channel.GuildId.Value.ToString(CultureInfo.InvariantCulture);
@@ -99,6 +107,7 @@ namespace DSharpPlus.Entities
         [JsonProperty("channel_id", NullValueHandling = NullValueHandling.Ignore)]
         public ulong ChannelId { get; internal set; }
 
+
         /// <summary>
         /// Gets the components this message was sent with.
         /// </summary>
@@ -132,6 +141,7 @@ namespace DSharpPlus.Entities
         [JsonProperty("edited_timestamp", NullValueHandling = NullValueHandling.Ignore)]
         public DateTimeOffset? EditedTimestamp { get; internal set; }
 
+
         /// <summary>
         /// Gets whether this message was edited.
         /// </summary>
@@ -155,13 +165,13 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordUser> MentionedUsers
-            => this._mentionedUsers.AsReadOnly();
+            => this._mentionedUsersLazy.Value;
 
-        /// <remarks>
-        /// If copying from a different source (such as <see cref="EventArgs.MessageUpdateEventArgs" />) and pairing with <see cref="PopulateMentions" />, take extra care to ensure that this property is copied as well so that new user mentions can be cached.
-        /// </remarks>
         [JsonProperty("mentions", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordUser> _mentionedUsers;
+
+        [JsonIgnore]
+        internal readonly Lazy<IReadOnlyList<DiscordUser>> _mentionedUsersLazy;
 
         // TODO this will probably throw an exception in DMs since it tries to wrap around a null List...
         // this is probably low priority but need to find out a clean way to solve it...
@@ -170,7 +180,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordRole> MentionedRoles
-            => this._mentionedRoles.AsReadOnly();
+            => this._mentionedRolesLazy.Value;
 
         [JsonIgnore]
         internal List<DiscordRole> _mentionedRoles;
@@ -178,45 +188,56 @@ namespace DSharpPlus.Entities
         [JsonProperty("mention_roles")]
         internal List<ulong> _mentionedRoleIds;
 
+        [JsonIgnore]
+        private readonly Lazy<IReadOnlyList<DiscordRole>> _mentionedRolesLazy;
+
         /// <summary>
         /// Gets channels mentioned by this message.
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordChannel> MentionedChannels
-            => this._mentionedChannels.AsReadOnly();
+            => this._mentionedChannelsLazy.Value;
 
         [JsonIgnore]
         internal List<DiscordChannel> _mentionedChannels;
+        [JsonIgnore]
+        private readonly Lazy<IReadOnlyList<DiscordChannel>> _mentionedChannelsLazy;
 
         /// <summary>
         /// Gets files attached to this message.
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordAttachment> Attachments
-            => this._attachments.AsReadOnly();
+            => this._attachmentsLazy.Value;
 
         [JsonProperty("attachments", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordAttachment> _attachments = new();
+        [JsonIgnore]
+        private readonly Lazy<IReadOnlyList<DiscordAttachment>> _attachmentsLazy;
 
         /// <summary>
         /// Gets embeds attached to this message.
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordEmbed> Embeds
-            => this._embeds.AsReadOnly();
+            => this._embedsLazy.Value;
 
         [JsonProperty("embeds", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordEmbed> _embeds = new();
+        [JsonIgnore]
+        private readonly Lazy<IReadOnlyList<DiscordEmbed>> _embedsLazy;
 
         /// <summary>
         /// Gets reactions used on this message.
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordReaction> Reactions
-            => this._reactions.AsReadOnly();
+            => this._reactionsLazy.Value;
 
         [JsonProperty("reactions", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordReaction> _reactions = new();
+        [JsonIgnore]
+        private readonly Lazy<IReadOnlyList<DiscordReaction>> _reactionsLazy;
 
         /*
         /// <summary>
@@ -291,10 +312,12 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public IReadOnlyList<DiscordMessageSticker> Stickers
-            => this._stickers.AsReadOnly();
+            => this._stickersLazy.Value;
 
         [JsonProperty("sticker_items", NullValueHandling = NullValueHandling.Ignore)]
         internal List<DiscordMessageSticker> _stickers = new();
+        [JsonIgnore]
+        private readonly Lazy<IReadOnlyList<DiscordMessageSticker>> _stickersLazy;
 
         [JsonProperty("guild_id", NullValueHandling = NullValueHandling.Ignore)]
         internal ulong? GuildId { get; set; }
@@ -387,129 +410,61 @@ namespace DSharpPlus.Entities
 
         internal void PopulateMentions()
         {
-            if (this.Content == null)
-            {
-                // Nothing to cache, I think
-                return;
-            }
-
             var guild = this.Channel?.Guild;
             this._mentionedUsers ??= new List<DiscordUser>();
             this._mentionedRoles ??= new List<DiscordRole>();
             this._mentionedChannels ??= new List<DiscordChannel>();
 
+            var mentionedUsers = new HashSet<DiscordUser>(new DiscordUserComparer());
             if (guild != null)
             {
-                foreach (var mentionedUser in this._mentionedUsers)
+                foreach (var usr in this._mentionedUsers)
                 {
-                    // Prevent StackOverflowException
-                    // https://github.com/DSharpPlus/DSharpPlus/pull/1257
-                    if (mentionedUser is DiscordMember mentionedMember)
+                    var member = usr as DiscordMember;
+                    if (member != null)
                     {
                         this.Discord.UpdateUserCache(new DiscordUser()
                         {
-                            Id = mentionedMember.Id,
-                            Username = mentionedMember.Username,
-                            Discriminator = mentionedMember.Discriminator,
-                            AvatarHash = mentionedMember.AvatarHash,
-                            _bannerColor = mentionedMember._bannerColor,
-                            BannerHash = mentionedMember.BannerHash,
-                            IsBot = mentionedMember.IsBot,
-                            MfaEnabled = mentionedMember.MfaEnabled,
-                            Verified = mentionedMember.Verified,
-                            Email = mentionedMember.Email,
-                            PremiumType = mentionedMember.PremiumType,
-                            Locale = mentionedMember.Locale,
-                            Flags = mentionedMember.Flags,
-                            OAuthFlags = mentionedMember.OAuthFlags,
+                            Id = member.Id,
+                            Username = member.Username,
+                            Discriminator = member.Discriminator,
+                            AvatarHash = member.AvatarHash,
+                            _bannerColor = member._bannerColor,
+                            BannerHash = member.BannerHash,
+                            IsBot = member.IsBot,
+                            MfaEnabled = member.MfaEnabled,
+                            Verified = member.Verified,
+                            Email = member.Email,
+                            PremiumType = member.PremiumType,
+                            Locale = member.Locale,
+                            Flags = member.Flags,
+                            OAuthFlags = member.OAuthFlags,
                             Discord = this.Discord
                         });
                     }
                     else
                     {
-                        mentionedUser.Discord = this.Discord;
-                        this.Discord.UpdateUserCache(mentionedUser);
+                        usr.Discord = this.Discord;
+                        this.Discord.UpdateUserCache(usr);
                     }
+
+                    mentionedUsers.Add(member ?? (guild._members.TryGetValue(usr.Id, out var cachedMember) ? cachedMember : usr));
                 }
             }
-
-            // This is meant to stop having to Regex the same string multiple times.
-            // Yes, I'm using it as an exercise. Shush.
-            StringBuilder snowflakeBuilder = new(20);
-            for (int stringIndex = 0, snowflakeIndex; stringIndex < this.Content.Length; stringIndex++)
+            if (!string.IsNullOrWhiteSpace(this.Content))
             {
-                // Parse channel mentions. DOESN'T include mentions to other DM channels or channels from different guilds that the bot MAY be in.
-                if (guild != null && this.Content[stringIndex] == '#' && this.Content[stringIndex - 1] == '<')
+                //uncomment if this breaks
+                //mentionedUsers.UnionWith(Utilities.GetUserMentions(this).Select(this.Discord.GetCachedOrEmptyUserInternal));
+
+                if (guild != null)
                 {
-                    // Reset the snowflake index from other mentions AND increment the string index before snowflakeIndex assignment to skip the '#' character.
-                    snowflakeIndex = ++stringIndex;
-
-                    // While the snowflake index is less than 20 (ulong.MaxValue.ToString().Length).
-                    // While the snowflake index is less than the length of the string.
-                    // While the snowflake index isn't on the end of a mention.
-                    while (snowflakeIndex < stringIndex + 20 && snowflakeIndex < this.Content.Length && this.Content[snowflakeIndex] != '>')
-                    {
-                        // Append the current character to a StringBuilder.
-                        snowflakeBuilder.Append(this.Content[snowflakeIndex]);
-
-                        // Advance to the next character.
-                        snowflakeIndex++;
-                    }
-
-                    // Try to parse the snowflake as a number
-                    if (ulong.TryParse(snowflakeBuilder.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var channelId)
-                        // Try to fetch the channel from the current guild.
-                        && guild._channels.TryGetValue(channelId, out var channel)
-                        // Make sure we're not adding duplicates.
-                        && !this._mentionedChannels.Contains(channel))
-                    {
-                        // Add the mentioned channel.
-                        this._mentionedChannels.Add(channel);
-                    }
-
-                    // Clear the StringBuilder so other mentions can be parsed.
-                    snowflakeBuilder.Clear();
-                }
-                // If we're at the start of a user or role mention
-                else if (this.Content[stringIndex] == '@' && this.Content[stringIndex - 1] == '<')
-                {
-                    // If the next character isn't out of bounds and is a '&' (role)
-                    var isRole =  this.Content.Length > stringIndex + 1 && this.Content[stringIndex + 1] == '&';
-                    // If the next character isn't out of bounds and is a '!' (outdated nick mention, mostly unused)
-                    var isNickname = this.Content.Length > stringIndex + 1 && this.Content[stringIndex + 1] == '!';
-
-                    // If it's a role or nick mention, skip 2 characters (@& or &!), otherwise skip 1 (@)
-                    stringIndex += isRole || isNickname ? 2 : 1;
-                    snowflakeIndex = stringIndex;
-
-                    while (snowflakeIndex < stringIndex + 20 && snowflakeIndex < this.Content.Length && this.Content[snowflakeIndex] != '>')
-                    {
-                        snowflakeBuilder.Append(this.Content[snowflakeIndex]);
-                        snowflakeIndex++;
-                    }
-
-                    // Make sure we have ourselves a valid snowflake.
-                    if (ulong.TryParse(snowflakeBuilder.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var userOrRoleId))
-                    {
-                        if (isRole && guild._roles.TryGetValue(userOrRoleId, out var role) && !this._mentionedRoles.Contains(role))
-                        {
-                            this._mentionedRoles.Add(role);
-                        }
-                        // Try to add a member casted to a user to the mentioned users.
-                        else if (guild._members.TryGetValue(userOrRoleId, out var member) && !this._mentionedUsers.Contains(member))
-                        {
-                            this._mentionedUsers.Add(member);
-                        }
-                        // Try to get the user from the cache.
-                        else if (this.Discord.TryGetCachedUserInternal(userOrRoleId, out var user) && !this._mentionedUsers.Contains(user))
-                        {
-                            this._mentionedUsers.Add(user);
-                        }
-                    }
-
-                    snowflakeBuilder.Clear();
+                    //uncomment if this breaks
+                    //this._mentionedRoles = this._mentionedRoles.Union(Utilities.GetRoleMentions(this).Select(xid => guild.GetRole(xid))).ToList();
+                    this._mentionedRoles = this._mentionedRoles.Union(this._mentionedRoleIds.Select(xid => guild.GetRole(xid))).ToList();
+                    this._mentionedChannels = this._mentionedChannels.Union(Utilities.GetChannelMentions(this).Select(xid => guild.GetChannel(xid))).ToList();
                 }
             }
+            this._mentionedUsers = mentionedUsers.ToList();
         }
 
         /// <summary>
@@ -561,6 +516,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public Task<DiscordMessage> ModifyAsync(Optional<string> content, Optional<IEnumerable<DiscordEmbed>> embeds = default)
             => this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, content, embeds, this.GetMentions(), default, Array.Empty<DiscordMessageFile>(), null, default);
+
 
         /// <summary>
         /// Edits the message.

--- a/DSharpPlus/EventArgs/Message/MessageUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/MessageUpdateEventArgs.cs
@@ -67,6 +67,9 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the collection of mentioned roles.
         /// </summary>
+        /// <remarks>
+        /// Only shows the mentioned roles from <see cref="DiscordClient.MessageCreated" />. EDITS ARE NOT INCLUDED.
+        /// </remarks>
         public IReadOnlyList<DiscordRole> MentionedRoles { get; internal set; }
 
         /// <summary>


### PR DESCRIPTION
#1331 manually parsed mentions from the message content, which is not what the lib currently does and is considered a breaking change. This reverts #1331 and fixes the bug that #1331 was intended to fix in the first place. See the description of #1331 for the original bug.

Also adds an XML remark on MentionedRoles, specifying that it does not get updated with the Message Updated event. Unsure if that's considered a bug in any regard.