### PR TITLE
Improve performance of RunChecksAsync by removing the conversion of the returned value

### DIFF
--- a/DSharpPlus.CommandsNext/Entities/Command.cs
+++ b/DSharpPlus.CommandsNext/Entities/Command.cs
@@ -149,7 +149,7 @@ namespace DSharpPlus.CommandsNext
         /// <param name="ctx">Context in which the command is executed.</param>
         /// <param name="help">Whether this check is being executed from help or not. This can be used to probe whether command can be run without setting off certain fail conditions (such as cooldowns).</param>
         /// <returns>Pre-execution checks that fail for given context.</returns>
-        public async Task<IEnumerable<CheckBaseAttribute>> RunChecksAsync(CommandContext ctx, bool help)
+        public async Task<List<CheckBaseAttribute>> RunChecksAsync(CommandContext ctx, bool help)
         {
             var fchecks = new List<CheckBaseAttribute>();
             if (this.ExecutionChecks.Any())


### PR DESCRIPTION
# Summary
Improves performance of RunChecksAsync by returning the value as is without wrapping in IEnumerable.
The difference is small, but the method gets called quite often.

# Details
I can't come up with a reason to wrap the list and return it as an IEnumerable here.
The decompile shows what that actually causes:
```cs
public async Task<IEnumerable<CheckBaseAttribute>> RunChecksAsync(CommandContext ctx, bool help)
{
  List<CheckBaseAttribute> fchecks = new List<CheckBaseAttribute>();
  if (this.ExecutionChecks.Any<CheckBaseAttribute>())
  {
    foreach (CheckBaseAttribute ec in (IEnumerable<CheckBaseAttribute>) this.ExecutionChecks)
    {
      bool flag = await ec.ExecuteCheckAsync(ctx, help).ConfigureAwait(false);
      if (!flag)
        fchecks.Add(ec);
    }
  }
  IEnumerable<CheckBaseAttribute> checkBaseAttributes = (IEnumerable<CheckBaseAttribute>) fchecks;
  fchecks = (List<CheckBaseAttribute>) null;
  return checkBaseAttributes;
}
```