### PR TITLE
Fix a small issue where TargetUser can be null in message context men…

### DIFF
--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -709,7 +709,7 @@ namespace DSharpPlus.SlashCommands
                     Type = e.Type
                 };
 
-                if (e.Interaction.Guild != null && e.Interaction.Guild.Members.TryGetValue(e.TargetUser.Id, out var member))
+                if (e.Interaction.Guild != null && e.TargetUser != null && e.Interaction.Guild.Members.TryGetValue(e.TargetUser.Id, out var member))
                 {
                     context.TargetMember = member;
                 }


### PR DESCRIPTION
…u command

# Summary
TargetUser can be null when executing a Context Menu Command on a message. This is a small fix for said issue. I may or may not have missed some other minor things but eh it'll probably fix.

# Details
Add `e.TargetUser != null` to the check before fetching a cached member.

# Notes
it's been a while :^)