### PR TITLE
Use IJsonTypeInfoResolver to ignore Optional<T>

### DIFF
--- a/DSharpPlus.Core/DSharpPlus.Core.csproj
+++ b/DSharpPlus.Core/DSharpPlus.Core.csproj
@@ -12,4 +12,7 @@
         <Description>A C# API for Discord based off DiscordSharp, but rewritten twice to fit the API standards.</Description>
         <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, webhooks</PackageTags>
     </PropertyGroup>
+    <ItemGroup>
+      <PackageReference Include="System.Text.Json" Version="7.0.0-preview.6.22324.4" />
+    </ItemGroup>
 </Project>

--- a/DSharpPlus.Core/Entities/Optional.cs
+++ b/DSharpPlus.Core/Entities/Optional.cs
@@ -110,5 +110,7 @@ namespace DSharpPlus.Core.Entities
         public static explicit operator T(Optional<T> optional) => optional.Value;
         public static bool operator ==(Optional<T> opt, T t) => opt.Equals(t);
         public static bool operator !=(Optional<T> opt, T t) => !opt.Equals(t);
+        public static bool operator ==(Optional<T> lhs, Optional<T> rhs) => lhs.Equals(rhs);
+        public static bool operator !=(Optional<T> lhs, Optional<T> rhs) => !lhs.Equals(rhs);
     }
 }

--- a/DSharpPlus.Core/JsonConverters/DiscordJsonTypeInfoResolverHelper.cs
+++ b/DSharpPlus.Core/JsonConverters/DiscordJsonTypeInfoResolverHelper.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization.Metadata;
+using DSharpPlus.Core.Entities;
+
+namespace DSharpPlus.Core.JsonConverters
+{
+    using ShouldSerializeDel = Func<object, object?, bool>;
+
+    public static class DiscordJsonTypeInfoResolver
+    {
+        public static IJsonTypeInfoResolver Default { get; } = new DefaultJsonTypeInfoResolver
+        {
+            Modifiers =
+            {
+                Modifier
+            }
+        };
+
+        public static void Modifier(JsonTypeInfo typeInfo)
+        {
+            foreach (JsonPropertyInfo prop in typeInfo.Properties)
+            {
+                if (prop.PropertyType.IsConstructedGenericType &&
+                    prop.PropertyType.GetGenericTypeDefinition() == typeof(Optional<>))
+                {
+                    prop.ShouldSerialize = (ShouldSerializeDel)typeof(IgnoreCondition<>)
+                        .MakeGenericType(prop.PropertyType.GetGenericArguments()[0])
+                        .GetField(nameof(IgnoreCondition<int>.Delegate))!
+                        .GetValue(null)!;
+                }
+            }
+        }
+
+        private static class IgnoreCondition<T>
+        {
+            public static readonly ShouldSerializeDel Delegate = ShouldIgnore;
+            private static bool ShouldIgnore(object _, object? value) => Unsafe.Unbox<Optional<T>>(value!).HasValue;
+        }
+    }
+}

--- a/DSharpPlus.Test/Serialization/Core/JsonOptional.cs
+++ b/DSharpPlus.Test/Serialization/Core/JsonOptional.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using DSharpPlus.Core.Entities;
+using DSharpPlus.Core.JsonConverters;
+using NUnit.Framework;
+
+namespace DSharpPlus.Test.Serialization.Core
+{
+    public class JsonOptional
+    {
+        private static readonly JsonSerializerOptions stjOptions = new()
+        {
+            TypeInfoResolver = DiscordJsonTypeInfoResolver.Default
+        };
+
+        [Test]
+        public void Deserialize()
+        {
+            RecordWithOptional? empty = JsonSerializer.Deserialize<RecordWithOptional>("{}", stjOptions);
+            Assert.That(empty, Is.EqualTo(new RecordWithOptional(Optional<int>.Empty)));
+
+            RecordWithOptional? withFive = JsonSerializer.Deserialize<RecordWithOptional>(@"{""Value"": 5}", stjOptions);
+            Assert.That(withFive, Is.EqualTo(new RecordWithOptional(5)));
+        }
+
+        [Test]
+        public void Serialize()
+        {
+            string empty = JsonSerializer.Serialize(new RecordWithOptional(Optional<int>.Empty), stjOptions);
+            Assert.That(empty, Is.EqualTo("{}"));
+
+            string withFive = JsonSerializer.Serialize(new RecordWithOptional(5), stjOptions);
+            Assert.That(withFive, Is.EqualTo(@"{""Value"":5}"));
+        }
+
+        public record RecordWithOptional(Optional<int> Value);
+    }
+}

--- a/DSharpPlus.Test/Serialization/Core/TestPayloadSerialization.cs
+++ b/DSharpPlus.Test/Serialization/Core/TestPayloadSerialization.cs
@@ -43,10 +43,7 @@ namespace DSharpPlus.Test.Serialization.Core
     {
         private static readonly JsonSerializerOptions stjOptions = new()
         {
-            Converters =
-            {
-                new ReflectJsonConverterFactory()
-            }
+            TypeInfoResolver = DiscordJsonTypeInfoResolver.Default
         };
 
         private static readonly Regex NormalizeJsonWhitespace = new("(\"(?:[^\"\\\\]|\\\\.)*\")|\\s+", RegexOptions.Compiled);


### PR DESCRIPTION
# Summary
This provides a `IJsonTypeInfoResolver` through `DiscordJsonTypeInfoResolver.Default` to be used instead of the reflecting serializer currently used.
The class can also be used to get a modifier to attach to any other `DefaultJsonTypeInfoResolver` or used however else needed.

# Notes
This intends to *replace* the `ReflectJsonConverter`. 
Also, this currently requires a preview version of STJ.