### PR TITLE
Make DiscordConfiguration.LogUnknownEvents actually work

### DIFF
--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -223,6 +223,7 @@ namespace DSharpPlus
             this.ReconnectIndefinitely = other.ReconnectIndefinitely;
             this.Intents = other.Intents;
             this.LoggerFactory = other.LoggerFactory;
+            this.LogUnknownEvents = other.LogUnknownEvents;
         }
     }
 }


### PR DESCRIPTION
Makes #1346 actually function as intended.

# Summary
Makes #1346 function.

# Details
Makes #1346 function.

# Changes proposed
* Add `this.LogUnknownEvents = other.LogUnknownEvents;` to `DiscordConfiguration(DiscordConfiguration other)`

# Notes
@OoLunar pls remember to test

I have tested these changes. Previously it would ignore my `LogUnknownEvents` setting and make it `true` even though I set `false`, now it does not. If unset, it defaults to `true` as intended.