### PR TITLE
Change GuildMemberUpdatedEventArgs to contain before and after DiscordMember objects

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1239,46 +1239,21 @@ namespace DSharpPlus
 
         internal async Task OnGuildMemberUpdateEventAsync(TransportMember member, DiscordGuild guild, IEnumerable<ulong> roles, string nick, bool? pending, DateTimeOffset? comunication_disabled_until)
         {
-            var usr = new DiscordUser(member.User) { Discord = this };
-            usr = this.UpdateUserCache(usr);
+            var userAfter = new DiscordUser(member.User) { Discord = this };
+            userAfter = this.UpdateUserCache(userAfter);
 
-            if (!guild.Members.TryGetValue(member.User.Id, out var mbr))
-                mbr = new DiscordMember(usr) { Discord = this, _guild_id = guild.Id };
+            var memberAfter = new DiscordMember(member) { Discord = this, _guild_id = guild.Id };
 
-            var nick_old = mbr.Nickname;
-            var pending_old = mbr.IsPending;
-            var roles_old = new ReadOnlyCollection<DiscordRole>(new List<DiscordRole>(mbr.Roles));
-            var avatar_old = mbr.GuildAvatarHash;
-            var username_old = mbr.Username;
-            var commm_old = mbr.CommunicationDisabledUntil;
-
-            mbr.Username = member.User.Username;
-            mbr._avatarHash = member.AvatarHash;
-            mbr.Nickname = nick;
-            mbr.IsPending = pending;
-            mbr._role_ids.Clear();
-            mbr._role_ids.AddRange(roles);
-            mbr.CommunicationDisabledUntil = comunication_disabled_until;
+            if (!guild.Members.TryGetValue(member.User.Id, out var memberBefore))
+                memberBefore = new DiscordMember(userAfter) { Discord = this, _guild_id = guild.Id };
 
             var ea = new GuildMemberUpdateEventArgs
             {
                 Guild = guild,
-                Member = mbr,
-
-                NicknameAfter = mbr.Nickname,
-                RolesAfter = new ReadOnlyCollection<DiscordRole>(new List<DiscordRole>(mbr.Roles)),
-                AvatarHashAfter = mbr.AvatarHash,
-                UsernameAfter = mbr.Username,
-                PendingAfter = mbr.IsPending,
-                CommunicationDisabledUntilAfter = mbr.CommunicationDisabledUntil,
-
-                NicknameBefore = nick_old,
-                RolesBefore = roles_old,
-                AvatarHashBefore = avatar_old,
-                UsernameBefore = username_old,
-                PendingBefore = pending_old,
-                CommunicationDisabledUntilBefore = commm_old
+                MemberAfter = memberAfter,
+                MemberBefore = memberBefore,
             };
+
             await this._guildMemberUpdated.InvokeAsync(this, ea).ConfigureAwait(false);
         }
 

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -214,7 +214,7 @@ namespace DSharpPlus
 
                 case "guild_member_update":
                     gid = (ulong)dat["guild_id"];
-                    await this.OnGuildMemberUpdateEventAsync(dat.ToDiscordObject<TransportMember>(), this._guilds[gid], dat["roles"].ToDiscordObject<IEnumerable<ulong>>(), (string)dat["nick"], (bool?)dat["pending"], (DateTimeOffset?)dat["communication_disabled_until"]).ConfigureAwait(false);
+                    await this.OnGuildMemberUpdateEventAsync(dat.ToDiscordObject<TransportMember>(), this._guilds[gid]).ConfigureAwait(false);
                     break;
 
                 case "guild_members_chunk":
@@ -1237,7 +1237,7 @@ namespace DSharpPlus
             await this._guildMemberRemoved.InvokeAsync(this, ea).ConfigureAwait(false);
         }
 
-        internal async Task OnGuildMemberUpdateEventAsync(TransportMember member, DiscordGuild guild, IEnumerable<ulong> roles, string nick, bool? pending, DateTimeOffset? comunication_disabled_until)
+        internal async Task OnGuildMemberUpdateEventAsync(TransportMember member, DiscordGuild guild)
         {
             var userAfter = new DiscordUser(member.User) { Discord = this };
             userAfter = this.UpdateUserCache(userAfter);

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -54,19 +54,19 @@ namespace DSharpPlus.Entities
             this._role_ids_lazy = new Lazy<IReadOnlyList<ulong>>(() => new ReadOnlyCollection<ulong>(this._role_ids));
         }
 
-        internal DiscordMember(TransportMember mbr)
+        internal DiscordMember(TransportMember member)
         {
-            this.Id = mbr.User.Id;
-            this.IsDeafened = mbr.IsDeafened;
-            this.IsMuted = mbr.IsMuted;
-            this.JoinedAt = mbr.JoinedAt;
-            this.Nickname = mbr.Nickname;
-            this.PremiumSince = mbr.PremiumSince;
-            this.IsPending = mbr.IsPending;
-            this._avatarHash = mbr.AvatarHash;
-            this._role_ids = mbr.Roles ?? new List<ulong>();
+            this.Id = member.User.Id;
+            this.IsDeafened = member.IsDeafened;
+            this.IsMuted = member.IsMuted;
+            this.JoinedAt = member.JoinedAt;
+            this.Nickname = member.Nickname;
+            this.PremiumSince = member.PremiumSince;
+            this.IsPending = member.IsPending;
+            this._avatarHash = member.AvatarHash;
+            this._role_ids = member.Roles ?? new List<ulong>();
             this._role_ids_lazy = new Lazy<IReadOnlyList<ulong>>(() => new ReadOnlyCollection<ulong>(this._role_ids));
-            this.CommunicationDisabledUntil = mbr.CommunicationDisabledUntil;
+            this.CommunicationDisabledUntil = member.CommunicationDisabledUntil;
         }
 
         /// <summary>
@@ -94,9 +94,7 @@ namespace DSharpPlus.Entities
         /// Gets this member's display name.
         /// </summary>
         [JsonIgnore]
-        public string DisplayName
-            => this.Nickname ?? this.Username;
-
+        public string DisplayName => this.Nickname ?? this.Username;
 
         /// <summary>
         /// How long this member's communication will be supressed for.
@@ -108,8 +106,7 @@ namespace DSharpPlus.Entities
         /// List of role IDs
         /// </summary>
         [JsonIgnore]
-        internal IReadOnlyList<ulong> RoleIds
-            => this._role_ids_lazy.Value;
+        internal IReadOnlyList<ulong> RoleIds => this._role_ids_lazy.Value;
 
         [JsonProperty("roles", NullValueHandling = NullValueHandling.Ignore)]
         internal List<ulong> _role_ids;

--- a/DSharpPlus/EventArgs/Guild/Member/GuildMemberUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/Member/GuildMemberUpdateEventArgs.cs
@@ -46,7 +46,7 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Get the member with pre-update info
         /// </summary>
-        public DiscordMember? MemberBefore { get; internal set; }
+        public DiscordMember MemberBefore { get; internal set; }
 
         /// <summary>
         /// Gets a collection containing post-update roles.
@@ -56,7 +56,7 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets a collection containing pre-update roles.
         /// </summary>
-        public IReadOnlyList<DiscordRole> RolesBefore => this.MemberBefore?.Roles.ToList();
+        public IReadOnlyList<DiscordRole> RolesBefore => this.MemberBefore.Roles.ToList();
 
         /// <summary>
         /// Gets the member's new nickname.
@@ -66,7 +66,7 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the member's old nickname.
         /// </summary>
-        public string NicknameBefore => this.MemberBefore?.Nickname;
+        public string NicknameBefore => this.MemberBefore.Nickname;
 
         /// <summary>
         /// Gets the member's old guild avatar hash.
@@ -76,7 +76,7 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the member's new guild avatar hash.
         /// </summary>
-        public string GuildAvatarHashAfter => this.MemberAfter?.GuildAvatarHash;
+        public string GuildAvatarHashAfter => this.MemberAfter.GuildAvatarHash;
 
         /// <summary>
         /// Gets the member's old username.
@@ -86,7 +86,7 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the member's new username.
         /// </summary>
-        public string UsernameAfter => this.MemberAfter?.Username;
+        public string UsernameAfter => this.MemberAfter.Username;
 
         /// <summary>
         /// Gets the member's old avatar hash.
@@ -96,7 +96,7 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the member's new avatar hash.
         /// </summary>
-        public string AvatarHashAfter => this.MemberAfter?.AvatarHash;
+        public string AvatarHashAfter => this.MemberAfter.AvatarHash;
 
         /// <summary>
         /// Gets whether the member had passed membership screening before the update
@@ -106,7 +106,7 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets whether the member had passed membership screening after the update
         /// </summary>
-        public bool? PendingAfter => this.MemberAfter?.IsPending;
+        public bool? PendingAfter => this.MemberAfter.IsPending;
 
         /// <summary>
         /// Gets the member's communication restriction before the update
@@ -116,7 +116,7 @@ namespace DSharpPlus.EventArgs
         /// <summary>
         /// Gets the member's communication restriction after the update
         /// </summary>
-        public DateTimeOffset? CommunicationDisabledUntilAfter => this.MemberAfter?.CommunicationDisabledUntil;
+        public DateTimeOffset? CommunicationDisabledUntilAfter => this.MemberAfter.CommunicationDisabledUntil;
 
         /// <summary>
         /// Gets the member that was updated.

--- a/DSharpPlus/EventArgs/Guild/Member/GuildMemberUpdateEventArgs.cs
+++ b/DSharpPlus/EventArgs/Guild/Member/GuildMemberUpdateEventArgs.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.EventArgs
@@ -38,69 +39,89 @@ namespace DSharpPlus.EventArgs
         public DiscordGuild Guild { get; internal set; }
 
         /// <summary>
+        /// Get the member with post-update info
+        /// </summary>
+        public DiscordMember MemberAfter { get; internal set; }
+
+        /// <summary>
+        /// Get the member with pre-update info
+        /// </summary>
+        public DiscordMember? MemberBefore { get; internal set; }
+
+        /// <summary>
         /// Gets a collection containing post-update roles.
         /// </summary>
-        public IReadOnlyList<DiscordRole> RolesAfter { get; internal set; }
+        public IReadOnlyList<DiscordRole> RolesAfter => this.MemberAfter.Roles.ToList();
 
         /// <summary>
         /// Gets a collection containing pre-update roles.
         /// </summary>
-        public IReadOnlyList<DiscordRole> RolesBefore { get; internal set; }
+        public IReadOnlyList<DiscordRole> RolesBefore => this.MemberBefore?.Roles.ToList();
 
         /// <summary>
         /// Gets the member's new nickname.
         /// </summary>
-        public string NicknameAfter { get; internal set; }
+        public string NicknameAfter => this.MemberAfter.Nickname;
 
         /// <summary>
         /// Gets the member's old nickname.
         /// </summary>
-        public string NicknameBefore { get; internal set; }
+        public string NicknameBefore => this.MemberBefore?.Nickname;
 
         /// <summary>
-        /// Gets the member's old avatar hash.
+        /// Gets the member's old guild avatar hash.
         /// </summary>
-        public string AvatarHashBefore { get; internal set; }
+        public string GuildAvatarHashBefore => this.MemberBefore.GuildAvatarHash;
 
         /// <summary>
-        /// Gets the member's new avatar hash.
+        /// Gets the member's new guild avatar hash.
         /// </summary>
-        public string AvatarHashAfter { get; internal set; }
+        public string GuildAvatarHashAfter => this.MemberAfter?.GuildAvatarHash;
 
         /// <summary>
         /// Gets the member's old username.
         /// </summary>
-        public string UsernameBefore { get; internal set; }
+        public string UsernameBefore => this.MemberBefore.Username;
 
         /// <summary>
         /// Gets the member's new username.
         /// </summary>
-        public string UsernameAfter { get; internal set; }
+        public string UsernameAfter => this.MemberAfter?.Username;
+
+        /// <summary>
+        /// Gets the member's old avatar hash.
+        /// </summary>
+        public string AvatarHashBefore => this.MemberBefore.AvatarHash;
+
+        /// <summary>
+        /// Gets the member's new avatar hash.
+        /// </summary>
+        public string AvatarHashAfter => this.MemberAfter?.AvatarHash;
 
         /// <summary>
         /// Gets whether the member had passed membership screening before the update
         /// </summary>
-        public bool? PendingBefore { get; internal set; }
+        public bool? PendingBefore => this.MemberBefore.IsPending;
 
         /// <summary>
         /// Gets whether the member had passed membership screening after the update
         /// </summary>
-        public bool? PendingAfter { get; internal set; }
+        public bool? PendingAfter => this.MemberAfter?.IsPending;
 
         /// <summary>
         /// Gets the member's communication restriction before the update
         /// </summary>
-        public DateTimeOffset? CommunicationDisabledUntilBefore { get; internal set; }
+        public DateTimeOffset? CommunicationDisabledUntilBefore => this.MemberBefore.CommunicationDisabledUntil;
 
         /// <summary>
         /// Gets the member's communication restriction after the update
         /// </summary>
-        public DateTimeOffset? CommunicationDisabledUntilAfter { get; internal set; }
+        public DateTimeOffset? CommunicationDisabledUntilAfter => this.MemberAfter?.CommunicationDisabledUntil;
 
         /// <summary>
         /// Gets the member that was updated.
         /// </summary>
-        public DiscordMember Member { get; internal set; }
+        public DiscordMember Member => this.MemberAfter;
 
         internal GuildMemberUpdateEventArgs() : base() { }
     }


### PR DESCRIPTION
# Summary
When user properties change e.g. Username and Avatar (not guild avatar) GuildMemberUpdated event is broadcasted. This makes it easier to grab the old username or avatar from the cached user (if it exists). 

# Changes proposed
Add MemberAfter and MemberBefore properties to GuildMemberUpdatedEventArgs.
NicknameBefore/After, RolesBefore/After, (non-guild)AvatarBefore/After are now just shortcuts to properties of MemberAfter and MemberBefore respectively. 