### PR TITLE
Fix #1325 - WebhookBuilder Throws Bad Request

### DIFF
--- a/DSharpPlus/Net/Abstractions/Rest/RestWebhookPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestWebhookPayloads.cs
@@ -77,7 +77,7 @@ namespace DSharpPlus.Net.Abstractions
         public IEnumerable<DiscordEmbed> Embeds { get; set; }
 
         [JsonProperty("allowed_mentions", NullValueHandling = NullValueHandling.Ignore)]
-        public IEnumerable<IMention> Mentions { get; set; }
+        public DiscordMentions Mentions { get; set; }
 
         [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
         public IEnumerable<DiscordActionRowComponent> Components { get; set; }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -2869,7 +2869,7 @@ namespace DSharpPlus.Net
         {
             builder.Validate(true);
 
-            var mentions = builder.Mentions != null ? new DiscordMentions(builder.Mentions, builder.Mentions?.Any() ?? false) : null;
+            var mentions = builder.Mentions != null ? new DiscordMentions(builder.Mentions, builder.Mentions.Any()) : null;
 
             var pld = new RestWebhookMessageEditPayload
             {

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -2869,11 +2869,13 @@ namespace DSharpPlus.Net
         {
             builder.Validate(true);
 
+            var mentions = builder.Mentions != null ? new DiscordMentions(builder.Mentions, builder.Mentions?.Any() ?? false) : null;
+
             var pld = new RestWebhookMessageEditPayload
             {
                 Content = builder.Content,
                 Embeds = builder.Embeds,
-                Mentions = new DiscordMentions(builder.Mentions ?? Mentions.All, builder.Mentions?.Any() ?? false),
+                Mentions =  mentions,
                 Components = builder.Components,
                 Attachments = attachments
             };

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -2873,7 +2873,7 @@ namespace DSharpPlus.Net
             {
                 Content = builder.Content,
                 Embeds = builder.Embeds,
-                Mentions = builder.Mentions,
+                Mentions = new DiscordMentions(builder.Mentions ?? Mentions.All, builder.Mentions?.Any() ?? false),
                 Components = builder.Components,
                 Attachments = attachments
             };


### PR DESCRIPTION
# Summary
Fixes #1325 by Changing `RestWebhookPayloads.Mentions` to use `DiscordMentions` instead of `IEnumerable<IMention>`

# Details
the api expects `"users":[]`, `"roles":[]`, or `"parse":[]` for the allowed_mentions field. The DiscordJson serializer is populating this field with `"id": 123456...` instead which is causing an exception when sending the request. This inadvertently keeps the interaction that created the request alive, seemingly forever.

# Notes
I haven't tested this to any real extent and know very little of this lib... so you know... *shrug