### PR TITLE
Fix memberBefore missing roles in GuildMemberUpdateEventArgs when not…

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1240,12 +1240,12 @@ namespace DSharpPlus
         internal async Task OnGuildMemberUpdateEventAsync(TransportMember member, DiscordGuild guild)
         {
             var userAfter = new DiscordUser(member.User) { Discord = this };
-            userAfter = this.UpdateUserCache(userAfter);
+            _ = this.UpdateUserCache(userAfter);
 
             var memberAfter = new DiscordMember(member) { Discord = this, _guild_id = guild.Id };
 
             if (!guild.Members.TryGetValue(member.User.Id, out var memberBefore))
-                memberBefore = new DiscordMember(userAfter) { Discord = this, _guild_id = guild.Id };
+                memberBefore = new DiscordMember(member) { Discord = this, _guild_id = guild.Id };
 
             var ea = new GuildMemberUpdateEventArgs
             {

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1245,7 +1245,11 @@ namespace DSharpPlus
             var memberAfter = new DiscordMember(member) { Discord = this, _guild_id = guild.Id };
 
             if (!guild.Members.TryGetValue(member.User.Id, out var memberBefore))
+            {
                 memberBefore = new DiscordMember(member) { Discord = this, _guild_id = guild.Id };
+            }
+
+            guild._members.AddOrUpdate(member.User.Id, memberAfter, (_, _) => memberAfter);
 
             var ea = new GuildMemberUpdateEventArgs
             {

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1245,9 +1245,7 @@ namespace DSharpPlus
             var memberAfter = new DiscordMember(member) { Discord = this, _guild_id = guild.Id };
 
             if (!guild.Members.TryGetValue(member.User.Id, out var memberBefore))
-            {
                 memberBefore = new DiscordMember(member) { Discord = this, _guild_id = guild.Id };
-            }
 
             guild._members.AddOrUpdate(member.User.Id, memberAfter, (_, _) => memberAfter);
 


### PR DESCRIPTION
# Summary
Fix memberBefore missing roles in GuildMemberUpdateEventArgs when it's not retrieved from cache.

# Details
When the pre-update member object is not in the guild member cache, the copy is created from a DiscordUser object which doesn't have roles. 

# Changes proposed
Initalize memberBefore copy from TransportMember object so that it populates roles. 
In addition, update cached guild member in OnGuildMemberUpdateEventAsync internal event handler

# Notes
Follow-up to #1359 