### PR TITLE
Add CNext check for message content intent

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -137,7 +137,7 @@ namespace DSharpPlus
             this._webSocketClient.ExceptionThrown += SocketOnException;
 
             var gwuri = new QueryUriBuilder(this.GatewayUri)
-                .AddParameter("v", "9")
+                .AddParameter("v", "10")
                 .AddParameter("encoding", "json");
 
             if (this.Configuration.GatewayCompressionLevel == GatewayCompressionLevel.Stream)

--- a/DSharpPlus/DiscordIntents.cs
+++ b/DSharpPlus/DiscordIntents.cs
@@ -165,6 +165,14 @@ namespace DSharpPlus
         DirectMessageTyping = 1 << 14,
 
         /// <summary>
+        /// Whether to include message content. This is a privileged event.
+        ///
+        /// <para>Message content includes text, attachments, embeds, components, and reply content.</para>
+        /// <para>This intent is required for CommandsNext to function correctly.</para>
+        /// </summary>
+        MessageContents = 1 << 15,
+
+        /// <summary>
         /// Whether to include scheduled event messages.
         /// //TODO: reference events
         /// </summary>
@@ -181,6 +189,6 @@ namespace DSharpPlus
         /// Includes all intents.
         /// <para>The <see cref="DiscordIntents.GuildMembers"/> and <see cref="DiscordIntents.GuildPresences"/> intents are privileged, and must be enabled on the bot's developer page.</para>
         /// </summary>
-        All = AllUnprivileged | GuildMembers | GuildPresences
+        All = AllUnprivileged | GuildMembers | GuildPresences | MessageContents
     }
 }

--- a/DSharpPlus/Entities/Interaction/Components/TextInputComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/TextInputComponent.cs
@@ -92,6 +92,7 @@ namespace DSharpPlus.Entities
             this.CustomId = customId;
             this.Type = ComponentType.FormInput;
             this.Label = label;
+            this.Required = required;
             this.Placeholder = placeholder;
             this.MinimumLength = min_length;
             this.MaximumLength = max_length;

--- a/DSharpPlus/Net/Rest/Endpoints.cs
+++ b/DSharpPlus/Net/Rest/Endpoints.cs
@@ -27,7 +27,7 @@ namespace DSharpPlus.Net
 {
     internal static class Endpoints
     {
-        public const string API_VERSION = "9";
+        public const string API_VERSION = "10";
         public const string BASE_URI = "https://discord.com/api/v" + API_VERSION;
 
         public const string ORIGINAL = "/@original";

--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -184,7 +184,7 @@ namespace DSharpPlus
         }
 
         internal static bool HasMessageIntents(DiscordIntents intents)
-            => intents.HasIntent(DiscordIntents.GuildMessages) || intents.HasIntent(DiscordIntents.DirectMessages);
+            => (intents.HasIntent(DiscordIntents.GuildMessages) && intents.HasIntent(DiscordIntents.MessageContents)) || intents.HasIntent(DiscordIntents.DirectMessages);
 
         internal static bool HasReactionIntents(DiscordIntents intents)
             => intents.HasIntent(DiscordIntents.GuildMessageReactions) || intents.HasIntent(DiscordIntents.DirectMessageReactions);


### PR DESCRIPTION
# Summary
As the title says.

# Details
CNext logs an error if the intent config doesn't specify `GuildMessages` or `DirectMessages`, but as of V10, it's required to have the `MessageContents` intent as well.

# Changes proposed
- Add `DiscordIntents.MessageContents`
- Add `DiscordIntents.MessageContents` to `DiscordIntents.All`
- Add `DiscordIntents.MessageContents` to `Utilities.HasMessageIntents`
- Bump GW and API version to 10 (V10).

# Notes
This is a breaking change and should be announced on the server.