### PR TITLE
categorization for the cnext default help command

### DIFF
--- a/DSharpPlus.CommandsNext/Attributes/CategoryAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/CategoryAttribute.cs
@@ -1,0 +1,43 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DSharpPlus.CommandsNext.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public sealed class CategoryAttribute : Attribute
+    {
+        public string? Name { get; }
+
+        public CategoryAttribute(string? name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentNullException(nameof(name), "Command category names cannot be null, empty, or all-whitespace.");
+
+            this.Name = name;
+        }
+    }
+}

--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -589,6 +589,10 @@ namespace DSharpPlus.CommandsNext
                             commandBuilder.WithHiddenStatus(true);
                             break;
 
+                        case CategoryAttribute c:
+                            commandBuilder.WithCategory(c.Name);
+                            break;
+
                         default:
                             commandBuilder.WithCustomAttribute(xa);
                             break;

--- a/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
+++ b/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
@@ -98,7 +98,21 @@ namespace DSharpPlus.CommandsNext.Converters
         /// <returns>This help formatter.</returns>
         public override BaseHelpFormatter WithSubcommands(IEnumerable<Command> subcommands)
         {
-            this.EmbedBuilder.AddField(this.Command is not null ? "Subcommands" : "Commands", string.Join(", ", subcommands.Select(x => Formatter.InlineCode(x.Name))), false);
+            var categories = subcommands.Where(xm => xm.Category != null).Select(xm => xm.Category).Distinct();
+
+            if (categories.Count() == 0)
+            {
+                this.EmbedBuilder.AddField(this.Command is not null ? "Subcommands" : "Commands", string.Join(", ", subcommands.Select(x => Formatter.InlineCode(x.Name))), false);
+
+                return this;
+            }
+
+            foreach(var category in categories)
+            {
+                this.EmbedBuilder.AddField(category, string.Join(", ", subcommands.Where(xm => xm.Category == category).Select(xm => Formatter.InlineCode(xm.Name))), false);
+            }
+
+            this.EmbedBuilder.AddField("Uncategorized commands", string.Join(", ", subcommands.Where(xm => xm.Category == null).Select(xm => Formatter.InlineCode(xm.Name))), false);
 
             return this;
         }

--- a/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
+++ b/DSharpPlus.CommandsNext/Converters/DefaultHelpFormatter.cs
@@ -98,21 +98,21 @@ namespace DSharpPlus.CommandsNext.Converters
         /// <returns>This help formatter.</returns>
         public override BaseHelpFormatter WithSubcommands(IEnumerable<Command> subcommands)
         {
-            var categories = subcommands.Where(xm => xm.Category != null).Select(xm => xm.Category).Distinct();
+            
+            var categories = subcommands.GroupBy(xm => xm.Category).OrderBy(xm => xm.Key == null).ThenBy(xm => xm.Key);
 
-            if (categories.Count() == 0)
+            // no known categories, proceed without categorization
+            if (categories.Count() == 1 && categories.Single().Key == null)
             {
                 this.EmbedBuilder.AddField(this.Command is not null ? "Subcommands" : "Commands", string.Join(", ", subcommands.Select(x => Formatter.InlineCode(x.Name))), false);
 
                 return this;
             }
 
-            foreach(var category in categories)
+            foreach (var category in categories)
             {
-                this.EmbedBuilder.AddField(category, string.Join(", ", subcommands.Where(xm => xm.Category == category).Select(xm => Formatter.InlineCode(xm.Name))), false);
+                this.EmbedBuilder.AddField(category.Key ?? "Uncategorized commands", string.Join(", ", category.Select(xm => Formatter.InlineCode(xm.Name))), false);
             }
-
-            this.EmbedBuilder.AddField("Uncategorized commands", string.Join(", ", subcommands.Where(xm => xm.Category == null).Select(xm => Formatter.InlineCode(xm.Name))), false);
 
             return this;
         }

--- a/DSharpPlus.CommandsNext/Entities/Builders/CommandBuilder.cs
+++ b/DSharpPlus.CommandsNext/Entities/Builders/CommandBuilder.cs
@@ -42,6 +42,11 @@ namespace DSharpPlus.CommandsNext.Builders
         public string Name { get; private set; } = null!;
 
         /// <summary>
+        /// Gets the category set for this command.
+        /// </summary>
+        public string? Category { get; private set; }
+
+        /// <summary>
         /// Gets the aliases set for this command.
         /// </summary>
         public IReadOnlyList<string> Aliases { get; }
@@ -123,6 +128,17 @@ namespace DSharpPlus.CommandsNext.Builders
                 throw new ArgumentException("Command name cannot be one of its aliases.", nameof(name));
 
             this.Name = name;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the category for this command.
+        /// </summary>
+        /// <param name="category">Category for this command. May be <see langword="null"/>.</param>
+        /// <returns>This builder.</returns>
+        public CommandBuilder WithCategory(string? category)
+        {
+            this.Category = category;
             return this;
         }
 
@@ -265,6 +281,7 @@ namespace DSharpPlus.CommandsNext.Builders
                     ? throw new InvalidOperationException($"Cannot build a command with an invalid name. Use the method {nameof(this.WithName)} to set a valid name.")
                     : this.Name,
 
+                Category = this.Category,
                 Description = this.Description,
                 Aliases = this.Aliases,
                 ExecutionChecks = this.ExecutionChecks,

--- a/DSharpPlus.CommandsNext/Entities/Command.cs
+++ b/DSharpPlus.CommandsNext/Entities/Command.cs
@@ -41,6 +41,11 @@ namespace DSharpPlus.CommandsNext
         public string Name { get; internal set; } = string.Empty;
 
         /// <summary>
+        /// Gets the category this command belongs to.
+        /// </summary>
+        public string? Category { get; internal set; } = null;
+
+        /// <summary>
         /// Gets this command's qualified name (i.e. one that includes all module names).
         /// </summary>
         public string QualifiedName => this.Parent is not null ? string.Concat(this.Parent.QualifiedName, " ", this.Name) : this.Name;


### PR DESCRIPTION
as discussed approximately here: https://discord.com/channels/379378609942560770/379386901725052928/995957157298192447

this PR adds support for categorizing commands using a new `CategoryAttribute`. the categorizing behaviour is only invoked when at least one command in the searched batch is marked with the attribute, and it can be disabled by commenting out all related attributes - i do not believe a config toggle makes sense here, given the configuration is already quite huge.