### PR TITLE
fix #1393

### DIFF
--- a/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
@@ -115,9 +115,9 @@ namespace DSharpPlus.Interactivity.EventHandling
             {
                 if (req._message.Id == eventargs.Message.Id)
                 {
-                    if (req._collected.Any(x => x.Emoji == eventargs.Emoji && x.Users.Any(y => y.Id == eventargs.User.Id)))
+                    if (req._collected.Any(x => x.Emoji == eventargs.Emoji && x.Users.Any(y => y.Id != eventargs.User.Id)))
                     {
-                        var reaction = req._collected.First(x => x.Emoji == eventargs.Emoji && x.Users.Any(y => y.Id == eventargs.User.Id));
+                        var reaction = req._collected.First(x => x.Emoji == eventargs.Emoji && x.Users.Any(y => y.Id != eventargs.User.Id));
                         req._collected.TryRemove(reaction);
                         reaction.Users.Add(eventargs.User);
                         req._collected.Add(reaction);


### PR DESCRIPTION
fixes #1393 

currently, `CollectReactionsAsync` will return a list of all individual reactions, with their count set to 1 and the reacting user being the only user in the `Reaction` object. this also means that if two users react with the same reaction, `CollectReactionsAsync` will return two different objects. this has been fixed in this pull request.