### PR TITLE
Fix Permissions.All not including Permissions.ModerateMembers 

### DIFF
--- a/DSharpPlus/Enums/Permission.cs
+++ b/DSharpPlus/Enums/Permission.cs
@@ -27,7 +27,7 @@ namespace DSharpPlus
 {
     public static class PermissionMethods
     {
-        internal static Permissions FULL_PERMS { get; } = (Permissions)1099511627775L;
+        internal static Permissions FULL_PERMS { get; } = (Permissions)2199023255551L;
 
         /// <summary>
         /// Calculates whether this permission set contains the given permission.
@@ -92,7 +92,7 @@ namespace DSharpPlus
         /// Indicates all permissions are granted
         /// </summary>
         [PermissionString("All permissions")]
-        All = 1099511627775,
+        All = 2199023255551,
 
         /// <summary>
         /// Allows creation of instant channel invites.


### PR DESCRIPTION
# Summary
This fixes Permissions.All not including the ModerateMembers permission.

# Details
Permissions.All in binary is 1 bit off of including every possible permissions, this notably breaks things like Permissions.ToPermissionString() not outputing the expected "Moderate Members" string and possibly others i haven't noticed

# Changes proposed
* Double the number of the All value so that the ModerateMembers bit is set
* Also double FULL_PERMS because it is using the same hard coded value

# Notes
This could potentially break applications using the old raw Permissions.All value