### PR TITLE
Ensure packet queue size property is copied.

### DIFF
--- a/DSharpPlus.VoiceNext/VoiceNextConfiguration.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConfiguration.cs
@@ -59,6 +59,7 @@ namespace DSharpPlus.VoiceNext
         {
             this.AudioFormat = new AudioFormat(other.AudioFormat.SampleRate, other.AudioFormat.ChannelCount, other.AudioFormat.VoiceApplication);
             this.EnableIncoming = other.EnableIncoming;
+            this.PacketQueueSize = other.PacketQueueSize;
         }
     }
 }


### PR DESCRIPTION
# Summary
Fixes #1388 

# Details
Previously in the VoiceNextConfiguration, the packet queue size property is not copied for the copy constructor. The property has now been added.

# Changes proposed
* Add property to be copied.