### PR TITLE
Remove critical log message for non connecting clients

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -195,8 +195,6 @@ namespace DSharpPlus
                 this.Logger.LogDebug(LoggerEvents.ConnectionClose, "Connection closed ({CloseCode}, '{CloseMessage}')", e.CloseCode, e.CloseMessage);
                 await this._socketClosed.InvokeAsync(this, e).ConfigureAwait(false);
 
-
-
                 if (this.Configuration.AutoReconnect && (e.CloseCode < 4001 || e.CloseCode >= 5000))
                 {
                     this.Logger.LogCritical(LoggerEvents.ConnectionClose, "Connection terminated ({CloseCode}, '{CloseMessage}'), reconnecting", e.CloseCode, e.CloseMessage);
@@ -211,7 +209,7 @@ namespace DSharpPlus
                 }
                 else
                 {
-                    this.Logger.LogCritical(LoggerEvents.ConnectionClose, "Connection terminated ({CloseCode}, '{CloseMessage}')", e.CloseCode, e.CloseMessage);
+                    this.Logger.LogInformation(LoggerEvents.ConnectionClose, "Connection terminated ({CloseCode}, '{CloseMessage}')", e.CloseCode, e.CloseMessage);
                 }
             }
         }


### PR DESCRIPTION
# Summary
Fixes #1290

# Details
The logs should not record a critical message if the client chooses not to connect or disconnects with a non-error op code.

# Changes proposed
* Change log output to not be critical in these cases.