### PR TITLE
Implement Guild Specific Member Banners

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -647,16 +647,16 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Constructs the url for a guild member's avatar, defaulting to the user's avatar if none is set.
+        /// Constructs the url for a guild member's banner, defaulting to the user's avatar if none is set.
         /// </summary>
-        /// <param name="imageFormat">The image format of the avatar to get.</param>
-        /// <param name="imageSize">The maximum size of the avatar. Must be a power of two, minimum 16, maximum 4096.</param>
+        /// <param name="imageFormat">The image format of the banner to get.</param>
+        /// <param name="imageSize">The maximum size of the banner. Must be a power of two, minimum 16, maximum 4096.</param>
         /// <returns>The URL of the user's avatar.</returns>
         public string GetGuildBannerUrl(ImageFormat imageFormat, ushort imageSize = 1024)
         {
             // Run this if statement before any others to prevent running the if statements twice.
             if (string.IsNullOrWhiteSpace(this.GuildBannerHash))
-                return this.GetAvatarUrl(imageFormat, imageSize);
+                return this.BannerUrl;
 
             if (imageFormat == ImageFormat.Unknown)
                 throw new ArgumentException("You must specify valid image format.", nameof(imageFormat));

--- a/DSharpPlus/Net/Abstractions/Transport/TransportMember.cs
+++ b/DSharpPlus/Net/Abstractions/Transport/TransportMember.cs
@@ -32,6 +32,9 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("avatar", NullValueHandling = NullValueHandling.Ignore)]
         public string AvatarHash { get; internal set; }
 
+        [JsonProperty("avatar", NullValueHandling = NullValueHandling.Ignore)]
+        public string BannerHash { get; internal set; }
+
         [JsonProperty("user", NullValueHandling = NullValueHandling.Ignore)]
         public TransportUser User { get; internal set; }
 

--- a/DSharpPlus/Net/Abstractions/Transport/TransportMember.cs
+++ b/DSharpPlus/Net/Abstractions/Transport/TransportMember.cs
@@ -32,7 +32,7 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("avatar", NullValueHandling = NullValueHandling.Ignore)]
         public string AvatarHash { get; internal set; }
 
-        [JsonProperty("avatar", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("banner", NullValueHandling = NullValueHandling.Ignore)]
         public string BannerHash { get; internal set; }
 
         [JsonProperty("user", NullValueHandling = NullValueHandling.Ignore)]

--- a/DSharpPlus/Net/Rest/Endpoints.cs
+++ b/DSharpPlus/Net/Rest/Endpoints.cs
@@ -92,5 +92,6 @@ namespace DSharpPlus.Net
         public const string STICKERS = "/stickers";
         public const string STICKERPACKS = "/sticker-packs";
         public const string STAGE_INSTANCES = "/stage-instances";
+        public const string BANNERS = "/banners";
     }
 }


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Implements functionality for Guild Specific Member Banners

# Details
Similar to Guild Avatars There are Guild Profile Banners for Nitro Users. 

This adds support to get the image URL for the Guild Banner. 
`GuildBannerUrl`  Keeping the same naming convention as `GuildAvatarUrl`

# Notes
