### PR TITLE
Fix ChannelTypes argument ignored in DiscordChannelSelectComponent

### DIFF
--- a/DSharpPlus/Entities/Interaction/Components/Selects/DiscordChannelSelectComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/Selects/DiscordChannelSelectComponent.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities
@@ -68,6 +69,7 @@ namespace DSharpPlus.Entities
         {
             this.CustomId = customId;
             this.Placeholder = placeholder;
+            this.ChannelTypes = channelTypes?.ToList();
             this.Disabled = disabled;
             this.MinimumSelectedValues = minOptions;
             this.MaximumSelectedValues = maxOptions;


### PR DESCRIPTION
# Summary
#1251 added DiscordChannelSelectComponent. The channelTypes parameter was ignored when a new instance was created.

# Details
IEnumerable parameter is converted into a list and assigned to the class variable.

# Changes proposed
-

# Notes
-