### PR TITLE
Make IOptional public

### DIFF
--- a/DSharpPlus/Entities/Optional.cs
+++ b/DSharpPlus/Entities/Optional.cs
@@ -59,7 +59,7 @@ namespace DSharpPlus.Entities
     }
 
     // used internally to make serialization more convenient, do NOT change this, do NOT implement this yourself
-    internal interface IOptional
+    public interface IOptional
     {
         bool HasValue { get; }
         object RawValue { get; } // must NOT throw InvalidOperationException


### PR DESCRIPTION
# Summary
This allows for `Optional<T>` to be used through reflection without the use of generics (by casting to `IOptional`).

# Details
With `IOptional` being public, this paves way for user defined argument converters (particularly when the converters themselves are invoked).

# Changes proposed
* Make `IOptional` public.

# Notes
Untested. See https://discord.com/channels/379378609942560770/379386901725052928/1039981684415799397 for light details.