### PR TITLE
Add AttributeTargets.Method on GuildOnlyAttribute since it's missing

### DIFF
--- a/DSharpPlus.SlashCommands/Attributes/GuildOnlyAttribute.cs
+++ b/DSharpPlus.SlashCommands/Attributes/GuildOnlyAttribute.cs
@@ -27,6 +27,6 @@ namespace DSharpPlus.SlashCommands
     /// <summary>
     /// Indicates that a global application command cannot be invoked in DMs.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
     public class GuildOnlyAttribute : Attribute { }
 }


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Adds AttributeTargets.Method to GuildOnlyAttribute so it can be used on SlashCommand Methods

# Details
The SlashCommands extension has the code for handling these on a per-method basis, but it can not be used on a per-method basis. This PR fixes that.

# Notes
bing bong ding dong