### PR TITLE
Add abstractions for MessageBuilders (IDiscordMessageBuilder)

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -754,7 +754,7 @@ namespace DSharpPlus
         {
             builder.Validate(true);
 
-            return await this.ApiClient.EditMessageAsync(channel_id, message_id, builder.Content, new Optional<IEnumerable<DiscordEmbed>>(builder.Embeds), builder.Mentions, builder.Components, builder.Files, suppressEmbeds ? MessageFlags.SuppressedEmbeds : null, attachments).ConfigureAwait(false);
+            return await this.ApiClient.EditMessageAsync(channel_id, message_id, builder.Content, new Optional<IEnumerable<DiscordEmbed>>(builder.Embeds), builder._mentions, builder.Components, builder.Files, suppressEmbeds ? MessageFlags.SuppressedEmbeds : null, attachments).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -225,7 +225,7 @@ namespace DSharpPlus.Test
                 // Verify that the lib resets the position when asked
                 var builder = new DiscordMessageBuilder()
                     .WithContent("Testing the `Dictionary<string, stream>` Overload with resetting the postion turned on.")
-                    .WithFiles(new Dictionary<string, Stream>() { { "ADumbFile1.txt", fs } }, true);
+                    .AddFiles(new Dictionary<string, Stream>() { { "ADumbFile1.txt", fs } }, true);
 
                 await builder.SendAsync(ctx.Channel);
                 await builder.SendAsync(ctx.Channel);
@@ -234,7 +234,7 @@ namespace DSharpPlus.Test
 
                 //Verify the lib doesnt reset the position.  THe file sent should have 0 bytes.
                 builder.WithContent("Testing the `WithFile(Dictionary<string, stream> files)` Overload with resetting the postion turned off  The 2nd file sent should have 0 bytes.")
-                    .WithFiles(new Dictionary<string, Stream>() { { "ADumbFile1.txt", fs } }, false);
+                    .AddFiles(new Dictionary<string, Stream>() { { "ADumbFile1.txt", fs } }, false);
 
                 await builder.SendAsync(ctx.Channel);
                 await builder.SendAsync(ctx.Channel);
@@ -245,7 +245,7 @@ namespace DSharpPlus.Test
 
                 // Verify that the lib resets the position when asked
                 builder.WithContent("Testing the `WithFile(Stream stream)` Overload with resetting the postion turned on.")
-                    .WithFile(fs, true);
+                    .AddFile(fs, true);
 
                 await builder.SendAsync(ctx.Channel);
                 await builder.SendAsync(ctx.Channel);
@@ -254,7 +254,7 @@ namespace DSharpPlus.Test
 
                 //Verify the lib doesnt reset the position.  THe file sent should have 0 bytes.
                 builder.WithContent("Testing the `WithFile(Stream stream)` Overload with resetting the postion turned off.  The 2nd file sent should have 0 bytes.")
-                    .WithFile(fs, false);
+                    .AddFile(fs, false);
 
                 await builder.SendAsync(ctx.Channel);
                 await builder.SendAsync(ctx.Channel);
@@ -265,7 +265,7 @@ namespace DSharpPlus.Test
 
                 // Verify that the lib resets the position when asked
                 builder.WithContent("Testing the `WithFile(string fileName, Stream stream)` Overload with resetting the postion turned on.")
-                    .WithFile("ADumbFile2.txt", fs, true);
+                    .AddFile("ADumbFile2.txt", fs, true);
 
                 await builder.SendAsync(ctx.Channel);
                 await builder.SendAsync(ctx.Channel);
@@ -274,7 +274,7 @@ namespace DSharpPlus.Test
 
                 //Verify the lib doesnt reset the position.  THe file sent should have 0 bytes.
                 builder.WithContent("Testing the `WithFile(string fileName, Stream stream)` Overload with resetting the postion turned off.  The 2nd file sent should have 0 bytes.")
-                    .WithFile("ADumbFile2.txt", fs, false);
+                    .AddFile("ADumbFile2.txt", fs, false);
 
                 await builder.SendAsync(ctx.Channel);
                 await builder.SendAsync(ctx.Channel);
@@ -299,7 +299,7 @@ namespace DSharpPlus.Test
                 var builder = new DiscordMessageBuilder();
                 builder.WithContent("Here is a really dumb file that i am testing with.");
                 //builder.WithFile(fileName);
-                builder.WithFile(fs);
+                builder.AddFile(fs);
 
                 foreach (var file in builder.Files)
                 {

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -504,7 +504,7 @@ namespace DSharpPlus.Entities
         public async Task<DiscordMessage> ModifyAsync(DiscordMessageBuilder builder, bool suppressEmbeds = false, IEnumerable<DiscordAttachment> attachments = default)
         {
             builder.Validate(true);
-            return await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, builder.Content, new Optional<IEnumerable<DiscordEmbed>>(builder.Embeds), builder.Mentions, builder.Components, builder.Files, suppressEmbeds ? MessageFlags.SuppressedEmbeds : null, attachments).ConfigureAwait(false);
+            return await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, builder.Content, new Optional<IEnumerable<DiscordEmbed>>(builder.Embeds), builder._mentions, builder.Components, builder.Files, suppressEmbeds ? MessageFlags.SuppressedEmbeds : null, attachments).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -523,7 +523,7 @@ namespace DSharpPlus.Entities
             var builder = new DiscordMessageBuilder();
             action(builder);
             builder.Validate(true);
-            return await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, builder.Content, new Optional<IEnumerable<DiscordEmbed>>(builder.Embeds), builder.Mentions, builder.Components, builder.Files, suppressEmbeds ? MessageFlags.SuppressedEmbeds : null, attachments).ConfigureAwait(false);
+            return await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, builder.Content, new Optional<IEnumerable<DiscordEmbed>>(builder.Embeds), builder._mentions, builder.Components, builder.Files, suppressEmbeds ? MessageFlags.SuppressedEmbeds : null, attachments).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/IDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/IDiscordMessageBuilder.cs
@@ -35,44 +35,132 @@ namespace DSharpPlus.Entities
     public interface IDiscordMessageBuilder<T> where T : IDiscordMessageBuilder<T>
         // This has got to be the most big brain thing I have ever done with interfaces lmfao
     {
+        /// <summary>
+        /// Getter / setter for message content.
+        /// </summary>
         string Content { get; set; }
 
+        /// <summary>
+        /// Whether this message will play as a text-to-speech message.
+        /// </summary>
         bool IsTTS { get; set; }
 
+        /// <summary>
+        /// All embeds on this message.
+        /// </summary>
         IReadOnlyList<DiscordEmbed> Embeds { get; }
 
+        /// <summary>
+        /// All files on this message.
+        /// </summary>
         IReadOnlyList<DiscordMessageFile> Files { get; }
 
+        /// <summary>
+        /// All components on this message.
+        /// </summary>
         IReadOnlyList<DiscordActionRowComponent> Components { get; }
 
+        /// <summary>
+        /// All allowed mentions on this message.
+        /// </summary>
         IReadOnlyList<IMention> Mentions { get; }
 
+        /// <summary>
+        /// Adds content to this message
+        /// </summary>
+        /// <param name="content">Message content to use</param>
+        /// <returns></returns>
         T WithContent(string content);
 
+        /// <summary>
+        /// Adds components to this message. Each call should append to a new row.
+        /// </summary>
+        /// <param name="components">Components to add.</param>
+        /// <returns></returns>
         T AddComponents(params DiscordComponent[] components);
 
+        /// <summary>
+        /// Adds components to this message. Each call should append to a new row.
+        /// </summary>
+        /// <param name="components">Components to add.</param>
+        /// <returns></returns>
         T AddComponents(IEnumerable<DiscordComponent> components);
 
+        /// <summary>
+        /// Adds an action row component to this message.
+        /// </summary>
+        /// <param name="components">Action row to add to this message. Should contain child components.</param>
+        /// <returns></returns>
         T AddComponents(IEnumerable<DiscordActionRowComponent> components);
 
+        /// <summary>
+        /// Sets whether this message should play as a text-to-speech message.
+        /// </summary>
+        /// <param name="isTTS"></param>
+        /// <returns></returns>
         T WithTTS(bool isTTS);
 
+        /// <summary>
+        /// Adds an embed to this message.
+        /// </summary>
+        /// <param name="embed">Embed to add.</param>
+        /// <returns></returns>
         T AddEmbed(DiscordEmbed embed);
 
+        /// <summary>
+        /// Adds multiple embeds to this message.
+        /// </summary>
+        /// <param name="embeds">Collection of embeds to add.</param>
+        /// <returns></returns>
         T AddEmbeds(IEnumerable<DiscordEmbed> embeds);
 
+        /// <summary>
+        /// Attaches a file to this message.
+        /// </summary>
+        /// <param name="fileName">Name of the file to attach.</param>
+        /// <param name="stream">Stream containing said file's contents.</param>
+        /// <param name="resetStream">Whether to reset the stream to position 0 after sending.</param>
+        /// <returns></returns>
         T AddFile(string fileName, Stream stream, bool resetStream = false);
 
+        /// <summary>
+        /// Attaches a file to this message.
+        /// </summary>
+        /// <param name="stream">FileStream pointiong to the file to attach.</param>
+        /// <param name="resetStream">Whether to reset the stream position to 0 after sending.</param>
+        /// <returns></returns>
         T AddFile(FileStream stream, bool resetStream = false);
 
+        /// <summary>
+        /// Attaches multiple files to this message.
+        /// </summary>
+        /// <param name="files">Dictionary of files to add, where <see cref="string"/> is a file name and <see cref="Stream"/> is a stream containing the file's contents.</param>
+        /// <param name="resetStreams">Whether to reset all stream positions to 0 after sending.</param>
+        /// <returns></returns>
         T AddFiles(IDictionary<string, Stream> files, bool resetStreams = false);
 
+        /// <summary>
+        /// Adds an allowed mention to this message.
+        /// </summary>
+        /// <param name="mention">Mention to allow in this message.</param>
+        /// <returns></returns>
         T AddMention(IMention mention);
 
+        /// <summary>
+        /// Adds multiple allowed mentions to this message.
+        /// </summary>
+        /// <param name="mentions">Collection of mentions to allow in this message.</param>
+        /// <returns></returns>
         T AddMentions(IEnumerable<IMention> mentions);
 
+        /// <summary>
+        /// Clears all components attached to this builder.
+        /// </summary>
         void ClearComponents();
 
+        /// <summary>
+        /// Clears this builder.
+        /// </summary>
         void Clear();
     }
 }

--- a/DSharpPlus/Entities/IDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/IDiscordMessageBuilder.cs
@@ -1,0 +1,78 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2022 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace DSharpPlus.Entities
+{
+    /// <summary>
+    /// Interface that provides abstractions for the various message builder types in DSharpPlus,
+    /// allowing re-use of code.
+    /// </summary>
+    public interface IDiscordMessageBuilder<T> where T : IDiscordMessageBuilder<T>
+        // This has got to be the most big brain thing I have ever done with interfaces lmfao
+    {
+        string Content { get; set; }
+
+        bool IsTTS { get; set; }
+
+        IReadOnlyList<DiscordEmbed> Embeds { get; }
+
+        IReadOnlyList<DiscordMessageFile> Files { get; }
+
+        IReadOnlyList<DiscordActionRowComponent> Components { get; }
+
+        IReadOnlyList<IMention> Mentions { get; }
+
+        T WithContent(string content);
+
+        T AddComponents(params DiscordComponent[] components);
+
+        T AddComponents(IEnumerable<DiscordComponent> components);
+
+        T AddComponents(IEnumerable<DiscordActionRowComponent> components);
+
+        T WithTTS(bool isTTS);
+
+        T AddEmbed(DiscordEmbed embed);
+
+        T AddEmbeds(IEnumerable<DiscordEmbed> embeds);
+
+        T AddFile(string fileName, Stream stream, bool resetStream = false);
+
+        T AddFile(FileStream stream, bool resetStream = false);
+
+        T AddFiles(IDictionary<string, Stream> files, bool resetStreams = false);
+
+        T AddMention(IMention mention);
+
+        T AddMentions(IEnumerable<IMention> mentions);
+
+        void ClearComponents();
+
+        void Clear();
+    }
+}

--- a/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
@@ -31,7 +31,7 @@ namespace DSharpPlus.Entities
     /// <summary>
     /// Constructs a followup message to an interaction.
     /// </summary>
-    public sealed class DiscordFollowupMessageBuilder
+    public sealed class DiscordFollowupMessageBuilder : IDiscordMessageBuilder<DiscordFollowupMessageBuilder>
     {
         /// <summary>
         /// Whether this followup message is text-to-speech.
@@ -226,7 +226,7 @@ namespace DSharpPlus.Entities
         /// <param name="files">Dictionary of file name and file data.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordFollowupMessageBuilder AddFiles(Dictionary<string, Stream> files, bool resetStreamPosition = false)
+        public DiscordFollowupMessageBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
         {
             if (this.Files.Count + files.Count > 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -33,7 +33,7 @@ namespace DSharpPlus.Entities
     /// <summary>
     /// Constructs an interaction response.
     /// </summary>
-    public sealed class DiscordInteractionResponseBuilder
+    public sealed class DiscordInteractionResponseBuilder : IDiscordMessageBuilder<DiscordInteractionResponseBuilder>
     {
         /// <summary>
         /// Whether this interaction response is text-to-speech.
@@ -51,7 +51,7 @@ namespace DSharpPlus.Entities
         public string CustomId { get; set; }
 
         /// <summary>
-        /// The title to send with this interaction response. Only applicable
+        /// The title to send with this interaction response. Only applicable when creating a modal.
         /// </summary>
         public string Title { get; set; }
 
@@ -97,7 +97,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Mentions to send on this interaction response.
         /// </summary>
-        public IEnumerable<IMention> Mentions => this._mentions;
+        public IReadOnlyList<IMention> Mentions => this._mentions;
         private readonly List<IMention> _mentions = new();
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace DSharpPlus.Entities
         public DiscordInteractionResponseBuilder(DiscordMessageBuilder builder)
         {
             this._content = builder.Content;
-            this._mentions = builder.Mentions;
+            this._mentions = builder._mentions;
             this._embeds.AddRange(builder.Embeds);
             this._components.AddRange(builder.Components);
         }
@@ -332,7 +332,7 @@ namespace DSharpPlus.Entities
         /// <param name="files">Dictionary of file name and file data.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordInteractionResponseBuilder AddFiles(Dictionary<string, Stream> files, bool resetStreamPosition = false)
+        public DiscordInteractionResponseBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
         {
             if (this.Files.Count + files.Count > 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");

--- a/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
@@ -32,7 +32,7 @@ namespace DSharpPlus.Entities
     /// <summary>
     /// Constructs ready-to-send webhook requests.
     /// </summary>
-    public sealed class DiscordWebhookBuilder
+    public sealed class DiscordWebhookBuilder : IDiscordMessageBuilder<DiscordWebhookBuilder>
     {
         /// <summary>
         /// Username to use for this webhook request.
@@ -261,7 +261,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="files">Dictionary of file name and file data.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        public DiscordWebhookBuilder AddFiles(Dictionary<string, Stream> files, bool resetStreamPosition = false)
+        public DiscordWebhookBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
         {
             if (this.Files.Count() + files.Count() > 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");


### PR DESCRIPTION
# Summary
This PR introduces abstractions for various message builders.

# Details
The message builder types that I have applied these abstractions to include:

- `DiscordMessageBuilder`
- `DiscordFollowupMessageBuilder`
- `DiscordWebhookBuilder`
- `DiscordInteractionResponseBuilder`
If I've missed any, please let me know.

With this change, these builders can be reused in various situations. I've personally encountered situations where I wanted to reuse these, but couldn't even though the methods they contain are essentially the same.

This update contains a couple of renamed methods, which is considered a breaking change but is easy enough to change. I'd argue these methods being consistent in naming is something they initially should've had anyway.

# Notes
I fully intend to start maintaining the library again. Lib dev role in Discord API when?