### PR TITLE
Add DeferAsync() to DiscordInteraction

### DIFF
--- a/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
@@ -123,6 +123,14 @@ namespace DSharpPlus.Entities
             this.Discord.ApiClient.CreateInteractionResponseAsync(this.Id, this.Token, type, builder);
 
         /// <summary>
+        ///     Creates a deferred response to this interaction.
+        /// </summary>
+        /// <param name="ephemeral">Whether the response should be ephemeral.</param>
+        public Task DeferAsync(bool ephemeral = false) => this.CreateResponseAsync(
+            InteractionResponseType.DeferredChannelMessageWithSource,
+            new DiscordInteractionResponseBuilder().AsEphemeral(ephemeral));
+
+        /// <summary>
         /// Gets the original interaction response.
         /// </summary>
         /// <returns>The origingal message that was sent. This <b>does not work on ephemeral messages.</b></returns>


### PR DESCRIPTION
# Summary
BaseContext exposes the DeferAsync() shorthand. DiscordInteraction does not inherit from BaseContext, so DeferAsync() is missing when working with DiscordInteractions. This PR adds said DeferAsync() to DiscordInteraction.

# Details
/

# Changes proposed
/

# Notes
/