### PR TITLE
Make InitializeShardsAsync public

### DIFF
--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -236,7 +236,7 @@ namespace DSharpPlus
 
         #region Internal Methods
 
-        internal async Task<int> InitializeShardsAsync()
+        public async Task<int> InitializeShardsAsync()
         {
             if (this._shards.Count != 0)
                 return this._shards.Count;


### PR DESCRIPTION
This allows external extensions to register themselves to the sharded client before connecting to the gateway.