### PR TITLE
Simplify getting the mention string for slash commands

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -695,6 +695,20 @@ namespace DSharpPlus
             this.ApiClient.GetGlobalApplicationCommandAsync(this.CurrentApplication.Id, commandId);
 
         /// <summary>
+        /// Gets a global application command by its name.
+        /// </summary>
+        /// <param name="commandName">The name of the command to get.</param>
+        /// <returns>The command with the name.</returns>
+        public async Task<DiscordApplicationCommand> GetGlobalApplicationCommandAsync(string commandName)
+        {
+            foreach (var command in await this.ApiClient.GetGlobalApplicationCommandsAsync(this.CurrentApplication.Id))
+                if (command.Name == commandName)
+                    return command;
+
+            return null;
+        }
+
+        /// <summary>
         /// Edits a global application command.
         /// </summary>
         /// <param name="commandId">The ID of the command to edit.</param>

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -2879,6 +2879,28 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
+        /// Gets a application command in this guild by its id.
+        /// </summary>
+        /// <param name="commandId">The ID of the command to get.</param>
+        /// <returns>The command with the ID.</returns>
+        public Task<DiscordApplicationCommand> GetApplicationCommandAsync(ulong commandId) =>
+            this.Discord.ApiClient.GetGlobalApplicationCommandAsync(this.Discord.CurrentApplication.Id, commandId);
+
+        /// <summary>
+        /// Gets a application command in this guild by its name.
+        /// </summary>
+        /// <param name="commandName">The name of the command to get.</param>
+        /// <returns>The command with the name.</returns>
+        public async Task<DiscordApplicationCommand> GetApplicationCommandAsync(string commandName)
+        {
+            foreach (var command in await this.Discord.ApiClient.GetGlobalApplicationCommandsAsync(this.Discord.CurrentApplication.Id))
+                if (command.Name == commandName)
+                    return command;
+
+            return null;
+        }
+
+        /// <summary>
         /// Gets this guild's welcome screen.
         /// </summary>
         /// <returns>This guild's welcome screen object.</returns>

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
@@ -154,7 +154,12 @@ namespace DSharpPlus.Entities
         /// <param name="name">The name of the subgroup and/or subcommand.</param>
         /// <returns>Formatted mention.</returns>
         public string GetSubcommandMention(params string[] name)
-            => $"</{this.Name} {string.Join(" ", name)}:{this.Id.ToString(CultureInfo.InvariantCulture)}>";
+        {
+            if (!this.Options.Any(x => x.Name == name[0]))
+                throw new ArgumentException("Specified subgroup/subcommand doesn't exist.");
+
+            return $"</{this.Name} {string.Join(" ", name)}:{this.Id.ToString(CultureInfo.InvariantCulture)}>";
+        }
 
         /// <summary>
         /// Checks whether this <see cref="DiscordApplicationCommand"/> object is equal to another object.

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json;
 
@@ -96,6 +97,13 @@ namespace DSharpPlus.Entities
         public IReadOnlyDictionary<string, string> DescriptionLocalizations { get; internal set; }
 
         /// <summary>
+        /// Gets the command's mention string.
+        /// </summary>
+        [JsonIgnore]
+        public string Mention
+            => Formatter.Mention(this);
+
+        /// <summary>
         /// Creates a new instance of a <see cref="DiscordApplicationCommand"/>.
         /// </summary>
         /// <param name="name">The name of the command.</param>
@@ -139,6 +147,14 @@ namespace DSharpPlus.Entities
             this.AllowDMUsage = allowDMUsage;
             this.DefaultMemberPermissions = defaultMemberPermissions;
         }
+
+        /// <summary>
+        /// Creates a mention for a subcommand.
+        /// </summary>
+        /// <param name="name">The name of the subgroup and/or subcommand.</param>
+        /// <returns>Formatted mention.</returns>
+        public string GetSubcommandMention(params string[] name)
+            => $"</{this.Name} {string.Join(" ", name)}:{this.Id.ToString(CultureInfo.InvariantCulture)}>";
 
         /// <summary>
         /// Checks whether this <see cref="DiscordApplicationCommand"/> object is equal to another object.

--- a/DSharpPlus/Formatter.cs
+++ b/DSharpPlus/Formatter.cs
@@ -198,6 +198,14 @@ namespace DSharpPlus
             => $"<@&{role.Id.ToString(CultureInfo.InvariantCulture)}>";
 
         /// <summary>
+        /// Creates a mention for specified application command.
+        /// </summary>
+        /// <param name="command">Application command to mention.</param>
+        /// <returns>Formatted mention.</returns>
+        public static string Mention(DiscordApplicationCommand command)
+            => $"</{command.Name}:{command.Id.ToString(CultureInfo.InvariantCulture)}>";
+
+        /// <summary>
         /// Creates a custom emoji string.
         /// </summary>
         /// <param name="emoji">Emoji to display.</param>


### PR DESCRIPTION
# Summary
This PR simplifies getting the mention string for slash commands from a `DiscordApplicationCommand` object.

# Changes proposed
* Adds `DiscordApplicationCommand.Mention` (This gets the mention string for the command.)
* Adds `DiscordApplicationCommand.GetSubcommandMention()` (This gets the mention string for a subcommand.)
* Adds `DiscordGuild.GetApplicationCommandAsync()` (This gets a guild application command by its name or snowflake id)
* Adds an overload of `DiscordClient.GetGlobalApplicationCommandAsync()` that gets a global application command by its name

# Notes
I wasn't sure how to make `DiscordApplicationCommand.Mention` work for subcommands, so I put it in a separate method.