### PR TITLE
Ensure DiscordInteractionResponseBuilder correctly copies files 

### DIFF
--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -116,6 +116,7 @@ namespace DSharpPlus.Entities
             this._mentions = builder._mentions;
             this._embeds.AddRange(builder.Embeds);
             this._components.AddRange(builder.Components);
+            this._files.AddRange(builder.Files);
         }
 
 


### PR DESCRIPTION
In the constructor of `DiscordInteractionResponseBuilder`, it copies both components and embeds but not files. This PR has been tested and confirmed functioning as intended.