### PR TITLE
Minor hotfix making MessageBuilders useable in more situations

### DIFF
--- a/DSharpPlus.Test/TestBotCommands.cs
+++ b/DSharpPlus.Test/TestBotCommands.cs
@@ -90,13 +90,13 @@ namespace DSharpPlus.Test
         [Command("editmention")]
         public async Task EditMentionsAsync(CommandContext ctx)
         {
-            var builder = new DiscordMessageBuilder()
+            IDiscordMessageBuilder builder = new DiscordMessageBuilder()
                 .WithContent("Mentioning <@&879398655130472508> and <@743323785549316197>")
                 .WithReply(ctx.Message.Id, true)
-                .WithAllowedMention(new RoleMention(879398655130472508));
+                .AddMention(new RoleMention(879398655130472508));
             //.WithAllowedMention(new UserMention(743323785549316197));//.WithAllowedMention(new RoleMention(879398655130472508));
 
-            var msg = await builder.SendAsync(ctx.Channel);
+            var msg = await (builder as DiscordMessageBuilder).SendAsync(ctx.Channel);
             await msg.ModifyAsync("Mentioning <@&879398655130472508> and <@743323785549316197>, but edited!");
         }
 

--- a/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
@@ -48,7 +48,7 @@ namespace DSharpPlus.Entities
                 this._content = value;
             }
         }
-        protected string _content;
+        internal string _content;
 
         public bool IsTTS { get; set; }
 
@@ -56,25 +56,25 @@ namespace DSharpPlus.Entities
         /// Embeds to send on this webhook request.
         /// </summary>
         public IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
-        protected List<DiscordEmbed> _embeds = new();
+        internal List<DiscordEmbed> _embeds = new();
 
         /// <summary>
         /// Files to send on this webhook request.
         /// </summary>
         public IReadOnlyList<DiscordMessageFile> Files => this._files;
-        protected List<DiscordMessageFile> _files = new();
+        internal List<DiscordMessageFile> _files = new();
 
         /// <summary>
         /// Mentions to send on this webhook request.
         /// </summary>
         public IReadOnlyList<IMention> Mentions => this._mentions;
-        protected List<IMention> _mentions = new();
+        internal List<IMention> _mentions = new();
 
         /// <summary>
         /// Components to send on this followup message.
         /// </summary>
         public IReadOnlyList<DiscordActionRowComponent> Components => this._components;
-        protected List<DiscordActionRowComponent> _components = new();
+        internal List<DiscordActionRowComponent> _components = new();
 
         /// <summary>
         /// Thou shalt NOT PASS! ⚡

--- a/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
@@ -21,10 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace DSharpPlus.Entities
 {
@@ -32,57 +30,69 @@ namespace DSharpPlus.Entities
     /// Interface that provides abstractions for the various message builder types in DSharpPlus,
     /// allowing re-use of code.
     /// </summary>
-    public interface IDiscordMessageBuilder<T> : IDiscordMessageBuilder where T : IDiscordMessageBuilder<T>
+    public abstract class BaseDiscordMessageBuilder<T> : IDiscordMessageBuilder where T : BaseDiscordMessageBuilder<T>
         // This has got to be the most big brain thing I have ever done with interfaces lmfao
     {
+        public abstract string Content { get; set; }
+        public abstract bool IsTTS { get; set; }
+        public abstract IReadOnlyList<DiscordEmbed> Embeds { get; }
+        public abstract IReadOnlyList<DiscordMessageFile> Files { get; }
+        public abstract IReadOnlyList<DiscordActionRowComponent> Components { get; }
+        public abstract IReadOnlyList<IMention> Mentions { get; }
+
+        /// <summary>
+        /// You shall not pass ⚡
+        /// </summary>
+        internal BaseDiscordMessageBuilder(){}
+
         /// <summary>
         /// Adds content to this message
         /// </summary>
         /// <param name="content">Message content to use</param>
         /// <returns></returns>
-        new T WithContent(string content);
+        public abstract T WithContent(string content);
 
         /// <summary>
         /// Adds components to this message. Each call should append to a new row.
         /// </summary>
         /// <param name="components">Components to add.</param>
         /// <returns></returns>
-        new T AddComponents(params DiscordComponent[] components);
+        public abstract T AddComponents(params DiscordComponent[] components);
 
         /// <summary>
         /// Adds components to this message. Each call should append to a new row.
         /// </summary>
         /// <param name="components">Components to add.</param>
         /// <returns></returns>
-        new T AddComponents(IEnumerable<DiscordComponent> components);
+        public abstract T AddComponents(IEnumerable<DiscordComponent> components);
 
         /// <summary>
         /// Adds an action row component to this message.
         /// </summary>
         /// <param name="components">Action row to add to this message. Should contain child components.</param>
         /// <returns></returns>
-        new T AddComponents(IEnumerable<DiscordActionRowComponent> components);
+        public abstract T AddComponents(IEnumerable<DiscordActionRowComponent> components);
 
         /// <summary>
         /// Sets whether this message should play as a text-to-speech message.
         /// </summary>
         /// <param name="isTTS"></param>
         /// <returns></returns>
-        new T WithTTS(bool isTTS);
+        public abstract T WithTTS(bool isTTS);
 
         /// <summary>
         /// Adds an embed to this message.
         /// </summary>
         /// <param name="embed">Embed to add.</param>
         /// <returns></returns>
-        new T AddEmbed(DiscordEmbed embed);
+        public abstract T AddEmbed(DiscordEmbed embed);
 
         /// <summary>
         /// Adds multiple embeds to this message.
         /// </summary>
         /// <param name="embeds">Collection of embeds to add.</param>
         /// <returns></returns>
-        new T AddEmbeds(IEnumerable<DiscordEmbed> embeds);
+        public abstract T AddEmbeds(IEnumerable<DiscordEmbed> embeds);
 
         /// <summary>
         /// Attaches a file to this message.
@@ -91,7 +101,7 @@ namespace DSharpPlus.Entities
         /// <param name="stream">Stream containing said file's contents.</param>
         /// <param name="resetStream">Whether to reset the stream to position 0 after sending.</param>
         /// <returns></returns>
-        new T AddFile(string fileName, Stream stream, bool resetStream = false);
+        public abstract T AddFile(string fileName, Stream stream, bool resetStream = false);
 
         /// <summary>
         /// Attaches a file to this message.
@@ -99,7 +109,7 @@ namespace DSharpPlus.Entities
         /// <param name="stream">FileStream pointiong to the file to attach.</param>
         /// <param name="resetStream">Whether to reset the stream position to 0 after sending.</param>
         /// <returns></returns>
-        new T AddFile(FileStream stream, bool resetStream = false);
+        public abstract T AddFile(FileStream stream, bool resetStream = false);
 
         /// <summary>
         /// Attaches multiple files to this message.
@@ -107,21 +117,35 @@ namespace DSharpPlus.Entities
         /// <param name="files">Dictionary of files to add, where <see cref="string"/> is a file name and <see cref="Stream"/> is a stream containing the file's contents.</param>
         /// <param name="resetStreams">Whether to reset all stream positions to 0 after sending.</param>
         /// <returns></returns>
-        new T AddFiles(IDictionary<string, Stream> files, bool resetStreams = false);
+        public abstract T AddFiles(IDictionary<string, Stream> files, bool resetStreams = false);
 
         /// <summary>
         /// Adds an allowed mention to this message.
         /// </summary>
         /// <param name="mention">Mention to allow in this message.</param>
         /// <returns></returns>
-        new T AddMention(IMention mention);
+        public abstract T AddMention(IMention mention);
 
         /// <summary>
         /// Adds multiple allowed mentions to this message.
         /// </summary>
         /// <param name="mentions">Collection of mentions to allow in this message.</param>
         /// <returns></returns>
-        new T AddMentions(IEnumerable<IMention> mentions);
+        public abstract T AddMentions(IEnumerable<IMention> mentions);
+        IDiscordMessageBuilder IDiscordMessageBuilder.WithContent(string content) => this.WithContent(content);
+        IDiscordMessageBuilder IDiscordMessageBuilder.AddComponents(params DiscordComponent[] components) => this.AddComponents(components);
+        IDiscordMessageBuilder IDiscordMessageBuilder.AddComponents(IEnumerable<DiscordComponent> components) => this.AddComponents(components);
+        IDiscordMessageBuilder IDiscordMessageBuilder.AddComponents(IEnumerable<DiscordActionRowComponent> components) => this.AddComponents(components);
+        IDiscordMessageBuilder IDiscordMessageBuilder.WithTTS(bool isTTS) => this.WithTTS(isTTS);
+        IDiscordMessageBuilder IDiscordMessageBuilder.AddEmbed(DiscordEmbed embed) => this.AddEmbed(embed);
+        IDiscordMessageBuilder IDiscordMessageBuilder.AddEmbeds(IEnumerable<DiscordEmbed> embeds) => this.AddEmbeds(embeds);
+        IDiscordMessageBuilder IDiscordMessageBuilder.AddFile(string fileName, Stream stream, bool resetStream) => this.AddFile(fileName, stream, resetStream);
+        IDiscordMessageBuilder IDiscordMessageBuilder.AddFile(FileStream stream, bool resetStream) => this.AddFile(stream, resetStream);
+        IDiscordMessageBuilder IDiscordMessageBuilder.AddFiles(IDictionary<string, Stream> files, bool resetStreams) => this.AddFiles(files, resetStreams);
+        IDiscordMessageBuilder IDiscordMessageBuilder.AddMention(IMention mention) => this.AddMention(mention);
+        IDiscordMessageBuilder IDiscordMessageBuilder.AddMentions(IEnumerable<IMention> mentions) => this.AddMentions(mentions);
+        public abstract void ClearComponents();
+        public abstract void Clear();
     }
 
     public interface IDiscordMessageBuilder

--- a/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
@@ -41,7 +41,7 @@ namespace DSharpPlus.Entities
         public abstract IReadOnlyList<IMention> Mentions { get; }
 
         /// <summary>
-        /// You shall not pass ⚡
+        /// Thou shalt NOT PASS! ⚡
         /// </summary>
         internal BaseDiscordMessageBuilder(){}
 

--- a/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
@@ -132,6 +132,18 @@ namespace DSharpPlus.Entities
         /// <param name="mentions">Collection of mentions to allow in this message.</param>
         /// <returns></returns>
         public abstract T AddMentions(IEnumerable<IMention> mentions);
+
+        /// <summary>
+        /// Clears all components attached to this builder.
+        /// </summary>
+        public abstract void ClearComponents();
+
+        /// <summary>
+        /// Clears this builder.
+        /// </summary>
+        public abstract void Clear();
+
+
         IDiscordMessageBuilder IDiscordMessageBuilder.WithContent(string content) => this.WithContent(content);
         IDiscordMessageBuilder IDiscordMessageBuilder.AddComponents(params DiscordComponent[] components) => this.AddComponents(components);
         IDiscordMessageBuilder IDiscordMessageBuilder.AddComponents(IEnumerable<DiscordComponent> components) => this.AddComponents(components);
@@ -144,8 +156,6 @@ namespace DSharpPlus.Entities
         IDiscordMessageBuilder IDiscordMessageBuilder.AddFiles(IDictionary<string, Stream> files, bool resetStreams) => this.AddFiles(files, resetStreams);
         IDiscordMessageBuilder IDiscordMessageBuilder.AddMention(IMention mention) => this.AddMention(mention);
         IDiscordMessageBuilder IDiscordMessageBuilder.AddMentions(IEnumerable<IMention> mentions) => this.AddMentions(mentions);
-        public abstract void ClearComponents();
-        public abstract void Clear();
     }
 
     public interface IDiscordMessageBuilder

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -23,9 +23,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace DSharpPlus.Entities
@@ -35,22 +33,6 @@ namespace DSharpPlus.Entities
     /// </summary>
     public sealed class DiscordMessageBuilder : BaseDiscordMessageBuilder<DiscordMessageBuilder>
     {
-        /// <summary>
-        /// Gets or Sets the Message to be sent.
-        /// </summary>
-        public override string Content
-        {
-            get => this._content;
-            set
-            {
-                if (value != null && value.Length > 2000)
-                    throw new ArgumentException("Content cannot exceed 2000 characters.", nameof(value));
-                this._content = value;
-            }
-        }
-        private string _content;
-
-
         /// <summary>
         /// Gets or sets the embed for the builder. This will always set the builder to have one embed.
         /// </summary>
@@ -70,35 +52,6 @@ namespace DSharpPlus.Entities
         public DiscordMessageSticker Sticker { get; set; }
 
         /// <summary>
-        /// Gets the Embeds to be sent.
-        /// </summary>
-        public override IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
-        internal readonly List<DiscordEmbed> _embeds = new();
-
-        /// <summary>
-        /// Gets or Sets if the message should be TTS.
-        /// </summary>
-        public override bool IsTTS { get; set; } = false;
-
-        /// <summary>
-        /// Gets the Allowed Mentions for the message to be sent.
-        /// </summary>
-        public override IReadOnlyList<IMention> Mentions => this._mentions;
-        internal List<IMention> _mentions = new();
-
-        /// <summary>
-        /// Gets the Files to be sent in the Message.
-        /// </summary>
-        public override IReadOnlyList<DiscordMessageFile> Files => this._files;
-        internal readonly List<DiscordMessageFile> _files = new();
-
-        /// <summary>
-        /// Gets the components that will be attached to the message.
-        /// </summary>
-        public override IReadOnlyList<DiscordActionRowComponent> Components => this._components;
-        internal readonly List<DiscordActionRowComponent> _components = new(5);
-
-        /// <summary>
         /// Gets the Reply Message ID.
         /// </summary>
         public ulong? ReplyId { get; private set; } = null;
@@ -116,15 +69,15 @@ namespace DSharpPlus.Entities
         public bool FailOnInvalidReply { get; set; }
 
         /// <summary>
-        /// Sets the Content of the Message.
+        /// Constructs a new discord message builder
         /// </summary>
-        /// <param name="content">The content to be set.</param>
-        /// <returns>The current builder to be chained.</returns>
-        public override DiscordMessageBuilder WithContent(string content)
-        {
-            this.Content = content;
-            return this;
-        }
+        public DiscordMessageBuilder() { }
+
+        /// <summary>
+        /// Constructs a new discord message builder based on a previous builder
+        /// </summary>
+        /// <param name="builder"></param>
+        public DiscordMessageBuilder(IDiscordMessageBuilder builder) : base(builder) { }
 
         /// <summary>
         /// Adds a sticker to the message. Sticker must be from current guild.
@@ -134,68 +87,6 @@ namespace DSharpPlus.Entities
         public DiscordMessageBuilder WithSticker(DiscordMessageSticker sticker)
         {
             this.Sticker = sticker;
-            return this;
-        }
-
-        /// <summary>
-        /// Adds a row of components to a message, up to 5 components per row, and up to 5 rows per message.
-        /// </summary>
-        /// <param name="components">The components to add to the message.</param>
-        /// <returns>The current builder to be chained.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">No components were passed.</exception>
-        public override DiscordMessageBuilder AddComponents(params DiscordComponent[] components)
-            => this.AddComponents((IEnumerable<DiscordComponent>)components);
-
-
-        /// <summary>
-        /// Appends several rows of components to the message
-        /// </summary>
-        /// <param name="components">The rows of components to add, holding up to five each.</param>
-        /// <returns></returns>
-        public override DiscordMessageBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
-        {
-            var ara = components.ToArray();
-
-            if (ara.Length + this._components.Count > 5)
-                throw new ArgumentException("ActionRow count exceeds maximum of five.");
-
-            foreach (var ar in ara)
-                this._components.Add(ar);
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds a row of components to a message, up to 5 components per row, and up to 5 rows per message.
-        /// </summary>
-        /// <param name="components">The components to add to the message.</param>
-        /// <returns>The current builder to be chained.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">No components were passed.</exception>
-        public override DiscordMessageBuilder AddComponents(IEnumerable<DiscordComponent> components)
-        {
-            var cmpArr = components.ToArray();
-            var count = cmpArr.Length;
-
-            if (!cmpArr.Any())
-                throw new ArgumentOutOfRangeException(nameof(components), "You must provide at least one component");
-
-            if (count > 5)
-                throw new ArgumentException("Cannot add more than 5 components per action row!");
-
-            var comp = new DiscordActionRowComponent(cmpArr);
-            this._components.Add(comp);
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets if the message should be TTS.
-        /// </summary>
-        /// <param name="isTTS">If TTS should be set.</param>
-        /// <returns>The current builder to be chained.</returns>
-        public override DiscordMessageBuilder WithTTS(bool isTTS)
-        {
-            this.IsTTS = isTTS;
             return this;
         }
 
@@ -214,45 +105,12 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Appends an embed to the current builder.
-        /// </summary>
-        /// <param name="embed">The embed that should be appended.</param>
-        /// <returns>The current builder to be chained.</returns>
-        public override DiscordMessageBuilder AddEmbed(DiscordEmbed embed)
-        {
-            if (embed == null)
-                return this; //Providing null embeds will produce a 400 response from Discord.//
-            this._embeds.Add(embed);
-            return this;
-        }
-
-        /// <summary>
-        /// Appends several embeds to the current builder.
-        /// </summary>
-        /// <param name="embeds">The embeds that should be appended.</param>
-        /// <returns>The current builder to be chained.</returns>
-        public override DiscordMessageBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
-        {
-            this._embeds.AddRange(embeds);
-            return this;
-        }
-
-
-
-        /// <summary>
         /// Sets if the message has allowed mentions.
         /// </summary>
         /// <param name="allowedMention">The allowed Mention that should be sent.</param>
         /// <returns>The current builder to be chained.</returns>
         public DiscordMessageBuilder WithAllowedMention(IMention allowedMention)
-        {
-            if (this._mentions != null)
-                this._mentions.Add(allowedMention);
-            else
-                this._mentions = new List<IMention> { allowedMention };
-
-            return this;
-        }
+            => this.AddMention(allowedMention);
 
         /// <summary>
         /// Sets if the message has allowed mentions.
@@ -260,84 +118,7 @@ namespace DSharpPlus.Entities
         /// <param name="allowedMentions">The allowed Mentions that should be sent.</param>
         /// <returns>The current builder to be chained.</returns>
         public DiscordMessageBuilder WithAllowedMentions(IEnumerable<IMention> allowedMentions)
-        {
-            if (this._mentions != null)
-                this._mentions.AddRange(allowedMentions);
-            else
-                this._mentions = allowedMentions.ToList();
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets if the message has files to be sent.
-        /// </summary>
-        /// <param name="fileName">The fileName that the file should be sent as.</param>
-        /// <param name="stream">The Stream to the file.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        /// <returns>The current builder to be chained.</returns>
-        public override DiscordMessageBuilder AddFile(string fileName, Stream stream, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count >= 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            if (this._files.Any(x => x.FileName == fileName))
-                throw new ArgumentException("A File with that filename already exists");
-
-            if (resetStreamPosition)
-                this._files.Add(new DiscordMessageFile(fileName, stream, stream.Position));
-            else
-                this._files.Add(new DiscordMessageFile(fileName, stream, null));
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets if the message has files to be sent.
-        /// </summary>
-        /// <param name="stream">The Stream to the file.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        /// <returns>The current builder to be chained.</returns>
-        public override DiscordMessageBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count >= 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            if (this._files.Any(x => x.FileName == stream.Name))
-                throw new ArgumentException("A File with that filename already exists");
-
-            if (resetStreamPosition)
-                this._files.Add(new DiscordMessageFile(stream.Name, stream, stream.Position));
-            else
-                this._files.Add(new DiscordMessageFile(stream.Name, stream, null));
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets if the message has files to be sent.
-        /// </summary>
-        /// <param name="files">The Files that should be sent.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        /// <returns>The current builder to be chained.</returns>
-        public override DiscordMessageBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count + files.Count > 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            foreach (var file in files)
-            {
-                if (this._files.Any(x => x.FileName == file.Key))
-                    throw new ArgumentException("A File with that filename already exists");
-
-                if (resetStreamPosition)
-                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, file.Value.Position));
-                else
-                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, null));
-            }
-
-            return this;
-        }
+            => this.AddMentions(allowedMentions);
 
         /// <summary>
         /// Sets if the message is a reply
@@ -362,26 +143,6 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Adds the mention to the mentions to parse, etc. with the interaction response.
-        /// </summary>
-        /// <param name="mention">Mention to add.</param>
-        public override DiscordMessageBuilder AddMention(IMention mention)
-        {
-            this._mentions.Add(mention);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the mentions to the mentions to parse, etc. with the interaction response.
-        /// </summary>
-        /// <param name="mentions">Mentions to add.</param>
-        public override DiscordMessageBuilder AddMentions(IEnumerable<IMention> mentions)
-        {
-            this._mentions.AddRange(mentions);
-            return this;
-        }
-
-        /// <summary>
         /// Sends the Message to a specific channel
         /// </summary>
         /// <param name="channel">The channel the message should be sent to.</param>
@@ -396,25 +157,12 @@ namespace DSharpPlus.Entities
         /// <returns>The current builder to be chained.</returns>
         public Task<DiscordMessage> ModifyAsync(DiscordMessage msg) => msg.ModifyAsync(this);
 
-        /// <summary>
-        /// Clears all message components on this builder.
-        /// </summary>
         public override void ClearComponents()
-            => this._components.Clear();
-
-        /// <summary>
-        /// Allows for clearing the Message Builder so that it can be used again to send a new message.
-        /// </summary>
-        public override void Clear()
         {
-            this.Content = "";
-            this._embeds.Clear();
-            this.IsTTS = false;
-            this._mentions.Clear();
-            this._files.Clear();
             this.ReplyId = null;
             this.MentionOnReply = false;
-            this._components.Clear();
+
+            base.ClearComponents();
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -33,12 +33,12 @@ namespace DSharpPlus.Entities
     /// <summary>
     /// Constructs a Message to be sent.
     /// </summary>
-    public sealed class DiscordMessageBuilder : IDiscordMessageBuilder<DiscordMessageBuilder>
+    public sealed class DiscordMessageBuilder : BaseDiscordMessageBuilder<DiscordMessageBuilder>
     {
         /// <summary>
         /// Gets or Sets the Message to be sent.
         /// </summary>
-        public string Content
+        public override string Content
         {
             get => this._content;
             set
@@ -72,30 +72,30 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the Embeds to be sent.
         /// </summary>
-        public IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
+        public override IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
         internal readonly List<DiscordEmbed> _embeds = new();
 
         /// <summary>
         /// Gets or Sets if the message should be TTS.
         /// </summary>
-        public bool IsTTS { get; set; } = false;
+        public override bool IsTTS { get; set; } = false;
 
         /// <summary>
         /// Gets the Allowed Mentions for the message to be sent.
         /// </summary>
-        public IReadOnlyList<IMention> Mentions => this._mentions;
+        public override IReadOnlyList<IMention> Mentions => this._mentions;
         internal List<IMention> _mentions = new();
 
         /// <summary>
         /// Gets the Files to be sent in the Message.
         /// </summary>
-        public IReadOnlyList<DiscordMessageFile> Files => this._files;
+        public override IReadOnlyList<DiscordMessageFile> Files => this._files;
         internal readonly List<DiscordMessageFile> _files = new();
 
         /// <summary>
         /// Gets the components that will be attached to the message.
         /// </summary>
-        public IReadOnlyList<DiscordActionRowComponent> Components => this._components;
+        public override IReadOnlyList<DiscordActionRowComponent> Components => this._components;
         internal readonly List<DiscordActionRowComponent> _components = new(5);
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="content">The content to be set.</param>
         /// <returns>The current builder to be chained.</returns>
-        public DiscordMessageBuilder WithContent(string content)
+        public override DiscordMessageBuilder WithContent(string content)
         {
             this.Content = content;
             return this;
@@ -143,7 +143,7 @@ namespace DSharpPlus.Entities
         /// <param name="components">The components to add to the message.</param>
         /// <returns>The current builder to be chained.</returns>
         /// <exception cref="ArgumentOutOfRangeException">No components were passed.</exception>
-        public DiscordMessageBuilder AddComponents(params DiscordComponent[] components)
+        public override DiscordMessageBuilder AddComponents(params DiscordComponent[] components)
             => this.AddComponents((IEnumerable<DiscordComponent>)components);
 
 
@@ -152,7 +152,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="components">The rows of components to add, holding up to five each.</param>
         /// <returns></returns>
-        public DiscordMessageBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
+        public override DiscordMessageBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
         {
             var ara = components.ToArray();
 
@@ -171,7 +171,7 @@ namespace DSharpPlus.Entities
         /// <param name="components">The components to add to the message.</param>
         /// <returns>The current builder to be chained.</returns>
         /// <exception cref="ArgumentOutOfRangeException">No components were passed.</exception>
-        public DiscordMessageBuilder AddComponents(IEnumerable<DiscordComponent> components)
+        public override DiscordMessageBuilder AddComponents(IEnumerable<DiscordComponent> components)
         {
             var cmpArr = components.ToArray();
             var count = cmpArr.Length;
@@ -193,7 +193,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="isTTS">If TTS should be set.</param>
         /// <returns>The current builder to be chained.</returns>
-        public DiscordMessageBuilder WithTTS(bool isTTS)
+        public override DiscordMessageBuilder WithTTS(bool isTTS)
         {
             this.IsTTS = isTTS;
             return this;
@@ -218,7 +218,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="embed">The embed that should be appended.</param>
         /// <returns>The current builder to be chained.</returns>
-        public DiscordMessageBuilder AddEmbed(DiscordEmbed embed)
+        public override DiscordMessageBuilder AddEmbed(DiscordEmbed embed)
         {
             if (embed == null)
                 return this; //Providing null embeds will produce a 400 response from Discord.//
@@ -231,7 +231,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="embeds">The embeds that should be appended.</param>
         /// <returns>The current builder to be chained.</returns>
-        public DiscordMessageBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
+        public override DiscordMessageBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
         {
             this._embeds.AddRange(embeds);
             return this;
@@ -276,7 +276,7 @@ namespace DSharpPlus.Entities
         /// <param name="stream">The Stream to the file.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The current builder to be chained.</returns>
-        public DiscordMessageBuilder AddFile(string fileName, Stream stream, bool resetStreamPosition = false)
+        public override DiscordMessageBuilder AddFile(string fileName, Stream stream, bool resetStreamPosition = false)
         {
             if (this.Files.Count >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -298,7 +298,7 @@ namespace DSharpPlus.Entities
         /// <param name="stream">The Stream to the file.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The current builder to be chained.</returns>
-        public DiscordMessageBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
+        public override DiscordMessageBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
         {
             if (this.Files.Count >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -320,7 +320,7 @@ namespace DSharpPlus.Entities
         /// <param name="files">The Files that should be sent.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The current builder to be chained.</returns>
-        public DiscordMessageBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
+        public override DiscordMessageBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
         {
             if (this.Files.Count + files.Count > 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -365,7 +365,7 @@ namespace DSharpPlus.Entities
         /// Adds the mention to the mentions to parse, etc. with the interaction response.
         /// </summary>
         /// <param name="mention">Mention to add.</param>
-        public DiscordMessageBuilder AddMention(IMention mention)
+        public override DiscordMessageBuilder AddMention(IMention mention)
         {
             this._mentions.Add(mention);
             return this;
@@ -375,7 +375,7 @@ namespace DSharpPlus.Entities
         /// Adds the mentions to the mentions to parse, etc. with the interaction response.
         /// </summary>
         /// <param name="mentions">Mentions to add.</param>
-        public DiscordMessageBuilder AddMentions(IEnumerable<IMention> mentions)
+        public override DiscordMessageBuilder AddMentions(IEnumerable<IMention> mentions)
         {
             this._mentions.AddRange(mentions);
             return this;
@@ -399,13 +399,13 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Clears all message components on this builder.
         /// </summary>
-        public void ClearComponents()
+        public override void ClearComponents()
             => this._components.Clear();
 
         /// <summary>
         /// Allows for clearing the Message Builder so that it can be used again to send a new message.
         /// </summary>
-        public void Clear()
+        public override void Clear()
         {
             this.Content = "";
             this._embeds.Clear();

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -77,7 +77,13 @@ namespace DSharpPlus.Entities
         /// Constructs a new discord message builder based on a previous builder
         /// </summary>
         /// <param name="builder"></param>
-        public DiscordMessageBuilder(IDiscordMessageBuilder builder) : base(builder) { }
+        public DiscordMessageBuilder(DiscordMessageBuilder builder) : base(builder)
+        {
+            this.Sticker = builder.Sticker;
+            this.ReplyId = builder.ReplyId;
+            this.MentionOnReply = builder.MentionOnReply;
+            this.FailOnInvalidReply = builder.FailOnInvalidReply;
+        }
 
         /// <summary>
         /// Adds a sticker to the message. Sticker must be from current guild.
@@ -161,6 +167,8 @@ namespace DSharpPlus.Entities
         {
             this.ReplyId = null;
             this.MentionOnReply = false;
+            this.Sticker = default;
+            this.FailOnInvalidReply = default;
 
             base.ClearComponents();
         }

--- a/DSharpPlus/Entities/IDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/IDiscordMessageBuilder.cs
@@ -164,5 +164,134 @@ namespace DSharpPlus.Entities
         void Clear();
     }
 
-    public interface IDiscordMessageBuilder { }
+    public interface IDiscordMessageBuilder
+    {
+        /// <summary>
+        /// Getter / setter for message content.
+        /// </summary>
+        string Content { get; set; }
+
+        /// <summary>
+        /// Whether this message will play as a text-to-speech message.
+        /// </summary>
+        bool IsTTS { get; set; }
+
+        /// <summary>
+        /// All embeds on this message.
+        /// </summary>
+        IReadOnlyList<DiscordEmbed> Embeds { get; }
+
+        /// <summary>
+        /// All files on this message.
+        /// </summary>
+        IReadOnlyList<DiscordMessageFile> Files { get; }
+
+        /// <summary>
+        /// All components on this message.
+        /// </summary>
+        IReadOnlyList<DiscordActionRowComponent> Components { get; }
+
+        /// <summary>
+        /// All allowed mentions on this message.
+        /// </summary>
+        IReadOnlyList<IMention> Mentions { get; }
+
+        /// <summary>
+        /// Adds content to this message
+        /// </summary>
+        /// <param name="content">Message content to use</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder WithContent(string content);
+
+        /// <summary>
+        /// Adds components to this message. Each call should append to a new row.
+        /// </summary>
+        /// <param name="components">Components to add.</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder AddComponents(params DiscordComponent[] components);
+
+        /// <summary>
+        /// Adds components to this message. Each call should append to a new row.
+        /// </summary>
+        /// <param name="components">Components to add.</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder AddComponents(IEnumerable<DiscordComponent> components);
+
+        /// <summary>
+        /// Adds an action row component to this message.
+        /// </summary>
+        /// <param name="components">Action row to add to this message. Should contain child components.</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components);
+
+        /// <summary>
+        /// Sets whether this message should play as a text-to-speech message.
+        /// </summary>
+        /// <param name="isTTS"></param>
+        /// <returns></returns>
+        IDiscordMessageBuilder WithTTS(bool isTTS);
+
+        /// <summary>
+        /// Adds an embed to this message.
+        /// </summary>
+        /// <param name="embed">Embed to add.</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder AddEmbed(DiscordEmbed embed);
+
+        /// <summary>
+        /// Adds multiple embeds to this message.
+        /// </summary>
+        /// <param name="embeds">Collection of embeds to add.</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds);
+
+        /// <summary>
+        /// Attaches a file to this message.
+        /// </summary>
+        /// <param name="fileName">Name of the file to attach.</param>
+        /// <param name="stream">Stream containing said file's contents.</param>
+        /// <param name="resetStream">Whether to reset the stream to position 0 after sending.</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder AddFile(string fileName, Stream stream, bool resetStream = false);
+
+        /// <summary>
+        /// Attaches a file to this message.
+        /// </summary>
+        /// <param name="stream">FileStream pointiong to the file to attach.</param>
+        /// <param name="resetStream">Whether to reset the stream position to 0 after sending.</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder AddFile(FileStream stream, bool resetStream = false);
+
+        /// <summary>
+        /// Attaches multiple files to this message.
+        /// </summary>
+        /// <param name="files">Dictionary of files to add, where <see cref="string"/> is a file name and <see cref="Stream"/> is a stream containing the file's contents.</param>
+        /// <param name="resetStreams">Whether to reset all stream positions to 0 after sending.</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreams = false);
+
+        /// <summary>
+        /// Adds an allowed mention to this message.
+        /// </summary>
+        /// <param name="mention">Mention to allow in this message.</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder AddMention(IMention mention);
+
+        /// <summary>
+        /// Adds multiple allowed mentions to this message.
+        /// </summary>
+        /// <param name="mentions">Collection of mentions to allow in this message.</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder AddMentions(IEnumerable<IMention> mentions);
+
+        /// <summary>
+        /// Clears all components attached to this builder.
+        /// </summary>
+        void ClearComponents();
+
+        /// <summary>
+        /// Clears this builder.
+        /// </summary>
+        void Clear();
+    }
 }

--- a/DSharpPlus/Entities/IDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/IDiscordMessageBuilder.cs
@@ -36,83 +36,53 @@ namespace DSharpPlus.Entities
         // This has got to be the most big brain thing I have ever done with interfaces lmfao
     {
         /// <summary>
-        /// Getter / setter for message content.
-        /// </summary>
-        string Content { get; set; }
-
-        /// <summary>
-        /// Whether this message will play as a text-to-speech message.
-        /// </summary>
-        bool IsTTS { get; set; }
-
-        /// <summary>
-        /// All embeds on this message.
-        /// </summary>
-        IReadOnlyList<DiscordEmbed> Embeds { get; }
-
-        /// <summary>
-        /// All files on this message.
-        /// </summary>
-        IReadOnlyList<DiscordMessageFile> Files { get; }
-
-        /// <summary>
-        /// All components on this message.
-        /// </summary>
-        IReadOnlyList<DiscordActionRowComponent> Components { get; }
-
-        /// <summary>
-        /// All allowed mentions on this message.
-        /// </summary>
-        IReadOnlyList<IMention> Mentions { get; }
-
-        /// <summary>
         /// Adds content to this message
         /// </summary>
         /// <param name="content">Message content to use</param>
         /// <returns></returns>
-        T WithContent(string content);
+        new T WithContent(string content);
 
         /// <summary>
         /// Adds components to this message. Each call should append to a new row.
         /// </summary>
         /// <param name="components">Components to add.</param>
         /// <returns></returns>
-        T AddComponents(params DiscordComponent[] components);
+        new T AddComponents(params DiscordComponent[] components);
 
         /// <summary>
         /// Adds components to this message. Each call should append to a new row.
         /// </summary>
         /// <param name="components">Components to add.</param>
         /// <returns></returns>
-        T AddComponents(IEnumerable<DiscordComponent> components);
+        new T AddComponents(IEnumerable<DiscordComponent> components);
 
         /// <summary>
         /// Adds an action row component to this message.
         /// </summary>
         /// <param name="components">Action row to add to this message. Should contain child components.</param>
         /// <returns></returns>
-        T AddComponents(IEnumerable<DiscordActionRowComponent> components);
+        new T AddComponents(IEnumerable<DiscordActionRowComponent> components);
 
         /// <summary>
         /// Sets whether this message should play as a text-to-speech message.
         /// </summary>
         /// <param name="isTTS"></param>
         /// <returns></returns>
-        T WithTTS(bool isTTS);
+        new T WithTTS(bool isTTS);
 
         /// <summary>
         /// Adds an embed to this message.
         /// </summary>
         /// <param name="embed">Embed to add.</param>
         /// <returns></returns>
-        T AddEmbed(DiscordEmbed embed);
+        new T AddEmbed(DiscordEmbed embed);
 
         /// <summary>
         /// Adds multiple embeds to this message.
         /// </summary>
         /// <param name="embeds">Collection of embeds to add.</param>
         /// <returns></returns>
-        T AddEmbeds(IEnumerable<DiscordEmbed> embeds);
+        new T AddEmbeds(IEnumerable<DiscordEmbed> embeds);
 
         /// <summary>
         /// Attaches a file to this message.
@@ -121,7 +91,7 @@ namespace DSharpPlus.Entities
         /// <param name="stream">Stream containing said file's contents.</param>
         /// <param name="resetStream">Whether to reset the stream to position 0 after sending.</param>
         /// <returns></returns>
-        T AddFile(string fileName, Stream stream, bool resetStream = false);
+        new T AddFile(string fileName, Stream stream, bool resetStream = false);
 
         /// <summary>
         /// Attaches a file to this message.
@@ -129,7 +99,7 @@ namespace DSharpPlus.Entities
         /// <param name="stream">FileStream pointiong to the file to attach.</param>
         /// <param name="resetStream">Whether to reset the stream position to 0 after sending.</param>
         /// <returns></returns>
-        T AddFile(FileStream stream, bool resetStream = false);
+        new T AddFile(FileStream stream, bool resetStream = false);
 
         /// <summary>
         /// Attaches multiple files to this message.
@@ -137,31 +107,21 @@ namespace DSharpPlus.Entities
         /// <param name="files">Dictionary of files to add, where <see cref="string"/> is a file name and <see cref="Stream"/> is a stream containing the file's contents.</param>
         /// <param name="resetStreams">Whether to reset all stream positions to 0 after sending.</param>
         /// <returns></returns>
-        T AddFiles(IDictionary<string, Stream> files, bool resetStreams = false);
+        new T AddFiles(IDictionary<string, Stream> files, bool resetStreams = false);
 
         /// <summary>
         /// Adds an allowed mention to this message.
         /// </summary>
         /// <param name="mention">Mention to allow in this message.</param>
         /// <returns></returns>
-        T AddMention(IMention mention);
+        new T AddMention(IMention mention);
 
         /// <summary>
         /// Adds multiple allowed mentions to this message.
         /// </summary>
         /// <param name="mentions">Collection of mentions to allow in this message.</param>
         /// <returns></returns>
-        T AddMentions(IEnumerable<IMention> mentions);
-
-        /// <summary>
-        /// Clears all components attached to this builder.
-        /// </summary>
-        void ClearComponents();
-
-        /// <summary>
-        /// Clears this builder.
-        /// </summary>
-        void Clear();
+        new T AddMentions(IEnumerable<IMention> mentions);
     }
 
     public interface IDiscordMessageBuilder
@@ -295,3 +255,8 @@ namespace DSharpPlus.Entities
         void Clear();
     }
 }
+
+/*
+ * Zǎoshang hǎo zhōngguó xiànzài wǒ yǒu BING CHILLING 🥶🍦
+ * wǒ hěn xǐhuān BING CHILLING 🥶🍦
+ */

--- a/DSharpPlus/Entities/IDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/IDiscordMessageBuilder.cs
@@ -32,7 +32,7 @@ namespace DSharpPlus.Entities
     /// Interface that provides abstractions for the various message builder types in DSharpPlus,
     /// allowing re-use of code.
     /// </summary>
-    public interface IDiscordMessageBuilder<T> where T : IDiscordMessageBuilder<T>
+    public interface IDiscordMessageBuilder<T> : IDiscordMessageBuilder where T : IDiscordMessageBuilder<T>
         // This has got to be the most big brain thing I have ever done with interfaces lmfao
     {
         /// <summary>
@@ -163,4 +163,6 @@ namespace DSharpPlus.Entities
         /// </summary>
         void Clear();
     }
+
+    public interface IDiscordMessageBuilder { }
 }

--- a/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
@@ -44,6 +44,11 @@ namespace DSharpPlus.Entities
         /// </summary>
         public DiscordFollowupMessageBuilder() { }
 
+        public DiscordFollowupMessageBuilder(DiscordFollowupMessageBuilder builder) : base(builder)
+        {
+            this.IsEphemeral = builder.IsEphemeral;
+        }
+
         /// <summary>
         /// Constructs a new followup message builder based on a previous IDiscordMessageBuilder
         /// </summary>

--- a/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
@@ -22,8 +22,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace DSharpPlus.Entities
@@ -34,239 +32,23 @@ namespace DSharpPlus.Entities
     public sealed class DiscordFollowupMessageBuilder : BaseDiscordMessageBuilder<DiscordFollowupMessageBuilder>
     {
         /// <summary>
-        /// Whether this followup message is text-to-speech.
-        /// </summary>
-        public override bool IsTTS { get; set; }
-
-        /// <summary>
         /// Whether this followup message should be ephemeral.
         /// </summary>
         public bool IsEphemeral { get; set; }
 
-        internal int? Flags
+        internal int? _flags
             => this.IsEphemeral ? 64 : null;
 
         /// <summary>
-        /// Message to send on followup message.
+        /// Constructs a new followup message builder
         /// </summary>
-        public override string Content
-        {
-            get => this._content;
-            set
-            {
-                if (value != null && value.Length > 2000)
-                    throw new ArgumentException("Content length cannot exceed 2000 characters.", nameof(value));
-                this._content = value;
-            }
-        }
-        private string _content;
+        public DiscordFollowupMessageBuilder() { }
 
         /// <summary>
-        /// Embeds to send on followup message.
+        /// Constructs a new followup message builder based on a previous IDiscordMessageBuilder
         /// </summary>
-        public override IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
-        private readonly List<DiscordEmbed> _embeds = new();
-
-        /// <summary>
-        /// Files to send on this followup message.
-        /// </summary>
-        public override IReadOnlyList<DiscordMessageFile> Files => this._files;
-        private readonly List<DiscordMessageFile> _files = new();
-
-        /// <summary>
-        /// Components to send on this followup message.
-        /// </summary>
-        public override IReadOnlyList<DiscordActionRowComponent> Components => this._components;
-        private readonly List<DiscordActionRowComponent> _components = new();
-
-        /// <summary>
-        /// Mentions to send on this followup message.
-        /// </summary>
-        public override IReadOnlyList<IMention> Mentions => this._mentions;
-        private readonly List<IMention> _mentions = new();
-
-
-        /// <summary>
-        /// Appends a collection of components to the message.
-        /// </summary>
-        /// <param name="components">The collection of components to add.</param>
-        /// <returns>The builder to chain calls with.</returns>
-        /// <exception cref="ArgumentException"><paramref name="components"/> contained more than 5 components.</exception>
-        public override DiscordFollowupMessageBuilder AddComponents(params DiscordComponent[] components)
-            => this.AddComponents((IEnumerable<DiscordComponent>)components);
-
-        /// <summary>
-        /// Appends several rows of components to the message
-        /// </summary>
-        /// <param name="components">The rows of components to add, holding up to five each.</param>
-        /// <returns></returns>
-        public override DiscordFollowupMessageBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
-        {
-            var ara = components.ToArray();
-
-            if (ara.Length + this._components.Count > 5)
-                throw new ArgumentException("ActionRow count exceeds maximum of five.");
-
-            foreach (var ar in ara)
-                this._components.Add(ar);
-
-            return this;
-        }
-
-        /// <summary>
-        /// Appends a collection of components to the message.
-        /// </summary>
-        /// <param name="components">The collection of components to add.</param>
-        /// <returns>The builder to chain calls with.</returns>
-        /// <exception cref="ArgumentException"><paramref name="components"/> contained more than 5 components.</exception>
-        public override DiscordFollowupMessageBuilder AddComponents(IEnumerable<DiscordComponent> components)
-        {
-            var compArr = components.ToArray();
-            var count = compArr.Length;
-
-            if (count > 5)
-                throw new ArgumentException("Cannot add more than 5 components per action row!");
-
-            var arc = new DiscordActionRowComponent(compArr);
-            this._components.Add(arc);
-            return this;
-        }
-        /// <summary>
-        /// Indicates if the followup message must use text-to-speech.
-        /// </summary>
-        /// <param name="tts">Text-to-speech</param>
-        /// <returns>The builder to chain calls with.</returns>
-        public override DiscordFollowupMessageBuilder WithTTS(bool tts)
-        {
-            this.IsTTS = tts;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the message to send with the followup message..
-        /// </summary>
-        /// <param name="content">Message to send.</param>
-        /// <returns>The builder to chain calls with.</returns>
-        public override DiscordFollowupMessageBuilder WithContent(string content)
-        {
-            this.Content = content;
-            return this;
-        }
-
-        /// <summary>
-        /// Adds an embed to the followup message.
-        /// </summary>
-        /// <param name="embed">Embed to add.</param>
-        /// <returns>The builder to chain calls with.</returns>
-        public override DiscordFollowupMessageBuilder AddEmbed(DiscordEmbed embed)
-        {
-            this._embeds.Add(embed);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the given embeds to the followup message.
-        /// </summary>
-        /// <param name="embeds">Embeds to add.</param>
-        /// <returns>The builder to chain calls with.</returns>
-        public override DiscordFollowupMessageBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
-        {
-            this._embeds.AddRange(embeds);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds a file to the followup message.
-        /// </summary>
-        /// <param name="filename">Name of the file.</param>
-        /// <param name="data">File data.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        /// <returns>The builder to chain calls with.</returns>
-        public override DiscordFollowupMessageBuilder AddFile(string filename, Stream data, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count >= 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            if (this._files.Any(x => x.FileName == filename))
-                throw new ArgumentException("A File with that filename already exists");
-
-            if (resetStreamPosition)
-                this._files.Add(new DiscordMessageFile(filename, data, data.Position));
-            else
-                this._files.Add(new DiscordMessageFile(filename, data, null));
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets if the message has files to be sent.
-        /// </summary>
-        /// <param name="stream">The Stream to the file.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        /// <returns>The builder to chain calls with.</returns>
-        public override DiscordFollowupMessageBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count >= 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            if (this._files.Any(x => x.FileName == stream.Name))
-                throw new ArgumentException("A File with that filename already exists");
-
-            if (resetStreamPosition)
-                this._files.Add(new DiscordMessageFile(stream.Name, stream, stream.Position));
-            else
-                this._files.Add(new DiscordMessageFile(stream.Name, stream, null));
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the given files to the followup message.
-        /// </summary>
-        /// <param name="files">Dictionary of file name and file data.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        /// <returns>The builder to chain calls with.</returns>
-        public override DiscordFollowupMessageBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count + files.Count > 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            foreach (var file in files)
-            {
-                if (this._files.Any(x => x.FileName == file.Key))
-                    throw new ArgumentException("A File with that filename already exists");
-
-                if (resetStreamPosition)
-                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, file.Value.Position));
-                else
-                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, null));
-            }
-
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the mention to the mentions to parse, etc. with the followup message.
-        /// </summary>
-        /// <param name="mention">Mention to add.</param>
-        /// <returns>The builder to chain calls with.</returns>
-        public override DiscordFollowupMessageBuilder AddMention(IMention mention)
-        {
-            this._mentions.Add(mention);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the mentions to the mentions to parse, etc. with the followup message.
-        /// </summary>
-        /// <param name="mentions">Mentions to add.</param>
-        /// <returns>The builder to chain calls with.</returns>
-        public override DiscordFollowupMessageBuilder AddMentions(IEnumerable<IMention> mentions)
-        {
-            this._mentions.AddRange(mentions);
-            return this;
-        }
+        /// <param name="builder"></param>
+        public DiscordFollowupMessageBuilder(IDiscordMessageBuilder builder) : base(builder) { }
 
         /// <summary>
         /// Sets the followup message to be ephemeral.
@@ -280,23 +62,13 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Clears all message components on this builder.
-        /// </summary>
-        public override void ClearComponents()
-            => this._components.Clear();
-
-        /// <summary>
         /// Allows for clearing the Followup Message builder so that it can be used again to send a new message.
         /// </summary>
         public override void Clear()
         {
-            this.Content = "";
-            this._embeds.Clear();
-            this.IsTTS = false;
-            this._mentions.Clear();
-            this._files.Clear();
             this.IsEphemeral = false;
-            this._components.Clear();
+
+            base.Clear();
         }
 
         internal void Validate()

--- a/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
@@ -31,12 +31,12 @@ namespace DSharpPlus.Entities
     /// <summary>
     /// Constructs a followup message to an interaction.
     /// </summary>
-    public sealed class DiscordFollowupMessageBuilder : IDiscordMessageBuilder<DiscordFollowupMessageBuilder>
+    public sealed class DiscordFollowupMessageBuilder : BaseDiscordMessageBuilder<DiscordFollowupMessageBuilder>
     {
         /// <summary>
         /// Whether this followup message is text-to-speech.
         /// </summary>
-        public bool IsTTS { get; set; }
+        public override bool IsTTS { get; set; }
 
         /// <summary>
         /// Whether this followup message should be ephemeral.
@@ -49,7 +49,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Message to send on followup message.
         /// </summary>
-        public string Content
+        public override string Content
         {
             get => this._content;
             set
@@ -64,25 +64,25 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Embeds to send on followup message.
         /// </summary>
-        public IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
+        public override IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
         private readonly List<DiscordEmbed> _embeds = new();
 
         /// <summary>
         /// Files to send on this followup message.
         /// </summary>
-        public IReadOnlyList<DiscordMessageFile> Files => this._files;
+        public override IReadOnlyList<DiscordMessageFile> Files => this._files;
         private readonly List<DiscordMessageFile> _files = new();
 
         /// <summary>
         /// Components to send on this followup message.
         /// </summary>
-        public IReadOnlyList<DiscordActionRowComponent> Components => this._components;
+        public override IReadOnlyList<DiscordActionRowComponent> Components => this._components;
         private readonly List<DiscordActionRowComponent> _components = new();
 
         /// <summary>
         /// Mentions to send on this followup message.
         /// </summary>
-        public IReadOnlyList<IMention> Mentions => this._mentions;
+        public override IReadOnlyList<IMention> Mentions => this._mentions;
         private readonly List<IMention> _mentions = new();
 
 
@@ -92,7 +92,7 @@ namespace DSharpPlus.Entities
         /// <param name="components">The collection of components to add.</param>
         /// <returns>The builder to chain calls with.</returns>
         /// <exception cref="ArgumentException"><paramref name="components"/> contained more than 5 components.</exception>
-        public DiscordFollowupMessageBuilder AddComponents(params DiscordComponent[] components)
+        public override DiscordFollowupMessageBuilder AddComponents(params DiscordComponent[] components)
             => this.AddComponents((IEnumerable<DiscordComponent>)components);
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="components">The rows of components to add, holding up to five each.</param>
         /// <returns></returns>
-        public DiscordFollowupMessageBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
+        public override DiscordFollowupMessageBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
         {
             var ara = components.ToArray();
 
@@ -119,7 +119,7 @@ namespace DSharpPlus.Entities
         /// <param name="components">The collection of components to add.</param>
         /// <returns>The builder to chain calls with.</returns>
         /// <exception cref="ArgumentException"><paramref name="components"/> contained more than 5 components.</exception>
-        public DiscordFollowupMessageBuilder AddComponents(IEnumerable<DiscordComponent> components)
+        public override DiscordFollowupMessageBuilder AddComponents(IEnumerable<DiscordComponent> components)
         {
             var compArr = components.ToArray();
             var count = compArr.Length;
@@ -136,7 +136,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="tts">Text-to-speech</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordFollowupMessageBuilder WithTTS(bool tts)
+        public override DiscordFollowupMessageBuilder WithTTS(bool tts)
         {
             this.IsTTS = tts;
             return this;
@@ -147,7 +147,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="content">Message to send.</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordFollowupMessageBuilder WithContent(string content)
+        public override DiscordFollowupMessageBuilder WithContent(string content)
         {
             this.Content = content;
             return this;
@@ -158,7 +158,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="embed">Embed to add.</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordFollowupMessageBuilder AddEmbed(DiscordEmbed embed)
+        public override DiscordFollowupMessageBuilder AddEmbed(DiscordEmbed embed)
         {
             this._embeds.Add(embed);
             return this;
@@ -169,7 +169,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="embeds">Embeds to add.</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordFollowupMessageBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
+        public override DiscordFollowupMessageBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
         {
             this._embeds.AddRange(embeds);
             return this;
@@ -182,7 +182,7 @@ namespace DSharpPlus.Entities
         /// <param name="data">File data.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordFollowupMessageBuilder AddFile(string filename, Stream data, bool resetStreamPosition = false)
+        public override DiscordFollowupMessageBuilder AddFile(string filename, Stream data, bool resetStreamPosition = false)
         {
             if (this.Files.Count >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -204,7 +204,7 @@ namespace DSharpPlus.Entities
         /// <param name="stream">The Stream to the file.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordFollowupMessageBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
+        public override DiscordFollowupMessageBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
         {
             if (this.Files.Count >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -226,7 +226,7 @@ namespace DSharpPlus.Entities
         /// <param name="files">Dictionary of file name and file data.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordFollowupMessageBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
+        public override DiscordFollowupMessageBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
         {
             if (this.Files.Count + files.Count > 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -251,7 +251,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="mention">Mention to add.</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordFollowupMessageBuilder AddMention(IMention mention)
+        public override DiscordFollowupMessageBuilder AddMention(IMention mention)
         {
             this._mentions.Add(mention);
             return this;
@@ -262,7 +262,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="mentions">Mentions to add.</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordFollowupMessageBuilder AddMentions(IEnumerable<IMention> mentions)
+        public override DiscordFollowupMessageBuilder AddMentions(IEnumerable<IMention> mentions)
         {
             this._mentions.AddRange(mentions);
             return this;
@@ -282,13 +282,13 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Clears all message components on this builder.
         /// </summary>
-        public void ClearComponents()
+        public override void ClearComponents()
             => this._components.Clear();
 
         /// <summary>
         /// Allows for clearing the Followup Message builder so that it can be used again to send a new message.
         /// </summary>
-        public void Clear()
+        public override void Clear()
         {
             this.Content = "";
             this._embeds.Clear();

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -58,6 +58,12 @@ namespace DSharpPlus.Entities
         /// </summary>
         public DiscordInteractionResponseBuilder() { }
 
+        public DiscordInteractionResponseBuilder(DiscordInteractionResponseBuilder builder) : base(builder)
+        {
+            this.IsEphemeral = builder.IsEphemeral;
+            this._choices.AddRange(builder._choices);
+        }
+
         /// <summary>
         /// If responding with a modal, sets the title of the modal.
         /// </summary>

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -23,10 +23,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IO;
 using System.Linq;
-using System.Runtime.Versioning;
 
 namespace DSharpPlus.Entities
 {
@@ -35,11 +32,6 @@ namespace DSharpPlus.Entities
     /// </summary>
     public sealed class DiscordInteractionResponseBuilder : BaseDiscordMessageBuilder<DiscordInteractionResponseBuilder>
     {
-        /// <summary>
-        /// Whether this interaction response is text-to-speech.
-        /// </summary>
-        public override bool IsTTS { get; set; }
-
         /// <summary>
         /// Whether this interaction response should be ephemeral.
         /// </summary>
@@ -56,95 +48,21 @@ namespace DSharpPlus.Entities
         public string Title { get; set; }
 
         /// <summary>
-        /// Content of the message to send.
-        /// </summary>
-        public override string Content
-        {
-            get => this._content;
-            set
-            {
-                if (value != null && value.Length > 2000)
-                    throw new ArgumentException("Content length cannot exceed 2000 characters.", nameof(value));
-                this._content = value;
-            }
-        }
-        private string _content;
-
-        /// <summary>
-        /// Embeds to send on this interaction response.
-        /// </summary>
-        public override IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
-        private readonly List<DiscordEmbed> _embeds = new();
-
-        /// <summary>
-        /// Files to send on this interaction response.
-        /// </summary>
-        public override IReadOnlyList<DiscordMessageFile> Files => this._files;
-        private readonly List<DiscordMessageFile> _files = new();
-
-        /// <summary>
-        /// Components to send on this interaction response.
-        /// </summary>
-        public override IReadOnlyList<DiscordActionRowComponent> Components => this._components;
-        private readonly List<DiscordActionRowComponent> _components = new();
-
-        /// <summary>
         /// The choices to send on this interaction response. Mutually exclusive with content, embed, and components.
         /// </summary>
         public IReadOnlyList<DiscordAutoCompleteChoice> Choices => this._choices;
         private readonly List<DiscordAutoCompleteChoice> _choices = new();
 
         /// <summary>
-        /// Mentions to send on this interaction response.
-        /// </summary>
-        public override IReadOnlyList<IMention> Mentions => this._mentions;
-        private readonly List<IMention> _mentions = new();
-
-        /// <summary>
         /// Constructs a new empty interaction response builder.
         /// </summary>
         public DiscordInteractionResponseBuilder() { }
 
-
         /// <summary>
-        /// Constructs a new <see cref="DiscordInteractionResponseBuilder"/> based on an existing <see cref="DiscordMessageBuilder"/>.
+        /// Constructs a new interaction response builder based on another IDiscordMessageBuilder
         /// </summary>
-        /// <param name="builder">The builder to copy.</param>
-        public DiscordInteractionResponseBuilder(DiscordMessageBuilder builder)
-        {
-            this._content = builder.Content;
-            this._mentions = builder._mentions;
-            this._embeds.AddRange(builder.Embeds);
-            this._components.AddRange(builder.Components);
-        }
-
-
-        /// <summary>
-        /// Appends a collection of components to the builder. Each call will append to a new row.
-        /// </summary>
-        /// <param name="components">The components to append. Up to five.</param>
-        /// <returns>The current builder to chain calls with.</returns>
-        /// <exception cref="ArgumentException">Thrown when passing more than 5 components.</exception>
-        public override DiscordInteractionResponseBuilder AddComponents(params DiscordComponent[] components)
-            => this.AddComponents((IEnumerable<DiscordComponent>)components);
-
-        /// <summary>
-        /// Appends several rows of components to the message
-        /// </summary>
-        /// <param name="components">The rows of components to add, holding up to five each.</param>
-        /// <returns></returns>
-        public override DiscordInteractionResponseBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
-        {
-            var ara = components.ToArray();
-
-            if (ara.Length + this._components.Count > 5)
-                throw new ArgumentException("ActionRow count exceeds maximum of five.");
-
-            foreach (var ar in ara)
-                this._components.Add(ar);
-
-            return this;
-        }
+        /// <param name="builder"></param>
+        public DiscordInteractionResponseBuilder(IDiscordMessageBuilder builder) : base(builder) { }
 
         /// <summary>
         /// If responding with a modal, sets the title of the modal.
@@ -171,25 +89,6 @@ namespace DSharpPlus.Entities
                 throw new ArgumentException("Custom ID must be between 1 and 100 characters.");
 
             this.CustomId = id;
-            return this;
-        }
-
-        /// <summary>
-        /// Appends a collection of components to the builder. Each call will append to a new row.
-        /// </summary>
-        /// <param name="components">The components to append. Up to five.</param>
-        /// <returns>The current builder to chain calls with.</returns>
-        /// <exception cref="ArgumentException">Thrown when passing more than 5 components.</exception>
-        public override DiscordInteractionResponseBuilder AddComponents(IEnumerable<DiscordComponent> components)
-        {
-            var compArr = components.ToArray();
-            var count = compArr.Length;
-
-            if (count > 5)
-                throw new ArgumentException("Cannot add more than 5 components per action row!");
-
-            var arc = new DiscordActionRowComponent(compArr);
-            this._components.Add(arc);
             return this;
         }
 
@@ -230,16 +129,6 @@ namespace DSharpPlus.Entities
             => this.AddAutoCompleteChoices((IEnumerable<DiscordAutoCompleteChoice>)choices);
 
         /// <summary>
-        /// Indicates if the interaction response will be text-to-speech.
-        /// </summary>
-        /// <param name="tts">Text-to-speech</param>
-        public override DiscordInteractionResponseBuilder WithTTS(bool tts)
-        {
-            this.IsTTS = tts;
-            return this;
-        }
-
-        /// <summary>
         /// Sets the interaction response to be ephemeral.
         /// </summary>
         /// <param name="ephemeral">Ephemeral.</param>
@@ -250,147 +139,14 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Sets the content of the message to send.
-        /// </summary>
-        /// <param name="content">Content to send.</param>
-        public override DiscordInteractionResponseBuilder WithContent(string content)
-        {
-            this.Content = content;
-            return this;
-        }
-
-        /// <summary>
-        /// Adds an embed to send with the interaction response.
-        /// </summary>
-        /// <param name="embed">Embed to add.</param>
-        public override DiscordInteractionResponseBuilder AddEmbed(DiscordEmbed embed)
-        {
-            if (embed != null)
-                this._embeds.Add(embed); // Interactions will 400 silently //
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the given embeds to send with the interaction response.
-        /// </summary>
-        /// <param name="embeds">Embeds to add.</param>
-        public override DiscordInteractionResponseBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
-        {
-            this._embeds.AddRange(embeds);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds a file to the interaction response.
-        /// </summary>
-        /// <param name="filename">Name of the file.</param>
-        /// <param name="data">File data.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        /// <returns>The builder to chain calls with.</returns>
-        public override DiscordInteractionResponseBuilder AddFile(string filename, Stream data, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count >= 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            if (this._files.Any(x => x.FileName == filename))
-                throw new ArgumentException("A File with that filename already exists");
-
-            if (resetStreamPosition)
-                this._files.Add(new DiscordMessageFile(filename, data, data.Position));
-            else
-                this._files.Add(new DiscordMessageFile(filename, data, null));
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets if the message has files to be sent.
-        /// </summary>
-        /// <param name="stream">The Stream to the file.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        /// <returns>The builder to chain calls with.</returns>
-        public override DiscordInteractionResponseBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count >= 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            if (this._files.Any(x => x.FileName == stream.Name))
-                throw new ArgumentException("A File with that filename already exists");
-
-            if (resetStreamPosition)
-                this._files.Add(new DiscordMessageFile(stream.Name, stream, stream.Position));
-            else
-                this._files.Add(new DiscordMessageFile(stream.Name, stream, null));
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the given files to the interaction response builder.
-        /// </summary>
-        /// <param name="files">Dictionary of file name and file data.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        /// <returns>The builder to chain calls with.</returns>
-        public override DiscordInteractionResponseBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count + files.Count > 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            foreach (var file in files)
-            {
-                if (this._files.Any(x => x.FileName == file.Key))
-                    throw new ArgumentException("A File with that filename already exists");
-
-                if (resetStreamPosition)
-                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, file.Value.Position));
-                else
-                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, null));
-            }
-
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the mention to the mentions to parse, etc. with the interaction response.
-        /// </summary>
-        /// <param name="mention">Mention to add.</param>
-        public override DiscordInteractionResponseBuilder AddMention(IMention mention)
-        {
-            this._mentions.Add(mention);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the mentions to the mentions to parse, etc. with the interaction response.
-        /// </summary>
-        /// <param name="mentions">Mentions to add.</param>
-        public override DiscordInteractionResponseBuilder AddMentions(IEnumerable<IMention> mentions)
-        {
-            this._mentions.AddRange(mentions);
-            return this;
-        }
-
-        /// <summary>
-        /// Clears all message components on this builder.
-        /// </summary>
-        public override void ClearComponents()
-            => this._components.Clear();
-
-        /// <summary>
         /// Allows for clearing the Interaction Response Builder so that it can be used again to send a new response.
         /// </summary>
         public override void Clear()
         {
-            this.Content = "";
-            this._embeds.Clear();
-            this.IsTTS = false;
             this.IsEphemeral = false;
-            this._mentions.Clear();
-            this._components.Clear();
-            this._files.Clear();
             this._choices.Clear();
+
+            base.Clear();
         }
     }
 }

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -33,12 +33,12 @@ namespace DSharpPlus.Entities
     /// <summary>
     /// Constructs an interaction response.
     /// </summary>
-    public sealed class DiscordInteractionResponseBuilder : IDiscordMessageBuilder<DiscordInteractionResponseBuilder>
+    public sealed class DiscordInteractionResponseBuilder : BaseDiscordMessageBuilder<DiscordInteractionResponseBuilder>
     {
         /// <summary>
         /// Whether this interaction response is text-to-speech.
         /// </summary>
-        public bool IsTTS { get; set; }
+        public override bool IsTTS { get; set; }
 
         /// <summary>
         /// Whether this interaction response should be ephemeral.
@@ -58,7 +58,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Content of the message to send.
         /// </summary>
-        public string Content
+        public override string Content
         {
             get => this._content;
             set
@@ -73,19 +73,19 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Embeds to send on this interaction response.
         /// </summary>
-        public IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
+        public override IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
         private readonly List<DiscordEmbed> _embeds = new();
 
         /// <summary>
         /// Files to send on this interaction response.
         /// </summary>
-        public IReadOnlyList<DiscordMessageFile> Files => this._files;
+        public override IReadOnlyList<DiscordMessageFile> Files => this._files;
         private readonly List<DiscordMessageFile> _files = new();
 
         /// <summary>
         /// Components to send on this interaction response.
         /// </summary>
-        public IReadOnlyList<DiscordActionRowComponent> Components => this._components;
+        public override IReadOnlyList<DiscordActionRowComponent> Components => this._components;
         private readonly List<DiscordActionRowComponent> _components = new();
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Mentions to send on this interaction response.
         /// </summary>
-        public IReadOnlyList<IMention> Mentions => this._mentions;
+        public override IReadOnlyList<IMention> Mentions => this._mentions;
         private readonly List<IMention> _mentions = new();
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace DSharpPlus.Entities
         /// <param name="components">The components to append. Up to five.</param>
         /// <returns>The current builder to chain calls with.</returns>
         /// <exception cref="ArgumentException">Thrown when passing more than 5 components.</exception>
-        public DiscordInteractionResponseBuilder AddComponents(params DiscordComponent[] components)
+        public override DiscordInteractionResponseBuilder AddComponents(params DiscordComponent[] components)
             => this.AddComponents((IEnumerable<DiscordComponent>)components);
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="components">The rows of components to add, holding up to five each.</param>
         /// <returns></returns>
-        public DiscordInteractionResponseBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
+        public override DiscordInteractionResponseBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
         {
             var ara = components.ToArray();
 
@@ -180,7 +180,7 @@ namespace DSharpPlus.Entities
         /// <param name="components">The components to append. Up to five.</param>
         /// <returns>The current builder to chain calls with.</returns>
         /// <exception cref="ArgumentException">Thrown when passing more than 5 components.</exception>
-        public DiscordInteractionResponseBuilder AddComponents(IEnumerable<DiscordComponent> components)
+        public override DiscordInteractionResponseBuilder AddComponents(IEnumerable<DiscordComponent> components)
         {
             var compArr = components.ToArray();
             var count = compArr.Length;
@@ -233,7 +233,7 @@ namespace DSharpPlus.Entities
         /// Indicates if the interaction response will be text-to-speech.
         /// </summary>
         /// <param name="tts">Text-to-speech</param>
-        public DiscordInteractionResponseBuilder WithTTS(bool tts)
+        public override DiscordInteractionResponseBuilder WithTTS(bool tts)
         {
             this.IsTTS = tts;
             return this;
@@ -253,7 +253,7 @@ namespace DSharpPlus.Entities
         /// Sets the content of the message to send.
         /// </summary>
         /// <param name="content">Content to send.</param>
-        public DiscordInteractionResponseBuilder WithContent(string content)
+        public override DiscordInteractionResponseBuilder WithContent(string content)
         {
             this.Content = content;
             return this;
@@ -263,7 +263,7 @@ namespace DSharpPlus.Entities
         /// Adds an embed to send with the interaction response.
         /// </summary>
         /// <param name="embed">Embed to add.</param>
-        public DiscordInteractionResponseBuilder AddEmbed(DiscordEmbed embed)
+        public override DiscordInteractionResponseBuilder AddEmbed(DiscordEmbed embed)
         {
             if (embed != null)
                 this._embeds.Add(embed); // Interactions will 400 silently //
@@ -275,7 +275,7 @@ namespace DSharpPlus.Entities
         /// Adds the given embeds to send with the interaction response.
         /// </summary>
         /// <param name="embeds">Embeds to add.</param>
-        public DiscordInteractionResponseBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
+        public override DiscordInteractionResponseBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
         {
             this._embeds.AddRange(embeds);
             return this;
@@ -288,7 +288,7 @@ namespace DSharpPlus.Entities
         /// <param name="data">File data.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordInteractionResponseBuilder AddFile(string filename, Stream data, bool resetStreamPosition = false)
+        public override DiscordInteractionResponseBuilder AddFile(string filename, Stream data, bool resetStreamPosition = false)
         {
             if (this.Files.Count >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -310,7 +310,7 @@ namespace DSharpPlus.Entities
         /// <param name="stream">The Stream to the file.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordInteractionResponseBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
+        public override DiscordInteractionResponseBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
         {
             if (this.Files.Count >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -332,7 +332,7 @@ namespace DSharpPlus.Entities
         /// <param name="files">Dictionary of file name and file data.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The builder to chain calls with.</returns>
-        public DiscordInteractionResponseBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
+        public override DiscordInteractionResponseBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
         {
             if (this.Files.Count + files.Count > 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -356,7 +356,7 @@ namespace DSharpPlus.Entities
         /// Adds the mention to the mentions to parse, etc. with the interaction response.
         /// </summary>
         /// <param name="mention">Mention to add.</param>
-        public DiscordInteractionResponseBuilder AddMention(IMention mention)
+        public override DiscordInteractionResponseBuilder AddMention(IMention mention)
         {
             this._mentions.Add(mention);
             return this;
@@ -366,7 +366,7 @@ namespace DSharpPlus.Entities
         /// Adds the mentions to the mentions to parse, etc. with the interaction response.
         /// </summary>
         /// <param name="mentions">Mentions to add.</param>
-        public DiscordInteractionResponseBuilder AddMentions(IEnumerable<IMention> mentions)
+        public override DiscordInteractionResponseBuilder AddMentions(IEnumerable<IMention> mentions)
         {
             this._mentions.AddRange(mentions);
             return this;
@@ -375,13 +375,13 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Clears all message components on this builder.
         /// </summary>
-        public void ClearComponents()
+        public override void ClearComponents()
             => this._components.Clear();
 
         /// <summary>
         /// Allows for clearing the Interaction Response Builder so that it can be used again to send a new response.
         /// </summary>
-        public void Clear()
+        public override void Clear()
         {
             this.Content = "";
             this._embeds.Clear();

--- a/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
@@ -22,8 +22,6 @@
 // SOFTWARE.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -45,110 +43,20 @@ namespace DSharpPlus.Entities
         public Optional<string> AvatarUrl { get; set; }
 
         /// <summary>
-        /// Whether this webhook request is text-to-speech.
-        /// </summary>
-        public override bool IsTTS { get; set; }
-
-        /// <summary>
-        /// Message to send on this webhook request.
-        /// </summary>
-        public override string Content
-        {
-            get => this._content;
-            set
-            {
-                if (value != null && value.Length > 2000)
-                    throw new ArgumentException("Content length cannot exceed 2000 characters.", nameof(value));
-                this._content = value;
-            }
-        }
-
-        private string _content;
-
-        /// <summary>
         /// Id of the thread to send the webhook request to.
         /// </summary>
         public ulong? ThreadId { get; set; }
-
-        /// <summary>
-        /// Embeds to send on this webhook request.
-        /// </summary>
-        public override IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
-        private readonly List<DiscordEmbed> _embeds = new();
-
-        /// <summary>
-        /// Files to send on this webhook request.
-        /// </summary>
-        public override IReadOnlyList<DiscordMessageFile> Files => this._files;
-        private readonly List<DiscordMessageFile> _files = new();
-
-        /// <summary>
-        /// Mentions to send on this webhook request.
-        /// </summary>
-        public override IReadOnlyList<IMention> Mentions => this._mentions;
-        private readonly List<IMention> _mentions = new();
-
-
-        public override IReadOnlyList<DiscordActionRowComponent> Components => this._components;
-        private readonly List<DiscordActionRowComponent> _components = new();
-
 
         /// <summary>
         /// Constructs a new empty webhook request builder.
         /// </summary>
         public DiscordWebhookBuilder() { } // I still see no point in initializing collections with empty collections. //
 
-
         /// <summary>
-        /// Adds a row of components to the builder, up to 5 components per row, and up to 5 rows per message.
+        /// Constructs a new webhook request builder based on a previous message builder
         /// </summary>
-        /// <param name="components">The components to add to the builder.</param>
-        /// <returns>The current builder to be chained.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">No components were passed.</exception>
-        public override DiscordWebhookBuilder AddComponents(params DiscordComponent[] components)
-            => this.AddComponents((IEnumerable<DiscordComponent>)components);
-
-
-        /// <summary>
-        /// Appends several rows of components to the builder
-        /// </summary>
-        /// <param name="components">The rows of components to add, holding up to five each.</param>
-        /// <returns></returns>
-        public override DiscordWebhookBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
-        {
-            var ara = components.ToArray();
-
-            if (ara.Length + this._components.Count > 5)
-                throw new ArgumentException("ActionRow count exceeds maximum of five.");
-
-            foreach (var ar in ara)
-                this._components.Add(ar);
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds a row of components to the builder, up to 5 components per row, and up to 5 rows per message.
-        /// </summary>
-        /// <param name="components">The components to add to the builder.</param>
-        /// <returns>The current builder to be chained.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">No components were passed.</exception>
-        public override DiscordWebhookBuilder AddComponents(IEnumerable<DiscordComponent> components)
-        {
-            var cmpArr = components.ToArray();
-            var count = cmpArr.Length;
-
-            if (!cmpArr.Any())
-                throw new ArgumentOutOfRangeException(nameof(components), "You must provide at least one component");
-
-            if (count > 5)
-                throw new ArgumentException("Cannot add more than 5 components per action row!");
-
-            var comp = new DiscordActionRowComponent(cmpArr);
-            this._components.Add(comp);
-
-            return this;
-        }
+        /// <param name="builder"></param>
+        public DiscordWebhookBuilder(IDiscordMessageBuilder builder) : base(builder) { }
 
         /// <summary>
         /// Sets the username for this webhook builder.
@@ -167,137 +75,6 @@ namespace DSharpPlus.Entities
         public DiscordWebhookBuilder WithAvatarUrl(string avatarUrl)
         {
             this.AvatarUrl = avatarUrl;
-            return this;
-        }
-
-        /// <summary>
-        /// Indicates if the webhook must use text-to-speech.
-        /// </summary>
-        /// <param name="tts">Text-to-speech</param>
-        public override DiscordWebhookBuilder WithTTS(bool tts)
-        {
-            this.IsTTS = tts;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the message to send at the execution of the webhook.
-        /// </summary>
-        /// <param name="content">Message to send.</param>
-        public override DiscordWebhookBuilder WithContent(string content)
-        {
-            this.Content = content;
-            return this;
-        }
-
-        /// <summary>
-        /// Adds an embed to send at the execution of the webhook.
-        /// </summary>
-        /// <param name="embed">Embed to add.</param>
-        public override DiscordWebhookBuilder AddEmbed(DiscordEmbed embed)
-        {
-            if (embed != null)
-                this._embeds.Add(embed);
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the given embeds to send at the execution of the webhook.
-        /// </summary>
-        /// <param name="embeds">Embeds to add.</param>
-        public override DiscordWebhookBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
-        {
-            this._embeds.AddRange(embeds);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds a file to send at the execution of the webhook.
-        /// </summary>
-        /// <param name="filename">Name of the file.</param>
-        /// <param name="data">File data.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        public override DiscordWebhookBuilder AddFile(string filename, Stream data, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count() >= 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            if (this._files.Any(x => x.FileName == filename))
-                throw new ArgumentException("A File with that filename already exists");
-
-            if (resetStreamPosition)
-                this._files.Add(new DiscordMessageFile(filename, data, data.Position));
-            else
-                this._files.Add(new DiscordMessageFile(filename, data, null));
-
-            return this;
-        }
-
-        /// <summary>
-        /// Sets if the message has files to be sent.
-        /// </summary>
-        /// <param name="stream">The Stream to the file.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        /// <returns></returns>
-        public override DiscordWebhookBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count() >= 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            if (this._files.Any(x => x.FileName == stream.Name))
-                throw new ArgumentException("A File with that filename already exists");
-
-            if (resetStreamPosition)
-                this._files.Add(new DiscordMessageFile(stream.Name, stream, stream.Position));
-            else
-                this._files.Add(new DiscordMessageFile(stream.Name, stream, null));
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the given files to send at the execution of the webhook.
-        /// </summary>
-        /// <param name="files">Dictionary of file name and file data.</param>
-        /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        public override DiscordWebhookBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count() + files.Count() > 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            foreach (var file in files)
-            {
-                if (this._files.Any(x => x.FileName == file.Key))
-                    throw new ArgumentException("A File with that filename already exists");
-
-                if (resetStreamPosition)
-                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, file.Value.Position));
-                else
-                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, null));
-            }
-
-
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the mention to the mentions to parse, etc. at the execution of the webhook.
-        /// </summary>
-        /// <param name="mention">Mention to add.</param>
-        public override DiscordWebhookBuilder AddMention(IMention mention)
-        {
-            this._mentions.Add(mention);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds the mentions to the mentions to parse, etc. at the execution of the webhook.
-        /// </summary>
-        /// <param name="mentions">Mentions to add.</param>
-        public override DiscordWebhookBuilder AddMentions(IEnumerable<IMention> mentions)
-        {
-            this._mentions.AddRange(mentions);
             return this;
         }
 
@@ -332,24 +109,6 @@ namespace DSharpPlus.Entities
         /// <param name="messageId">The id of the message to modify.</param>
         /// <returns>The modified message</returns>
         public async Task<DiscordMessage> ModifyAsync(DiscordWebhook webhook, ulong messageId) => await webhook.EditMessageAsync(messageId, this).ConfigureAwait(false);
-
-        /// <summary>
-        /// Clears all message components on this builder.
-        /// </summary>
-        public override void ClearComponents()
-            => this._components.Clear();
-
-        /// <summary>
-        /// Allows for clearing the Webhook Builder so that it can be used again to send a new message.
-        /// </summary>
-        public override void Clear()
-        {
-            this.Content = "";
-            this._embeds.Clear();
-            this.IsTTS = false;
-            this._mentions.Clear();
-            this._files.Clear();
-        }
 
         /// <summary>
         /// Does the validation before we send a the Create/Modify request.

--- a/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
@@ -56,7 +56,12 @@ namespace DSharpPlus.Entities
         /// Constructs a new webhook request builder based on a previous message builder
         /// </summary>
         /// <param name="builder"></param>
-        public DiscordWebhookBuilder(IDiscordMessageBuilder builder) : base(builder) { }
+        public DiscordWebhookBuilder(DiscordWebhookBuilder builder) : base(builder)
+        {
+            this.Username = builder.Username;
+            this.AvatarUrl = builder.AvatarUrl;
+            this.ThreadId= builder.ThreadId;
+        }
 
         /// <summary>
         /// Sets the username for this webhook builder.
@@ -86,6 +91,14 @@ namespace DSharpPlus.Entities
         {
             this.ThreadId = threadId;
             return this;
+        }
+
+        public override void Clear()
+        {
+            this.Username = default;
+            this.AvatarUrl = default;
+            this.ThreadId = default;
+            base.Clear();
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
@@ -32,7 +32,7 @@ namespace DSharpPlus.Entities
     /// <summary>
     /// Constructs ready-to-send webhook requests.
     /// </summary>
-    public sealed class DiscordWebhookBuilder : IDiscordMessageBuilder<DiscordWebhookBuilder>
+    public sealed class DiscordWebhookBuilder : BaseDiscordMessageBuilder<DiscordWebhookBuilder>
     {
         /// <summary>
         /// Username to use for this webhook request.
@@ -47,12 +47,12 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Whether this webhook request is text-to-speech.
         /// </summary>
-        public bool IsTTS { get; set; }
+        public override bool IsTTS { get; set; }
 
         /// <summary>
         /// Message to send on this webhook request.
         /// </summary>
-        public string Content
+        public override string Content
         {
             get => this._content;
             set
@@ -73,23 +73,23 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Embeds to send on this webhook request.
         /// </summary>
-        public IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
+        public override IReadOnlyList<DiscordEmbed> Embeds => this._embeds;
         private readonly List<DiscordEmbed> _embeds = new();
 
         /// <summary>
         /// Files to send on this webhook request.
         /// </summary>
-        public IReadOnlyList<DiscordMessageFile> Files => this._files;
+        public override IReadOnlyList<DiscordMessageFile> Files => this._files;
         private readonly List<DiscordMessageFile> _files = new();
 
         /// <summary>
         /// Mentions to send on this webhook request.
         /// </summary>
-        public IReadOnlyList<IMention> Mentions => this._mentions;
+        public override IReadOnlyList<IMention> Mentions => this._mentions;
         private readonly List<IMention> _mentions = new();
 
 
-        public IReadOnlyList<DiscordActionRowComponent> Components => this._components;
+        public override IReadOnlyList<DiscordActionRowComponent> Components => this._components;
         private readonly List<DiscordActionRowComponent> _components = new();
 
 
@@ -105,7 +105,7 @@ namespace DSharpPlus.Entities
         /// <param name="components">The components to add to the builder.</param>
         /// <returns>The current builder to be chained.</returns>
         /// <exception cref="ArgumentOutOfRangeException">No components were passed.</exception>
-        public DiscordWebhookBuilder AddComponents(params DiscordComponent[] components)
+        public override DiscordWebhookBuilder AddComponents(params DiscordComponent[] components)
             => this.AddComponents((IEnumerable<DiscordComponent>)components);
 
 
@@ -114,7 +114,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="components">The rows of components to add, holding up to five each.</param>
         /// <returns></returns>
-        public DiscordWebhookBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
+        public override DiscordWebhookBuilder AddComponents(IEnumerable<DiscordActionRowComponent> components)
         {
             var ara = components.ToArray();
 
@@ -133,7 +133,7 @@ namespace DSharpPlus.Entities
         /// <param name="components">The components to add to the builder.</param>
         /// <returns>The current builder to be chained.</returns>
         /// <exception cref="ArgumentOutOfRangeException">No components were passed.</exception>
-        public DiscordWebhookBuilder AddComponents(IEnumerable<DiscordComponent> components)
+        public override DiscordWebhookBuilder AddComponents(IEnumerable<DiscordComponent> components)
         {
             var cmpArr = components.ToArray();
             var count = cmpArr.Length;
@@ -174,7 +174,7 @@ namespace DSharpPlus.Entities
         /// Indicates if the webhook must use text-to-speech.
         /// </summary>
         /// <param name="tts">Text-to-speech</param>
-        public DiscordWebhookBuilder WithTTS(bool tts)
+        public override DiscordWebhookBuilder WithTTS(bool tts)
         {
             this.IsTTS = tts;
             return this;
@@ -184,7 +184,7 @@ namespace DSharpPlus.Entities
         /// Sets the message to send at the execution of the webhook.
         /// </summary>
         /// <param name="content">Message to send.</param>
-        public DiscordWebhookBuilder WithContent(string content)
+        public override DiscordWebhookBuilder WithContent(string content)
         {
             this.Content = content;
             return this;
@@ -194,7 +194,7 @@ namespace DSharpPlus.Entities
         /// Adds an embed to send at the execution of the webhook.
         /// </summary>
         /// <param name="embed">Embed to add.</param>
-        public DiscordWebhookBuilder AddEmbed(DiscordEmbed embed)
+        public override DiscordWebhookBuilder AddEmbed(DiscordEmbed embed)
         {
             if (embed != null)
                 this._embeds.Add(embed);
@@ -206,7 +206,7 @@ namespace DSharpPlus.Entities
         /// Adds the given embeds to send at the execution of the webhook.
         /// </summary>
         /// <param name="embeds">Embeds to add.</param>
-        public DiscordWebhookBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
+        public override DiscordWebhookBuilder AddEmbeds(IEnumerable<DiscordEmbed> embeds)
         {
             this._embeds.AddRange(embeds);
             return this;
@@ -218,7 +218,7 @@ namespace DSharpPlus.Entities
         /// <param name="filename">Name of the file.</param>
         /// <param name="data">File data.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        public DiscordWebhookBuilder AddFile(string filename, Stream data, bool resetStreamPosition = false)
+        public override DiscordWebhookBuilder AddFile(string filename, Stream data, bool resetStreamPosition = false)
         {
             if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -240,7 +240,7 @@ namespace DSharpPlus.Entities
         /// <param name="stream">The Stream to the file.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns></returns>
-        public DiscordWebhookBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
+        public override DiscordWebhookBuilder AddFile(FileStream stream, bool resetStreamPosition = false)
         {
             if (this.Files.Count() >= 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -261,7 +261,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="files">Dictionary of file name and file data.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
-        public DiscordWebhookBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
+        public override DiscordWebhookBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
         {
             if (this.Files.Count() + files.Count() > 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -285,7 +285,7 @@ namespace DSharpPlus.Entities
         /// Adds the mention to the mentions to parse, etc. at the execution of the webhook.
         /// </summary>
         /// <param name="mention">Mention to add.</param>
-        public DiscordWebhookBuilder AddMention(IMention mention)
+        public override DiscordWebhookBuilder AddMention(IMention mention)
         {
             this._mentions.Add(mention);
             return this;
@@ -295,7 +295,7 @@ namespace DSharpPlus.Entities
         /// Adds the mentions to the mentions to parse, etc. at the execution of the webhook.
         /// </summary>
         /// <param name="mentions">Mentions to add.</param>
-        public DiscordWebhookBuilder AddMentions(IEnumerable<IMention> mentions)
+        public override DiscordWebhookBuilder AddMentions(IEnumerable<IMention> mentions)
         {
             this._mentions.AddRange(mentions);
             return this;
@@ -336,13 +336,13 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Clears all message components on this builder.
         /// </summary>
-        public void ClearComponents()
+        public override void ClearComponents()
             => this._components.Clear();
 
         /// <summary>
         /// Allows for clearing the Webhook Builder so that it can be used again to send a new message.
         /// </summary>
-        public void Clear()
+        public override void Clear()
         {
             this.Content = "";
             this._embeds.Clear();

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -3481,7 +3481,7 @@ namespace DSharpPlus.Net
                 Content = builder.Content,
                 IsTTS = builder.IsTTS,
                 Embeds = builder.Embeds,
-                Flags = builder.Flags,
+                Flags = builder._flags,
                 Components = builder.Components
             };
 


### PR DESCRIPTION
# Summary
This change allows for the generic `DiscordMessageBuilder` to be used in more situations, and fixes my initial intended use cases.

# Details
Adds a new `IDiscordMessageBuilder` that gets implemented by a `BaseDiscordMessageBuilder<T>` because our runtime does not support default interface implementations 🔥⚡

# Changes proposed
* Implement an `IDiscordMessageBuilder` without generic type
* Copy methods from `IDiscordMessageBuilder<T>` back to `IDiscordMessageBuilder`
* Make `IDiscordMessageBuilder<T>` into an abstract class named `BaseDiscordMessageBuilder<T>` so we can provide default implementations (that in turn are actually just abstract methods that we override in our REAL™️ concrete implementations)
* Do a little pirouette and clap in your hands seven times

# Notes
1. This is a minor possible breaking change.
999999999. Instead of reinventing the wheel you can also just, idk, copy and paste the wheel and break it's license terms. Breaking license terms is cute, apparently 🤓