### PR TITLE
Add missing constructors to Discord Message Builders

### DIFF
--- a/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
@@ -79,14 +79,14 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Thou shalt NOT PASS! ⚡
         /// </summary>
-        internal BaseDiscordMessageBuilder(){}
+        internal BaseDiscordMessageBuilder() { }
 
         /// <summary>
         /// Constructs a new <see cref="BaseDiscordMessageBuilder{T}"/> based on an existing <see cref="IDiscordMessageBuilder"/>.
         /// Existing file streams will have their position reset to 0.
         /// </summary>
         /// <param name="builder">The builder to copy.</param>
-        public BaseDiscordMessageBuilder(IDiscordMessageBuilder builder)
+        protected BaseDiscordMessageBuilder(IDiscordMessageBuilder builder)
         {
             this._content = builder.Content;
             this._mentions.AddRange(builder.Mentions.ToList());
@@ -308,7 +308,6 @@ namespace DSharpPlus.Entities
             this._files.Clear();
             this._components.Clear();
         }
-
 
         IDiscordMessageBuilder IDiscordMessageBuilder.WithContent(string content) => this.WithContent(content);
         IDiscordMessageBuilder IDiscordMessageBuilder.AddComponents(params DiscordComponent[] components) => this.AddComponents(components);

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -47,9 +47,23 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Gets or Sets a sticker to be attached.
+        /// Gets or sets the sticker for the builder. This will always set the builder to have one sticker.
         /// </summary>
-        public DiscordMessageSticker Sticker { get; set; }
+        public DiscordMessageSticker Sticker
+        {
+            get => this._stickers.Count > 0 ? this._stickers[0] : null;
+            set
+            {
+                this._stickers.Clear();
+                this._stickers.Add(value);
+            }
+        }
+
+        /// <summary>
+        /// The stickers to attach to the message.
+        /// </summary>
+        public IReadOnlyList<DiscordMessageSticker> Stickers => this._stickers;
+        internal List<DiscordMessageSticker> _stickers = new();
 
         /// <summary>
         /// Gets the Reply Message ID.
@@ -92,6 +106,32 @@ namespace DSharpPlus.Entities
         public DiscordMessageBuilder(IDiscordMessageBuilder builder) : base(builder) { }
 
         /// <summary>
+        /// Constructs a new discord message builder based on the passed message.
+        /// </summary>
+        /// <param name="baseMessage">The message to copy.</param>
+        public DiscordMessageBuilder(DiscordMessage baseMessage)
+        {
+            this.IsTTS = baseMessage.IsTTS;
+            this.ReplyId = baseMessage.ReferencedMessage.Id;
+            this._components = baseMessage.Components.ToList(); // Calling ToList copies the list instead of referencing it
+            this._content = baseMessage.Content;
+            this._embeds = baseMessage.Embeds.ToList();
+            this._mentions = new();
+            this._stickers = baseMessage.Stickers.ToList();
+
+            foreach (var user in baseMessage._mentionedUsers)
+            {
+                this._mentions.Add(new UserMention(user.Id));
+            }
+
+            // Unsure about mentionedRoleIds
+            foreach (var role in baseMessage._mentionedRoles)
+            {
+                this._mentions.Add(new RoleMention(role.Id));
+            }
+        }
+
+        /// <summary>
         /// Adds a sticker to the message. Sticker must be from current guild.
         /// </summary>
         /// <param name="sticker">The sticker to add.</param>
@@ -99,6 +139,17 @@ namespace DSharpPlus.Entities
         public DiscordMessageBuilder WithSticker(DiscordMessageSticker sticker)
         {
             this.Sticker = sticker;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a sticker to the message. Sticker must be from current guild.
+        /// </summary>
+        /// <param name="stickers">The sticker to add.</param>
+        /// <returns>The current builder to be chained.</returns>
+        public DiscordMessageBuilder WithStickers(IEnumerable<DiscordMessageSticker> stickers)
+        {
+            this._stickers = stickers.ToList();
             return this;
         }
 

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -253,6 +253,9 @@ namespace DSharpPlus.Entities
 
             if (this.Components.Any(c => c.Components.Count > 5))
                 throw new InvalidOperationException("Action rows can only have 5 components");
+
+            if (this.Stickers?.Count > 3)
+                throw new InvalidOperationException("You can only have 3 stickers per message.");
         }
     }
 }

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -112,22 +112,28 @@ namespace DSharpPlus.Entities
         public DiscordMessageBuilder(DiscordMessage baseMessage)
         {
             this.IsTTS = baseMessage.IsTTS;
-            this.ReplyId = baseMessage.ReferencedMessage.Id;
+            this.ReplyId = baseMessage.ReferencedMessage?.Id;
             this._components = baseMessage.Components.ToList(); // Calling ToList copies the list instead of referencing it
             this._content = baseMessage.Content;
             this._embeds = baseMessage.Embeds.ToList();
-            this._mentions = new();
             this._stickers = baseMessage.Stickers.ToList();
+            this._mentions = new();
 
-            foreach (var user in baseMessage._mentionedUsers)
+            if (baseMessage._mentionedRoles != null)
             {
-                this._mentions.Add(new UserMention(user.Id));
+                foreach (var user in baseMessage._mentionedUsers)
+                {
+                    this._mentions.Add(new UserMention(user.Id));
+                }
             }
 
             // Unsure about mentionedRoleIds
-            foreach (var role in baseMessage._mentionedRoles)
+            if (baseMessage._mentionedRoles != null)
             {
-                this._mentions.Add(new RoleMention(role.Id));
+                foreach (var role in baseMessage._mentionedRoles)
+                {
+                    this._mentions.Add(new RoleMention(role.Id));
+                }
             }
         }
 

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -74,9 +74,9 @@ namespace DSharpPlus.Entities
         public DiscordMessageBuilder() { }
 
         /// <summary>
-        /// Constructs a new discord message builder based on a previous builder
+        /// Constructs a new discord message builder based on a previous builder.
         /// </summary>
-        /// <param name="builder"></param>
+        /// <param name="builder">The builder to copy.</param>
         public DiscordMessageBuilder(DiscordMessageBuilder builder) : base(builder)
         {
             this.Sticker = builder.Sticker;
@@ -84,6 +84,12 @@ namespace DSharpPlus.Entities
             this.MentionOnReply = builder.MentionOnReply;
             this.FailOnInvalidReply = builder.FailOnInvalidReply;
         }
+
+        /// <summary>
+        /// Copies the common properties from the passed builder.
+        /// </summary>
+        /// <param name="builder">The builder to copy.</param>
+        public DiscordMessageBuilder(IDiscordMessageBuilder builder) : base(builder) { }
 
         /// <summary>
         /// Adds a sticker to the message. Sticker must be from current guild.

--- a/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
@@ -50,9 +50,9 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Constructs a new followup message builder based on a previous IDiscordMessageBuilder
+        /// Copies the common properties from the passed builder.
         /// </summary>
-        /// <param name="builder"></param>
+        /// <param name="builder">The builder to copy.</param>
         public DiscordFollowupMessageBuilder(IDiscordMessageBuilder builder) : base(builder) { }
 
         /// <summary>

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionResponseBuilder.cs
@@ -58,6 +58,16 @@ namespace DSharpPlus.Entities
         /// </summary>
         public DiscordInteractionResponseBuilder() { }
 
+        /// <summary>
+        /// Copies the common properties from the passed builder.
+        /// </summary>
+        /// <param name="builder">The builder to copy.</param>
+        public DiscordInteractionResponseBuilder(IDiscordMessageBuilder builder) : base(builder) { }
+
+        /// <summary>
+        /// Constructs a new interaction response builder based on the passed builder.
+        /// </summary>
+        /// <param name="builder">The builder to copy.</param>
         public DiscordInteractionResponseBuilder(DiscordInteractionResponseBuilder builder) : base(builder)
         {
             this.IsEphemeral = builder.IsEphemeral;

--- a/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
+++ b/DSharpPlus/Entities/Webhook/DiscordWebhookBuilder.cs
@@ -55,13 +55,19 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Constructs a new webhook request builder based on a previous message builder
         /// </summary>
-        /// <param name="builder"></param>
+        /// <param name="builder">The builder to copy.</param>
         public DiscordWebhookBuilder(DiscordWebhookBuilder builder) : base(builder)
         {
             this.Username = builder.Username;
             this.AvatarUrl = builder.AvatarUrl;
-            this.ThreadId= builder.ThreadId;
+            this.ThreadId = builder.ThreadId;
         }
+
+        /// <summary>
+        /// Copies the common properties from the passed builder.
+        /// </summary>
+        /// <param name="builder">The builder to copy.</param>
+        public DiscordWebhookBuilder(IDiscordMessageBuilder builder) : base(builder) { }
 
         /// <summary>
         /// Sets the username for this webhook builder.

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1358,7 +1358,7 @@ namespace DSharpPlus.Net
             {
                 HasContent = builder.Content != null,
                 Content = builder.Content,
-                StickersIds = builder.Sticker is null ? Array.Empty<ulong>() : new[] {builder.Sticker.Id},
+                StickersIds = builder._stickers?.Select(x => x.Id).ToArray(),
                 IsTTS = builder.IsTTS,
                 HasEmbed = builder.Embeds != null,
                 Embeds = builder.Embeds,


### PR DESCRIPTION
# Summary
This PR adds the missing `IDiscordBuilder` constructors to other message builders, allowing others to easily convert builders into other builders by copying the common properties (`DiscordMessageBuilder` -> `DiscordInteractionResponseBuilder`).

# Changes proposed
* Adds `IDiscordMessageBuilder` as an available constructor to all message builders, which copies common properties such as `Content` or `Embeds`
* Adds a `DiscordMessage` constructor to `DiscordMessageBuilder`
* Adds a `Stickers` property onto `DiscordMessageBuilder` and modifies `DiscordApiClient.CreateMessageAsync` to allow for multiple stickers to be sent, [as accepted by the docs](https://discord.com/developers/docs/resources/channel#create-message-jsonform-params) (`sticker_ids`)

# Notes
Changes have been tested, except for multi-sticker support.