### PR TITLE
Fix cooldown attribute

### DIFF
--- a/DSharpPlus.CommandsNext/Attributes/CooldownAttribute.cs
+++ b/DSharpPlus.CommandsNext/Attributes/CooldownAttribute.cs
@@ -53,7 +53,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <summary>
         /// Gets the cooldown buckets for this command.
         /// </summary>
-        private ConcurrentDictionary<string, CommandCooldownBucket> Buckets { get; }
+        private static readonly ConcurrentDictionary<string, CommandCooldownBucket> _buckets = new();
 
         /// <summary>
         /// Defines a cooldown for this command. This means that users will be able to use the command a specific number of times before they have to wait to use it again.
@@ -66,7 +66,6 @@ namespace DSharpPlus.CommandsNext.Attributes
             this.MaxUses = maxUses;
             this.Reset = TimeSpan.FromSeconds(resetAfter);
             this.BucketType = bucketType;
-            this.Buckets = new ConcurrentDictionary<string, CommandCooldownBucket>();
         }
 
         /// <summary>
@@ -77,7 +76,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         public CommandCooldownBucket GetBucket(CommandContext ctx)
         {
             var bid = this.GetBucketId(ctx, out _, out _, out _);
-            this.Buckets.TryGetValue(bid, out var bucket);
+            _buckets.TryGetValue(bid, out var bucket);
             return bucket;
         }
 
@@ -89,10 +88,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         public TimeSpan GetRemainingCooldown(CommandContext ctx)
         {
             var bucket = this.GetBucket(ctx);
-            if (bucket is null)
-                return TimeSpan.Zero;
-
-            return bucket.RemainingUses > 0 ? TimeSpan.Zero : bucket.ResetsAt - DateTimeOffset.UtcNow;
+            return (bucket is null || bucket.RemainingUses > 0) ? TimeSpan.Zero : bucket.ResetsAt - DateTimeOffset.UtcNow;
         }
 
         /// <summary>
@@ -106,21 +102,28 @@ namespace DSharpPlus.CommandsNext.Attributes
         private string GetBucketId(CommandContext ctx, out ulong userId, out ulong channelId, out ulong guildId)
         {
             userId = 0ul;
-            if ((this.BucketType & CooldownBucketType.User) != 0)
+            if (this.BucketType.HasFlag(CooldownBucketType.User))
                 userId = ctx.User.Id;
 
             channelId = 0ul;
-            if ((this.BucketType & CooldownBucketType.Channel) != 0)
-                channelId = ctx.Channel.Id;
-            if ((this.BucketType & CooldownBucketType.Guild) != 0 && ctx.Guild == null)
+            if (this.BucketType.HasFlag(CooldownBucketType.Channel))
                 channelId = ctx.Channel.Id;
 
             guildId = 0ul;
-            if (ctx.Guild != null && (this.BucketType & CooldownBucketType.Guild) != 0)
-                guildId = ctx.Guild.Id;
+            if (this.BucketType.HasFlag(CooldownBucketType.Guild))
+            {
+                if (ctx.Guild == null)
+                {
+                    channelId = ctx.Channel.Id;
+                }
+                else
+                {
+                    guildId = ctx.Guild.Id;
+                }
+            }
 
-            var bid = CommandCooldownBucket.MakeId(userId, channelId, guildId);
-            return bid;
+            var bucketId = CommandCooldownBucket.MakeId(ctx.Command!.QualifiedName, userId, channelId, guildId);
+            return bucketId;
         }
 
         public override async Task<bool> ExecuteCheckAsync(CommandContext ctx, bool help)
@@ -128,11 +131,11 @@ namespace DSharpPlus.CommandsNext.Attributes
             if (help)
                 return true;
 
-            var bid = this.GetBucketId(ctx, out var usr, out var chn, out var gld);
-            if (!this.Buckets.TryGetValue(bid, out var bucket))
+            var bucketId = this.GetBucketId(ctx, out var userId, out var channelId, out var guildId);
+            if (!_buckets.TryGetValue(bucketId, out var bucket))
             {
-                bucket = new CommandCooldownBucket(this.MaxUses, this.Reset, usr, chn, gld);
-                this.Buckets.AddOrUpdate(bid, bucket, (k, v) => bucket);
+                bucket = new CommandCooldownBucket(ctx.Command!.QualifiedName, this.MaxUses, this.Reset, userId, channelId, guildId);
+                _buckets.AddOrUpdate(bucketId, bucket, (key, value) => bucket);
             }
 
             return await bucket.DecrementUseAsync().ConfigureAwait(false);
@@ -171,6 +174,11 @@ namespace DSharpPlus.CommandsNext.Attributes
     public sealed class CommandCooldownBucket : IEquatable<CommandCooldownBucket>
     {
         /// <summary>
+        /// The command's full name (includes groups and subcommands).
+        /// </summary>
+        public string FullCommandName { get; }
+
+        /// <summary>
         /// Gets the ID of the user with whom this cooldown is associated.
         /// </summary>
         public ulong UserId { get; }
@@ -193,10 +201,8 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <summary>
         /// Gets the remaining number of uses before the cooldown is triggered.
         /// </summary>
-        public int RemainingUses
-            => Volatile.Read(ref this._remaining_uses);
-
-        private int _remaining_uses;
+        public int RemainingUses => Volatile.Read(ref this._remainingUses);
+        private int _remainingUses;
 
         /// <summary>
         /// Gets the maximum number of times this command can be used in given timespan.
@@ -216,27 +222,29 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <summary>
         /// Gets the semaphore used to lock the use value.
         /// </summary>
-        private SemaphoreSlim UsageSemaphore { get; }
+        private SemaphoreSlim _usageSemaphore { get; }
 
         /// <summary>
         /// Creates a new command cooldown bucket.
         /// </summary>
+        /// <param name="fullCommandName">Full name of the command.</param>
         /// <param name="maxUses">Maximum number of uses for this bucket.</param>
         /// <param name="resetAfter">Time after which this bucket resets.</param>
         /// <param name="userId">ID of the user with which this cooldown is associated.</param>
         /// <param name="channelId">ID of the channel with which this cooldown is associated.</param>
         /// <param name="guildId">ID of the guild with which this cooldown is associated.</param>
-        internal CommandCooldownBucket(int maxUses, TimeSpan resetAfter, ulong userId = 0, ulong channelId = 0, ulong guildId = 0)
+        internal CommandCooldownBucket(string fullCommandName, int maxUses, TimeSpan resetAfter, ulong userId = 0, ulong channelId = 0, ulong guildId = 0)
         {
-            this._remaining_uses = maxUses;
+            this.FullCommandName = fullCommandName;
             this.MaxUses = maxUses;
             this.ResetsAt = DateTimeOffset.UtcNow + resetAfter;
             this.Reset = resetAfter;
             this.UserId = userId;
             this.ChannelId = channelId;
             this.GuildId = guildId;
-            this.BucketId = MakeId(userId, channelId, guildId);
-            this.UsageSemaphore = new SemaphoreSlim(1, 1);
+            this.BucketId = MakeId(fullCommandName, userId, channelId, guildId);
+            this._remainingUses = maxUses;
+            this._usageSemaphore = new SemaphoreSlim(1, 1);
         }
 
         /// <summary>
@@ -245,14 +253,14 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <returns>Whether decrement succeded or not.</returns>
         internal async Task<bool> DecrementUseAsync()
         {
-            await this.UsageSemaphore.WaitAsync().ConfigureAwait(false);
+            await this._usageSemaphore.WaitAsync().ConfigureAwait(false);
 
             // if we're past reset time...
             var now = DateTimeOffset.UtcNow;
             if (now >= this.ResetsAt)
             {
                 // ...do the reset and set a new reset time
-                Interlocked.Exchange(ref this._remaining_uses, this.MaxUses);
+                Interlocked.Exchange(ref this._remainingUses, this.MaxUses);
                 this.ResetsAt = now + this.Reset;
             }
 
@@ -261,12 +269,12 @@ namespace DSharpPlus.CommandsNext.Attributes
             if (this.RemainingUses > 0)
             {
                 // ...decrement, and return success...
-                Interlocked.Decrement(ref this._remaining_uses);
+                Interlocked.Decrement(ref this._remainingUses);
                 success = true;
             }
 
             // ...otherwise just fail
-            this.UsageSemaphore.Release();
+            this._usageSemaphore.Release();
             return success;
         }
 
@@ -288,15 +296,7 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// </summary>
         /// <param name="other"><see cref="CommandCooldownBucket"/> to compare to.</param>
         /// <returns>Whether the <see cref="CommandCooldownBucket"/> is equal to this <see cref="CommandCooldownBucket"/>.</returns>
-        public bool Equals(CommandCooldownBucket other)
-        {
-            if (other is null)
-                return false;
-
-            return ReferenceEquals(this, other)
-                ? true
-                : this.UserId == other.UserId && this.ChannelId == other.ChannelId && this.GuildId == other.GuildId;
-        }
+        public bool Equals(CommandCooldownBucket other) => other is not null && (ReferenceEquals(this, other) || (this.UserId == other.UserId && this.ChannelId == other.ChannelId && this.GuildId == other.GuildId));
 
         /// <summary>
         /// Gets the hash code for this <see cref="CommandCooldownBucket"/>.
@@ -324,10 +324,7 @@ namespace DSharpPlus.CommandsNext.Attributes
             var null1 = bucket1 is null;
             var null2 = bucket2 is null;
 
-            if (null1 && null2)
-                return true;
-
-            return null1 != null2 ? false : null1.Equals(null2);
+            return (null1 && null2) || (null1 == null2 && null1.Equals(null2));
         }
 
         /// <summary>
@@ -336,17 +333,17 @@ namespace DSharpPlus.CommandsNext.Attributes
         /// <param name="bucket1">First bucket to compare.</param>
         /// <param name="bucket2">Second bucket to compare.</param>
         /// <returns>Whether the two buckets are not equal.</returns>
-        public static bool operator !=(CommandCooldownBucket bucket1, CommandCooldownBucket bucket2)
-            => !(bucket1 == bucket2);
+        public static bool operator !=(CommandCooldownBucket bucket1, CommandCooldownBucket bucket2) => !(bucket1 == bucket2);
 
         /// <summary>
         /// Creates a bucket ID from given bucket parameters.
         /// </summary>
+        /// <param name="fullCommandName">Full name of the command with which this cooldown is associated.</param>
         /// <param name="userId">ID of the user with which this cooldown is associated.</param>
         /// <param name="channelId">ID of the channel with which this cooldown is associated.</param>
         /// <param name="guildId">ID of the guild with which this cooldown is associated.</param>
         /// <returns>Generated bucket ID.</returns>
-        public static string MakeId(ulong userId = 0, ulong channelId = 0, ulong guildId = 0)
-            => $"{userId.ToString(CultureInfo.InvariantCulture)}:{channelId.ToString(CultureInfo.InvariantCulture)}:{guildId.ToString(CultureInfo.InvariantCulture)}";
+        public static string MakeId(string fullCommandName, ulong userId = 0, ulong channelId = 0, ulong guildId = 0)
+            => $"{userId.ToString(CultureInfo.InvariantCulture)}:{channelId.ToString(CultureInfo.InvariantCulture)}:{guildId.ToString(CultureInfo.InvariantCulture)}:{fullCommandName}";
     }
 }

--- a/DSharpPlus.SlashCommands/Built-in Checks/SlashCooldownAttribute.cs
+++ b/DSharpPlus.SlashCommands/Built-in Checks/SlashCooldownAttribute.cs
@@ -122,7 +122,7 @@ namespace DSharpPlus.SlashCommands.Attributes
                 }
             }
 
-            var bucketId = SlashCommandCooldownBucket.MakeId(ctx.CommandName, userId, channelId, guildId);
+            var bucketId = SlashCommandCooldownBucket.MakeId(ctx.QualifiedName, userId, channelId, guildId);
             return bucketId;
         }
 
@@ -131,7 +131,7 @@ namespace DSharpPlus.SlashCommands.Attributes
             var bucketId = this.GetBucketId(ctx, out var userId, out var channelId, out var guildId);
             if (!_buckets.TryGetValue(bucketId, out var bucket))
             {
-                bucket = new SlashCommandCooldownBucket(ctx.CommandName, this.MaxUses, this.Reset, userId, channelId, guildId);
+                bucket = new SlashCommandCooldownBucket(ctx.QualifiedName, this.MaxUses, this.Reset, userId, channelId, guildId);
                 _buckets.AddOrUpdate(bucketId, bucket, (key, value) => bucket);
             }
 

--- a/DSharpPlus.SlashCommands/Built-in Checks/SlashCooldownAttribute.cs
+++ b/DSharpPlus.SlashCommands/Built-in Checks/SlashCooldownAttribute.cs
@@ -122,7 +122,7 @@ namespace DSharpPlus.SlashCommands.Attributes
                 }
             }
 
-            var bucketId = SlashCommandCooldownBucket.MakeId(ctx.QualifiedName, userId, channelId, guildId);
+            var bucketId = SlashCommandCooldownBucket.MakeId(ctx.QualifiedName, ctx.Client.CurrentUser.Id, userId, channelId, guildId);
             return bucketId;
         }
 
@@ -131,7 +131,7 @@ namespace DSharpPlus.SlashCommands.Attributes
             var bucketId = this.GetBucketId(ctx, out var userId, out var channelId, out var guildId);
             if (!_buckets.TryGetValue(bucketId, out var bucket))
             {
-                bucket = new SlashCommandCooldownBucket(ctx.QualifiedName, this.MaxUses, this.Reset, userId, channelId, guildId);
+                bucket = new SlashCommandCooldownBucket(ctx.QualifiedName, ctx.Client.CurrentUser.Id, this.MaxUses, this.Reset, userId, channelId, guildId);
                 _buckets.AddOrUpdate(bucketId, bucket, (key, value) => bucket);
             }
 
@@ -174,6 +174,11 @@ namespace DSharpPlus.SlashCommands.Attributes
         /// The command's full name (includes groups and subcommands).
         /// </summary>
         public string FullCommandName { get; }
+
+        /// <summary>
+        /// The bot's ID.
+        /// </summary>
+        public ulong BotId { get; }
 
         /// <summary>
         /// Gets the ID of the user with whom this cooldown is associated.
@@ -225,21 +230,23 @@ namespace DSharpPlus.SlashCommands.Attributes
         /// Creates a new command cooldown bucket.
         /// </summary>
         /// <param name="fullCommandName">Full name of the command.</param>
+        /// <param name="botId">ID of the bot.</param>
         /// <param name="maxUses">Maximum number of uses for this bucket.</param>
         /// <param name="resetAfter">Time after which this bucket resets.</param>
         /// <param name="userId">ID of the user with which this cooldown is associated.</param>
         /// <param name="channelId">ID of the channel with which this cooldown is associated.</param>
         /// <param name="guildId">ID of the guild with which this cooldown is associated.</param>
-        internal SlashCommandCooldownBucket(string fullCommandName, int maxUses, TimeSpan resetAfter, ulong userId = 0, ulong channelId = 0, ulong guildId = 0)
+        internal SlashCommandCooldownBucket(string fullCommandName, ulong botId, int maxUses, TimeSpan resetAfter, ulong userId = 0, ulong channelId = 0, ulong guildId = 0)
         {
             this.FullCommandName = fullCommandName;
+            this.BotId = botId;
             this.MaxUses = maxUses;
             this.ResetsAt = DateTimeOffset.UtcNow + resetAfter;
             this.Reset = resetAfter;
             this.UserId = userId;
             this.ChannelId = channelId;
             this.GuildId = guildId;
-            this.BucketId = MakeId(fullCommandName, userId, channelId, guildId);
+            this.BucketId = MakeId(fullCommandName, botId, userId, channelId, guildId);
             this._remainingUses = maxUses;
             this._usageSemaphore = new SemaphoreSlim(1, 1);
         }
@@ -336,11 +343,12 @@ namespace DSharpPlus.SlashCommands.Attributes
         /// Creates a bucket ID from given bucket parameters.
         /// </summary>
         /// <param name="fullCommandName">Full name of the command with which this cooldown is associated.</param>
+        /// <param name="botId">ID of the bot with which this cooldown is associated.</param>
         /// <param name="userId">ID of the user with which this cooldown is associated.</param>
         /// <param name="channelId">ID of the channel with which this cooldown is associated.</param>
         /// <param name="guildId">ID of the guild with which this cooldown is associated.</param>
         /// <returns>Generated bucket ID.</returns>
-        public static string MakeId(string fullCommandName, ulong userId = 0, ulong channelId = 0, ulong guildId = 0)
-            => $"{userId.ToString(CultureInfo.InvariantCulture)}:{channelId.ToString(CultureInfo.InvariantCulture)}:{guildId.ToString(CultureInfo.InvariantCulture)}:{fullCommandName}";
+        public static string MakeId(string fullCommandName, ulong botId, ulong userId = 0, ulong channelId = 0, ulong guildId = 0)
+            => $"{userId.ToString(CultureInfo.InvariantCulture)}:{channelId.ToString(CultureInfo.InvariantCulture)}:{guildId.ToString(CultureInfo.InvariantCulture)}:{botId}:{fullCommandName}";
     }
 }

--- a/DSharpPlus.SlashCommands/Contexts/BaseContext.cs
+++ b/DSharpPlus.SlashCommands/Contexts/BaseContext.cs
@@ -63,6 +63,11 @@ namespace DSharpPlus.SlashCommands
         public string CommandName { get; internal set; }
 
         /// <summary>
+        /// Gets the qualified name of the command.
+        /// </summary>
+        public string QualifiedName { get; internal set; }
+
+        /// <summary>
         /// Gets the type of this interaction.
         /// </summary>
         public ApplicationCommandType Type { get; internal set; }

--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -568,6 +569,14 @@ namespace DSharpPlus.SlashCommands
             {
                 if (e.Interaction.Type == InteractionType.ApplicationCommand)
                 {
+                    var qualifiedName = new StringBuilder(e.Interaction.Data.Name);
+                    var options = e.Interaction.Data.Options ?? Enumerable.Empty<DiscordInteractionDataOption>();
+                    while (options.Any() && options.First().Type is ApplicationCommandOptionType.SubCommandGroup or ApplicationCommandOptionType.SubCommand) // ... I'm sorry
+                    {
+                        _ = qualifiedName.AppendFormat(" {0}", options.First().Name);
+                        options = options.First().Options ?? Enumerable.Empty<DiscordInteractionDataOption>();
+                    }
+
                     //Creates the context
                     var context = new InteractionContext
                     {
@@ -578,6 +587,7 @@ namespace DSharpPlus.SlashCommands
                         Client = client,
                         SlashCommandsExtension = this,
                         CommandName = e.Interaction.Data.Name,
+                        QualifiedName = qualifiedName.ToString(),
                         InteractionId = e.Interaction.Id,
                         Token = e.Interaction.Token,
                         Services = this._configuration?.Services,

--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -570,11 +570,17 @@ namespace DSharpPlus.SlashCommands
                 if (e.Interaction.Type == InteractionType.ApplicationCommand)
                 {
                     var qualifiedName = new StringBuilder(e.Interaction.Data.Name);
-                    var options = e.Interaction.Data.Options ?? Enumerable.Empty<DiscordInteractionDataOption>();
-                    while (options.Any() && options.First().Type is ApplicationCommandOptionType.SubCommandGroup or ApplicationCommandOptionType.SubCommand) // ... I'm sorry
+                    var options = e.Interaction.Data.Options?.ToArray() ?? Array.Empty<DiscordInteractionDataOption>();
+                    while (options.Any())
                     {
-                        _ = qualifiedName.AppendFormat(" {0}", options.First().Name);
-                        options = options.First().Options ?? Enumerable.Empty<DiscordInteractionDataOption>();
+                        var firstOption = options[0];
+                        if (firstOption.Type is not ApplicationCommandOptionType.SubCommandGroup and not ApplicationCommandOptionType.SubCommand)
+                        {
+                            break;
+                        }
+
+                        _ = qualifiedName.AppendFormat(" {0}", firstOption.Name);
+                        options = firstOption.Options?.ToArray() ?? Array.Empty<DiscordInteractionDataOption>();
                     }
 
                     //Creates the context


### PR DESCRIPTION
# Summary
Closes #1377 and closes #1419 using both of their reproduction example code respectively.

# Details
![Before and After image of both ping1 and ping2test failing as intended.](https://user-images.githubusercontent.com/46751150/207501371-e407631b-4bc1-4f5f-91ae-8d9c11914043.png)

![command groups work as well.](https://user-images.githubusercontent.com/46751150/207503836-cc0bb5ef-9dd6-4148-a0c5-060836fbd55f.png)


# Changes proposed
* Adds a new `QualifiedName` property to `InteractionContext` using bad LINQ. Improvements welcome.
* Cleans up CooldownAttribute on both CNext and Slashies
* Theoretically fixes cooldown not working on multiple shards (global commands) by making the dictionary static.

# Notes
Tested. By making `_buckets` static, there is a missing edge case that could be hit. If a user decides to host multiple bots in the same program using the same commands, the cooldowns from bot a could be incorrectly applied to commands from bot b. This could easily be fixed by appending the user id to the bucket id, however I am unsure if this is a scenario we wish to support.