### PR TITLE
Pull git history

### DIFF
--- a/.github/workflows/publish_nightly_master.yml
+++ b/.github/workflows/publish_nightly_master.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/publish_nightly_v5.yml
+++ b/.github/workflows/publish_nightly_v5.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: v5
+          fetch-depth: '0'
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/publish_release_master.yml
+++ b/.github/workflows/publish_release_master.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/publish_release_v5.yml
+++ b/.github/workflows/publish_release_v5.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: v5
+          fetch-depth: '0'
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3


### PR DESCRIPTION
# Summary
My PR #1427 updates the Github Actions, allowing the channel topic to be updated while also making way for v5. When updating the channel topic, the action makes use of `git describe`, which requires the git history. By default, the `actions/checkout` action only pulls the latest commit and nothing more. This PR fixes this and should allow our actions to execute successfully... Theoretically