### PR TITLE
Correctly write the error

### DIFF
--- a/tools/AutoUpdateChannelDescription/src/Program.cs
+++ b/tools/AutoUpdateChannelDescription/src/Program.cs
@@ -41,7 +41,7 @@ namespace DSharpPlus.Tools.AutoUpdateChannelDescription
                     }
                     catch (DiscordException error)
                     {
-                        Console.WriteLine(error.WebResponse);
+                        Console.WriteLine($"Error: HTTP {error.WebResponse.ResponseCode}, {error.WebResponse.Response}");
                         Environment.Exit(1);
                     }
                     Environment.Exit(0);


### PR DESCRIPTION
Correctly writes the exception to console instead of printing "DSharpPlus.Net.RestResponse"