### PR TITLE
Replace 1091 with 1195 due to the run number "resetting"

### DIFF
--- a/.github/workflows/publish_nightly_master.yml
+++ b/.github/workflows/publish_nightly_master.yml
@@ -31,7 +31,7 @@ jobs:
           DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet # Attempts to install to `/usr/share/dotnet`, which is not writable on GitHub Actions by default.
 
       - name: Package
-        run: "mkdir build && dotnet pack -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --include-source -o build -p:VersionSuffix='nightly' -p:BuildNumber=$(printf \"%0*d\n\" 5 $(( 1091 + ${{ github.run_number }} )))" # We add 1091 since it's the last build number AppVeyor used.
+        run: "mkdir build && dotnet pack -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --include-source -o build -p:VersionSuffix='nightly' -p:BuildNumber=$(printf \"%0*d\n\" 5 $(( 1195 + ${{ github.run_number }} )))" # We add 1195 since it's the last build number AppVeyor used.
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
@@ -45,7 +45,7 @@ jobs:
 
       - name: Update Discord Channel Topic
         if: ${{ github.event_name == 'push' }} # Only update channel topic when a PR is merged
-        run: "dotnet run --project ./tools/AutoUpdateChannelDescription -p:VersionSuffix='nightly' -p:BuildNumber=$(printf \"%0*d\n\" 5 $(( 1091 + ${{ github.run_number }} ))) -- $(git describe --abbrev=0 --tags)"
+        run: "dotnet run --project ./tools/AutoUpdateChannelDescription -p:VersionSuffix='nightly' -p:BuildNumber=$(printf \"%0*d\n\" 5 $(( 1195 + ${{ github.run_number }} ))) -- $(git describe --abbrev=0 --tags)"
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}

--- a/.github/workflows/publish_release_master.yml
+++ b/.github/workflows/publish_release_master.yml
@@ -48,7 +48,7 @@ jobs:
           omitNameDuringUpdate: true # We don't want to update the name of the release.
 
       - name: Update Discord Channel Topic
-        run: "dotnet run --project ./tools/AutoUpdateChannelDescription -p:Nightly=$(printf \"%0*d\n\" 5 $(( 1091 + ${{ github.run_number }} )) -- $(git describe --abbrev=0 --tags)"
+        run: "dotnet run --project ./tools/AutoUpdateChannelDescription -p:Nightly=$(printf \"%0*d\n\" 5 $(( 1195 + ${{ github.run_number }} )) -- $(git describe --abbrev=0 --tags)"
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}


### PR DESCRIPTION
# Summary
Replace 1091 with 1195 due to the run number "resetting."

# Details
Due to me separating (and renaming) the Github Actions files, the run number for these actions are "reset." To be more correct, each github action has the run number set to zero, as it is not global. Because the actions files were renamed,  Github Actions sees these as entirely new actions and the run number was set to 0.

This PR is important as GH Actions will eventually try publishing a package that already exists, which will lead to the action failing.
![image](https://user-images.githubusercontent.com/46751150/207736618-56c3e150-b84f-484e-a195-f22b62b1966b.png)

My apologies for overlooking this. I pray for both me and everyone else involved that this is the last time I will be touching GH Actions