### PR TITLE
[ci-skip] Don't download the .NET SDK every action, instead reuse it.

### DIFF
--- a/.github/workflows/publish_nightly_master.yml
+++ b/.github/workflows/publish_nightly_master.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           dotnet-version: 7
         env:
-          DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet # Attempts to install to `/usr/share/dotnet`, which is not writable on GitHub Actions by default.
+          DOTNET_INSTALL_DIR: ${{ github.workspace }}/../.dotnet # Attempts to install to `/usr/share/dotnet`, which is not writable on GitHub Actions by default.
 
       - name: Package
         run: "mkdir build && dotnet pack -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --include-source -o build -p:VersionSuffix='nightly' -p:BuildNumber=$(printf \"%0*d\n\" 5 $(( 1195 + ${{ github.run_number }} )))" # We add 1195 since it's the last build number AppVeyor used.

--- a/.github/workflows/publish_nightly_v5.yml
+++ b/.github/workflows/publish_nightly_v5.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           dotnet-version: 7
         env:
-          DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet # Attempts to install to `/usr/share/dotnet`, which is not writable on GitHub Actions by default.
+          DOTNET_INSTALL_DIR: ${{ github.workspace }}/../.dotnet # Attempts to install to `/usr/share/dotnet`, which is not writable on GitHub Actions by default.
 
       - name: Package
         run: "mkdir build && dotnet pack -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --include-source -o build -p:VersionPrefix='5.0.0' -p:VersionSuffix='nightly' -p:BuildNumber=$(printf \"%0*d\n\" 5 ${{ github.run_number }})"

--- a/.github/workflows/publish_release_master.yml
+++ b/.github/workflows/publish_release_master.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           dotnet-version: 7
         env:
-          DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet # Attempts to install to `/usr/share/dotnet`, which is not writable on GitHub Actions by default.
+          DOTNET_INSTALL_DIR: ${{ github.workspace }}/../.dotnet # Attempts to install to `/usr/share/dotnet`, which is not writable on GitHub Actions by default.
 
       - name: Build Nuget Packages
         run: "mkdir build && dotnet pack -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -c Release -o build"

--- a/.github/workflows/publish_release_v5.yml
+++ b/.github/workflows/publish_release_v5.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           dotnet-version: 7
         env:
-          DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet # Attempts to install to `/usr/share/dotnet`, which is not writable on GitHub Actions by default.
+          DOTNET_INSTALL_DIR: ${{ github.workspace }}/../.dotnet # Attempts to install to `/usr/share/dotnet`, which is not writable on GitHub Actions by default.
 
       - name: Build Nuget Packages
         run: "mkdir build && dotnet pack -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -c Release -o build"


### PR DESCRIPTION
# Summary
As it is right now, everytime an action is invoked, the action must redownload the .NET SDK due to `actions/checkout` resetting the repo to a clean state. To prevent this, we download the SDK to the parent directory.

# Notes
These changes have been tested. This will shave 40 seconds off of each action invoked.