### PR TITLE
Sed: Convert `IReadOnlyCollection<T>` to `IReadOnlyList<T>`

### DIFF
--- a/src/DSharpPlus.CommandsNext/main/Entities/CommandArgument.cs
+++ b/src/DSharpPlus.CommandsNext/main/Entities/CommandArgument.cs
@@ -66,5 +66,5 @@ public sealed class CommandArgument
     /// <summary>
     /// Gets the custom attributes attached to this argument.
     /// </summary>
-    public IReadOnlyCollection<Attribute> CustomAttributes { get; internal set; } = Array.Empty<Attribute>();
+    public IReadOnlyList<Attribute> CustomAttributes { get; internal set; } = Array.Empty<Attribute>();
 }

--- a/src/DSharpPlus.VoiceNext/main/AudioFormat.cs
+++ b/src/DSharpPlus.VoiceNext/main/AudioFormat.cs
@@ -37,17 +37,17 @@ public struct AudioFormat
     /// <summary>
     /// Gets the collection of sampling rates (in Hz) the Opus encoder can use.
     /// </summary>
-    public static IReadOnlyCollection<int> AllowedSampleRates { get; } = new ReadOnlyCollection<int>(new[] { 8000, 12000, 16000, 24000, 48000 });
+    public static IReadOnlyList<int> AllowedSampleRates { get; } = new ReadOnlyCollection<int>(new[] { 8000, 12000, 16000, 24000, 48000 });
 
     /// <summary>
     /// Gets the collection of channel counts the Opus encoder can use.
     /// </summary>
-    public static IReadOnlyCollection<int> AllowedChannelCounts { get; } = new ReadOnlyCollection<int>(new[] { 1, 2 });
+    public static IReadOnlyList<int> AllowedChannelCounts { get; } = new ReadOnlyCollection<int>(new[] { 1, 2 });
 
     /// <summary>
     /// Gets the collection of sample durations (in ms) the Opus encoder can use.
     /// </summary>
-    public static IReadOnlyCollection<int> AllowedSampleDurations { get; } = new ReadOnlyCollection<int>(new[] { 5, 10, 20, 40, 60 });
+    public static IReadOnlyList<int> AllowedSampleDurations { get; } = new ReadOnlyCollection<int>(new[] { 5, 10, 20, 40, 60 });
 
     /// <summary>
     /// Gets the default audio format. This is a format configured for 48kHz sampling rate, 2 channels, with music quality preset.

--- a/src/DSharpPlus/main/Clients/DiscordClient.Dispatch.cs
+++ b/src/DSharpPlus/main/Clients/DiscordClient.Dispatch.cs
@@ -1411,7 +1411,7 @@ public sealed partial class DiscordClient
         GuildMembersChunkEventArgs ea = new GuildMembersChunkEventArgs
         {
             Guild = guild,
-            Members = new ReadOnlySet<DiscordMember>(mbrs),
+            Members = new List<DiscordMember>(mbrs).AsReadOnly(),
             ChunkIndex = chunkIndex,
             ChunkCount = chunkCount,
             Nonce = nonce,
@@ -1440,13 +1440,13 @@ public sealed partial class DiscordClient
                 pres.Add(xp);
             }
 
-            ea.Presences = new ReadOnlySet<DiscordPresence>(pres);
+            ea.Presences = new List<DiscordPresence>(pres).AsReadOnly();
         }
 
         if (dat["not_found"] != null)
         {
             ISet<ulong> nf = dat["not_found"].ToDiscordObject<ISet<ulong>>();
-            ea.NotFound = new ReadOnlySet<ulong>(nf);
+            ea.NotFound = new List<ulong>(nf).AsReadOnly();
         }
 
         await _guildMembersChunked.InvokeAsync(this, ea).ConfigureAwait(false);

--- a/src/DSharpPlus/main/Entities/Channel/Message/DiscordMessage.cs
+++ b/src/DSharpPlus/main/Entities/Channel/Message/DiscordMessage.cs
@@ -107,7 +107,7 @@ public class DiscordMessage : SnowflakeObject, IEquatable<DiscordMessage>
     /// Gets the components this message was sent with.
     /// </summary>
     [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
-    public IReadOnlyCollection<DiscordActionRowComponent> Components { get; internal set; }
+    public IReadOnlyList<DiscordActionRowComponent> Components { get; internal set; }
 
     /// <summary>
     /// Gets the user or member that sent the message.

--- a/src/DSharpPlus/main/Entities/DiscordTeam.cs
+++ b/src/DSharpPlus/main/Entities/DiscordTeam.cs
@@ -131,7 +131,7 @@ public sealed class DiscordTeamMember : IEquatable<DiscordTeamMember>
     internal DiscordTeamMember(TransportTeamMember ttm)
     {
         MembershipStatus = (DiscordTeamMembershipStatus)ttm.MembershipState;
-        Permissions = new ReadOnlySet<string>(new HashSet<string>(ttm.Permissions));
+        Permissions = new List<string>(ttm.Permissions).AsReadOnly();
     }
 
     /// <summary>

--- a/src/DSharpPlus/main/Entities/DiscordTeam.cs
+++ b/src/DSharpPlus/main/Entities/DiscordTeam.cs
@@ -116,7 +116,7 @@ public sealed class DiscordTeamMember : IEquatable<DiscordTeamMember>
     /// <summary>
     /// Gets the member's permissions within the team.
     /// </summary>
-    public IReadOnlyCollection<string> Permissions { get; internal set; }
+    public IReadOnlyList<string> Permissions { get; internal set; }
 
     /// <summary>
     /// Gets the team this member belongs to.

--- a/src/DSharpPlus/main/Entities/Guild/DiscordGuild.cs
+++ b/src/DSharpPlus/main/Entities/Guild/DiscordGuild.cs
@@ -1365,7 +1365,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
     public async Task<IReadOnlyList<DiscordMember>> GetAllMembersAsync()
     {
-        HashSet<DiscordMember> recmbr = new HashSet<DiscordMember>();
+        List<DiscordMember> recmbr = new();
 
         int recd = 1000;
         ulong last = 0ul;
@@ -1387,7 +1387,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
             last = tm?.User.Id ?? 0;
         }
 
-        return new ReadOnlySet<DiscordMember>(recmbr);
+        return recmbr.AsReadOnly();
     }
 
     /// <summary>

--- a/src/DSharpPlus/main/Entities/Guild/DiscordGuild.cs
+++ b/src/DSharpPlus/main/Entities/Guild/DiscordGuild.cs
@@ -1363,7 +1363,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     /// </summary>
     /// <returns>A collection of all members in this guild.</returns>
     /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-    public async Task<IReadOnlyCollection<DiscordMember>> GetAllMembersAsync()
+    public async Task<IReadOnlyList<DiscordMember>> GetAllMembersAsync()
     {
         HashSet<DiscordMember> recmbr = new HashSet<DiscordMember>();
 

--- a/src/DSharpPlus/main/Entities/Interaction/Application/DiscordApplicationCommand.cs
+++ b/src/DSharpPlus/main/Entities/Interaction/Application/DiscordApplicationCommand.cs
@@ -62,7 +62,7 @@ public sealed class DiscordApplicationCommand : SnowflakeObject, IEquatable<Disc
     /// Gets the potential parameters for this command.
     /// </summary>
     [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
-    public IReadOnlyCollection<DiscordApplicationCommandOption> Options { get; internal set; }
+    public IReadOnlyList<DiscordApplicationCommandOption> Options { get; internal set; }
 
     /// <summary>
     /// Gets whether the command is enabled by default when the application is added to a guild.

--- a/src/DSharpPlus/main/Entities/Interaction/Application/DiscordApplicationCommandOption.cs
+++ b/src/DSharpPlus/main/Entities/Interaction/Application/DiscordApplicationCommandOption.cs
@@ -68,19 +68,19 @@ public sealed class DiscordApplicationCommandOption
     /// Gets the optional choices for this command parameter. Not applicable for auto-complete options.
     /// </summary>
     [JsonProperty("choices", NullValueHandling = NullValueHandling.Ignore)]
-    public IReadOnlyCollection<DiscordApplicationCommandOptionChoice> Choices { get; internal set; }
+    public IReadOnlyList<DiscordApplicationCommandOptionChoice> Choices { get; internal set; }
 
     /// <summary>
     /// Gets the optional subcommand parameters for this parameter.
     /// </summary>
     [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
-    public IReadOnlyCollection<DiscordApplicationCommandOption> Options { get; internal set; }
+    public IReadOnlyList<DiscordApplicationCommandOption> Options { get; internal set; }
 
     /// <summary>
     /// Gets the channel types this command parameter is restricted to, if of type <see cref="ApplicationCommandOptionType.Channel"/>..
     /// </summary>
     [JsonProperty("channel_types", NullValueHandling = NullValueHandling.Ignore)]
-    public IReadOnlyCollection<ChannelType> ChannelTypes { get; internal set; }
+    public IReadOnlyList<ChannelType> ChannelTypes { get; internal set; }
 
     /// <summary>
     /// Gets the minimum value for this slash command parameter.

--- a/src/DSharpPlus/main/Entities/Interaction/Components/DiscordActionRowComponent.cs
+++ b/src/DSharpPlus/main/Entities/Interaction/Components/DiscordActionRowComponent.cs
@@ -34,7 +34,7 @@ public sealed class DiscordActionRowComponent : DiscordComponent
     /// <summary>
     /// The components contained within the action row.
     /// </summary>
-    public IReadOnlyCollection<DiscordComponent> Components
+    public IReadOnlyList<DiscordComponent> Components
     {
         get => _components ?? new List<DiscordComponent>();
         set => _components = new List<DiscordComponent>(value);

--- a/src/DSharpPlus/main/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
+++ b/src/DSharpPlus/main/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
@@ -50,8 +50,8 @@ internal class DiscordInteractionApplicationCommandCallbackData
     public MessageFlags? Flags { get; internal set; }
 
     [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
-    public IReadOnlyCollection<DiscordActionRowComponent> Components { get; internal set; }
+    public IReadOnlyList<DiscordActionRowComponent> Components { get; internal set; }
 
     [JsonProperty("choices")]
-    public IReadOnlyCollection<DiscordAutoCompleteChoice> Choices { get; internal set; }
+    public IReadOnlyList<DiscordAutoCompleteChoice> Choices { get; internal set; }
 }

--- a/src/DSharpPlus/main/Entities/Invite/DiscordStageInvite.cs
+++ b/src/DSharpPlus/main/Entities/Invite/DiscordStageInvite.cs
@@ -35,7 +35,7 @@ public class DiscordStageInvite
     /// Gets the members that are currently speaking in the stage channel.
     /// </summary>
     [JsonProperty("members")]
-    public IReadOnlyCollection<DiscordMember> Members { get; internal set; }
+    public IReadOnlyList<DiscordMember> Members { get; internal set; }
 
     /// <summary>
     /// Gets the number of participants in the stage channel.

--- a/src/DSharpPlus/main/EventArgs/Guild/Member/GuildMembersChunkEventArgs.cs
+++ b/src/DSharpPlus/main/EventArgs/Guild/Member/GuildMembersChunkEventArgs.cs
@@ -39,7 +39,7 @@ public class GuildMembersChunkEventArgs : DiscordEventArgs
     /// <summary>
     /// Gets the collection of members returned from this chunk.
     /// </summary>
-    public IReadOnlyCollection<DiscordMember> Members { get; internal set; }
+    public IReadOnlyList<DiscordMember> Members { get; internal set; }
 
     /// <summary>
     /// Gets the current chunk index from the response.
@@ -54,12 +54,12 @@ public class GuildMembersChunkEventArgs : DiscordEventArgs
     /// <summary>
     /// Gets the collection of presences returned from this chunk, if specified.
     /// </summary>
-    public IReadOnlyCollection<DiscordPresence> Presences { get; internal set; }
+    public IReadOnlyList<DiscordPresence> Presences { get; internal set; }
 
     /// <summary>
     /// Gets the returned Ids that were not found in the chunk, if specified.
     /// </summary>
-    public IReadOnlyCollection<ulong> NotFound { get; internal set; }
+    public IReadOnlyList<ulong> NotFound { get; internal set; }
 
     /// <summary>
     /// Gets the unique string used to identify the request, if specified.

--- a/src/DSharpPlus/main/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
+++ b/src/DSharpPlus/main/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
@@ -67,7 +67,7 @@ internal class RestApplicationCommandEditPayload
     public Optional<string> Description { get; set; }
 
     [JsonProperty("options")]
-    public Optional<IReadOnlyCollection<DiscordApplicationCommandOption>> Options { get; set; }
+    public Optional<IReadOnlyList<DiscordApplicationCommandOption>> Options { get; set; }
 
     [JsonProperty("default_permission", NullValueHandling = NullValueHandling.Ignore)]
     public Optional<bool?> DefaultPermission { get; set; }
@@ -112,7 +112,7 @@ internal class RestFollowupMessageCreatePayload
     public int? Flags { get; set; }
 
     [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
-    public IReadOnlyCollection<DiscordActionRowComponent> Components { get; set; }
+    public IReadOnlyList<DiscordActionRowComponent> Components { get; set; }
 }
 
 internal class RestEditApplicationCommandPermissionsPayload

--- a/src/DSharpPlus/main/Net/Abstractions/Rest/RestChannelPayloads.cs
+++ b/src/DSharpPlus/main/Net/Abstractions/Rest/RestChannelPayloads.cs
@@ -166,7 +166,7 @@ internal class RestChannelMessageEditPayload
     public DiscordMentions Mentions { get; set; }
 
     [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
-    public IReadOnlyCollection<DiscordActionRowComponent> Components { get; set; }
+    public IReadOnlyList<DiscordActionRowComponent> Components { get; set; }
 
     [JsonProperty("flags", NullValueHandling = NullValueHandling.Ignore)]
     public MessageFlags? Flags { get; set; }

--- a/src/DSharpPlus/main/Net/Models/ApplicationCommandEditModel.cs
+++ b/src/DSharpPlus/main/Net/Models/ApplicationCommandEditModel.cs
@@ -70,7 +70,7 @@ public class ApplicationCommandEditModel
     /// <summary>
     /// Sets the command's new options.
     /// </summary>
-    public Optional<IReadOnlyCollection<DiscordApplicationCommandOption>> Options { internal get; set; }
+    public Optional<IReadOnlyList<DiscordApplicationCommandOption>> Options { internal get; set; }
 
     /// <summary>
     /// Sets whether the command is enabled by default when the application is added to a guild.

--- a/src/DSharpPlus/main/Net/Rest/DiscordApiClient.cs
+++ b/src/DSharpPlus/main/Net/Rest/DiscordApiClient.cs
@@ -169,7 +169,7 @@ public sealed class DiscordApiClient
     }
 
     private Task<RestResponse> DoMultipartAsync(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, string route, IReadOnlyDictionary<string, string> headers = null, IReadOnlyDictionary<string, string> values = null,
-        IReadOnlyCollection<DiscordMessageFile> files = null, double? ratelimitWaitOverride = null, bool removeFileCount = false)
+        IReadOnlyList<DiscordMessageFile> files = null, double? ratelimitWaitOverride = null, bool removeFileCount = false)
     {
         MultipartWebRequest req = new MultipartWebRequest(client, bucket, url, method, route, headers, values, files, ratelimitWaitOverride)
         {
@@ -1622,7 +1622,7 @@ public sealed class DiscordApiClient
         return ret;
     }
 
-    internal async Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, Optional<string> content, Optional<IEnumerable<DiscordEmbed>> embeds, Optional<IEnumerable<IMention>> mentions, IReadOnlyList<DiscordActionRowComponent> components, IReadOnlyCollection<DiscordMessageFile> files, MessageFlags? flags, IEnumerable<DiscordAttachment> attachments)
+    internal async Task<DiscordMessage> EditMessageAsync(ulong channel_id, ulong message_id, Optional<string> content, Optional<IEnumerable<DiscordEmbed>> embeds, Optional<IEnumerable<IMention>> mentions, IReadOnlyList<DiscordActionRowComponent> components, IReadOnlyList<DiscordMessageFile> files, MessageFlags? flags, IEnumerable<DiscordAttachment> attachments)
     {
         if (embeds.HasValue && embeds.Value != null)
         {
@@ -3544,7 +3544,7 @@ public sealed class DiscordApiClient
         return ret;
     }
 
-    internal async Task<DiscordApplicationCommand> EditGlobalApplicationCommandAsync(ulong application_id, ulong command_id, Optional<string> name, Optional<string> description, Optional<IReadOnlyCollection<DiscordApplicationCommandOption>> options, Optional<bool?> defaultPermission, IReadOnlyDictionary<string, string> name_localizations = null, IReadOnlyDictionary<string, string> description_localizations = null, Optional<bool> allowDMUsage = default, Optional<Permissions?> defaultMemberPermissions = default)
+    internal async Task<DiscordApplicationCommand> EditGlobalApplicationCommandAsync(ulong application_id, ulong command_id, Optional<string> name, Optional<string> description, Optional<IReadOnlyList<DiscordApplicationCommandOption>> options, Optional<bool?> defaultPermission, IReadOnlyDictionary<string, string> name_localizations = null, IReadOnlyDictionary<string, string> description_localizations = null, Optional<bool> allowDMUsage = default, Optional<Permissions?> defaultMemberPermissions = default)
     {
         RestApplicationCommandEditPayload pld = new RestApplicationCommandEditPayload
         {
@@ -3671,7 +3671,7 @@ public sealed class DiscordApiClient
         return ret;
     }
 
-    internal async Task<DiscordApplicationCommand> EditGuildApplicationCommandAsync(ulong application_id, ulong guild_id, ulong command_id, Optional<string> name, Optional<string> description, Optional<IReadOnlyCollection<DiscordApplicationCommandOption>> options, Optional<bool?> defaultPermission, IReadOnlyDictionary<string, string> name_localizations = null, IReadOnlyDictionary<string, string> description_localizations = null, Optional<bool> allowDMUsage = default, Optional<Permissions?> defaultMemberPermissions = default)
+    internal async Task<DiscordApplicationCommand> EditGuildApplicationCommandAsync(ulong application_id, ulong guild_id, ulong command_id, Optional<string> name, Optional<string> description, Optional<IReadOnlyList<DiscordApplicationCommandOption>> options, Optional<bool?> defaultPermission, IReadOnlyDictionary<string, string> name_localizations = null, IReadOnlyDictionary<string, string> description_localizations = null, Optional<bool> allowDMUsage = default, Optional<Permissions?> defaultMemberPermissions = default)
     {
         RestApplicationCommandEditPayload pld = new RestApplicationCommandEditPayload
         {

--- a/src/DSharpPlus/main/Net/Rest/MultipartWebRequest.cs
+++ b/src/DSharpPlus/main/Net/Rest/MultipartWebRequest.cs
@@ -40,12 +40,12 @@ internal sealed class MultipartWebRequest : BaseRestRequest
     /// <summary>
     /// Gets the dictionary of files attached to this request.
     /// </summary>
-    public IReadOnlyCollection<DiscordMessageFile> Files { get; }
+    public IReadOnlyList<DiscordMessageFile> Files { get; }
 
     internal bool _removeFileCount;
 
     internal MultipartWebRequest(BaseDiscordClient client, RateLimitBucket bucket, Uri url, RestRequestMethod method, string route, IReadOnlyDictionary<string, string> headers = null, IReadOnlyDictionary<string, string> values = null,
-        IReadOnlyCollection<DiscordMessageFile> files = null, double? ratelimit_wait_override = null, bool removeFileCount = false)
+        IReadOnlyList<DiscordMessageFile> files = null, double? ratelimit_wait_override = null, bool removeFileCount = false)
         : base(client, bucket, url, method, route, headers, ratelimit_wait_override)
     {
         Values = values;


### PR DESCRIPTION
# Summary
Allows indexing returned readonly collections by converting IReadOnlyCollection<T> to IReadOnlyList<T>

# Details
First commit is the sed, second commit is the manual work (which needs revision)

# Notes
`dotnet format` when