### PR TITLE
Move API base URI to DiscordConfiguration -> testability

### DIFF
--- a/src/DSharpPlus.Test/main/TestBot.cs
+++ b/src/DSharpPlus.Test/main/TestBot.cs
@@ -70,7 +70,8 @@ namespace DSharpPlus.Test
                 ShardCount = this.Config.ShardCount,
                 MessageCacheSize = 2048,
                 LogTimestampFormat = "dd-MM-yyyy HH:mm:ss zzz",
-                Intents = DiscordIntents.All // if 4013 is received, change to DiscordIntents.AllUnprivileged
+                Intents = DiscordIntents.All, // if 4013 is received, change to DiscordIntents.AllUnprivileged
+                ApiBaseUri = this.Config.ApiEndpointUrl
             };
             this.Discord = new DiscordClient(dcfg);
 

--- a/src/DSharpPlus.Test/main/TestBotConfig.cs
+++ b/src/DSharpPlus.Test/main/TestBotConfig.cs
@@ -38,5 +38,8 @@ namespace DSharpPlus.Test
 
         [JsonProperty("slash_command_guild")]
         public ulong SlashCommandGuild { get; private set; }
+        
+        [JsonProperty("api_endpoint_url")]
+        public string ApiEndpointUrl { get; private set; } = "https://discord.com/api/v10";
     }
 }

--- a/src/DSharpPlus/main/Clients/DiscordClient.cs
+++ b/src/DSharpPlus/main/Clients/DiscordClient.cs
@@ -302,6 +302,13 @@ namespace DSharpPlus
             {
                 if (this.Configuration.TokenType != TokenType.Bot)
                     this.Logger.LogWarning(LoggerEvents.Misc, "You are logging in with a token that is not a bot token. This is not officially supported by Discord, and can result in your account being terminated if you aren't careful.");
+
+                if (this.Configuration.ApiBaseUri != DiscordConfiguration.DefaultApiBaseUri)
+                {
+                    this.Logger.LogWarning(LoggerEvents.Misc, $"Using custom API base URI: {this.Configuration.ApiBaseUri}");
+                    this.Logger.LogWarning(LoggerEvents.Misc, "Any issues that may arise from this are not supported by the D#+ team");
+                }
+
                 this.Logger.LogInformation(LoggerEvents.Startup, "DSharpPlus, version {Version}", this.VersionString);
             }
 

--- a/src/DSharpPlus/main/Clients/DiscordShardedClient.cs
+++ b/src/DSharpPlus/main/Clients/DiscordShardedClient.cs
@@ -267,7 +267,7 @@ namespace DSharpPlus
 
         private async Task<GatewayInfo> GetGatewayInfoAsync()
         {
-            var url = $"{Utilities.GetApiBaseUri()}{Endpoints.GATEWAY}{Endpoints.BOT}";
+            var url = $"{Utilities.GetApiBaseUri(this.Configuration)}{Endpoints.GATEWAY}{Endpoints.BOT}";
             var http = new HttpClient();
 
             http.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", Utilities.GetUserAgent());

--- a/src/DSharpPlus/main/DiscordConfiguration.cs
+++ b/src/DSharpPlus/main/DiscordConfiguration.cs
@@ -35,6 +35,11 @@ namespace DSharpPlus
     /// </summary>
     public sealed class DiscordConfiguration
     {
+        // This summary block is inherited in the summary for ApiBaseUrl.
+        // It is here to keep this value close to the definition.
+        /// <summary><code>https://discord.com/api/v10</code></summary>
+        internal const string DefaultApiBaseUri = "https://discord.com/api/v10";
+
         /// <summary>
         /// Sets the token used to identify the client.
         /// </summary>
@@ -194,9 +199,11 @@ namespace DSharpPlus
         public bool LogUnknownEvents { internal get; set; } = true;
 
         /// <summary>
-        /// Base URI for the Discord API. Defaults to "https://discord.com/api/v10".
+        /// <para>Base URI for the Discord API.</para>
+        /// <para>Defaults to "<inheritdoc cref="DefaultApiBaseUri"/>".</para>
+        /// <para>NOTE: Changing this variable will waive any rights to support!</para>
         /// </summary>
-        public string ApiBaseUri { internal get; set; } = "https://discord.com/api/v10";
+        public string ApiBaseUri { internal get; set; } = DefaultApiBaseUri;
 
         /// <summary>
         /// Creates a new configuration with default values.

--- a/src/DSharpPlus/main/DiscordConfiguration.cs
+++ b/src/DSharpPlus/main/DiscordConfiguration.cs
@@ -194,6 +194,11 @@ namespace DSharpPlus
         public bool LogUnknownEvents { internal get; set; } = true;
 
         /// <summary>
+        /// Base URI for the Discord API. Defaults to "https://discord.com/api/v10".
+        /// </summary>
+        public string ApiBaseUri { internal get; set; } = "https://discord.com/api/v10";
+
+        /// <summary>
         /// Creates a new configuration with default values.
         /// </summary>
         public DiscordConfiguration()
@@ -224,6 +229,7 @@ namespace DSharpPlus
             this.Intents = other.Intents;
             this.LoggerFactory = other.LoggerFactory;
             this.LogUnknownEvents = other.LogUnknownEvents;
+            this.ApiBaseUri = other.ApiBaseUri;
         }
     }
 }

--- a/src/DSharpPlus/main/Entities/Guild/DiscordGuild.cs
+++ b/src/DSharpPlus/main/Entities/Guild/DiscordGuild.cs
@@ -1265,7 +1265,7 @@ namespace DSharpPlus.Entities
                 WidgetType.Banner4 => "banner4",
                 _ => "shield",
             };
-            return $"{Net.Endpoints.BASE_URI}{Net.Endpoints.GUILDS}/{this.Id}{Net.Endpoints.WIDGET_PNG}?style={param}";
+            return $"{this.Discord.Configuration.ApiBaseUri}{Net.Endpoints.GUILDS}/{this.Id}{Net.Endpoints.WIDGET_PNG}?style={param}";
         }
 
         /// <summary>

--- a/src/DSharpPlus/main/Net/Rest/DiscordApiClient.cs
+++ b/src/DSharpPlus/main/Net/Rest/DiscordApiClient.cs
@@ -182,7 +182,7 @@ namespace DSharpPlus.Net
                 ["query"] = name,
                 ["limit"] = limit.ToString()
             };
-            var url = Utilities.GetApiUriFor(path, BuildQueryString(querydict));
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, BuildQueryString(querydict));
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
             var json = JArray.Parse(res.Response);
             var tms = json.ToDiscordObject<IReadOnlyList<TransportMember>>();
@@ -204,7 +204,7 @@ namespace DSharpPlus.Net
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.BANS}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new {guild_id, user_id}, out var url);
-            var uri = Utilities.GetApiUriFor(url);
+            var uri = Utilities.GetApiUriFor(this._discord.Configuration, url);
             var res = await this.DoRequestAsync(this._discord, bucket, uri, RestRequestMethod.GET, route).ConfigureAwait(false);
             var json = JObject.Parse(res.Response);
 
@@ -238,7 +238,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var json = JObject.Parse(res.Response);
@@ -261,7 +261,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}{Endpoints.TEMPLATES}/:template_code";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { template_code }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var json = JObject.Parse(res.Response);
@@ -278,7 +278,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route).ConfigureAwait(false);
         }
 
@@ -323,7 +323,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id = guildId }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var json = JObject.Parse(res.Response);
@@ -350,7 +350,7 @@ namespace DSharpPlus.Net
             if (after != null)
                 queryParams["after"] = after.ToString();
 
-            var url = Utilities.GetApiUriFor(path, BuildQueryString(queryParams));
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, BuildQueryString(queryParams));
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var bans_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordBan>>(res.Response).Select(xb =>
@@ -386,7 +386,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.BANS}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PUT, route, new { guild_id, user_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path, BuildQueryString(urlparams));
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, BuildQueryString(urlparams));
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route, headers);
         }
 
@@ -399,7 +399,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.BANS}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, user_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
@@ -408,7 +408,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.GUILDS}/:guild_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route);
         }
 
@@ -426,7 +426,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PUT, route, new { guild_id, user_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var tm = JsonConvert.DeserializeObject<TransportMember>(res.Response);
@@ -445,7 +445,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var members_raw = JsonConvert.DeserializeObject<List<TransportMember>>(res.Response);
@@ -461,7 +461,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id{Endpoints.ROLES}/:role_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PUT, route, new { guild_id, user_id, role_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route, headers);
         }
 
@@ -474,7 +474,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id{Endpoints.ROLES}/:role_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, user_id, role_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
@@ -487,7 +487,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.CHANNELS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld));
         }
 
@@ -500,7 +500,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.ROLES}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld));
         }
 
@@ -513,7 +513,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.ROLES}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(newRolePositions)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordRole[]>(res.Response);
@@ -544,7 +544,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.AUDIT_LOGS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var audit_log_data_raw = JsonConvert.DeserializeObject<AuditLog>(res.Response);
@@ -557,7 +557,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.VANITY_URL}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var invite = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
@@ -570,7 +570,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.WIDGET_JSON}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var json = JObject.Parse(res.Response);
@@ -602,7 +602,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.WIDGET}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWidgetSettings>(res.Response);
@@ -626,7 +626,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.WIDGET}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWidgetSettings>(res.Response);
@@ -640,7 +640,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.TEMPLATES}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var templates_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordGuildTemplate>>(res.Response);
@@ -659,7 +659,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.TEMPLATES}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response);
@@ -672,7 +672,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.TEMPLATES}/:template_code";
             var bucket = this._rest.GetBucket(RestRequestMethod.PUT, route, new { guild_id, template_code }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route).ConfigureAwait(false);
 
             var template_raw = JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response);
@@ -691,7 +691,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.TEMPLATES}/:template_code";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, template_code }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var template_raw = JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response);
@@ -704,7 +704,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.TEMPLATES}/:template_code";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, template_code }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route).ConfigureAwait(false);
 
             var template_raw = JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response);
@@ -717,7 +717,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBER_VERIFICATION}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var screening_raw = JsonConvert.DeserializeObject<DiscordGuildMembershipScreening>(res.Response);
@@ -737,7 +737,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBER_VERIFICATION}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var screening_raw = JsonConvert.DeserializeObject<DiscordGuildMembershipScreening>(res.Response);
@@ -750,7 +750,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.WELCOME_SCREEN}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordGuildWelcomeScreen>(res.Response);
@@ -773,7 +773,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.WELCOME_SCREEN}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordGuildWelcomeScreen>(res.Response);
@@ -792,7 +792,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.VOICE_STATES}/@me";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
         }
 
@@ -807,7 +807,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.VOICE_STATES}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, user_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
         }
         #endregion
@@ -818,7 +818,7 @@ namespace DSharpPlus.Net
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.STICKERS}/:sticker_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new {guild_id, sticker_id}, out var path);
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
 
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
             var json = JObject.Parse(res.Response);
@@ -839,7 +839,7 @@ namespace DSharpPlus.Net
         {
             var route = $"{Endpoints.STICKERS}/:sticker_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new {sticker_id}, out var path);
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
 
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
             var json = JObject.Parse(res.Response);
@@ -861,7 +861,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.STICKERPACKS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var json = JObject.Parse(res.Response)["sticker_packs"] as JArray;
@@ -874,7 +874,7 @@ namespace DSharpPlus.Net
         {
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.STICKERS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new {guild_id}, out var path);
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
 
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
             var json = JArray.Parse(res.Response);
@@ -905,7 +905,7 @@ namespace DSharpPlus.Net
 
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.STICKERS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new {guild_id}, out var path);
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
 
             if (!string.IsNullOrEmpty(reason))
                 headers[REASON_HEADER_NAME] = reason;
@@ -941,7 +941,7 @@ namespace DSharpPlus.Net
 
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.STICKERS}/:sticker_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new {guild_id, sticker_id}, out var path);
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
 
             var pld = new RestStickerModifyPayload()
             {
@@ -965,7 +965,7 @@ namespace DSharpPlus.Net
 
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.STICKERS}/:sticker_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new {guild_id, sticker_id}, out var path);
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
 
             await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers: headers).ConfigureAwait(false);
         }
@@ -1002,7 +1002,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.CHANNELS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordChannel>(res.Response);
@@ -1049,7 +1049,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld));
         }
 
@@ -1089,7 +1089,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld));
         }
 
@@ -1100,7 +1100,7 @@ namespace DSharpPlus.Net
 
             var query = new Dictionary<string, string>() { { "with_user_count", with_user_counts.ToString() } };
 
-            var url = Utilities.GetApiUriFor(path, BuildQueryString(query));
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, BuildQueryString(query));
 
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route, new Dictionary<string, string>(), string.Empty).ConfigureAwait(false);
 
@@ -1127,7 +1127,7 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
 
             var pld = new RestScheduledGuildEventCreatePayload
             {
@@ -1160,7 +1160,7 @@ namespace DSharpPlus.Net
 
             var headers = Utilities.GetBaseHeaders();
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers, null).ConfigureAwait(false);
         }
 
@@ -1180,7 +1180,7 @@ namespace DSharpPlus.Net
             if (after != null)
                 query.Add("after", after.Value.ToString(CultureInfo.InvariantCulture));
 
-            var url = Utilities.GetApiUriFor(path, BuildQueryString(query));
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, BuildQueryString(query));
 
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route, new Dictionary<string, string>(), string.Empty).ConfigureAwait(false);
 
@@ -1202,7 +1202,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EVENTS}/:guild_scheduled_event_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id, guild_scheduled_event_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route, Utilities.GetBaseHeaders(), string.Empty).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordScheduledGuildEvent>(res.Response);
@@ -1225,7 +1225,7 @@ namespace DSharpPlus.Net
             if (!string.IsNullOrWhiteSpace(reason))
                 headers[REASON_HEADER_NAME] = reason;
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var pld = new RestScheduledGuildEventModifyPayload
             {
                 Name = name,
@@ -1256,7 +1256,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordChannel>(res.Response);
@@ -1283,7 +1283,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
@@ -1292,7 +1292,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { channel_id, message_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = this.PrepareMessage(JObject.Parse(res.Response));
@@ -1337,7 +1337,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = this.PrepareMessage(JObject.Parse(res.Response));
@@ -1375,7 +1375,7 @@ namespace DSharpPlus.Net
                 var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
                 var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-                var url = Utilities.GetApiUriFor(path);
+                var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
                 var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
                 var ret = this.PrepareMessage(JObject.Parse(res.Response));
@@ -1391,7 +1391,7 @@ namespace DSharpPlus.Net
                 var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
                 var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-                var url = Utilities.GetApiUriFor(path);
+                var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
                 var res = await this.DoMultipartAsync(this._discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files).ConfigureAwait(false);
 
                 var ret = this.PrepareMessage(JObject.Parse(res.Response));
@@ -1410,7 +1410,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.CHANNELS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var channels_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordChannel>>(res.Response).Select(xc => { xc.Discord = this._discord; return xc; });
@@ -1440,7 +1440,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var msgs_raw = JArray.Parse(res.Response);
@@ -1456,7 +1456,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { channel_id, message_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = this.PrepareMessage(JObject.Parse(res.Response));
@@ -1491,7 +1491,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { channel_id, message_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoMultipartAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, values: values, files: files).ConfigureAwait(false);
 
             var ret = this.PrepareMessage(JObject.Parse(res.Response));
@@ -1513,7 +1513,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
@@ -1531,7 +1531,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}{Endpoints.BULK_DELETE}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld));
         }
 
@@ -1540,7 +1540,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.INVITES}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var invites_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordInvite>>(res.Response).Select(xi => { xi.Discord = this._discord; return xi; });
@@ -1568,7 +1568,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.INVITES}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
@@ -1586,7 +1586,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.PERMISSIONS}/:overwrite_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, overwrite_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
@@ -1606,7 +1606,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.PERMISSIONS}/:overwrite_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PUT, route, new { channel_id, overwrite_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route, headers, DiscordJson.SerializeObject(pld));
         }
 
@@ -1615,7 +1615,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.TYPING}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route);
         }
 
@@ -1624,7 +1624,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.PINS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var msgs_raw = JArray.Parse(res.Response);
@@ -1640,7 +1640,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.PINS}/:message_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PUT, route, new { channel_id, message_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route);
         }
 
@@ -1649,7 +1649,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.PINS}/:message_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route);
         }
 
@@ -1664,7 +1664,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.CHANNELS}/:channel_id{Endpoints.RECIPIENTS}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PUT, route, new { channel_id, user_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route, payload: DiscordJson.SerializeObject(pld));
         }
 
@@ -1673,7 +1673,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.CHANNELS}/:channel_id{Endpoints.RECIPIENTS}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, user_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route);
         }
 
@@ -1688,7 +1688,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.CHANNELS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordDmChannel>(res.Response);
@@ -1707,7 +1707,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.CHANNELS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordDmChannel>(res.Response);
@@ -1729,7 +1729,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.FOLLOWERS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var response = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             return JsonConvert.DeserializeObject<DiscordFollowedChannel>(response.Response);
@@ -1740,7 +1740,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.CROSSPOST}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id, message_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var response = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route).ConfigureAwait(false);
             return JsonConvert.DeserializeObject<DiscordMessage>(response.Response);
         }
@@ -1761,7 +1761,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.STAGE_INSTANCES}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var response = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var stage = JsonConvert.DeserializeObject<DiscordStageInstance>(response.Response);
@@ -1775,7 +1775,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.STAGE_INSTANCES}/:channel_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var response = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var stage = JsonConvert.DeserializeObject<DiscordStageInstance>(response.Response);
@@ -1799,7 +1799,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.STAGE_INSTANCES}/:channel_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var response = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var stage = JsonConvert.DeserializeObject<DiscordStageInstance>(response.Response);
@@ -1823,7 +1823,7 @@ namespace DSharpPlus.Net
             var route = $"/guilds/{guildId}{Endpoints.VOICE_STATES}/{user}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
 
             await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
         }
@@ -1837,7 +1837,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.STAGE_INSTANCES}/:channel_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers).ConfigureAwait(false);
         }
 
@@ -1860,7 +1860,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.THREADS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id, message_id }, out var path); //???
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var response = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(payload)).ConfigureAwait(false);
 
             var thread = JsonConvert.DeserializeObject<DiscordThreadChannel>(response.Response);
@@ -1885,7 +1885,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREADS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id}, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var response = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(payload)).ConfigureAwait(false);
 
             var thread = JsonConvert.DeserializeObject<DiscordThreadChannel>(response.Response);
@@ -1899,7 +1899,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREAD_MEMBERS}{Endpoints.ME}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id}, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route);
         }
 
@@ -1908,7 +1908,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREAD_MEMBERS}{Endpoints.ME}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id}, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route);
         }
 
@@ -1917,7 +1917,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREAD_MEMBERS}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id, user_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var response = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             return JsonConvert.DeserializeObject<DiscordThreadChannelMember>(response.Response);
@@ -1928,7 +1928,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREAD_MEMBERS}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id, user_id}, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route);
         }
 
@@ -1937,7 +1937,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREAD_MEMBERS}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id, user_id}, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route);
         }
 
@@ -1946,7 +1946,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREAD_MEMBERS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id}, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var response = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var threadMembers = JsonConvert.DeserializeObject<List<DiscordThreadChannelMember>>(response.Response);
@@ -1958,7 +1958,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.THREADS}{Endpoints.ACTIVE}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { guild_id}, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var response = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var result = JsonConvert.DeserializeObject<ThreadQueryResult>(response.Response);
@@ -1989,7 +1989,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREADS}{Endpoints.ARCHIVED}{Endpoints.PUBLIC}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id}, out var path);
 
-            var url = Utilities.GetApiUriFor(path, queryParams.Any() ? BuildQueryString(queryParams) : "");
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, queryParams.Any() ? BuildQueryString(queryParams) : "");
             var response = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var result = JsonConvert.DeserializeObject<ThreadQueryResult>(response.Response);
@@ -2019,7 +2019,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.THREADS}{Endpoints.ARCHIVED}{Endpoints.PRIVATE}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id}, out var path);
 
-            var url = Utilities.GetApiUriFor(path, queryParams.Any() ? BuildQueryString(queryParams) : "");
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, queryParams.Any() ? BuildQueryString(queryParams) : "");
             var response = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var result = JsonConvert.DeserializeObject<ThreadQueryResult>(response.Response);
@@ -2049,7 +2049,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.USERS}{Endpoints.ME}{Endpoints.THREADS}{Endpoints.ARCHIVED}{Endpoints.PUBLIC}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id}, out var path);
 
-            var url = Utilities.GetApiUriFor(path, queryParams.Any() ? BuildQueryString(queryParams) : "");
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, queryParams.Any() ? BuildQueryString(queryParams) : "");
             var response = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var result = JsonConvert.DeserializeObject<ThreadQueryResult>(response.Response);
@@ -2082,7 +2082,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.USERS}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { user_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var user_raw = JsonConvert.DeserializeObject<TransportUser>(res.Response);
@@ -2096,7 +2096,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id, user_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var tm = JsonConvert.DeserializeObject<TransportMember>(res.Response);
@@ -2120,7 +2120,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, user_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path, BuildQueryString(urlparams));
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, BuildQueryString(urlparams));
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route);
         }
 
@@ -2136,7 +2136,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.USERS}{Endpoints.ME}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var user_raw = JsonConvert.DeserializeObject<TransportUser>(res.Response);
@@ -2150,7 +2150,7 @@ namespace DSharpPlus.Net
 
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { }, out var path);
 
-            var url = Utilities.GetApiUriBuilderFor(path)
+            var url = Utilities.GetApiUriBuilderFor(this._discord.Configuration, path)
                 .AddParameter($"limit", limit.ToString(CultureInfo.InvariantCulture));
 
             if (before != null)
@@ -2193,7 +2193,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, user_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, payload: DiscordJson.SerializeObject(pld));
         }
 
@@ -2211,7 +2211,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.MEMBERS}{Endpoints.ME}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, payload: DiscordJson.SerializeObject(pld));
         }
         #endregion
@@ -2222,7 +2222,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.ROLES}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var roles_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordRole>>(res.Response).Select(xr => { xr.Discord = this._discord; xr._guild_id = guild_id; return xr; });
@@ -2239,7 +2239,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id = guildId }, out var path);
 
-            var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route, urlparams).ConfigureAwait(false);
 
             var json = JObject.Parse(res.Response);
@@ -2288,7 +2288,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.ROLES}/:role_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, role_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordRole>(res.Response);
@@ -2307,7 +2307,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.ROLES}/:role_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, role_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
@@ -2339,7 +2339,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.ROLES}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
 
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
@@ -2375,7 +2375,7 @@ namespace DSharpPlus.Net
 
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.PRUNE}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
-            var url = Utilities.GetApiUriFor(path, $"{BuildQueryString(urlparams)}{sb}");
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, $"{BuildQueryString(urlparams)}{sb}");
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var pruned = JsonConvert.DeserializeObject<RestGuildPruneResultPayload>(res.Response);
@@ -2412,7 +2412,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.PRUNE}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path, $"{BuildQueryString(urlparams)}{sb}");
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, $"{BuildQueryString(urlparams)}{sb}");
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, headers).ConfigureAwait(false);
 
             var pruned = JsonConvert.DeserializeObject<RestGuildPruneResultPayload>(res.Response);
@@ -2427,7 +2427,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}{Endpoints.TEMPLATES}/:code";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { code }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var templates_raw = JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response);
@@ -2440,7 +2440,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.INTEGRATIONS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var integrations_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordIntegration>>(res.Response).Select(xi => { xi.Discord = this._discord; return xi; });
@@ -2453,7 +2453,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.PREVIEW}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordGuildPreview>(res.Response);
@@ -2473,7 +2473,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.INTEGRATIONS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordIntegration>(res.Response);
@@ -2494,7 +2494,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.INTEGRATIONS}/:integration_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, integration_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordIntegration>(res.Response);
@@ -2512,7 +2512,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.INTEGRATIONS}/:integration_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, integration_id = integration.Id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers, DiscordJson.SerializeObject(integration));
         }
 
@@ -2521,7 +2521,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.INTEGRATIONS}/:integration_id{Endpoints.SYNC}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { guild_id, integration_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route);
         }
 
@@ -2530,7 +2530,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.REGIONS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var regions_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordVoiceRegion>>(res.Response);
@@ -2543,7 +2543,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.INVITES}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var invites_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordInvite>>(res.Response).Select(xi => { xi.Discord = this._discord; return xi; });
@@ -2565,7 +2565,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.INVITES}/:invite_code";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { invite_code }, out var path);
 
-            var url = Utilities.GetApiUriFor(path, urlparams.Any() ? BuildQueryString(urlparams) : "");
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, urlparams.Any() ? BuildQueryString(urlparams) : "");
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
@@ -2583,7 +2583,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.INVITES}/:invite_code";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { invite_code }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response);
@@ -2617,7 +2617,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.USERS}{Endpoints.ME}{Endpoints.CONNECTIONS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var connections_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordConnection>>(res.Response).Select(xc => { xc.Discord = this._discord; return xc; });
@@ -2632,7 +2632,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.VOICE}{Endpoints.REGIONS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var regions = JsonConvert.DeserializeObject<IEnumerable<DiscordVoiceRegion>>(res.Response);
@@ -2658,7 +2658,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.WEBHOOKS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
@@ -2673,7 +2673,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.WEBHOOKS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { channel_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var webhooks_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordWebhook>>(res.Response).Select(xw => { xw.Discord = this._discord; xw.ApiClient = this; return xw; });
@@ -2686,7 +2686,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.WEBHOOKS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var webhooks_raw = JsonConvert.DeserializeObject<IEnumerable<DiscordWebhook>>(res.Response).Select(xw => { xw.Discord = this._discord; xw.ApiClient = this; return xw; });
@@ -2699,7 +2699,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { webhook_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
@@ -2715,7 +2715,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
@@ -2732,7 +2732,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.MESSAGES}/:message_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { webhook_id, webhook_token, message_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
@@ -2757,7 +2757,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { webhook_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
@@ -2782,7 +2782,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response);
@@ -2801,7 +2801,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { webhook_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
@@ -2814,7 +2814,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
 
@@ -2848,8 +2848,8 @@ namespace DSharpPlus.Net
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
             var url = builder.ThreadId == null
-                ? Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build()
-                : Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").AddParameter("thread_id", builder.ThreadId.ToString()).Build();
+                ? Utilities.GetApiUriBuilderFor(this._discord.Configuration, path).AddParameter("wait", "true").Build()
+                : Utilities.GetApiUriBuilderFor(this._discord.Configuration, path).AddParameter("wait", "true").AddParameter("thread_id", builder.ThreadId.ToString()).Build();
 
             var res = await this.DoMultipartAsync(this._discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
@@ -2868,7 +2868,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.SLACK}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
+            var url = Utilities.GetApiUriBuilderFor(this._discord.Configuration, path).AddParameter("wait", "true").Build();
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, payload: json_payload).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this._discord;
@@ -2880,7 +2880,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.GITHUB}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { webhook_id, webhook_token }, out var path);
 
-            var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
+            var url = Utilities.GetApiUriBuilderFor(this._discord.Configuration, path).AddParameter("wait", "true").Build();
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, payload: json_payload).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this._discord;
@@ -2910,7 +2910,7 @@ namespace DSharpPlus.Net
                 ["payload_json"] = DiscordJson.SerializeObject(pld)
             };
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoMultipartAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, values: values, files: builder.Files).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
@@ -2930,7 +2930,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:webhook_id/:webhook_token{Endpoints.MESSAGES}/:message_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { webhook_id, webhook_token, message_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route).ConfigureAwait(false);
         }
         internal Task DeleteWebhookMessageAsync(ulong webhook_id, string webhook_token, ulong message_id) =>
@@ -2943,7 +2943,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}/:emoji{Endpoints.ME}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PUT, route, new { channel_id, message_id, emoji }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route, ratelimitWaitOverride: this._discord.Configuration.UseRelativeRatelimit ? null : (double?)0.26);
         }
 
@@ -2952,7 +2952,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}/:emoji{Endpoints.ME}";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id, emoji }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, ratelimitWaitOverride: this._discord.Configuration.UseRelativeRatelimit ? null : (double?)0.26);
         }
 
@@ -2965,7 +2965,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}/:emoji/:user_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id, emoji, user_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers, ratelimitWaitOverride: this._discord.Configuration.UseRelativeRatelimit ? null : (double?)0.26);
         }
 
@@ -2980,7 +2980,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}/:emoji";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { channel_id, message_id, emoji }, out var path);
 
-            var url = Utilities.GetApiUriFor(path, BuildQueryString(urlparams));
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path, BuildQueryString(urlparams));
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var reacters_raw = JsonConvert.DeserializeObject<IEnumerable<TransportUser>>(res.Response);
@@ -3005,7 +3005,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers, ratelimitWaitOverride: this._discord.Configuration.UseRelativeRatelimit ? null : (double?)0.26);
         }
 
@@ -3014,7 +3014,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.CHANNELS}/:channel_id{Endpoints.MESSAGES}/:message_id{Endpoints.REACTIONS}/:emoji";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { channel_id, message_id, emoji }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, ratelimitWaitOverride: this._discord.Configuration.UseRelativeRatelimit ? null : (double?)0.26);
         }
         #endregion
@@ -3025,7 +3025,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EMOJIS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var emojisRaw = JsonConvert.DeserializeObject<IEnumerable<JObject>>(res.Response);
@@ -3061,7 +3061,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EMOJIS}/:emoji_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { guild_id, emoji_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             this._discord.Guilds.TryGetValue(guild_id, out var gld);
@@ -3093,7 +3093,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EMOJIS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             this._discord.Guilds.TryGetValue(guild_id, out var gld);
@@ -3125,7 +3125,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EMOJIS}/:emoji_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { guild_id, emoji_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, headers, DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             this._discord.Guilds.TryGetValue(guild_id, out var gld);
@@ -3150,7 +3150,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.GUILDS}/:guild_id{Endpoints.EMOJIS}/:emoji_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { guild_id, emoji_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             return this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route, headers);
         }
         #endregion
@@ -3161,7 +3161,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { application_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response);
@@ -3192,7 +3192,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PUT, route, new { application_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response);
@@ -3219,7 +3219,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { application_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response);
@@ -3233,7 +3233,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}/:command_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { application_id, command_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response);
@@ -3259,7 +3259,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}/:command_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { application_id, command_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response);
@@ -3273,7 +3273,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}/:command_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { application_id, command_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route).ConfigureAwait(false);
         }
 
@@ -3282,7 +3282,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { application_id, guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response);
@@ -3313,7 +3313,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PUT, route, new { application_id, guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response);
@@ -3340,7 +3340,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { application_id, guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.POST, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response);
@@ -3354,7 +3354,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}/:command_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { application_id, guild_id, command_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response);
@@ -3380,7 +3380,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}/:command_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.PATCH, route, new { application_id, guild_id, command_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PATCH, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
 
             var ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response);
@@ -3394,7 +3394,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}/:command_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.DELETE, route, new { application_id, guild_id, command_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.DELETE, route).ConfigureAwait(false);
         }
 
@@ -3431,7 +3431,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.INTERACTIONS}/:interaction_id/:interaction_token{Endpoints.CALLBACK}";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { interaction_id, interaction_token }, out var path);
 
-            var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
+            var url = Utilities.GetApiUriBuilderFor(this._discord.Configuration, path).AddParameter("wait", "true").Build();
             if (builder != null)
             {
                 await this.DoMultipartAsync(this._discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files).ConfigureAwait(false);
@@ -3452,7 +3452,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:application_id/:interaction_token{Endpoints.MESSAGES}{Endpoints.ORIGINAL}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { application_id, interaction_token }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
 
@@ -3494,7 +3494,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.WEBHOOKS}/:application_id/:interaction_token";
             var bucket = this._rest.GetBucket(RestRequestMethod.POST, route, new { application_id, interaction_token }, out var path);
 
-            var url = Utilities.GetApiUriBuilderFor(path).AddParameter("wait", "true").Build();
+            var url = Utilities.GetApiUriBuilderFor(this._discord.Configuration, path).AddParameter("wait", "true").Build();
             var res = await this.DoMultipartAsync(this._discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
 
@@ -3521,7 +3521,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}{Endpoints.PERMISSIONS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { application_id, guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<IEnumerable<DiscordGuildApplicationCommandPermissions>>(res.Response);
 
@@ -3535,7 +3535,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}/:command_id{Endpoints.PERMISSIONS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { application_id, guild_id, command_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordGuildApplicationCommandPermissions>(res.Response);
 
@@ -3553,7 +3553,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}/:command_id{Endpoints.PERMISSIONS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PUT, route, new { application_id, guild_id, command_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route, payload: DiscordJson.SerializeObject(pld)).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<DiscordGuildApplicationCommandPermissions>(res.Response);
 
@@ -3566,7 +3566,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}{Endpoints.PERMISSIONS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.PUT, route, new { application_id, guild_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.PUT, route, payload: DiscordJson.SerializeObject(permissions)).ConfigureAwait(false);
             var ret = JsonConvert.DeserializeObject<IEnumerable<DiscordGuildApplicationCommandPermissions>>(res.Response);
 
@@ -3588,7 +3588,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.OAUTH2}{Endpoints.APPLICATIONS}/:application_id";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { application_id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             return JsonConvert.DeserializeObject<TransportApplication>(res.Response);
@@ -3599,7 +3599,7 @@ namespace DSharpPlus.Net
             var route = $"{Endpoints.OAUTH2}{Endpoints.APPLICATIONS}/:application_id{Endpoints.ASSETS}";
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { application_id = application.Id }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route).ConfigureAwait(false);
 
             var assets = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationAsset>>(res.Response);
@@ -3620,7 +3620,7 @@ namespace DSharpPlus.Net
                 route += Endpoints.BOT;
             var bucket = this._rest.GetBucket(RestRequestMethod.GET, route, new { }, out var path);
 
-            var url = Utilities.GetApiUriFor(path);
+            var url = Utilities.GetApiUriFor(this._discord.Configuration, path);
             var res = await this.DoRequestAsync(this._discord, bucket, url, RestRequestMethod.GET, route, headers).ConfigureAwait(false);
 
             var info = JObject.Parse(res.Response).ToDiscordObject<GatewayInfo>();

--- a/src/DSharpPlus/main/Net/Rest/Endpoints.cs
+++ b/src/DSharpPlus/main/Net/Rest/Endpoints.cs
@@ -27,9 +27,6 @@ namespace DSharpPlus.Net
 {
     internal static class Endpoints
     {
-        public const string API_VERSION = "10";
-        public const string BASE_URI = "https://discord.com/api/v" + API_VERSION;
-
         public const string ORIGINAL = "/@original";
         public const string OAUTH2 = "/oauth2";
         public const string APPLICATIONS = "/applications";

--- a/src/DSharpPlus/main/Net/Rest/RestClient.cs
+++ b/src/DSharpPlus/main/Net/Rest/RestClient.cs
@@ -68,7 +68,7 @@ namespace DSharpPlus.Net
         }
 
         internal RestClient(IWebProxy proxy, TimeSpan timeout, bool useRelativeRatelimit,
-            ILogger logger) // This is for meta-clients, such as the webhook client
+            ILogger logger, string ApiBaseUri = "https://discord.com/api/v10") // This is for meta-clients, such as the webhook client
         {
             this.Logger = logger;
 
@@ -82,7 +82,7 @@ namespace DSharpPlus.Net
 
             this.HttpClient = new HttpClient(httphandler)
             {
-                BaseAddress = new Uri(Utilities.GetApiBaseUri()),
+                BaseAddress = new Uri(ApiBaseUri),
                 Timeout = timeout
             };
 

--- a/src/DSharpPlus/main/Utilities.cs
+++ b/src/DSharpPlus/main/Utilities.cs
@@ -80,17 +80,17 @@ namespace DSharpPlus
             VersionHeader = $"DiscordBot (https://github.com/DSharpPlus/DSharpPlus, v{vs})";
         }
 
-        internal static string GetApiBaseUri()
-            => Endpoints.BASE_URI;
+        internal static string GetApiBaseUri(DiscordConfiguration configuration)
+            => configuration.ApiBaseUri;
 
-        internal static Uri GetApiUriFor(string path)
-            => new($"{GetApiBaseUri()}{path}");
+        internal static Uri GetApiUriFor(DiscordConfiguration configuration, string path)
+            => new($"{GetApiBaseUri(configuration)}{path}");
 
-        internal static Uri GetApiUriFor(string path, string queryString)
-            => new($"{GetApiBaseUri()}{path}{queryString}");
+        internal static Uri GetApiUriFor(DiscordConfiguration configuration, string path, string queryString)
+            => new($"{GetApiBaseUri(configuration)}{path}{queryString}");
 
-        internal static QueryUriBuilder GetApiUriBuilderFor(string path)
-            => new($"{GetApiBaseUri()}{path}");
+        internal static QueryUriBuilder GetApiUriBuilderFor(DiscordConfiguration configuration, string path)
+            => new($"{GetApiBaseUri(configuration)}{path}");
 
         internal static string GetFormattedToken(BaseDiscordClient client) => GetFormattedToken(client.Configuration);
 


### PR DESCRIPTION
# Summary
Moves API base URI to DiscordConfiguration, this allows for testing outside of discord.com.

# Details
This PR moves the base URI to the bot's configuration. 

# Changes proposed
* Pass configuration to GetBaseUri
* Add base URI as argument to RestClient (when not used with a Configuration)
* Add base URI to DiscordConfiguration
- (Both of these default to `https://discord.com/api/v10`)
* Update test bot to expose this property

# Notes
Probably not the cleanest edit, but does function as intended.