### PR TITLE
ListArchivedThreads functions use ISO8601 datetime standard when using date filter

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -2059,7 +2059,7 @@ namespace DSharpPlus
         /// <param name="before">Date to filter by.</param>
         /// <param name="limit">Limit.</param>
         public Task<ThreadQueryResult> ListPublicArchivedThreadsAsync(ulong guildId, ulong channelId, DateTimeOffset? before = null, int limit = 0)
-           => this.ApiClient.ListPublicArchivedThreadsAsync(guildId, channelId, (ulong?)before?.ToUnixTimeSeconds(), limit);
+           => this.ApiClient.ListPublicArchivedThreadsAsync(guildId, channelId, before?.ToString("o"), limit);
 
         /// <summary>
         /// Gets the threads that are public and archived for a channel.
@@ -2069,7 +2069,7 @@ namespace DSharpPlus
         /// <param name="before">Date to filter by.</param>
         /// <param name="limit">Limit.</param>
         public Task<ThreadQueryResult> ListPrivateArchivedThreadAsync(ulong guildId, ulong channelId, DateTimeOffset? before = null, int limit = 0)
-           => this.ApiClient.ListPrivateArchivedThreadsAsync(guildId, channelId, (ulong?)before?.ToUnixTimeSeconds(), limit);
+           => this.ApiClient.ListPrivateArchivedThreadsAsync(guildId, channelId, before?.ToString("o"), limit);
 
         /// <summary>
         /// Gets the private archived threads the user has joined for a channel.

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -574,7 +574,7 @@ namespace DSharpPlus.Entities
             if (this.Type != ChannelType.Text && this.Type != ChannelType.News)
                 throw new InvalidOperationException();
 
-            return this.Discord.ApiClient.ListPublicArchivedThreadsAsync(this.GuildId.Value, this.Id, (ulong?)before?.ToUnixTimeSeconds(), limit);
+            return this.Discord.ApiClient.ListPublicArchivedThreadsAsync(this.GuildId.Value, this.Id, before?.ToString("o"), limit);
         }
 
         /// <summary>
@@ -590,7 +590,7 @@ namespace DSharpPlus.Entities
             if (this.Type != ChannelType.Text && this.Type != ChannelType.News)
                 throw new InvalidOperationException();
 
-            return this.Discord.ApiClient.ListPrivateArchivedThreadsAsync(this.GuildId.Value, this.Id, (ulong?)before?.ToUnixTimeSeconds(), limit);
+            return this.Discord.ApiClient.ListPrivateArchivedThreadsAsync(this.GuildId.Value, this.Id, before?.ToString("o"), limit);
         }
 
         /// <summary>

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1978,7 +1978,7 @@ namespace DSharpPlus.Net
             return result;
         }
 
-        internal async Task<ThreadQueryResult> ListPublicArchivedThreadsAsync(ulong guild_id, ulong channel_id, ulong? before, int limit)
+        internal async Task<ThreadQueryResult> ListPublicArchivedThreadsAsync(ulong guild_id, ulong channel_id, string before, int limit)
         {
             var queryParams = new Dictionary<string, string>();
             if (before != null)
@@ -2008,7 +2008,7 @@ namespace DSharpPlus.Net
             return result;
         }
 
-        internal async Task<ThreadQueryResult> ListPrivateArchivedThreadsAsync(ulong guild_id, ulong channel_id, ulong? before, int limit)
+        internal async Task<ThreadQueryResult> ListPrivateArchivedThreadsAsync(ulong guild_id, ulong channel_id, string before, int limit)
         {
             var queryParams = new Dictionary<string, string>();
             if (before != null)


### PR DESCRIPTION
# Summary
This pull fixes an issue in using the "before" parameter in ListPublicArchivedThreadsAsync and ListPrivateArchivedThreadsAsync methods and receiving a 400 Bad Request from Discord.

# Details
When attempting to use either the ListPublicArchivedThreadsAsync or the ListPrivateArchivedThreadsAsync methods with a DateTimeOffset object set as the "before" parameter. Discord returns with a 400 Bad Request. This is due to Discord expecting a datetime in the ISO8601 standard format and DSharpPlus sending a UNIX timestamp. This pull request fixes this issue by formatting the DateTimeOffset object passed as the "before" parameter in the appropriate ISO8601 format before sending the value to Discord's API.

# Changes proposed
Convert "before" DateTimeOffset object to ISO8601 string before sending to Discord instead of converting to UNIX timestamp.