### PR TITLE
Cleanup Github Actions

### DIFF
--- a/.github/workflows/publish_nightly_master.yml
+++ b/.github/workflows/publish_nightly_master.yml
@@ -1,5 +1,4 @@
 name: .NET Build
-
 on:
   push:
     branches:
@@ -7,11 +6,9 @@ on:
   pull_request:
     branches:
       - master
-
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-
 jobs:
   build_and_publish:
     name: Publish Nightly (Master)
@@ -22,30 +19,25 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: '0'
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 7
-        env:
-          DOTNET_INSTALL_DIR: ${{ github.workspace }}/../.dotnet # Attempts to install to `/usr/share/dotnet`, which is not writable on GitHub Actions by default.
-
       - name: Package
         run: "mkdir build && dotnet pack -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --include-source -o build -p:VersionSuffix='nightly' -p:BuildNumber=$(printf \"%0*d\n\" 5 $(( 1195 + ${{ github.run_number }} )))" # We add 1195 since it's the last build number AppVeyor used.
-
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: DSharpPlus-Nightly-${{ github.run_number }}∕${{ github.run_attempt }}
           path: ./build/*
-
       - name: Publish Nightly Nuget Packages
         if: ${{ github.event_name == 'push' }} # Ensure we don't push nightlies to the nuget feed on PRs.
         run: "dotnet nuget push \"build/*\" -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json" # If the package version does not comply with SemVer, it will be set as a pre-release version automatically.
-
+      - name: Export Latest Tag
+        run: echo LATEST_STABLE_VERSION=$(git describe --abbrev=0 --tags) >> $GITHUB_ENV
       - name: Update Discord Channel Topic
         if: ${{ github.event_name == 'push' }} # Only update channel topic when a PR is merged
-        run: "dotnet run --project ./tools/AutoUpdateChannelDescription -p:VersionSuffix='nightly' -p:BuildNumber=$(printf \"%0*d\n\" 5 $(( 1195 + ${{ github.run_number }} ))) -- $(git describe --abbrev=0 --tags)"
+        run: "dotnet run --project ./tools/AutoUpdateChannelDescription -p:VersionSuffix='nightly' -p:BuildNumber=$(printf \"%0*d\n\" 5 $(( 1195 + ${{ github.run_number }} )))"
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
@@ -53,3 +45,4 @@ jobs:
           DISCORD_CHANNEL_TOPIC: ${{ secrets.DISCORD_CHANNEL_TOPIC }}
           NUGET_URL: ${{ secrets.NUGET_URL }}
           GITHUB_URL : ${{ github.server_url }}/${{ github.repository }}
+          LATEST_STABLE_VERSION: ${{ env.LATEST_STABLE_VERSION }}

--- a/.github/workflows/publish_nightly_master.yml
+++ b/.github/workflows/publish_nightly_master.yml
@@ -34,6 +34,7 @@ jobs:
         if: ${{ github.event_name == 'push' }} # Ensure we don't push nightlies to the nuget feed on PRs.
         run: "dotnet nuget push \"build/*\" -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json" # If the package version does not comply with SemVer, it will be set as a pre-release version automatically.
       - name: Export Latest Tag
+        if: ${{ github.event_name == 'push' }} # Only update channel topic when a PR is merged
         run: echo LATEST_STABLE_VERSION=$(git describe --abbrev=0 --tags) >> $GITHUB_ENV
       - name: Update Discord Channel Topic
         if: ${{ github.event_name == 'push' }} # Only update channel topic when a PR is merged

--- a/.github/workflows/publish_nightly_v5.yml
+++ b/.github/workflows/publish_nightly_v5.yml
@@ -1,5 +1,4 @@
 name: .NET Build
-
 on:
   push:
     branches:
@@ -7,11 +6,9 @@ on:
   pull_request:
     branches:
       - v5
-
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-
 jobs:
   build_and_publish:
     name: Publish Nightly (V5)
@@ -23,23 +20,17 @@ jobs:
         with:
           ref: v5
           fetch-depth: '0'
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 7
-        env:
-          DOTNET_INSTALL_DIR: ${{ github.workspace }}/../.dotnet # Attempts to install to `/usr/share/dotnet`, which is not writable on GitHub Actions by default.
-
       - name: Package
         run: "mkdir build && dotnet pack -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg --include-source -o build -p:VersionPrefix='5.0.0' -p:VersionSuffix='nightly' -p:BuildNumber=$(printf \"%0*d\n\" 5 ${{ github.run_number }})"
-
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: DSharpPlus-Nightly-V5-${{ github.run_number }}∕${{ github.run_attempt }}
           path: ./build/*
-
       - name: Publish Nightly Nuget Packages
         if: ${{ github.event_name == 'push' }} # Ensure we don't push nightlies to the nuget feed on PRs.
         run: "dotnet nuget push \"build/*\" -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json" # If the package version does not comply with SemVer, it will be set as a pre-release version automatically.

--- a/.github/workflows/publish_release_master.yml
+++ b/.github/workflows/publish_release_master.yml
@@ -2,11 +2,9 @@ name: "Publish Release"
 on:
   release:
     types: ["published"]
-
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-
 jobs:
   publish_release:
     name: Publish Release (Master)
@@ -17,26 +15,19 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: '0'
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 7
-        env:
-          DOTNET_INSTALL_DIR: ${{ github.workspace }}/../.dotnet # Attempts to install to `/usr/share/dotnet`, which is not writable on GitHub Actions by default.
-
       - name: Build Nuget Packages
         run: "mkdir build && dotnet pack -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -c Release -o build"
-
       - name: Publish Nuget Packages
         run: "dotnet nuget push \"build/*\" -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json"
-
       - name: Upload Nuget Packages To Github Actions
         uses: actions/upload-artifact@v3
         with:
           name: PR Nuget Packages
           path: build/*
-
       - name: Upload Nuget Packages To Github Release
         uses: "ncipollo/release-action@v1"
         with:
@@ -46,9 +37,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           omitBodyDuringUpdate: true # We don't want to update the body of the release.
           omitNameDuringUpdate: true # We don't want to update the name of the release.
-
+      - name: Export Latest Tag
+        run: echo LATEST_STABLE_VERSION=$(git describe --abbrev=0 --tags) >> $GITHUB_ENV
       - name: Update Discord Channel Topic
-        run: "dotnet run --project ./tools/AutoUpdateChannelDescription -p:Nightly=$(printf \"%0*d\n\" 5 $(( 1195 + ${{ github.run_number }} )) -- $(git describe --abbrev=0 --tags)"
+        run: "dotnet run --project ./tools/AutoUpdateChannelDescription -p:Nightly=$(printf \"%0*d\n\" 5 $(( 1195 + ${{ github.run_number }} ))"
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
@@ -56,3 +48,4 @@ jobs:
           DISCORD_CHANNEL_TOPIC: ${{ secrets.DISCORD_CHANNEL_TOPIC }}
           NUGET_URL: ${{ secrets.NUGET_URL }}
           GITHUB_URL : ${{ github.server_url }}/${{ github.repository }}
+          LATEST_STABLE_VERSION: ${{ env.LATEST_STABLE_VERSION }}

--- a/.github/workflows/publish_release_v5.yml
+++ b/.github/workflows/publish_release_v5.yml
@@ -2,11 +2,9 @@ name: "Publish Release"
 on:
   release:
     types: ["published"]
-
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-
 jobs:
   publish_release:
     name: Publish Release (Master)
@@ -18,26 +16,19 @@ jobs:
         with:
           ref: v5
           fetch-depth: '0'
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 7
-        env:
-          DOTNET_INSTALL_DIR: ${{ github.workspace }}/../.dotnet # Attempts to install to `/usr/share/dotnet`, which is not writable on GitHub Actions by default.
-
       - name: Build Nuget Packages
         run: "mkdir build && dotnet pack -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -c Release -o build"
-
       - name: Publish Nuget Packages
         run: "dotnet nuget push \"build/*\" -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json"
-
       - name: Upload Nuget Packages To Github Actions
         uses: actions/upload-artifact@v3
         with:
           name: PR Nuget Packages
           path: build/*
-
       - name: Upload Nuget Packages To Github Release
         uses: "ncipollo/release-action@v1"
         with:


### PR DESCRIPTION
# Summary
- Remove custom dotnet install dir since the runners are now in a Docker container (which has the .NET SDK preinstalled)
- Fix a bug in the release action which had removed/incorrect set the latest nightly version
- Readability

# Notes
Tested with [commit](https://github.com/OoLunar/DSharpPlus.CommandAll/commit/db9e7a2efd1c083959ec12fd392fe6a28969e1e6) and [release](https://github.com/OoLunar/DSharpPlus.CommandAll/releases/tag/1.1.0-rc2)