### PR TITLE
Fix wrong URI escaping in DSharpPlus.Lavalink

### DIFF
--- a/DSharpPlus.Lavalink/LavalinkRestClient.cs
+++ b/DSharpPlus.Lavalink/LavalinkRestClient.cs
@@ -126,7 +126,7 @@ namespace DSharpPlus.Lavalink
         /// <returns>A collection of tracks from the URL.</returns>
         public Task<LavalinkLoadResult> GetTracksAsync(Uri uri)
         {
-            var str = WebUtility.UrlEncode(uri.ToString());
+            var str = WebUtility.UrlEncode(uri.AbsoluteUri);
             var tracksUri = new Uri($"{this.RestEndpoint.ToHttpString()}{Endpoints.LOAD_TRACKS}?identifier={str}");
             return this.InternalResolveTracksAsync(tracksUri);
         }


### PR DESCRIPTION
# Summary
Fix wrong URI escaping in DSharpPlus.Lavalink

# Details
`LavalinkRestClient.GetTracksAsync(Uri uri)` uses `Uri.ToString()` for URI construction, which [does not escape](https://learn.microsoft.com/en-us/dotnet/api/system.uri.tostring?view=netstandard-2.0).
Thus providing Lavalink with a link containing a space the following error can be observed:
```
lavalink.server.player.AudioLoader       : Load failed
com.sedmelluq.discord.lavaplayer.tools.FriendlyException: Not a valid URL.
[…]
Caused by: java.net.URISyntaxException: Illegal character in path at index 24: https://example.com/link with space.ogg
[…]
```
By using `Uri.AbsoluteUri` proper escaping is applied
```
Uri.AbsoluteUri: https://example.com/link%20with%20space.ogg
Uri.ToString(): https://example.com/link with space.ogg
```
 
# Notes
Tested with [Lavalink 3.6.2](https://github.com/freyacodes/Lavalink/releases/tag/3.6.2)
