### PR TITLE
Add Type check in SlashCommand method registration

### DIFF
--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -205,6 +205,10 @@ namespace DSharpPlus.SlashCommands
                                     throw new ArgumentException($"The first argument must be an InteractionContext!");
                                 parameters = parameters.Skip(1).ToArray();
 
+                                //Check if the ReturnType can be safely casted to a Task later on execution
+                                if (!typeof(Task).IsAssignableFrom(submethod.ReturnType))
+                                    throw new InvalidOperationException("The method has to return a Task or Task<> value");
+                                
                                 var options = await this.ParseParameters(parameters, guildId);
 
                                 var nameLocalizations = this.GetNameLocalizations(submethod);


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
RetrunTypes from command methods are getting casted to a Task on execution. This PR adds a check if a command method returns a Task