### PR TITLE
Fixed a potential NRE when setting DiscordMessageBuilder's Embed or Sticker to null.

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -42,7 +42,8 @@ namespace DSharpPlus.Entities
             set
             {
                 this._embeds.Clear();
-                this._embeds.Add(value);
+                if (value != null)
+                    this._embeds.Add(value);
             }
         }
 
@@ -55,7 +56,8 @@ namespace DSharpPlus.Entities
             set
             {
                 this._stickers.Clear();
-                this._stickers.Add(value);
+                if (value != null)
+                    this._stickers.Add(value);
             }
         }
 

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1359,7 +1359,7 @@ namespace DSharpPlus.Net
             {
                 HasContent = builder.Content != null,
                 Content = builder.Content,
-                StickersIds = builder._stickers?.Select(x => x.Id).ToArray(),
+                StickersIds = builder._stickers?.Where(s => s != null).Select(s => s.Id).ToArray(),
                 IsTTS = builder.IsTTS,
                 HasEmbed = builder.Embeds != null,
                 Embeds = builder.Embeds,


### PR DESCRIPTION
# Summary
When the `DiscordMessageBuilder` `Embed` or `Sticker` property is set to null (EX: ClearComponents), the internal list `_embeds` or `_stickers` contain a null value.

# Changes proposed
Checking if the value being set is null before adding it to the internal list.