### PR TITLE
[ci skip] fix docs spacing

### DIFF
--- a/docs/articles/beyond_basics/events.md
+++ b/docs/articles/beyond_basics/events.md
@@ -22,7 +22,7 @@ private async Task Main(string[] args)
             await e.Message.RespondAsync("I want pictures of Spiderman!");
     };
 
-	discord.GuildMemberAdded += (s, e) =>
+    discord.GuildMemberAdded += (s, e) =>
     {
         // Non asynchronous code here.
         return Task.CompletedTask;
@@ -37,7 +37,7 @@ private async Task Main(string[] args)
     var discord = new DiscordClient();
 
     discord.MessageCreated += MessageCreatedHandler;
-	discord.GuildMemberAdded += MemberAddedHandler;
+    discord.GuildMemberAdded += MemberAddedHandler;
 }
 
 private async Task MessageCreatedHandler(DiscordClient s, MessageCreateEventArgs e)

--- a/docs/articles/beyond_basics/events.md
+++ b/docs/articles/beyond_basics/events.md
@@ -73,12 +73,12 @@ discord.MessageCreated += (s, e) =>
         var response = await QuerySlowWebServiceAsync(e.Message.Content);
 
         if (response.Status == HttpStatusCode.OK)
-		{
-			await e.Guild?.BanMemberAsync((DiscordMember)e.Author);
+        {
+            await e.Guild?.BanMemberAsync((DiscordMember)e.Author);
         }
     });
 
-	return Task.CompletedTask;
+    return Task.CompletedTask;
 };
 ```
 

--- a/docs/articles/commands/command_attributes.md
+++ b/docs/articles/commands/command_attributes.md
@@ -64,9 +64,9 @@ You can provide feedback to the user using the @DSharpPlus.CommandsNext.Commands
 private async Task Main(string[] args)
 {
     var discord = new DiscordClient();
-	var commands = discord.UseCommandsNext();
+    var commands = discord.UseCommandsNext();
 
-	commands.CommandErrored += CmdErroredHandler;
+    commands.CommandErrored += CmdErroredHandler;
 }
 
 private async Task CmdErroredHandler(CommandsNextExtension _, CommandErrorEventArgs e)

--- a/docs/articles/commands/dependency_injection.md
+++ b/docs/articles/commands/dependency_injection.md
@@ -29,7 +29,7 @@ We'll use `.AddSingleton` to add type `Random` to the collection, then chain tha
 ```cs
 var services = new ServiceCollection()
     .AddSingleton<Random>()
-	.BuildServiceProvider();
+    .BuildServiceProvider();
 ```
 
 Then we'll need to provide CommandsNext with our services.

--- a/docs/articles/migration/3x_to_4x.md
+++ b/docs/articles/migration/3x_to_4x.md
@@ -36,8 +36,8 @@ you will update it like this:
 ```cs
 await role.UpdateAsync(x =>
 {
-	x.Name = "Modified Role";
-	x.Color = new DiscordColor(0xFF00FF);
+    x.Name = "Modified Role";
+    x.Color = new DiscordColor(0xFF00FF);
 });
 ```
 


### PR DESCRIPTION
4 spaces. not 8.

fixes a bunch of tabs that docfx interprets as 8 spaces by making them into spaces instead