### PR TITLE
Fix docs, part 300

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -4,7 +4,7 @@
             "src": [
                 {
                     "src": "../",
-                    "files": "**/bin/**/netstandard2.0/**.dll",
+                    "files": "**.sln",
                     "exclude": [
                         "**/obj/**",
                         "_site/**"

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -17,6 +17,9 @@
         }
     ],
     "build": {
+	"xref": [
+	   "https://inftord.github.io/Common/xrefmap.yml"
+	],
         "xrefService": [
             "https://xref.docs.microsoft.com/query?uid={uid}"
         ],


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Using sln to build our docs, instead of .dlls. Adding a xref setting in our docfx.json.

# Notes
Tested, example of how it looks now:
https://inftord.github.io/DSharpPlus/api/DSharpPlus.DiscordClient.ChannelCreated.html