### PR TITLE
Fix broken XML tags

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -571,6 +571,10 @@ namespace DSharpPlus
         /// <param name="qualityMode">Voice channel video quality mode.</param>
         /// <param name="position">Sorting position of the channel.</param>
         /// <param name="reason">Reason this channel was created</param>
+        /// <param name="defaultAutoArchiveDuration">Default duration for newly created forum posts in the channel.</param>
+        /// <param name="defaultReactionEmoji">Default emoji used for reacting to forum posts.</param>
+        /// <param name="availableTags">Tags available for use by forum posts in the channel.</param>
+        /// <param name="defaultSortOrder">Default sorting order for forum posts in the channel.</param>
         /// <returns></returns>
         public Task<DiscordChannel> CreateGuildChannelAsync
         (
@@ -635,6 +639,13 @@ namespace DSharpPlus
         /// <param name="type">New channel type.</param>
         /// <param name="permissionOverwrites">New channel permission overwrites.</param>
         /// <param name="reason">Reason why this channel was modified</param>
+        /// <param name="flags">Channel flags.</param>
+        /// <param name="defaultAutoArchiveDuration">Default duration for newly created forum posts in the channel.</param>
+        /// <param name="defaultReactionEmoji">Default emoji used for reacting to forum posts.</param>
+        /// <param name="availableTags">Tags available for use by forum posts in the channel.</param>
+        /// <param name="defaultPerUserRatelimit">Default per-user ratelimit for forum posts in the channel.</param>
+        /// <param name="defaultSortOrder">Default sorting order for forum posts in the channel.</param>
+        /// <param name="defaultForumLayout">Default layout for forum posts in the channel.</param>
         /// <returns></returns>
         public Task ModifyChannelAsync
         (
@@ -698,7 +709,7 @@ namespace DSharpPlus
 
             return this.ApiClient.ModifyChannelAsync
             (
-                channelId,mdl.Name,
+                channelId, mdl.Name,
                 mdl.Position,
                 mdl.Topic,
                 mdl.Nsfw,

--- a/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
@@ -465,10 +465,9 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Applies <see cref="MessageFlags.SupressNotifications"/> to the message.
         /// </summary>
-        /// <param name="suppress">Whether to suprpess notifications</param>
         /// <returns></returns>
         /// <remarks>
-        /// As per <see cref="MessageFlag.SuppressNotification"/>, this does not change the message's allowed mentions
+        /// As per <see cref="MessageFlags.SupressNotifications"/>, this does not change the message's allowed mentions
         /// (controlled by <see cref="AddMentions"/>), but instead prevents a mention from triggering a push notification.
         /// </remarks>
         IDiscordMessageBuilder SuppressNotifications();

--- a/DSharpPlus/Entities/Channel/Thread/Forum/DiscordForumTag.cs
+++ b/DSharpPlus/Entities/Channel/Thread/Forum/DiscordForumTag.cs
@@ -33,7 +33,7 @@ namespace DSharpPlus.Entities
         public string Name { get; internal set; }
 
         /// <summary>
-        /// Gets whether this tag is moderated. Moderated tags can only be applied by users with the <see cref="DiscordPermissions.ManageThreads"/> permission.
+        /// Gets whether this tag is moderated. Moderated tags can only be applied by users with the <see cref="Permissions.ManageThreads"/> permission.
         /// </summary>
         [JsonProperty("moderated")]
         public bool Moderated { get; internal set; }
@@ -88,7 +88,7 @@ namespace DSharpPlus.Entities
         }
 
         /// <summary>
-        /// Sets this tag to be moderated (as in, it can only be set by users with the <see cref="DiscordPermissions.ManageThreads"/> permission).
+        /// Sets this tag to be moderated (as in, it can only be set by users with the <see cref="Permissions.ManageThreads"/> permission).
         /// </summary>
         /// <param name="moderated">Whether the tag is moderated.</param>
         /// <returns>The builder to chain calls with.</returns>


### PR DESCRIPTION
# Summary
With the merge of #1455, some XML tags were broken. Additionally, from before the merge of #1455, there were a few broken tags. All changes were spotted from building with DocFX.

# Notes
Untested.