### PR TITLE
remove link to emzi's lib xrefmap in docfx.json

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -17,9 +17,6 @@
         }
     ],
     "build": {
-	"xref": [
-	   "https://inftord.github.io/Common/xrefmap.yml"
-	],
         "xrefService": [
             "https://xref.docs.microsoft.com/query?uid={uid}"
         ],


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Removes xref link to Emzi's lib xrefmap, since it's useless now

# Notes
Making this PR from a phone was a mistake 