### PR TITLE
update concurrenthashset

### DIFF
--- a/DSharpPlus.Interactivity/DSharpPlus.Interactivity.csproj
+++ b/DSharpPlus.Interactivity/DSharpPlus.Interactivity.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ConcurrentHashSet" Version="1.1.0" />
+    <PackageReference Include="ConcurrentHashSet" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DSharpPlus.Interactivity/EventHandling/ComponentBased/ComponentPaginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ComponentBased/ComponentPaginator.cs
@@ -82,6 +82,8 @@ namespace DSharpPlus.Interactivity.EventHandling
             if (!this._requests.TryGetValue(e.Message.Id, out var req))
                 return;
 
+            await e.Interaction.CreateResponseAsync(InteractionResponseType.DeferredMessageUpdate).ConfigureAwait(false);
+
             if (await req.GetUserAsync().ConfigureAwait(false) != e.User)
             {
                 if (this._config.ResponseBehavior is InteractionResponseBehavior.Respond)

--- a/DSharpPlus.Interactivity/InteractivityConfiguration.cs
+++ b/DSharpPlus.Interactivity/InteractivityConfiguration.cs
@@ -97,7 +97,6 @@ namespace DSharpPlus.Interactivity
         /// <param name="other">Configuration the properties of which are to be copied.</param>
         public InteractivityConfiguration(InteractivityConfiguration other)
         {
-            this.AckPaginationButtons = other.AckPaginationButtons;
             this.PaginationButtons = other.PaginationButtons;
             this.ButtonBehavior = other.ButtonBehavior;
             this.PaginationBehaviour = other.PaginationBehaviour;

--- a/DSharpPlus.Test/PaginationTest.cs
+++ b/DSharpPlus.Test/PaginationTest.cs
@@ -39,12 +39,7 @@ namespace DSharpPlus.Test
 
         [Command("paginate")]
         public async Task PaginateAsync(CommandContext ctx)
-        {
-            var builder = new DiscordMessageBuilder().WithContent("** **").AddComponents(new DiscordButtonComponent(ButtonStyle.Primary, "a", "Paginate"));
-            await ctx.RespondAsync(builder);
-
-            ctx.Client.ComponentInteractionCreated += this.Handle;
-        }
+            => await ctx.Channel.SendPaginatedMessageAsync(ctx.User, ctx.Client.GetInteractivity().GeneratePagesInEmbed(Lorem));
 
         private Task Handle(DiscordClient sender, ComponentInteractionCreateEventArgs e)
         {

--- a/DSharpPlus.Test/PaginationTest.cs
+++ b/DSharpPlus.Test/PaginationTest.cs
@@ -23,8 +23,6 @@
 using System.Threading.Tasks;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
-using DSharpPlus.Entities;
-using DSharpPlus.EventArgs;
 using DSharpPlus.Interactivity.Extensions;
 
 namespace DSharpPlus.Test
@@ -40,15 +38,5 @@ namespace DSharpPlus.Test
         [Command("paginate")]
         public async Task PaginateAsync(CommandContext ctx)
             => await ctx.Channel.SendPaginatedMessageAsync(ctx.User, ctx.Client.GetInteractivity().GeneratePagesInEmbed(Lorem));
-
-        private Task Handle(DiscordClient sender, ComponentInteractionCreateEventArgs e)
-        {
-            if (e.Id != "a")
-                return Task.CompletedTask;
-            var pages = sender.GetInteractivity().GeneratePagesInContent(Lorem);
-            _ = sender.GetInteractivity().SendPaginatedResponseAsync(e.Interaction, true, e.User, pages);
-            sender.ComponentInteractionCreated -= this.Handle;
-            return Task.CompletedTask;
-        }
     }
 }

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#pragma warning disable CS0618
+//#pragma warning disable CS0618
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -36,6 +36,7 @@ using DSharpPlus.EventArgs;
 using DSharpPlus.Interactivity;
 using DSharpPlus.Interactivity.Enums;
 using DSharpPlus.Interactivity.EventHandling;
+using DSharpPlus.Interactivity.Extensions;
 using DSharpPlus.SlashCommands;
 using DSharpPlus.SlashCommands.EventArgs;
 using DSharpPlus.VoiceNext;
@@ -142,7 +143,6 @@ namespace DSharpPlus.Test
             var icfg = new InteractivityConfiguration()
             {
                 Timeout = TimeSpan.FromSeconds(10),
-                AckPaginationButtons = true,
                 ResponseBehavior = InteractionResponseBehavior.Respond,
                 PaginationBehaviour = PaginationBehaviour.Ignore,
                 ResponseMessage = "Sorry, but this wasn't a valid option, or does not belong to you!",
@@ -155,6 +155,8 @@ namespace DSharpPlus.Test
                     SkipRight = new DiscordButtonComponent(ButtonStyle.Primary, "skipr", null, false, new DiscordComponentEmoji(862259654403031050))
                 }
             };
+
+            this.Discord.UseInteractivity(icfg);
 
             this.SlashCommandService = this.Discord.UseSlashCommands();
             this.SlashCommandService.SlashCommandErrored += this.SlashCommandService_CommandErrored;


### PR DESCRIPTION
Updates ConcurrentHashSet to 1.3.0, fixing an one-line issue with interactivity not always acknowledging events (an issue caused by #1477 ) and updates the testbot to firstly actually register interactivity and to secondly to actually do interactivity properly