### PR TITLE
Enforce IDisposable for Extensions to ensure proper cleanup when the Client itself disposes.

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -47,7 +47,7 @@ namespace DSharpPlus.CommandsNext
     /// <summary>
     /// This is the class which handles command registration, management, and execution.
     /// </summary>
-    public class CommandsNextExtension : BaseExtension, IDisposable
+    public class CommandsNextExtension : BaseExtension
     {
         private CommandsNextConfiguration Config { get; }
         private HelpFormatterFactory HelpFormatter { get; }
@@ -165,8 +165,13 @@ namespace DSharpPlus.CommandsNext
         /// <summary>
         /// Disposes of this the resources used by CNext.
         /// </summary>
-        public void Dispose()
+        public override void Dispose()
             => this.Config.CommandExecutor.Dispose();
+
+        ~CommandsNextExtension()
+        {
+            this.Dispose();
+        }
 
         #region DiscordClient Registration
         /// <summary>

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -1057,5 +1057,24 @@ namespace DSharpPlus.Interactivity
 
             await at.ConfigureAwait(false);
         }
+
+        public override void Dispose()
+        {
+            this.ComponentEventWaiter.Dispose();
+            this.ModalEventWaiter.Dispose();
+            this.ReactionCollector.Dispose();
+            this.ComponentInteractionWaiter.Dispose();
+            this.MessageCreatedWaiter.Dispose();
+            this.MessageReactionAddWaiter.Dispose();
+            this.Paginator.Dispose();
+            this.Poller.Dispose();
+            this.TypingStartWaiter.Dispose();
+            this._compPaginator.Dispose();
+        }
+
+        ~InteractivityExtension()
+        {
+            this.Dispose();
+        }
     }
 }

--- a/DSharpPlus.Lavalink/LavalinkExtension.cs
+++ b/DSharpPlus.Lavalink/LavalinkExtension.cs
@@ -196,5 +196,25 @@ namespace DSharpPlus.Lavalink
 
         private Task Con_Disconnected(LavalinkNodeConnection node, NodeDisconnectedEventArgs e)
             => this._nodeDisconnected.InvokeAsync(node, e);
+
+        public override void Dispose()
+        {
+            foreach(var node in this._connectedNodes)
+            {
+                // undoubtedly there will be some GitHub comments about this. Help.
+                node.Value.StopAsync().GetAwaiter().GetResult();
+            }
+            this._connectedNodes.Clear();
+
+            // unhook events
+            _nodeDisconnected.UnregisterAll();
+
+            // Hi GC! <3 😘 clean me up uwu
+        }
+
+        ~LavalinkExtension()
+        {
+            this.Dispose();
+        }
     }
 }

--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -1234,6 +1234,28 @@ namespace DSharpPlus.SlashCommands
             remove => this._autocompleteExecuted.Register(value);
         }
         private AsyncEvent<SlashCommandsExtension, AutocompleteExecutedEventArgs> _autocompleteExecuted;
+
+
+        public override void Dispose()
+        {
+            this._slashError.UnregisterAll();
+            this._slashInvoked.UnregisterAll();
+            this._slashExecuted.UnregisterAll();
+            this._contextMenuErrored.UnregisterAll();
+            this._contextMenuExecuted.UnregisterAll();
+            this._contextMenuInvoked.UnregisterAll();
+            this._autocompleteErrored.UnregisterAll();
+            this._autocompleteExecuted.UnregisterAll();
+
+            this.Client.Ready -= this.Update;
+            this.Client.InteractionCreated -= this.InteractionHandler;
+            this.Client.ContextMenuInteractionCreated -= this.ContextMenuHandler;
+        }
+
+        ~SlashCommandsExtension()
+        {
+            this.Dispose();
+        }
     }
 
     //I'm not sure if creating separate classes is the cleanest thing here but I can't think of anything else so these stay

--- a/DSharpPlus.VoiceNext/VoiceNextExtension.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextExtension.cs
@@ -226,5 +226,21 @@ namespace DSharpPlus.VoiceNext
                 xe.SetResult(e);
             }
         }
+
+        public override void Dispose()
+        {
+            foreach(var conn in this.ActiveConnections)
+            {
+                conn.Value.Dispose();
+            }
+            this.Client.VoiceStateUpdated -= this.Client_VoiceStateUpdate;
+            this.Client.VoiceServerUpdated -= this.Client_VoiceServerUpdate;
+            // Lo and behold, the audacious man who dared lay his hand upon VoiceNext hath once more trespassed upon its profane ground!
+        }
+
+        ~VoiceNextExtension()
+        {
+            this.Dispose();
+        }
     }
 }

--- a/DSharpPlus/BaseExtension.cs
+++ b/DSharpPlus/BaseExtension.cs
@@ -21,17 +21,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
+
 namespace DSharpPlus
 {
     /// <summary>
     /// Represents base for all DSharpPlus extensions. To implement your own extension, extend this class, and implement its abstract members.
     /// </summary>
-    public abstract class BaseExtension
+    public abstract class BaseExtension : IDisposable
     {
         /// <summary>
         /// Gets the instance of <see cref="DiscordClient"/> this extension is attached to.
         /// </summary>
         public DiscordClient Client { get; protected set; }
+
+        public abstract void Dispose();
 
         /// <summary>
         /// Initializes this extension for given <see cref="DiscordClient"/> instance.


### PR DESCRIPTION
# Summary
Simply a fix for the sake of "correctness". We now enforce Extensions to dispose when the DiscordClient does. Implements #1509

# Details
Summary and Changes proposed should say enough.

# Changes proposed
All Extensions are enforced to implement a `Dispose` method through the `BaseExtension` abstract class. This ensures that all the extensions properly get cleaned up when the Client itself cleans up.

# Notes
- LavaLink nodes can only asynchronously disconnect. I have done some unholy black magic that may be all too familiar to you all. I am sorry. Suggestions on how to change this are more than welcome.