### PR TITLE
Fix incorrect link in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -99,7 +99,7 @@ be done to set this up.
 [2]: https://dotnet.microsoft.com/download
 [3]: xref:articles.audio.voicenext.prerequisites
 [4]: xref:articles.beyond_basics.events
-[5]: xref:articles.commands.command_attributes
+[5]: xref:articles.commands.dependency_injection
 [6]: ./images/faq_01.png
 [7]: ./images/faq_02.png
 [8]: xref:articles.beyond_basics.intents


### PR DESCRIPTION
# Summary
The portion of the FAQ which covers [DI with CNext](https://dsharpplus.github.io/DSharpPlus/faq.html#does-commandsnext-support-dependency-injection) currently contains an incorrect link which points to the [command attribute article](https://dsharpplus.github.io/DSharpPlus/articles/commands/command_attributes.html) rather than the [dependency injection article](https://dsharpplus.github.io/DSharpPlus/articles/commands/dependency_injection.html).

# Changes proposed
Fix broke link :godmode: 