### PR TITLE
Send raw events

### DIFF
--- a/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkGuildConnection.cs
@@ -191,7 +191,7 @@ namespace DSharpPlus.Lavalink
                 }
             };
             var vsj = JsonConvert.SerializeObject(vsd, Formatting.None);
-            await (this.Channel.Discord as DiscordClient).WsSendAsync(vsj).ConfigureAwait(false);
+            await (this.Channel.Discord as DiscordClient).SendRawPayloadAsync(vsj).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
+++ b/DSharpPlus.Lavalink/LavalinkNodeConnection.cs
@@ -277,7 +277,7 @@ namespace DSharpPlus.Lavalink
                 { throw; }
                 catch (Exception ex)
                 {
-                    if(!this.Configuration.SocketAutoReconnect || this._backoff == MaximumBackoff)
+                    if (!this.Configuration.SocketAutoReconnect || this._backoff == MaximumBackoff)
                     {
                         this.Discord.Logger.LogCritical(LavalinkEvents.LavalinkConnectionError, ex, "Failed to connect to Lavalink.");
                         throw ex;
@@ -340,7 +340,7 @@ namespace DSharpPlus.Lavalink
                 }
             };
             var vsj = JsonConvert.SerializeObject(vsd, Formatting.None);
-            await (channel.Discord as DiscordClient).WsSendAsync(vsj).ConfigureAwait(false);
+            await (channel.Discord as DiscordClient).SendRawPayloadAsync(vsj).ConfigureAwait(false);
             var vstu = await vstut.Task.ConfigureAwait(false);
             var vsru = await vsrut.Task.ConfigureAwait(false);
             await this.SendPayloadAsync(new LavalinkVoiceUpdate(vstu, vsru)).ConfigureAwait(false);

--- a/DSharpPlus.VoiceNext/VoiceNextExtension.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextExtension.cs
@@ -111,7 +111,7 @@ namespace DSharpPlus.VoiceNext
                 }
             };
             var vsj = JsonConvert.SerializeObject(vsd, Formatting.None);
-            await (channel.Discord as DiscordClient).WsSendAsync(vsj).ConfigureAwait(false);
+            await (channel.Discord as DiscordClient).SendRawPayloadAsync(vsj).ConfigureAwait(false);
 
             var vstu = await vstut.Task.ConfigureAwait(false);
             var vstup = new VoiceStateUpdatePayload
@@ -159,7 +159,7 @@ namespace DSharpPlus.VoiceNext
                 }
             };
             var vsj = JsonConvert.SerializeObject(vsd, Formatting.None);
-            await (guild.Discord as DiscordClient).WsSendAsync(vsj).ConfigureAwait(false);
+            await (guild.Discord as DiscordClient).SendRawPayloadAsync(vsj).ConfigureAwait(false);
         }
 
         private Task Client_VoiceStateUpdate(DiscordClient client, VoiceStateUpdateEventArgs e)

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -61,8 +61,8 @@ namespace DSharpPlus
 
         #region Connection Semaphore
 
-        private static ConcurrentDictionary<ulong, SocketLock> SocketLocks { get; } = new ConcurrentDictionary<ulong, SocketLock>();
-        private ManualResetEventSlim SessionLock { get; } = new ManualResetEventSlim(true);
+        private static ConcurrentDictionary<ulong, SocketLock> _socketLocks { get; } = new ConcurrentDictionary<ulong, SocketLock>();
+        private ManualResetEventSlim _sessionLock { get; } = new ManualResetEventSlim(true);
 
         #endregion
 
@@ -187,7 +187,7 @@ namespace DSharpPlus
             {
                 // release session and connection
                 this.ConnectionLock.Set();
-                this.SessionLock.Set();
+                this._sessionLock.Set();
 
                 if (!this._disposed)
                     this._cancelTokenSource.Cancel();
@@ -269,8 +269,8 @@ namespace DSharpPlus
         internal async Task OnInvalidateSessionAsync(bool data)
         {
             // begin a session if one is not open already
-            if (this.SessionLock.Wait(0))
-                this.SessionLock.Reset();
+            if (this._sessionLock.Wait(0))
+                this._sessionLock.Reset();
 
             // we are sending a fresh resume/identify, so lock the socket
             var socketLock = this.GetSocketLock();
@@ -295,9 +295,9 @@ namespace DSharpPlus
         {
             this.Logger.LogTrace(LoggerEvents.WebSocketReceive, "Received HELLO (OP10)");
 
-            if (this.SessionLock.Wait(0))
+            if (this._sessionLock.Wait(0))
             {
-                this.SessionLock.Reset();
+                this._sessionLock.Reset();
                 this.GetSocketLock().UnlockAfter(TimeSpan.FromSeconds(5));
             }
             else
@@ -381,7 +381,7 @@ namespace DSharpPlus
 
             var statusstr = JsonConvert.SerializeObject(status_update);
 
-            await this.WsSendAsync(statusstr).ConfigureAwait(false);
+            await this.SendRawPayloadAsync(statusstr).ConfigureAwait(false);
 
             if (!this._presences.ContainsKey(this.CurrentUser.Id))
             {
@@ -442,7 +442,7 @@ namespace DSharpPlus
                 Data = seq
             };
             var heartbeat_str = JsonConvert.SerializeObject(heartbeat);
-            await this.WsSendAsync(heartbeat_str).ConfigureAwait(false);
+            await this.SendRawPayloadAsync(heartbeat_str).ConfigureAwait(false);
 
             this._lastHeartbeat = DateTimeOffset.Now;
 
@@ -470,7 +470,7 @@ namespace DSharpPlus
                 Data = identify
             };
             var payloadstr = JsonConvert.SerializeObject(payload);
-            await this.WsSendAsync(payloadstr).ConfigureAwait(false);
+            await this.SendRawPayloadAsync(payloadstr).ConfigureAwait(false);
 
             this.Logger.LogDebug(LoggerEvents.Intents, "Registered gateway intents ({Intents})", this.Configuration.Intents);
         }
@@ -490,8 +490,9 @@ namespace DSharpPlus
             };
             var resumestr = JsonConvert.SerializeObject(resume_payload);
 
-            await this.WsSendAsync(resumestr).ConfigureAwait(false);
+            await this.SendRawPayloadAsync(resumestr).ConfigureAwait(false);
         }
+
         internal async Task InternalUpdateGatewayAsync()
         {
             var info = await this.GetGatewayInfoAsync().ConfigureAwait(false);
@@ -499,18 +500,35 @@ namespace DSharpPlus
             this.GatewayUri = new Uri(info.Url);
         }
 
-        internal async Task WsSendAsync(string payload)
+        internal async Task SendRawPayloadAsync(string rawJson)
         {
-            this.Logger.LogTrace(LoggerEvents.GatewayWsTx, payload);
-            await this._webSocketClient.SendMessageAsync(payload).ConfigureAwait(false);
+            this.Logger.LogTrace(LoggerEvents.GatewayWsTx, rawJson);
+            await this._webSocketClient.SendMessageAsync(rawJson).ConfigureAwait(false);
         }
 
+#nullable enable
+        [Obsolete("This method should not be used unless you know what you're doing. Instead, look towards the other explicitly implemented methods which come with client-side validation.")]
+        public Task SendPayloadAsync<T>(GatewayOpCode opCode, T data) => this.SendPayloadAsync(opCode, (object?)data);
+
+        [Obsolete("This method should not be used unless you know what you're doing. Instead, look towards the other explicitly implemented methods which come with client-side validation.")]
+        public Task SendPayloadAsync(GatewayOpCode opCode, object? data = null)
+        {
+            var payload = new GatewayPayload
+            {
+                OpCode = opCode,
+                Data = data
+            };
+
+            var payloadString = DiscordJson.SerializeObject(payload);
+            return this.SendRawPayloadAsync(payloadString);
+        }
+#nullable disable
         #endregion
 
         #region Semaphore Methods
 
         private SocketLock GetSocketLock()
-            => SocketLocks.GetOrAdd(this.CurrentApplication.Id, appId => new SocketLock(appId, this.GatewayInfo.SessionBucket.MaxConcurrency));
+            => _socketLocks.GetOrAdd(this.CurrentApplication.Id, appId => new SocketLock(appId, this.GatewayInfo.SessionBucket.MaxConcurrency));
 
         #endregion
     }

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -500,10 +500,10 @@ namespace DSharpPlus
             this.GatewayUri = new Uri(info.Url);
         }
 
-        internal async Task SendRawPayloadAsync(string rawJson)
+        internal async Task SendRawPayloadAsync(string jsonPayload)
         {
-            this.Logger.LogTrace(LoggerEvents.GatewayWsTx, rawJson);
-            await this._webSocketClient.SendMessageAsync(rawJson).ConfigureAwait(false);
+            this.Logger.LogTrace(LoggerEvents.GatewayWsTx, jsonPayload);
+            await this._webSocketClient.SendMessageAsync(jsonPayload).ConfigureAwait(false);
         }
 
 #nullable enable

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -507,9 +507,19 @@ namespace DSharpPlus
         }
 
 #nullable enable
+        /// <summary>
+        /// Sends a raw payload to the gateway. This method is not recommended for use unless you know what you're doing.
+        /// </summary>
+        /// <param name="opCode">The opcode to send to the Discord gateway.</param>
+        /// <param name="data">The data to deserialize.</param>
+        /// <typeparam name="T">The type of data that the object belongs to.</typeparam>
+        /// <returns>A task representing the payload being sent.</returns>
         [Obsolete("This method should not be used unless you know what you're doing. Instead, look towards the other explicitly implemented methods which come with client-side validation.")]
         public Task SendPayloadAsync<T>(GatewayOpCode opCode, T data) => this.SendPayloadAsync(opCode, (object?)data);
 
+        /// <inheritdoc cref="SendPayloadAsync{T}(GatewayOpCode, T)"/>
+        /// <param name="data">The data to deserialize.</param>
+        /// <param name="opCode">The opcode to send to the Discord gateway.</param>
         [Obsolete("This method should not be used unless you know what you're doing. Instead, look towards the other explicitly implemented methods which come with client-side validation.")]
         public Task SendPayloadAsync(GatewayOpCode opCode, object? data = null)
         {

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -1412,7 +1412,7 @@ namespace DSharpPlus.Entities
             };
 
             var payloadStr = JsonConvert.SerializeObject(payload, Formatting.None);
-            await client.WsSendAsync(payloadStr).ConfigureAwait(false);
+            await client.SendRawPayloadAsync(payloadStr).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/DSharpPlus/Net/Abstractions/Gateway/GatewayOpCode.cs
+++ b/DSharpPlus/Net/Abstractions/Gateway/GatewayOpCode.cs
@@ -26,7 +26,7 @@ namespace DSharpPlus.Net.Abstractions
     /// <summary>
     /// Specifies an OP code in a gateway payload.
     /// </summary>
-    internal enum GatewayOpCode : int
+    public enum GatewayOpCode : int
     {
         /// <summary>
         /// Used for dispatching events.


### PR DESCRIPTION
# Summary
Allows sending raw payloads to the Discord gateway.

# Details
Currently there is no way for any consumer to send a raw, not validated payload to the Discord gateway without having to make manual changes. For extension authors specifically, this could be incredibly hindering when certain API endpoints or entities are `internal` only. One specific case is with connecting to a voice channel, which requires sending a [Voice State Update Payload through the gateway](https://github.com/DSharpPlus/DSharpPlus/blob/master/DSharpPlus.VoiceNext/VoiceNextExtension.cs#L102-L114) . Currently I do not believe that the lib exposes the functionality that VNext requires, which is why I'm proposing this alternative quick and easy solution for both ease and future compatibility (such as when new gateway events are published before we're able to update) 

# Changes proposed
* Adds the `SendPayloadAsync<T>(GatewayOpCode opCode, T data)` and `SendPayloadAsync(GatewayOpCode opCode, object? data = null)` methods. Both are marked with `Obsolete` attributes to discourage use.
* Renames `WsSendAsync` to `SendRawPayloadAsync`

# Notes
Entirely untested but there is zero reason why this shouldn't work in theory.