### PR TITLE
Fix broken links

### DIFF
--- a/docs/natives/index.md
+++ b/docs/natives/index.md
@@ -6,8 +6,8 @@ title: Native Libraries
 #### Downloads
 Operating System|Download|Checksums|GPG Signatures 
 ---|---|---|---
-64-bit Windows|[Click Here](/natives/vnext_natives_win32_x64.zip)|[Click Here](/natives/vnext_natives_win32_x64.zip.checksums)|[Click Here](/natives/vnext_natives_win32_x64.zip.checksums.sig)
-32-bit Windows|[Click Here](/natives/vnext_natives_win32_x86.zip)|[Click Here](/natives/vnext_natives_win32_x86.zip.checksums)|[Click Here](/natives/vnext_natives_win32_x86.zip.checksums.sig)
+64-bit Windows|[Click Here](/docs/natives/vnext_natives_win32_x64.zip)|[Click Here](/docs/natives/vnext_natives_win32_x64.zip.checksums)|[Click Here](/docs/natives/vnext_natives_win32_x64.zip.checksums.sig)
+32-bit Windows|[Click Here](/docs/natives/vnext_natives_win32_x86.zip)|[Click Here](/docs/natives/vnext_natives_win32_x86.zip.checksums)|[Click Here](/docs/natives/vnext_natives_win32_x86.zip.checksums.sig)
 
 Signatures use key 246AB92A3C22030A.
 


### PR DESCRIPTION
The links to the VNext Natives were broken. Should be fixed with the added /docs/ prefix