### PR TITLE
remove outdated deps related to docfx

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,6 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageVersion Include="ConcurrentHashSet" Version="1.3.0" />
-    <PackageVersion Include="Microsoft.DocAsCode.App" Version="2.63.1" />
-    <PackageVersion Include="Microsoft.DocAsCode.Build.MemberLevelManagedReference" Version="2.63.1" />
     <PackageVersion Include="DSharpPlus.VoiceNext.Natives" Version="1.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Text.Json" Version="8.0.0-preview.2.23128.3" />


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Removes Microsoft.DocAsCode.App dependencies, because they're not needed anymore.

# Notes
Any additional notes go here.