### PR TITLE
Fix DiscordMessageBuilder being empty in ModifyAsync(Action<DiscordMessageBuilder>)

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -520,7 +520,7 @@ namespace DSharpPlus.Entities
         /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
         public async Task<DiscordMessage> ModifyAsync(Action<DiscordMessageBuilder> action, bool suppressEmbeds = false, IEnumerable<DiscordAttachment> attachments = default)
         {
-            var builder = new DiscordMessageBuilder();
+            var builder = new DiscordMessageBuilder(this);
             action(builder);
             builder.Validate(true);
             return await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, builder.Content, new Optional<IEnumerable<DiscordEmbed>>(builder.Embeds), builder._mentions, builder.Components, builder.Files, suppressEmbeds ? MessageFlags.SuppressedEmbeds : null, attachments).ConfigureAwait(false);


### PR DESCRIPTION
# Summary
As discussed in #lib-development, change to not using an empty MessageBuilder.

# Notes
Tested