### PR TITLE
[ci skip] Update docs for CreateThreadAsync

### DIFF
--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -1033,7 +1033,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         /// <param name="message">Message to create the thread from.</param>
         /// <param name="name">The name of the thread.</param>
-        /// <param name="archiveAfter">The auto archive duration of the thread. 3 day and 7 day archive durations require a level 1 and 2 server boost respectively.</param>
+        /// <param name="archiveAfter">The auto archive duration of the thread.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The created thread.</returns>
         /// <exception cref="NotFoundException">Thrown when the channel or message does not exist.</exception>
@@ -1055,8 +1055,8 @@ namespace DSharpPlus.Entities
         /// Creates a new thread within this channel.
         /// </summary>
         /// <param name="name">The name of the thread.</param>
-        /// <param name="archiveAfter">The auto archive duration of the thread. 3 day and 7 day archive durations require a level 1 and 2 server boost respectively.</param>
-        /// <param name="threadType">The type of thread to create, either a public, news or, private thread. Private threads requires a level 2 server boost and can only be created within channels of type <see cref="ChannelType.Text"/>.</param>
+        /// <param name="archiveAfter">The auto archive duration of the thread.</param>
+        /// <param name="threadType">The type of thread to create, either a public, news or, private thread.</param>
         /// <param name="reason">Reason for audit logs.</param>
         /// <returns>The created thread.</returns>
         /// <exception cref="NotFoundException">Thrown when the channel or message does not exist.</exception>


### PR DESCRIPTION
# Summary
Private threads are no longer locked behind server boosts

# Details
This PR removes the hint from the docs

# Changes proposed
* Removes the `3 day and 7 day archive durations require a level 1 and 2 server boost respectively.` hint from both CreateThreadAsync functions
* Also removes the `Private threads requires a level 2 server boost and can only be created within channels of type ChannelType.Text` hint, because im pretty sure you cant create threads in any channel type except text anyway. Please correct me if im wrong


# Notes
See [this](https://discord.com/channels/379378609942560770/379386901725052928/1098614722946945025)