### PR TITLE
Add null check on SlashCommandExtension Constructor

### DIFF
--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -50,7 +50,7 @@ namespace DSharpPlus.SlashCommands
 
         internal SlashCommandsExtension(SlashCommandsConfiguration configuration)
         {
-            this._configuration = configuration;
+            this._configuration = configuration ?? new SlashCommandsConfiguration();;
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary
Fixes issue when using `DiscordClient#UseSlashCommands` without a config

# Details
Constructor now checks for null and uses a new config in case of null