### PR TITLE
feat: add IInteractionContextAccessor, for log enrichment

### DIFF
--- a/DSharpPlus.SlashCommands/IInteractionContextAccessor.cs
+++ b/DSharpPlus.SlashCommands/IInteractionContextAccessor.cs
@@ -1,0 +1,42 @@
+using System.Threading; 
+using System;
+using DSharpPlus.SlashCommands;
+
+namespace DSharpPlus.SlashCommands;
+
+public interface IInteractionContextAccessor
+{
+    InteractionContext? InteractionContext { get; set; }
+
+}
+
+public class InteractionContextAccessor : IInteractionContextAccessor
+{
+    private static readonly AsyncLocal<InteractionContextHolder> _interactionContextCurrent = new AsyncLocal<InteractionContextHolder>();
+    private readonly string Id = Guid.NewGuid().ToString();
+    public InteractionContext? InteractionContext
+    {
+        get
+        {
+            return _interactionContextCurrent.Value?.Context;
+        }
+        set
+        {
+            var holder = _interactionContextCurrent.Value;
+            if (holder != null)
+            {
+                holder.Context = null;
+            }
+
+            if (value != null)
+            {
+                _interactionContextCurrent.Value = new InteractionContextHolder { Context = value };
+            }
+        }
+    }
+
+    private sealed class InteractionContextHolder
+    {
+        public InteractionContext? Context;
+    }
+}

--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -619,6 +619,13 @@ namespace DSharpPlus.SlashCommands
                         if (!methods.Any() && !groups.Any() && !subgroups.Any())
                             throw new InvalidOperationException("A slash command was executed, but no command was registered for it.");
 
+                        var ctxAccessor = context.Services.GetService<IInteractionContextAccessor>();
+                        if (ctxAccessor is not null)
+                        {
+                            ctxAccessor.InteractionContext = context;
+                        }
+
+
                         //Just read the code you'll get it
                         if (methods.Any())
                         {


### PR DESCRIPTION
# Summary
Adds an optionally-injected interface, `IInteractionContextAccessor`, for accessing the current `InteractionContext` outside of application commands and pre-execution checks.

# Details
This interface can be injected into a class that implements `Serilog.Core.ILogEventEnricher`.
This will allow enriching of logs with fields from the current `InteractionContext`.
To use, the `IInteractionContextAccessor` must be registered as a singleton.

An example enricher:
```c#
public class InteractionContextEnricher : ILogEventEnricher
{
    private IInteractionContextAccessor InteractionContextAccessor;
    public InteractionContextEnricher(IInteractionContextAccessor interactionContextAccessor)
    {
        IInteractionContextAccessor = interactionContextAccessor;
    }
    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
    {
        if (InteractionContextAccessor.InteractionContext is null)
        {
            return;
        }
        var ctx = InteractionContextAccessor.InteractionContext;
        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("command", ctx.CommandName));
        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("channel_name", ctx.Channel.Name));
        
    }
}
```
And the result from a logged line:
![image](https://github.com/DSharpPlus/DSharpPlus/assets/56777335/fc741394-1aaf-4a5a-a96c-ca25531f2b0a)

# Changes proposed
- Add `IInteractionContextAccessor` and default implementation, `InteractionContextAccessor`
