### PR TITLE
Add NSFW flag to Slash Commands

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -1830,7 +1830,7 @@ namespace DSharpPlus
             var mdl = new ApplicationCommandEditModel();
             action(mdl);
             var applicationId = this.CurrentApplication?.Id ?? (await this.GetCurrentApplicationAsync()).Id;
-            return await this.ApiClient.EditGlobalApplicationCommandAsync(applicationId, commandId, mdl.Name, mdl.Description, mdl.Options, mdl.DefaultPermission, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
+            return await this.ApiClient.EditGlobalApplicationCommandAsync(applicationId, commandId, mdl.Name, mdl.Description, mdl.Options, mdl.DefaultPermission, mdl.NSFW, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
         }
 
         /// <summary>
@@ -1887,7 +1887,7 @@ namespace DSharpPlus
             var mdl = new ApplicationCommandEditModel();
             action(mdl);
             var applicationId = this.CurrentApplication?.Id ?? (await this.GetCurrentApplicationAsync()).Id;
-            return await this.ApiClient.EditGuildApplicationCommandAsync(applicationId, guildId, commandId, mdl.Name, mdl.Description, mdl.Options, mdl.DefaultPermission, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
+            return await this.ApiClient.EditGuildApplicationCommandAsync(applicationId, guildId, commandId, mdl.Name, mdl.Description, mdl.Options, mdl.DefaultPermission, mdl.NSFW, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
         }
 
         /// <summary>

--- a/DSharpPlus.SlashCommands/Attributes/ContextMenuAttribute.cs
+++ b/DSharpPlus.SlashCommands/Attributes/ContextMenuAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace DSharpPlus.SlashCommands
 {
@@ -24,12 +24,18 @@ namespace DSharpPlus.SlashCommands
         public bool DefaultPermission { get; internal set; }
 
         /// <summary>
+        /// Gets whether this command is age restricted.
+        /// </summary>
+        public bool NSFW { get; }
+
+        /// <summary>
         /// Marks this method as a context menu.
         /// </summary>
         /// <param name="type">The type of the context menu.</param>
         /// <param name="name">The name of the context menu.</param>
         /// <param name="defaultPermission">Sets whether the command should be enabled by default.</param>
-        public ContextMenuAttribute(ApplicationCommandType type, string name, bool defaultPermission = true)
+        /// <param name="nsfw">Sets whether the command is age restricted.</param>
+        public ContextMenuAttribute(ApplicationCommandType type, string name, bool defaultPermission = true, bool nsfw = false)
         {
             if (type == ApplicationCommandType.SlashCommand)
                 throw new ArgumentException("Context menus cannot be of type SlashCommand.");
@@ -37,6 +43,7 @@ namespace DSharpPlus.SlashCommands
             this.Type = type;
             this.Name = name;
             this.DefaultPermission = defaultPermission;
+            this.NSFW = nsfw;
         }
     }
 }

--- a/DSharpPlus.SlashCommands/Attributes/SlashCommandAttribute.cs
+++ b/DSharpPlus.SlashCommands/Attributes/SlashCommandAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace DSharpPlus.SlashCommands
 {
@@ -24,16 +24,23 @@ namespace DSharpPlus.SlashCommands
         public bool DefaultPermission { get; }
 
         /// <summary>
+        /// Gets whether this command is age restricted.
+        /// </summary>
+        public bool NSFW { get; }
+
+        /// <summary>
         /// Marks this method as a slash command.
         /// </summary>
         /// <param name="name">Sets the name of this slash command.</param>
         /// <param name="description">Sets the description of this slash command.</param>
         /// <param name="defaultPermission">Sets whether the command should be enabled by default.</param>
-        public SlashCommandAttribute(string name, string description, bool defaultPermission = true)
+        /// <param name="nsfw">Sets whether the command is age restricted.</param>
+        public SlashCommandAttribute(string name, string description, bool defaultPermission = true, bool nsfw = false)
         {
             this.Name = name.ToLower();
             this.Description = description;
             this.DefaultPermission = defaultPermission;
+            this.NSFW = nsfw;
         }
     }
 }

--- a/DSharpPlus.SlashCommands/Attributes/SlashCommandGroupAttribute.cs
+++ b/DSharpPlus.SlashCommands/Attributes/SlashCommandGroupAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace DSharpPlus.SlashCommands
 {
@@ -24,16 +24,23 @@ namespace DSharpPlus.SlashCommands
         public bool DefaultPermission { get; }
 
         /// <summary>
+        /// Gets whether this command is age restricted.
+        /// </summary>
+        public bool NSFW { get; }
+
+        /// <summary>
         /// Marks this class as a slash command group.
         /// </summary>
         /// <param name="name">Sets the name of this command group.</param>
         /// <param name="description">Sets the description of this command group.</param>
         /// <param name="defaultPermission">Sets whether this command group is enabled on default.</param>
-        public SlashCommandGroupAttribute(string name, string description, bool defaultPermission = true)
+        /// <param name="nsfw">Sets whether the command group is age restricted.</param>
+        public SlashCommandGroupAttribute(string name, string description, bool defaultPermission = true, bool nsfw = false)
         {
             this.Name = name.ToLower();
             this.Description = description;
             this.DefaultPermission = defaultPermission;
+            this.NSFW = nsfw;
         }
     }
 }

--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -190,7 +190,7 @@ namespace DSharpPlus.SlashCommands
                             AddContextMenus(contextMethods);
 
                             //Initializes the command
-                            var payload = new DiscordApplicationCommand(groupAttribute.Name, groupAttribute.Description, defaultPermission: groupAttribute.DefaultPermission, allowDMUsage: allowDMs, defaultMemberPermissions: v2Permissions);
+                            var payload = new DiscordApplicationCommand(groupAttribute.Name, groupAttribute.Description, defaultPermission: groupAttribute.DefaultPermission, allowDMUsage: allowDMs, defaultMemberPermissions: v2Permissions, nsfw: groupAttribute.NSFW);
 
                             var commandmethods = new List<KeyValuePair<string, MethodInfo>>();
                             //Handles commands in the group
@@ -215,7 +215,7 @@ namespace DSharpPlus.SlashCommands
 
                                 //Creates the subcommand and adds it to the main command
                                 var subpayload = new DiscordApplicationCommandOption(commandAttribute.Name, commandAttribute.Description, ApplicationCommandOptionType.SubCommand, null, null, options, name_localizations: nameLocalizations, description_localizations: descriptionLocalizations);
-                                payload = new DiscordApplicationCommand(payload.Name, payload.Description, payload.Options?.Append(subpayload) ?? new[] { subpayload }, payload.DefaultPermission, allowDMUsage: allowDMs, defaultMemberPermissions: v2Permissions);
+                                payload = new DiscordApplicationCommand(payload.Name, payload.Description, payload.Options?.Append(subpayload) ?? new[] { subpayload }, payload.DefaultPermission, allowDMUsage: allowDMs, defaultMemberPermissions: v2Permissions, nsfw: payload.NSFW);
 
                                 //Adds it to the method lists
                                 commandmethods.Add(new(commandAttribute.Name, submethod));
@@ -263,7 +263,7 @@ namespace DSharpPlus.SlashCommands
                                 //Adds the group to the command and method lists
                                 var subpayload = new DiscordApplicationCommandOption(subGroupAttribute.Name, subGroupAttribute.Description, ApplicationCommandOptionType.SubCommandGroup, null, null, options);
                                 command.SubCommands.Add(new() { Name = subGroupAttribute.Name, Methods = currentMethods });
-                                payload = new DiscordApplicationCommand(payload.Name, payload.Description, payload.Options?.Append(subpayload) ?? new[] { subpayload }, payload.DefaultPermission, allowDMUsage: allowDMs, defaultMemberPermissions: v2Permissions);
+                                payload = new DiscordApplicationCommand(payload.Name, payload.Description, payload.Options?.Append(subpayload) ?? new[] { subpayload }, payload.DefaultPermission, allowDMUsage: allowDMs, defaultMemberPermissions: v2Permissions, nsfw: payload.NSFW);
 
                                 //Accounts for lifespans for the sub group
                                 if (subclass.GetCustomAttribute<SlashModuleLifespanAttribute>() is not null and { Lifespan: SlashModuleLifespan.Singleton })
@@ -308,7 +308,7 @@ namespace DSharpPlus.SlashCommands
                                 var allowDMs = (method.GetCustomAttribute<GuildOnlyAttribute>() ?? method.DeclaringType.GetCustomAttribute<GuildOnlyAttribute>()) is null;
                                 var v2Permissions = (method.GetCustomAttribute<SlashCommandPermissionsAttribute>() ?? method.DeclaringType.GetCustomAttribute<SlashCommandPermissionsAttribute>())?.Permissions;
 
-                                var payload = new DiscordApplicationCommand(commandattribute.Name, commandattribute.Description, options, commandattribute.DefaultPermission, name_localizations: nameLocalizations, description_localizations: descriptionLocalizations, allowDMUsage: allowDMs, defaultMemberPermissions: v2Permissions);
+                                var payload = new DiscordApplicationCommand(commandattribute.Name, commandattribute.Description, options, commandattribute.DefaultPermission, name_localizations: nameLocalizations, description_localizations: descriptionLocalizations, allowDMUsage: allowDMs, defaultMemberPermissions: v2Permissions, nsfw:commandattribute.NSFW);
                                 updateList.Add(payload);
                             }
 
@@ -330,7 +330,7 @@ namespace DSharpPlus.SlashCommands
                                 var contextAttribute = contextMethod.GetCustomAttribute<ContextMenuAttribute>();
                                 var allowDMUsage = (contextMethod.GetCustomAttribute<GuildOnlyAttribute>() ?? contextMethod.DeclaringType.GetCustomAttribute<GuildOnlyAttribute>()) is null;
                                 var permissions = (contextMethod.GetCustomAttribute<SlashCommandPermissionsAttribute>() ?? contextMethod.DeclaringType.GetCustomAttribute<SlashCommandPermissionsAttribute>())?.Permissions;
-                                var command = new DiscordApplicationCommand(contextAttribute.Name, null, type: contextAttribute.Type, defaultPermission: contextAttribute.DefaultPermission, allowDMUsage: allowDMUsage, defaultMemberPermissions: permissions);
+                                var command = new DiscordApplicationCommand(contextAttribute.Name, null, type: contextAttribute.Type, defaultPermission: contextAttribute.DefaultPermission, allowDMUsage: allowDMUsage, defaultMemberPermissions: permissions, nsfw: contextAttribute.NSFW);
 
                                 var parameters = contextMethod.GetParameters();
                                 if (parameters?.Length is null or 0 || !ReferenceEquals(parameters.FirstOrDefault()?.ParameterType, typeof(ContextMenuContext)))

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -719,7 +719,7 @@ namespace DSharpPlus
             var mdl = new ApplicationCommandEditModel();
             action(mdl);
             var applicationId = this.CurrentApplication?.Id ?? (await this.GetCurrentApplicationAsync()).Id;
-            return await this.ApiClient.EditGlobalApplicationCommandAsync(applicationId, commandId, mdl.Name, mdl.Description, mdl.Options, mdl.DefaultPermission, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
+            return await this.ApiClient.EditGlobalApplicationCommandAsync(applicationId, commandId, mdl.Name, mdl.Description, mdl.Options, mdl.DefaultPermission, mdl.NSFW, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
         }
 
         /// <summary>
@@ -776,7 +776,7 @@ namespace DSharpPlus
             var mdl = new ApplicationCommandEditModel();
             action(mdl);
             var applicationId = this.CurrentApplication?.Id ?? (await this.GetCurrentApplicationAsync()).Id;
-            return await this.ApiClient.EditGuildApplicationCommandAsync(applicationId, guildId, commandId, mdl.Name, mdl.Description, mdl.Options, mdl.DefaultPermission, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
+            return await this.ApiClient.EditGuildApplicationCommandAsync(applicationId, guildId, commandId, mdl.Name, mdl.Description, mdl.Options, mdl.DefaultPermission, mdl.NSFW, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -2923,7 +2923,7 @@ namespace DSharpPlus.Entities
         {
             var mdl = new ApplicationCommandEditModel();
             action(mdl);
-            return await this.Discord.ApiClient.EditGuildApplicationCommandAsync(this.Discord.CurrentApplication.Id, this.Id, commandId, mdl.Name, mdl.Description, mdl.Options, mdl.DefaultPermission, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
+            return await this.Discord.ApiClient.EditGuildApplicationCommandAsync(this.Discord.CurrentApplication.Id, this.Id, commandId, mdl.Name, mdl.Description, mdl.Options, mdl.DefaultPermission, mdl.NSFW, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
@@ -83,6 +83,11 @@ namespace DSharpPlus.Entities
         [JsonProperty("default_member_permissions")]
         public Permissions? DefaultMemberPermissions { get; internal set; }
 
+        /// <summary>
+        /// Whether this command is age-restricted.
+        /// </summary>
+        [JsonProperty("nsfw")]
+        public bool? NSFW { get; internal set; }
 
         /// <summary>
         /// Gets the auto-incrementing version number for this command.
@@ -115,7 +120,7 @@ namespace DSharpPlus.Entities
         /// <param name="description_localizations">Localization dictionary for <paramref name="description"/> field. Values follow the same restrictions as <paramref name="description"/>.</param>
         /// <param name="allowDMUsage">Whether this command can be invoked in DMs.</param>
         /// <param name="defaultMemberPermissions">What permissions this command requires to be invoked.</param>
-        public DiscordApplicationCommand(string name, string description, IEnumerable<DiscordApplicationCommandOption> options = null, bool? defaultPermission = null, ApplicationCommandType type = ApplicationCommandType.SlashCommand, IReadOnlyDictionary<string, string> name_localizations = null, IReadOnlyDictionary<string, string> description_localizations = null, bool? allowDMUsage = null, Permissions? defaultMemberPermissions = null)
+        public DiscordApplicationCommand(string name, string description, IEnumerable<DiscordApplicationCommandOption> options = null, bool? defaultPermission = null, ApplicationCommandType type = ApplicationCommandType.SlashCommand, IReadOnlyDictionary<string, string> name_localizations = null, IReadOnlyDictionary<string, string> description_localizations = null, bool? allowDMUsage = null, Permissions? defaultMemberPermissions = null, bool? nsfw = null)
         {
             if (type is ApplicationCommandType.SlashCommand)
             {
@@ -146,6 +151,7 @@ namespace DSharpPlus.Entities
             this.DescriptionLocalizations = description_localizations;
             this.AllowDMUsage = allowDMUsage;
             this.DefaultMemberPermissions = defaultMemberPermissions;
+            this.NSFW = nsfw;
         }
 
         /// <summary>

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
@@ -120,6 +120,7 @@ namespace DSharpPlus.Entities
         /// <param name="description_localizations">Localization dictionary for <paramref name="description"/> field. Values follow the same restrictions as <paramref name="description"/>.</param>
         /// <param name="allowDMUsage">Whether this command can be invoked in DMs.</param>
         /// <param name="defaultMemberPermissions">What permissions this command requires to be invoked.</param>
+        /// <param name="nsfw">Whether the command is age restricted.</param>
         public DiscordApplicationCommand(string name, string description, IEnumerable<DiscordApplicationCommandOption> options = null, bool? defaultPermission = null, ApplicationCommandType type = ApplicationCommandType.SlashCommand, IReadOnlyDictionary<string, string> name_localizations = null, IReadOnlyDictionary<string, string> description_localizations = null, bool? allowDMUsage = null, Permissions? defaultMemberPermissions = null, bool? nsfw = null)
         {
             if (type is ApplicationCommandType.SlashCommand)

--- a/DSharpPlus/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
@@ -56,6 +56,8 @@ namespace DSharpPlus.Net.Abstractions
         [JsonProperty("default_member_permissions", NullValueHandling = NullValueHandling.Ignore)]
         public Permissions? DefaultMemberPermissions { get; set; }
 
+        [JsonProperty("nsfw", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? NSFW { get; set; }
     }
 
     internal class RestApplicationCommandEditPayload
@@ -83,6 +85,9 @@ namespace DSharpPlus.Net.Abstractions
 
         [JsonProperty("default_member_permissions", NullValueHandling = NullValueHandling.Ignore)]
         public Optional<Permissions?> DefaultMemberPermissions { get; set; }
+
+        [JsonProperty("nsfw", NullValueHandling = NullValueHandling.Ignore)]
+        public Optional<bool?> NSFW { get; set; }
     }
 
     internal class RestInteractionResponsePayload

--- a/DSharpPlus/Net/Models/ApplicationCommandEditModel.cs
+++ b/DSharpPlus/Net/Models/ApplicationCommandEditModel.cs
@@ -80,5 +80,10 @@ namespace DSharpPlus.Net.Models
         /// Sets the requisite permissions for the command.
         /// </summary>
         public Optional<Permissions?> DefaultMemberPermissions { internal get; set; }
+
+        /// <summary>
+        /// Sets whether this command is age restricted.
+        /// </summary>
+        public Optional<bool?> NSFW { internal get; set; }
     }
 }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -3260,7 +3260,8 @@ namespace DSharpPlus.Net
                     NameLocalizations = command.NameLocalizations,
                     DescriptionLocalizations = command.DescriptionLocalizations,
                     AllowDMUsage = command.AllowDMUsage,
-                    DefaultMemberPermissions = command.DefaultMemberPermissions
+                    DefaultMemberPermissions = command.DefaultMemberPermissions,
+                    NSFW = command.NSFW
                 });
             }
 
@@ -3288,7 +3289,8 @@ namespace DSharpPlus.Net
                 NameLocalizations = command.NameLocalizations,
                 DescriptionLocalizations = command.DescriptionLocalizations,
                 AllowDMUsage = command.AllowDMUsage,
-                DefaultMemberPermissions = command.DefaultMemberPermissions
+                DefaultMemberPermissions = command.DefaultMemberPermissions,
+                NSFW = command.NSFW
             };
 
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}";
@@ -3317,7 +3319,7 @@ namespace DSharpPlus.Net
             return ret;
         }
 
-        internal async Task<DiscordApplicationCommand> EditGlobalApplicationCommandAsync(ulong application_id, ulong command_id, Optional<string> name, Optional<string> description, Optional<IReadOnlyCollection<DiscordApplicationCommandOption>> options, Optional<bool?> defaultPermission, IReadOnlyDictionary<string, string> name_localizations = null, IReadOnlyDictionary<string, string> description_localizations = null, Optional<bool> allowDMUsage = default, Optional<Permissions?> defaultMemberPermissions = default)
+        internal async Task<DiscordApplicationCommand> EditGlobalApplicationCommandAsync(ulong application_id, ulong command_id, Optional<string> name, Optional<string> description, Optional<IReadOnlyCollection<DiscordApplicationCommandOption>> options, Optional<bool?> defaultPermission, Optional<bool?> nsfw, IReadOnlyDictionary<string, string> name_localizations = null, IReadOnlyDictionary<string, string> description_localizations = null, Optional<bool> allowDMUsage = default, Optional<Permissions?> defaultMemberPermissions = default)
         {
             var pld = new RestApplicationCommandEditPayload
             {
@@ -3328,7 +3330,8 @@ namespace DSharpPlus.Net
                 NameLocalizations = name_localizations,
                 DescriptionLocalizations = description_localizations,
                 AllowDMUsage = allowDMUsage,
-                DefaultMemberPermissions = defaultMemberPermissions
+                DefaultMemberPermissions = defaultMemberPermissions,
+                NSFW = nsfw,
             };
 
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.COMMANDS}/:command_id";
@@ -3381,7 +3384,8 @@ namespace DSharpPlus.Net
                     NameLocalizations = command.NameLocalizations,
                     DescriptionLocalizations = command.DescriptionLocalizations,
                     AllowDMUsage = command.AllowDMUsage,
-                    DefaultMemberPermissions = command.DefaultMemberPermissions
+                    DefaultMemberPermissions = command.DefaultMemberPermissions,
+                    NSFW = command.NSFW
                 });
             }
 
@@ -3409,7 +3413,8 @@ namespace DSharpPlus.Net
                 NameLocalizations = command.NameLocalizations,
                 DescriptionLocalizations = command.DescriptionLocalizations,
                 AllowDMUsage = command.AllowDMUsage,
-                DefaultMemberPermissions = command.DefaultMemberPermissions
+                DefaultMemberPermissions = command.DefaultMemberPermissions,
+                NSFW = command.NSFW
             };
 
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}";
@@ -3438,7 +3443,7 @@ namespace DSharpPlus.Net
             return ret;
         }
 
-        internal async Task<DiscordApplicationCommand> EditGuildApplicationCommandAsync(ulong application_id, ulong guild_id, ulong command_id, Optional<string> name, Optional<string> description, Optional<IReadOnlyCollection<DiscordApplicationCommandOption>> options, Optional<bool?> defaultPermission, IReadOnlyDictionary<string, string> name_localizations = null, IReadOnlyDictionary<string, string> description_localizations = null, Optional<bool> allowDMUsage = default, Optional<Permissions?> defaultMemberPermissions = default)
+        internal async Task<DiscordApplicationCommand> EditGuildApplicationCommandAsync(ulong application_id, ulong guild_id, ulong command_id, Optional<string> name, Optional<string> description, Optional<IReadOnlyCollection<DiscordApplicationCommandOption>> options, Optional<bool?> defaultPermission, Optional<bool?> nsfw, IReadOnlyDictionary<string, string> name_localizations = null, IReadOnlyDictionary<string, string> description_localizations = null, Optional<bool> allowDMUsage = default, Optional<Permissions?> defaultMemberPermissions = default)
         {
             var pld = new RestApplicationCommandEditPayload
             {
@@ -3449,7 +3454,8 @@ namespace DSharpPlus.Net
                 NameLocalizations = name_localizations,
                 DescriptionLocalizations = description_localizations,
                 AllowDMUsage = allowDMUsage,
-                DefaultMemberPermissions = defaultMemberPermissions
+                DefaultMemberPermissions = defaultMemberPermissions,
+                NSFW = nsfw
             };
 
             var route = $"{Endpoints.APPLICATIONS}/:application_id{Endpoints.GUILDS}/:guild_id{Endpoints.COMMANDS}/:command_id";


### PR DESCRIPTION
# Summary
Discord recently announced the scanning of attachments on Slash Commands. Setting the slash command as NSFW would allow attachments to not be scanned. This PR adds the NSFW flag to Create/Edit slash command requests.

![DiscordCanary_XHrKcZAE5J](https://github.com/DSharpPlus/DSharpPlus/assets/13679909/69a0ba6a-d33c-49e3-b3b3-ba066402bd37)

# Notes
I went about adding the NSFW tag through the `SlashCommandAttribute` constructor. I wasn't sure if it'd be preferred to do it via its own attribute. If so, I can change that.