### PR TITLE
Fixing a very small typo

### DIFF
--- a/docs/articles/slash_commands.md
+++ b/docs/articles/slash_commands.md
@@ -109,7 +109,7 @@ public async Task DelayTestCommand(InteractionContext ctx)
 }
 ```
 
-You can also override `BeforeExecutionAsync` and `AfterExecutionAsync` to run code before and after all the commands in a module. This does not apply to groups, you have the override them individually for the group's class.
+You can also override `BeforeExecutionAsync` and `AfterExecutionAsync` to run code before and after all the commands in a module. This does not apply to groups, you have to override them individually for the group's class.
 `BeforeExecutionAsync` can also be used to prevent the command from running.
 
 ### Arguments


### PR DESCRIPTION
# Summary
Fixing a small typo in the docs

# Details
Changed "the" to "to"

# Changes proposed
See details