### PR TITLE
No more NREs when disposing/finalizing, fixes #1547

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -166,11 +166,11 @@ namespace DSharpPlus.CommandsNext
         /// Disposes of this the resources used by CNext.
         /// </summary>
         public override void Dispose()
-            => this.Config.CommandExecutor.Dispose();
-
-        ~CommandsNextExtension()
         {
-            this.Dispose();
+            this.Config.CommandExecutor.Dispose();
+
+            // Satisfy rule CA1816. Can be removed if this class is sealed.
+            GC.SuppressFinalize(this);
         }
 
         #region DiscordClient Registration

--- a/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
@@ -133,31 +133,33 @@ namespace DSharpPlus.Interactivity.EventHandling
             return Task.CompletedTask;
         }
 
-        ~EventWaiter()
-        {
-            this.Dispose();
-        }
-
         /// <summary>
         /// Disposes this EventWaiter
         /// </summary>
         public void Dispose()
         {
+            if (this._disposed)
+                return;
+
             this._disposed = true;
-            if (this._event != null)
+
+            if (this._event != null && this._handler != null)
                 this._event.Unregister(this._handler);
 
-            this._event = null;
-            this._handler = null;
-            this._client = null;
+            this._event = null!;
+            this._handler = null!;
+            this._client = null!;
 
             if (this._matchrequests != null)
                 this._matchrequests.Clear();
             if (this._collectrequests != null)
                 this._collectrequests.Clear();
 
-            this._matchrequests = null;
-            this._collectrequests = null;
+            this._matchrequests = null!;
+            this._collectrequests = null!;
+
+            // Satisfy rule CA1816. Can be removed if this class is sealed.
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/DSharpPlus.Interactivity/EventHandling/Paginator.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Paginator.cs
@@ -260,22 +260,23 @@ namespace DSharpPlus.Interactivity.EventHandling
             await builder.ModifyAsync(msg);
         }
 
-        ~Paginator()
-        {
-            this.Dispose();
-        }
-
         /// <summary>
         /// Disposes this EventWaiter
         /// </summary>
         public void Dispose()
         {
-            this._client.MessageReactionAdded -= this.HandleReactionAdd;
-            this._client.MessageReactionRemoved -= this.HandleReactionRemove;
-            this._client.MessageReactionsCleared -= this.HandleReactionClear;
-            this._client = null;
-            this._requests.Clear();
-            this._requests = null;
+            // Why doesn't this class implement IDisposable?
+
+            if (this._client != null)
+            {
+                this._client.MessageReactionAdded -= this.HandleReactionAdd;
+                this._client.MessageReactionRemoved -= this.HandleReactionRemove;
+                this._client.MessageReactionsCleared -= this.HandleReactionClear;
+                this._client = null!;
+            }
+
+            this._requests?.Clear();
+            this._requests = null!;
         }
     }
 }

--- a/DSharpPlus.Interactivity/EventHandling/Poller.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Poller.cs
@@ -128,22 +128,26 @@ namespace DSharpPlus.Interactivity.EventHandling
             return Task.CompletedTask;
         }
 
-        ~Poller()
-        {
-            this.Dispose();
-        }
-
         /// <summary>
         /// Disposes this EventWaiter
         /// </summary>
         public void Dispose()
         {
-            this._client.MessageReactionAdded -= this.HandleReactionAdd;
-            this._client.MessageReactionRemoved -= this.HandleReactionRemove;
-            this._client.MessageReactionsCleared -= this.HandleReactionClear;
-            this._client = null;
-            this._requests.Clear();
-            this._requests = null;
+            // Why doesn't this class implement IDisposable?
+
+            if (this._client != null)
+            {
+                this._client.MessageReactionAdded -= this.HandleReactionAdd;
+                this._client.MessageReactionRemoved -= this.HandleReactionRemove;
+                this._client.MessageReactionsCleared -= this.HandleReactionClear;
+                this._client = null!;
+            }
+
+            if (this._requests != null)
+            {
+                this._requests.Clear();
+                this._requests = null!;
+            }
         }
     }
 }

--- a/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ReactionCollector.cs
@@ -168,31 +168,34 @@ namespace DSharpPlus.Interactivity.EventHandling
             return Task.CompletedTask;
         }
 
-        ~ReactionCollector()
-        {
-            this.Dispose();
-        }
-
         /// <summary>
         /// Disposes this EventWaiter
         /// </summary>
         public void Dispose()
         {
-            this._client = null;
+            this._client = null!;
 
-            this._reactionAddEvent.Unregister(this._reactionAddHandler);
-            this._reactionRemoveEvent.Unregister(this._reactionRemoveHandler);
-            this._reactionClearEvent.Unregister(this._reactionClearHandler);
+            if (this._reactionAddHandler != null)
+                this._reactionAddEvent?.Unregister(this._reactionAddHandler);
 
-            this._reactionAddEvent = null;
-            this._reactionAddHandler = null;
-            this._reactionRemoveEvent = null;
-            this._reactionRemoveHandler = null;
-            this._reactionClearEvent = null;
-            this._reactionClearHandler = null;
+            if (this._reactionRemoveHandler != null)
+                this._reactionRemoveEvent?.Unregister(this._reactionRemoveHandler);
 
-            this._requests.Clear();
-            this._requests = null;
+            if (this._reactionClearHandler != null)
+                this._reactionClearEvent?.Unregister(this._reactionClearHandler);
+
+            this._reactionAddEvent = null!;
+            this._reactionAddHandler = null!;
+            this._reactionRemoveEvent = null!;
+            this._reactionRemoveHandler = null!;
+            this._reactionClearEvent = null!;
+            this._reactionClearHandler = null!;
+
+            this._requests?.Clear();
+            this._requests = null!;
+
+            // Satisfy rule CA1816. Can be removed if this class is sealed.
+            GC.SuppressFinalize(this);
         }
     }
 
@@ -214,19 +217,16 @@ namespace DSharpPlus.Interactivity.EventHandling
             this._ct.Token.Register(() => this._tcs.TrySetResult(null));
         }
 
-        ~ReactionCollectRequest()
-        {
-            this.Dispose();
-        }
-
         public void Dispose()
         {
-            GC.SuppressFinalize(this);
             this._ct.Dispose();
             this._tcs = null;
             this._message = null;
             this._collected?.Clear();
             this._collected = null;
+
+            // Satisfy rule CA1816. Can be removed if this class is sealed.
+            GC.SuppressFinalize(this);
         }
     }
 

--- a/DSharpPlus.Interactivity/EventHandling/Requests/CollectRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/CollectRequest.cs
@@ -57,24 +57,19 @@ namespace DSharpPlus.Interactivity.EventHandling
             this._collected = new ConcurrentHashSet<T>();
         }
 
-        ~CollectRequest()
-        {
-            this.Dispose();
-        }
-
         /// <summary>
         /// Disposes this CollectRequest.
         /// </summary>
         public void Dispose()
         {
             this._ct.Dispose();
-            this._tcs = null;
-            this._predicate = null;
+            this._tcs = null!;
+            this._predicate = null!;
 
             if (this._collected != null)
             {
                 this._collected.Clear();
-                this._collected = null;
+                this._collected = null!;
             }
         }
     }

--- a/DSharpPlus.Interactivity/EventHandling/Requests/MatchRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/MatchRequest.cs
@@ -54,19 +54,17 @@ namespace DSharpPlus.Interactivity.EventHandling
             this._timeout = timeout;
         }
 
-        ~MatchRequest()
-        {
-            this.Dispose();
-        }
-
         /// <summary>
         /// Disposes this MatchRequest.
         /// </summary>
         public void Dispose()
         {
-            this._ct.Dispose();
-            this._tcs = null;
-            this._predicate = null;
+            this._ct?.Dispose();
+            this._tcs = null!;
+            this._predicate = null!;
+
+            // Satisfy rule CA1816. Can be removed if this class is sealed.
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/DSharpPlus.Interactivity/EventHandling/Requests/PaginationRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/PaginationRequest.cs
@@ -195,18 +195,15 @@ namespace DSharpPlus.Interactivity.EventHandling
             return this._tcs;
         }
 
-        ~PaginationRequest()
-        {
-            this.Dispose();
-        }
-
         /// <summary>
         /// Disposes this PaginationRequest.
         /// </summary>
         public void Dispose()
         {
-            this._ct.Dispose();
-            this._tcs = null;
+            // Why doesn't this class implement IDisposable?
+
+            this._ct?.Dispose();
+            this._tcs = null!;
         }
     }
 }

--- a/DSharpPlus.Interactivity/EventHandling/Requests/PollRequest.cs
+++ b/DSharpPlus.Interactivity/EventHandling/Requests/PollRequest.cs
@@ -99,18 +99,15 @@ namespace DSharpPlus.Interactivity.EventHandling
             }
         }
 
-        ~PollRequest()
-        {
-            this.Dispose();
-        }
-
         /// <summary>
         /// Disposes this PollRequest.
         /// </summary>
         public void Dispose()
         {
-            this._ct.Dispose();
-            this._tcs = null;
+            // Why doesn't this class implement IDisposable?
+
+            this._ct?.Dispose();
+            this._tcs = null!;
         }
     }
 

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -1060,21 +1060,19 @@ namespace DSharpPlus.Interactivity
 
         public override void Dispose()
         {
-            this.ComponentEventWaiter.Dispose();
-            this.ModalEventWaiter.Dispose();
-            this.ReactionCollector.Dispose();
-            this.ComponentInteractionWaiter.Dispose();
-            this.MessageCreatedWaiter.Dispose();
-            this.MessageReactionAddWaiter.Dispose();
-            this.Paginator.Dispose();
-            this.Poller.Dispose();
-            this.TypingStartWaiter.Dispose();
-            this._compPaginator.Dispose();
-        }
+            this.ComponentEventWaiter?.Dispose();
+            this.ModalEventWaiter?.Dispose();
+            this.ReactionCollector?.Dispose();
+            this.ComponentInteractionWaiter?.Dispose();
+            this.MessageCreatedWaiter?.Dispose();
+            this.MessageReactionAddWaiter?.Dispose();
+            this.Paginator?.Dispose();
+            this.Poller?.Dispose();
+            this.TypingStartWaiter?.Dispose();
+            this._compPaginator?.Dispose();
 
-        ~InteractivityExtension()
-        {
-            this.Dispose();
+            // Satisfy rule CA1816. Can be removed if this class is sealed.
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/DSharpPlus.Lavalink/LavalinkExtension.cs
+++ b/DSharpPlus.Lavalink/LavalinkExtension.cs
@@ -199,22 +199,19 @@ namespace DSharpPlus.Lavalink
 
         public override void Dispose()
         {
-            foreach(var node in this._connectedNodes)
+            foreach (var node in this._connectedNodes)
             {
                 // undoubtedly there will be some GitHub comments about this. Help.
                 node.Value.StopAsync().GetAwaiter().GetResult();
             }
-            this._connectedNodes.Clear();
+
+            this._connectedNodes?.Clear();
 
             // unhook events
-            _nodeDisconnected.UnregisterAll();
+            _nodeDisconnected?.UnregisterAll();
 
-            // Hi GC! <3 😘 clean me up uwu
-        }
-
-        ~LavalinkExtension()
-        {
-            this.Dispose();
+            // Satisfy rule CA1816. Can be removed if this class is sealed.
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/DSharpPlus.Lavalink/LavalinkExtension.cs
+++ b/DSharpPlus.Lavalink/LavalinkExtension.cs
@@ -208,7 +208,7 @@ namespace DSharpPlus.Lavalink
             this._connectedNodes?.Clear();
 
             // unhook events
-            _nodeDisconnected?.UnregisterAll();
+            this._nodeDisconnected?.UnregisterAll();
 
             // Satisfy rule CA1816. Can be removed if this class is sealed.
             GC.SuppressFinalize(this);

--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -2293,7 +2293,7 @@ namespace DSharpPlus
                 return;
             this._disposed = true;
             this._guilds = null;
-            this.ApiClient._rest.Dispose();
+            this.ApiClient?._rest?.Dispose();
         }
     }
 }

--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -1238,23 +1238,24 @@ namespace DSharpPlus.SlashCommands
 
         public override void Dispose()
         {
-            this._slashError.UnregisterAll();
-            this._slashInvoked.UnregisterAll();
-            this._slashExecuted.UnregisterAll();
-            this._contextMenuErrored.UnregisterAll();
-            this._contextMenuExecuted.UnregisterAll();
-            this._contextMenuInvoked.UnregisterAll();
-            this._autocompleteErrored.UnregisterAll();
-            this._autocompleteExecuted.UnregisterAll();
+            this._slashError?.UnregisterAll();
+            this._slashInvoked?.UnregisterAll();
+            this._slashExecuted?.UnregisterAll();
+            this._contextMenuErrored?.UnregisterAll();
+            this._contextMenuExecuted?.UnregisterAll();
+            this._contextMenuInvoked?.UnregisterAll();
+            this._autocompleteErrored?.UnregisterAll();
+            this._autocompleteExecuted?.UnregisterAll();
 
-            this.Client.Ready -= this.Update;
-            this.Client.InteractionCreated -= this.InteractionHandler;
-            this.Client.ContextMenuInteractionCreated -= this.ContextMenuHandler;
-        }
+            if (this.Client != null)
+            {
+                this.Client.Ready -= this.Update;
+                this.Client.InteractionCreated -= this.InteractionHandler;
+                this.Client.ContextMenuInteractionCreated -= this.ContextMenuHandler;
+            }
 
-        ~SlashCommandsExtension()
-        {
-            this.Dispose();
+            // Satisfy rule CA1816. Can be removed if this class is sealed.
+            GC.SuppressFinalize(this);
         }
     }
 

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -257,11 +257,6 @@ namespace DSharpPlus.VoiceNext
             this.VoiceWs.ExceptionThrown += this.VoiceWs_SocketException;
         }
 
-        ~VoiceNextConnection()
-        {
-            this.Dispose();
-        }
-
         /// <summary>
         /// Connects to the specified voice channel.
         /// </summary>
@@ -724,15 +719,15 @@ namespace DSharpPlus.VoiceNext
 
             this.IsDisposed = true;
             this.IsInitialized = false;
-            this.TokenSource.Cancel();
-            this.SenderTokenSource.Cancel();
+            this.TokenSource?.Cancel();
+            this.SenderTokenSource?.Cancel();
             this.ReceiverTokenSource?.Cancel();
-            this.KeepaliveTokenSource.Cancel();
+            this.KeepaliveTokenSource?.Cancel();
 
-            this.TokenSource.Dispose();
-            this.SenderTokenSource.Dispose();
+            this.TokenSource?.Dispose();
+            this.SenderTokenSource?.Dispose();
             this.ReceiverTokenSource?.Dispose();
-            this.KeepaliveTokenSource.Dispose();
+            this.KeepaliveTokenSource?.Dispose();
 
             try
             {
@@ -742,11 +737,11 @@ namespace DSharpPlus.VoiceNext
             catch { }
 
             this.Opus?.Dispose();
-            this.Opus = null;
+            this.Opus = null!;
             this.Sodium?.Dispose();
-            this.Sodium = null;
+            this.Sodium = null!;
             this.Rtp?.Dispose();
-            this.Rtp = null;
+            this.Rtp = null!;
 
             this.VoiceDisconnected?.Invoke(this.Guild);
         }

--- a/DSharpPlus.VoiceNext/VoiceNextExtension.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextExtension.cs
@@ -229,18 +229,20 @@ namespace DSharpPlus.VoiceNext
 
         public override void Dispose()
         {
-            foreach(var conn in this.ActiveConnections)
+            foreach (var conn in this.ActiveConnections)
             {
-                conn.Value.Dispose();
+                conn.Value?.Dispose();
             }
-            this.Client.VoiceStateUpdated -= this.Client_VoiceStateUpdate;
-            this.Client.VoiceServerUpdated -= this.Client_VoiceServerUpdate;
-            // Lo and behold, the audacious man who dared lay his hand upon VoiceNext hath once more trespassed upon its profane ground!
-        }
 
-        ~VoiceNextExtension()
-        {
-            this.Dispose();
+            if (this.Client != null)
+            {
+                this.Client.VoiceStateUpdated -= this.Client_VoiceStateUpdate;
+                this.Client.VoiceServerUpdated -= this.Client_VoiceServerUpdate;
+            }
+            // Lo and behold, the audacious man who dared lay his hand upon VoiceNext hath once more trespassed upon its profane ground!
+
+            // Satisfy rule CA1816. Can be removed if this class is sealed.
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -1033,13 +1033,8 @@ namespace DSharpPlus
 
         #region Disposal
 
-        ~DiscordClient()
-        {
-            this.Dispose();
-        }
-
-
         private bool _disposed;
+
         /// <summary>
         /// Disposes your DiscordClient.
         /// </summary>
@@ -1049,17 +1044,19 @@ namespace DSharpPlus
                 return;
 
             this._disposed = true;
-            GC.SuppressFinalize(this);
 
             this.DisconnectAsync().GetAwaiter().GetResult();
             this.ApiClient._rest.Dispose();
-            this.CurrentUser = null;
+            this.CurrentUser = null!;
 
             var extensions = this._extensions; // prevent _extensions being modified during dispose
-            this._extensions = null;
+            this._extensions = null!;
+
             foreach (var extension in extensions)
+            {
                 if (extension is IDisposable disposable)
                     disposable.Dispose();
+            }
 
             try
             {
@@ -1068,9 +1065,9 @@ namespace DSharpPlus
             }
             catch { }
 
-            this._guilds = null;
-            this._heartbeatTask = null;
-            this._privateChannels = null;
+            this._guilds = null!;
+            this._heartbeatTask = null!;
+            this._privateChannels = null!;
         }
 
         #endregion

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -1046,7 +1046,7 @@ namespace DSharpPlus
             this._disposed = true;
 
             this.DisconnectAsync().GetAwaiter().GetResult();
-            this.ApiClient._rest.Dispose();
+            this.ApiClient?._rest?.Dispose();
             this.CurrentUser = null!;
 
             var extensions = this._extensions; // prevent _extensions being modified during dispose

--- a/DSharpPlus/Clients/DiscordWebhookClient.cs
+++ b/DSharpPlus/Clients/DiscordWebhookClient.cs
@@ -272,8 +272,8 @@ namespace DSharpPlus
 
         ~DiscordWebhookClient()
         {
-            this._hooks.Clear();
-            this._hooks = null;
+            this._hooks?.Clear();
+            this._hooks = null!;
             this._apiclient._rest.Dispose();
         }
     }

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -677,9 +677,6 @@ namespace DSharpPlus.Net
             this.Logger.LogDebug(LoggerEvents.RestCleaner, "Bucket cleaner task stopped.");
         }
 
-        ~RestClient()
-            => this.Dispose();
-
         public void Dispose()
         {
             if (this._disposed)
@@ -687,7 +684,7 @@ namespace DSharpPlus.Net
 
             this._disposed = true;
 
-            this.GlobalRateLimitEvent.Reset();
+            this.GlobalRateLimitEvent?.Reset();
 
             if (this._bucketCleanerTokenSource?.IsCancellationRequested == false)
             {
@@ -703,9 +700,9 @@ namespace DSharpPlus.Net
             }
             catch { }
 
-            this.RoutesToHashes.Clear();
-            this.HashesToBuckets.Clear();
-            this.RequestQueue.Clear();
+            this.RoutesToHashes?.Clear();
+            this.HashesToBuckets?.Clear();
+            this.RequestQueue?.Clear();
         }
     }
 }


### PR DESCRIPTION
# Summary
Fixes bug #1547

# Details
I removed finalizers while adding null guards to Dispose methods. I used [ripgrep](https://github.com/BurntSushi/ripgrep) to find all finalizers in the project (`rg "\~(\S+)\(\)" *`) and addressed them one by one. I was concerned about removing the finalizers from `DiscordWebhookClient` and `DiscordShardedClient` because they are doing more than just disposing resources and since I didn't want to risk introducing any breaking change, I decided to leave them alone.

These changes weren't tested beyond the bot in `DSharpPlus.Test`, which ran perfectly fine. I plan on doing proper testing this weekend, but for now you should consider this PR as untested. I'll update this post once I'm done with testing.

# Changes proposed
* No more exceptions thrown inside the garbage collector.

# Notes
Some classes contain Dispose methods, despite not implementing the `IDisposable` interface. I wrote a comment for those, since I didn't want to change the API of the library in a simple bug fix, but if you want, I can implement the interface before the PR is accepted.