### PR TITLE
Add GlobalName to members, update DisplayName

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -94,7 +94,7 @@ namespace DSharpPlus.Entities
         /// Gets this member's display name.
         /// </summary>
         [JsonIgnore]
-        public string DisplayName => this.Nickname ?? this.Username;
+        public string DisplayName => this.Nickname ?? this.GlobalName ?? this.Username;
 
         /// <summary>
         /// How long this member's communication will be suppressed for.
@@ -324,6 +324,16 @@ namespace DSharpPlus.Entities
         {
             get => this.User.Flags;
             internal set => this.User.Flags = value;
+        }
+
+        /// <summary>
+        /// Gets the member's global display name.
+        /// </summary>
+        [JsonIgnore]
+        public override string? GlobalName
+        {
+            get => this.User.GlobalName;
+            internal set => this.User.GlobalName = value;
         }
         #endregion
 


### PR DESCRIPTION
This PR is specifically against @VelvetToroyashi's `velvet/feat/pomelo` branch, to add inherited member data in the right place which fixes things like `message.Author` and many other events not populating GlobalName properly.

Also took the chance to update the DisplayName function to consider the global name in the right place in its hierarchy, making that function slightly more useful.