### PR TITLE
Use MemoryCache for message cache, allow custom cache implementations.

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1505,7 +1505,7 @@ namespace DSharpPlus
 
         internal async Task OnMessageAckEventAsync(DiscordChannel chn, ulong messageId)
         {
-            if (this.MessageCache == null || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == chn.Id, out var msg))
+            if (this.MessageCache == null || !this.MessageCache.TryGet(messageId, out var msg))
             {
                 msg = new DiscordMessage
                 {
@@ -1558,7 +1558,7 @@ namespace DSharpPlus
             DiscordMessage oldmsg = null;
             if (this.Configuration.MessageCacheSize == 0
                 || this.MessageCache == null
-                || !this.MessageCache.TryGet(xm => xm.Id == event_message.Id && xm.ChannelId == event_message.ChannelId, out message)) // previous message was not in cache
+                || !this.MessageCache.TryGet(event_message.Id, out message)) // previous message was not in cache
             {
                 message = event_message;
                 this.PopulateMessageReactionsAndCache(message, author, member);
@@ -1631,7 +1631,7 @@ namespace DSharpPlus
             if (channel == null
                 || this.Configuration.MessageCacheSize == 0
                 || this.MessageCache == null
-                || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
+                || !this.MessageCache.TryGet(messageId, out var msg))
             {
                 msg = new DiscordMessage
                 {
@@ -1643,7 +1643,7 @@ namespace DSharpPlus
             }
 
             if (this.Configuration.MessageCacheSize > 0)
-                this.MessageCache?.Remove(xm => xm.Id == msg.Id && xm.ChannelId == channelId);
+                this.MessageCache?.Remove(msg.Id);
 
             var ea = new MessageDeleteEventArgs
             {
@@ -1664,7 +1664,7 @@ namespace DSharpPlus
                 if (channel == null
                     || this.Configuration.MessageCacheSize == 0
                     || this.MessageCache == null
-                    || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
+                    || !this.MessageCache.TryGet(messageId, out var msg))
                 {
                     msg = new DiscordMessage
                     {
@@ -1674,7 +1674,7 @@ namespace DSharpPlus
                     };
                 }
                 if (this.Configuration.MessageCacheSize > 0)
-                    this.MessageCache?.Remove(xm => xm.Id == msg.Id && xm.ChannelId == channelId);
+                    this.MessageCache?.Remove(msg.Id);
                 msgs.Add(msg);
             }
 
@@ -1726,7 +1726,7 @@ namespace DSharpPlus
             if (channel == null
                 || this.Configuration.MessageCacheSize == 0
                 || this.MessageCache == null
-                || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
+                || !this.MessageCache.TryGet(messageId, out var msg))
             {
                 msg = new DiscordMessage
                 {
@@ -1792,7 +1792,7 @@ namespace DSharpPlus
             if (channel == null
                 || this.Configuration.MessageCacheSize == 0
                 || this.MessageCache == null
-                || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
+                || !this.MessageCache.TryGet(messageId, out var msg))
             {
                 msg = new DiscordMessage
                 {
@@ -1836,7 +1836,7 @@ namespace DSharpPlus
             if (channel == null
                 || this.Configuration.MessageCacheSize == 0
                 || this.MessageCache == null
-                || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
+                || !this.MessageCache.TryGet(messageId, out var msg))
             {
                 msg = new DiscordMessage
                 {
@@ -1878,7 +1878,7 @@ namespace DSharpPlus
             if (channel == null
                 || this.Configuration.MessageCacheSize == 0
                 || this.MessageCache == null
-                || !this.MessageCache.TryGet(xm => xm.Id == messageId && xm.ChannelId == channelId, out var msg))
+                || !this.MessageCache.TryGet(messageId, out var msg))
             {
                 msg = new DiscordMessage
                 {

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -50,7 +50,7 @@ namespace DSharpPlus
         #region Internal Fields/Properties
 
         internal bool _isShard = false;
-        internal IMessageCacheProvider MessageCache { get; }
+        internal IMessageCacheProvider? MessageCache { get; }
 
         private List<BaseExtension> _extensions = new();
         private StatusUpdate _status = null;
@@ -136,13 +136,11 @@ namespace DSharpPlus
         public DiscordClient(DiscordConfiguration config)
             : base(config)
         {
-            var intents = this.Configuration.Intents;
-            bool isEnableCache = (intents.HasIntent(DiscordIntents.GuildMessages) || intents.HasIntent(DiscordIntents.DirectMessages))
-                && ((this.Configuration.MessageCacheProvider == null && this.Configuration.MessageCacheSize > 0) || this.Configuration.MessageCacheProvider != null);
-
-            if (isEnableCache)
+            DiscordIntents intents = this.Configuration.Intents;
+            if (intents.HasIntent(DiscordIntents.GuildMessages) || intents.HasIntent(DiscordIntents.DirectMessages))
             {
-                this.MessageCache = this.Configuration.MessageCacheProvider ?? new MessageCache(this.Configuration.MessageCacheSize);
+                this.MessageCache = this.Configuration.MessageCacheProvider 
+                    ?? (this.Configuration.MessageCacheSize > 0 ? new MessageCache(this.Configuration.MessageCacheSize) : null);
             }
 
             this.InternalSetup();

--- a/DSharpPlus/DSharpPlus.csproj
+++ b/DSharpPlus/DSharpPlus.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>

--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -111,6 +111,7 @@ namespace DSharpPlus
         /// <summary>
         /// <para>Sets the size of the global message cache.</para>
         /// <para>Setting this to 0 will disable message caching entirely. Defaults to 1024.</para>
+        /// <para>This is only applied if the default message cache implementation is used.</para>
         /// </summary>
         public int MessageCacheSize { internal get; set; } = 1024;
 
@@ -194,6 +195,13 @@ namespace DSharpPlus
         public bool LogUnknownEvents { internal get; set; } = true;
 
         /// <summary>
+        /// <para>Sets the message cache implementation to use.</para>
+        /// <para>To create your own implementation, implement the <see cref="IMessageCacheProvider"/> instance.</para>
+        /// <para>Defaults to built-in implementation.</para>
+        /// </summary>
+        public IMessageCacheProvider? MessageCacheProvider { internal get; set; } = null;
+
+        /// <summary>
         /// Creates a new configuration with default values.
         /// </summary>
         public DiscordConfiguration()
@@ -224,6 +232,7 @@ namespace DSharpPlus
             this.Intents = other.Intents;
             this.LoggerFactory = other.LoggerFactory;
             this.LogUnknownEvents = other.LogUnknownEvents;
+            this.MessageCacheProvider = other.MessageCacheProvider;
         }
     }
 }

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -416,7 +416,7 @@ namespace DSharpPlus.Entities
                 && this.Discord.Configuration.MessageCacheSize > 0
                 && this.Discord is DiscordClient dc
                 && dc.MessageCache != null
-                && dc.MessageCache.TryGet(xm => xm.Id == id && xm.ChannelId == this.Id, out var msg)
+                && dc.MessageCache.TryGet(id, out var msg)
                 ? msg
                 : await this.Discord.ApiClient.GetMessageAsync(this.Id, id);
         }

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -347,7 +347,7 @@ namespace DSharpPlus.Entities
 
             else reference.Channel = channel;
 
-            if (client.MessageCache != null && client.MessageCache.TryGet(m => m.Id == messageId.Value && m.ChannelId == channelId, out var msg))
+            if (client.MessageCache != null && client.MessageCache.TryGet(messageId.Value, out var msg))
                 reference.Message = msg;
 
             else

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -2298,7 +2298,7 @@ namespace DSharpPlus.Entities
                         {
                             entrymsg.Target = this.Discord is DiscordClient dc
                                 && dc.MessageCache != null
-                                && dc.MessageCache.TryGet(xm => xm.Id == xac.TargetId.Value && xm.ChannelId == entrymsg.Channel.Id, out var msg)
+                                && dc.MessageCache.TryGet(xac.TargetId.Value, out var msg)
                                 ? msg
                                 : new DiscordMessage { Discord = this.Discord, Id = xac.TargetId.Value };
                         }
@@ -2320,7 +2320,7 @@ namespace DSharpPlus.Entities
                         if (xac.Options != null)
                         {
                             DiscordMessage message = default;
-                            dc.MessageCache?.TryGet(x => x.Id == xac.Options.MessageId && x.ChannelId == xac.Options.ChannelId, out message);
+                            dc.MessageCache?.TryGet(xac.Options.MessageId, out message);
 
                             entrypin.Channel = this.GetChannel(xac.Options.ChannelId) ?? new DiscordChannel { Id = xac.Options.ChannelId, Discord = this.Discord, GuildId = this.Id };
                             entrypin.Message = message ?? new DiscordMessage { Id = xac.Options.MessageId, Discord = this.Discord };

--- a/DSharpPlus/IMessageCacheProvider.cs
+++ b/DSharpPlus/IMessageCacheProvider.cs
@@ -1,0 +1,25 @@
+using DSharpPlus.Entities;
+
+namespace DSharpPlus;
+public interface IMessageCacheProvider
+{
+    /// <summary>
+    /// Add a <see cref="DiscordMessage"/> object to the cache.
+    /// </summary>
+    /// <param name="message">The <see cref="DiscordMessage"/> object to add to the cache.</param>
+    void Add(DiscordMessage message);
+
+    /// <summary>
+    /// Remove the <see cref="DiscordMessage"/> object associated with the message ID from the cache. 
+    /// </summary>
+    /// <param name="messageId">The ID of the message to remove from the cache.</param>
+    void Remove(ulong messageId);
+
+    /// <summary>
+    /// Try to get a <see cref="DiscordMessage"/> object associated with the message ID from the cache.
+    /// </summary>
+    /// <param name="messageId">The ID of the message to retrieve from the cache.</param>
+    /// <param name="message">The <see cref="DiscordMessage"/> object retrieved from the cache, if it exists; null otherwise.</param>
+    /// <returns><see langword="true"/> if the message can be retrieved from the cache, <see langword="false"/> otherwise.</returns>
+    bool TryGet(ulong messageId, out DiscordMessage? message);
+}

--- a/DSharpPlus/IMessageCacheProvider.cs
+++ b/DSharpPlus/IMessageCacheProvider.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2023 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using DSharpPlus.Entities;
 
 namespace DSharpPlus;

--- a/DSharpPlus/MessageCache.cs
+++ b/DSharpPlus/MessageCache.cs
@@ -1,0 +1,28 @@
+using DSharpPlus.Entities;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace DSharpPlus;
+internal class MessageCache : IMessageCacheProvider
+{
+    private readonly MemoryCache _cache;
+    private readonly MemoryCacheEntryOptions _entryOptions;
+
+    internal MessageCache(int capacity)
+    {
+        _cache = new MemoryCache(new MemoryCacheOptions()
+        {
+            SizeLimit = capacity,
+        });
+
+        _entryOptions = new MemoryCacheEntryOptions()
+        {
+            Size = 1,
+        };
+    }
+
+    public void Add(DiscordMessage message) => _cache.Set(message.Id, message, _entryOptions);
+
+    public void Remove(ulong messageId) => _cache.Remove(messageId);
+
+    public bool TryGet(ulong messageId, out DiscordMessage? message) => _cache.TryGetValue(messageId, out message);
+}

--- a/DSharpPlus/MessageCache.cs
+++ b/DSharpPlus/MessageCache.cs
@@ -19,10 +19,13 @@ internal class MessageCache : IMessageCacheProvider
             Size = 1,
         };
     }
-
+    
+    /// <inheritdoc/>
     public void Add(DiscordMessage message) => _cache.Set(message.Id, message, _entryOptions);
 
+    /// <inheritdoc/>
     public void Remove(ulong messageId) => _cache.Remove(messageId);
 
+    /// <inheritdoc/>
     public bool TryGet(ulong messageId, out DiscordMessage? message) => _cache.TryGetValue(messageId, out message);
 }

--- a/DSharpPlus/MessageCache.cs
+++ b/DSharpPlus/MessageCache.cs
@@ -1,3 +1,26 @@
+// This file is part of the DSharpPlus project.
+//
+// Copyright (c) 2015 Mike Santiago
+// Copyright (c) 2016-2023 DSharpPlus Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using DSharpPlus.Entities;
 using Microsoft.Extensions.Caching.Memory;
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.6.0-1.final" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />


### PR DESCRIPTION
# Summary
Changed the message cache to use a MemoryCache from Microsoft.Extensions.Caching.Memory. Besides that, added an interface for message cache that users can implement and configure the library to use instead of the default implementation. 

# Details
The cache should behave similarly as before for its users (e.g. DiscordClient), including default size and functionalities. However, cache lookups should be faster as it doesn't need to loop through the entire RingBuffer like before. Message matching when looking up in the cache is changed to only consider the message ID instead of using both the message and channel ID, but I believe this change won't break anything as message IDs should be unique across Discord. 

The reasoning for the second change is that I hope that the library can support more complex caching requirements (e.g. per-channel cache capacity, which I hope to have in my bot) without making the default behaviour overly complex. Hence, it is implemented as a configuration that advanced users can use instead of needing to maintain their own fork of D#+. But, if this does not align with the library's design goals, I'll be happy to revert the change and keep the current behaviour. 

# Changes proposed
* Use MemoryCache from Microsoft.Extensions.Caching.Memory for the message cache.
* Add an interface for the message cache that users can implement and pass to the library as a configuration. 
