### PR TITLE
Adding close codes 4001-4003 and 4005-4009 to auto reconnect logic

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -195,7 +195,7 @@ namespace DSharpPlus
                 this.Logger.LogDebug(LoggerEvents.ConnectionClose, "Connection closed ({CloseCode}, '{CloseMessage}')", e.CloseCode, e.CloseMessage);
                 await this._socketClosed.InvokeAsync(this, e);
 
-                if (this.Configuration.AutoReconnect && (e.CloseCode < 4001 || e.CloseCode >= 5000))
+                if (this.Configuration.AutoReconnect && (e.CloseCode <= 4003 || (e.CloseCode >= 4005 && e.CloseCode <= 4009) || e.CloseCode >= 5000))
                 {
                     this.Logger.LogCritical(LoggerEvents.ConnectionClose, "Connection terminated ({CloseCode}, '{CloseMessage}'), reconnecting", e.CloseCode, e.CloseMessage);
 


### PR DESCRIPTION
Adding close codes 4001-4003 and 4005-4009 to auto-reconnect logic

# Summary
Fixes issue #1537 
Adding close codes 4001-4003 and 4005-4009 to auto-reconnect logic as per the mentioned Discord Developer Documentation: https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes

# Notes
Specifics of the status codes added (copied from discord documentation above)

| Code | Description           | Explanation                                                                                                      | 
| ---- | --------------------- | ---------------------------------------------------------------------------------------------------------------- |
| 4001 | Unknown opcode        | You sent an invalid Gateway opcode or an invalid payload for an opcode. Don't do that!                           |
| 4002 | Decode error          | You sent an invalid payload to Discord. Don't do that!                                                           |
| 4003 | Not authenticated     | You sent us a payload prior to identifying.                                                                      |
| 4005 | Already authenticated | You sent more than one identify payload. Don't do that!                                                          |
| 4007 | Invalid `seq`         | The sequence sent when resuming the session was invalid. Reconnect and start a new session.                      |
| 4008 | Rate limited          | Woah nelly! You're sending payloads to us too quickly. Slow it down! You will be disconnected on receiving this. |
| 4009 | Session timed out     | Your session timed out. Reconnect and start a new one.                                                           |