### PR TITLE
Renamed DiscordClient Events

### DIFF
--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -73,7 +73,7 @@ namespace DSharpPlus.SlashCommands
             this._autocompleteErrored = new AsyncEvent<SlashCommandsExtension, AutocompleteErrorEventArgs>("AUTOCOMPLETE_ERRORED", this.Client.EventErrorHandler);
             this._autocompleteExecuted = new AsyncEvent<SlashCommandsExtension, AutocompleteExecutedEventArgs>("AUTOCOMPLETE_EXECUTED", this.Client.EventErrorHandler);
 
-            this.Client.Ready += this.Update;
+            this.Client.SessionCreated += this.Update;
             this.Client.InteractionCreated += this.InteractionHandler;
             this.Client.ContextMenuInteractionCreated += this.ContextMenuHandler;
         }
@@ -119,7 +119,7 @@ namespace DSharpPlus.SlashCommands
         }
 
         //To be run on ready
-        internal Task Update(DiscordClient client, ReadyEventArgs e) => this.Update();
+        internal Task Update(DiscordClient client, SessionReadyEventArgs e) => this.Update();
 
         //Actual method for registering, used for RegisterCommands and on Ready
         internal Task Update()
@@ -1249,7 +1249,7 @@ namespace DSharpPlus.SlashCommands
 
             if (this.Client != null)
             {
-                this.Client.Ready -= this.Update;
+                this.Client.SessionCreated -= this.Update;
                 this.Client.InteractionCreated -= this.InteractionHandler;
                 this.Client.ContextMenuInteractionCreated -= this.ContextMenuHandler;
             }

--- a/DSharpPlus.Test/TestBot.cs
+++ b/DSharpPlus.Test/TestBot.cs
@@ -78,7 +78,7 @@ internal sealed class TestBot
         this.Discord.UseVoiceNext();
 
         // events
-        this.Discord.Ready += this.Discord_Ready;
+        this.Discord.SessionCreated += this.Discord_SessionCreated;
         this.Discord.GuildStickersUpdated += this.Discord_StickersUpdated;
         this.Discord.GuildAvailable += this.Discord_GuildAvailable;
         //Discord.PresenceUpdated += this.Discord_PresenceUpdated;
@@ -240,7 +240,7 @@ internal sealed class TestBot
 
     public async Task StopAsync() => await this.Discord.DisconnectAsync();
 
-    private Task Discord_Ready(DiscordClient client, ReadyEventArgs e) => Task.CompletedTask;
+    private Task Discord_SessionCreated(DiscordClient client, SessionReadyEventArgs e) => Task.CompletedTask;
 
     private Task Discord_GuildAvailable(DiscordClient client, GuildCreateEventArgs e)
     {

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -681,13 +681,13 @@ namespace DSharpPlus
                 this._guilds[guild.Id] = guild;
             }
 
-            await this._ready.InvokeAsync(this, new ReadyEventArgs());
+            await this._ready.InvokeAsync(this, new SessionReadyEventArgs());
         }
 
         internal Task OnResumedAsync()
         {
             this.Logger.LogInformation(LoggerEvents.SessionUpdate, "Session resumed");
-            return this._resumed.InvokeAsync(this, new ReadyEventArgs());
+            return this._resumed.InvokeAsync(this, new SessionReadyEventArgs());
         }
 
         #endregion

--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -76,22 +76,22 @@ namespace DSharpPlus
         /// <i><see cref="Guilds"/> will not be populated when this event is fired.</i><br/>
         /// See also: <see cref="GuildAvailable"/>, <see cref="GuildDownloadCompleted"/>
         /// </remarks>
-        public event AsyncEventHandler<DiscordClient, ReadyEventArgs> Ready
+        public event AsyncEventHandler<DiscordClient, SessionReadyEventArgs> SessionCreated
         {
             add => this._ready.Register(value);
             remove => this._ready.Unregister(value);
         }
-        private AsyncEvent<DiscordClient, ReadyEventArgs> _ready;
+        private AsyncEvent<DiscordClient, SessionReadyEventArgs> _ready;
 
         /// <summary>
         /// Fired whenever a session is resumed.
         /// </summary>
-        public event AsyncEventHandler<DiscordClient, ReadyEventArgs> Resumed
+        public event AsyncEventHandler<DiscordClient, SessionReadyEventArgs> SessionResumed
         {
             add => this._resumed.Register(value);
             remove => this._resumed.Unregister(value);
         }
-        private AsyncEvent<DiscordClient, ReadyEventArgs> _resumed;
+        private AsyncEvent<DiscordClient, SessionReadyEventArgs> _resumed;
 
         /// <summary>
         /// Fired on received heartbeat ACK.

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -155,8 +155,8 @@ namespace DSharpPlus
             this._socketErrored = new AsyncEvent<DiscordClient, SocketErrorEventArgs>("SOCKET_ERRORED", this.Goof);
             this._socketOpened = new AsyncEvent<DiscordClient, SocketEventArgs>("SOCKET_OPENED", this.EventErrorHandler);
             this._socketClosed = new AsyncEvent<DiscordClient, SocketCloseEventArgs>("SOCKET_CLOSED", this.EventErrorHandler);
-            this._ready = new AsyncEvent<DiscordClient, ReadyEventArgs>("READY", this.EventErrorHandler);
-            this._resumed = new AsyncEvent<DiscordClient, ReadyEventArgs>("RESUMED", this.EventErrorHandler);
+            this._ready = new AsyncEvent<DiscordClient, SessionReadyEventArgs>("READY", this.EventErrorHandler);
+            this._resumed = new AsyncEvent<DiscordClient, SessionReadyEventArgs>("RESUMED", this.EventErrorHandler);
             this._channelCreated = new AsyncEvent<DiscordClient, ChannelCreateEventArgs>("CHANNEL_CREATED", this.EventErrorHandler);
             this._channelUpdated = new AsyncEvent<DiscordClient, ChannelUpdateEventArgs>("CHANNEL_UPDATED", this.EventErrorHandler);
             this._channelDeleted = new AsyncEvent<DiscordClient, ChannelDeleteEventArgs>("CHANNEL_DELETED", this.EventErrorHandler);

--- a/DSharpPlus/Clients/DiscordShardedClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.Events.cs
@@ -66,22 +66,22 @@ namespace DSharpPlus
         /// <summary>
         /// Fired when the client enters ready state.
         /// </summary>
-        public event AsyncEventHandler<DiscordClient, ReadyEventArgs> Ready
+        public event AsyncEventHandler<DiscordClient, SessionReadyEventArgs> SessionCreated
         {
             add => this._ready.Register(value);
             remove => this._ready.Unregister(value);
         }
-        private AsyncEvent<DiscordClient, ReadyEventArgs> _ready;
+        private AsyncEvent<DiscordClient, SessionReadyEventArgs> _ready;
 
         /// <summary>
         /// Fired whenever a session is resumed.
         /// </summary>
-        public event AsyncEventHandler<DiscordClient, ReadyEventArgs> Resumed
+        public event AsyncEventHandler<DiscordClient, SessionReadyEventArgs> SessionResumed
         {
             add => this._resumed.Register(value);
             remove => this._resumed.Unregister(value);
         }
-        private AsyncEvent<DiscordClient, ReadyEventArgs> _resumed;
+        private AsyncEvent<DiscordClient, SessionReadyEventArgs> _resumed;
 
         /// <summary>
         /// Fired on received heartbeat ACK.
@@ -851,10 +851,10 @@ namespace DSharpPlus
         private Task Client_SocketClosed(DiscordClient client, SocketCloseEventArgs e)
             => this._socketClosed.InvokeAsync(client, e);
 
-        private Task Client_Ready(DiscordClient client, ReadyEventArgs e)
+        private Task Client_Ready(DiscordClient client, SessionReadyEventArgs e)
             => this._ready.InvokeAsync(client, e);
 
-        private Task Client_Resumed(DiscordClient client, ReadyEventArgs e)
+        private Task Client_Resumed(DiscordClient client, SessionReadyEventArgs e)
             => this._resumed.InvokeAsync(client, e);
 
         private Task Client_ChannelCreated(DiscordClient client, ChannelCreateEventArgs e)

--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -440,8 +440,8 @@ namespace DSharpPlus
             this._socketErrored = new AsyncEvent<DiscordClient, SocketErrorEventArgs>("SOCKET_ERRORED", this.Goof);
             this._socketOpened = new AsyncEvent<DiscordClient, SocketEventArgs>("SOCKET_OPENED", this.EventErrorHandler);
             this._socketClosed = new AsyncEvent<DiscordClient, SocketCloseEventArgs>("SOCKET_CLOSED", this.EventErrorHandler);
-            this._ready = new AsyncEvent<DiscordClient, ReadyEventArgs>("READY", this.EventErrorHandler);
-            this._resumed = new AsyncEvent<DiscordClient, ReadyEventArgs>("RESUMED", this.EventErrorHandler);
+            this._ready = new AsyncEvent<DiscordClient, SessionReadyEventArgs>("READY", this.EventErrorHandler);
+            this._resumed = new AsyncEvent<DiscordClient, SessionReadyEventArgs>("RESUMED", this.EventErrorHandler);
             this._channelCreated = new AsyncEvent<DiscordClient, ChannelCreateEventArgs>("CHANNEL_CREATED", this.EventErrorHandler);
             this._channelUpdated = new AsyncEvent<DiscordClient, ChannelUpdateEventArgs>("CHANNEL_UPDATED", this.EventErrorHandler);
             this._channelDeleted = new AsyncEvent<DiscordClient, ChannelDeleteEventArgs>("CHANNEL_DELETED", this.EventErrorHandler);
@@ -515,8 +515,8 @@ namespace DSharpPlus
             client.SocketErrored += this.Client_SocketError;
             client.SocketOpened += this.Client_SocketOpened;
             client.SocketClosed += this.Client_SocketClosed;
-            client.Ready += this.Client_Ready;
-            client.Resumed += this.Client_Resumed;
+            client.SessionCreated += this.Client_Ready;
+            client.SessionResumed += this.Client_Resumed;
             client.ChannelCreated += this.Client_ChannelCreated;
             client.ChannelUpdated += this.Client_ChannelUpdated;
             client.ChannelDeleted += this.Client_ChannelDeleted;
@@ -587,8 +587,8 @@ namespace DSharpPlus
             client.SocketErrored -= this.Client_SocketError;
             client.SocketOpened -= this.Client_SocketOpened;
             client.SocketClosed -= this.Client_SocketClosed;
-            client.Ready -= this.Client_Ready;
-            client.Resumed -= this.Client_Resumed;
+            client.SessionCreated -= this.Client_Ready;
+            client.SessionResumed -= this.Client_Resumed;
             client.ChannelCreated -= this.Client_ChannelCreated;
             client.ChannelUpdated -= this.Client_ChannelUpdated;
             client.ChannelDeleted -= this.Client_ChannelDeleted;

--- a/DSharpPlus/EventArgs/SessionReadyEventArgs.cs
+++ b/DSharpPlus/EventArgs/SessionReadyEventArgs.cs
@@ -24,10 +24,10 @@
 namespace DSharpPlus.EventArgs
 {
     /// <summary>
-    /// Represents arguments for <see cref="DiscordClient.Ready"/> event.
+    /// Represents arguments for <see cref="DiscordClient.SessionCreated"/> event.
     /// </summary>
-    public sealed class ReadyEventArgs : DiscordEventArgs
+    public sealed class SessionReadyEventArgs : DiscordEventArgs
     {
-        internal ReadyEventArgs() : base() { }
+        internal SessionReadyEventArgs() : base() { }
     }
 }


### PR DESCRIPTION
# Summary
As per a [vote in the Discord Server](https://discord.com/channels/379378609942560770/379386730538860554/1113451899111358636) and [further discussion in the `#lib-development` channel](https://discord.com/channels/379378609942560770/379386901725052928/1126558333445361784), some events were renamed to prevent confusion.

# Details
Event `Ready` was renamed to `SessionCreated`
Event `Resumed` was renamed to `SessionResumed`
Event Arguments `ReadyEventArgs` was renamed to `SessionReadyEventArgs`

