### PR TITLE
Correct DefaultAvatarUrl for non-Pomelo users

### DIFF
--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -125,7 +125,7 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonIgnore]
         public string DefaultAvatarUrl
-            => $"https://cdn.discordapp.com/embed/avatars/{((this.DiscriminatorInt is 0 ? this.Id >> 22 : (ulong)this.DiscriminatorInt) % 6).ToString(CultureInfo.InvariantCulture)}.png?size=1024";
+            => $"https://cdn.discordapp.com/embed/avatars/{(this.DiscriminatorInt is 0 ? (this.Id >> 22) % 6 : (ulong)this.DiscriminatorInt % 5).ToString(CultureInfo.InvariantCulture)}.png?size=1024";
 
         /// <summary>
         /// Gets whether the user is a bot.


### PR DESCRIPTION
Properly addresses https://github.com/DSharpPlus/DSharpPlus/pull/1578#discussion_r1249719894

# Summary
Fixes concern here: https://github.com/DSharpPlus/DSharpPlus/pull/1578#discussion_r1249719894

Makes avatar behaviour in line with Discord documented behaviour: https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints
for both Pomelo and non-Pomelo users/bots.

# Details
I think it's important that this behaviour be correct, regardless of whether Pomelo'd users will one day take control of the Discord population. Many users opted not to change their usernames yet and bots without avatars exist. Having the default avatar be wrong when the fix is so simple bothered me.

# Notes
Has been tested with several users and bots.