### PR TITLE
Add missing DiscordClients on Event args

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -2674,16 +2674,19 @@ namespace DSharpPlus
         #region AutoModeration
         internal async Task OnAutoModerationRuleCreateAsync(DiscordAutoModerationRule ruleCreated)
         {
+            ruleCreated.Discord = this;
             await this._autoModerationRuleCreated.InvokeAsync(this, new AutoModerationRuleCreateEventArgs { Rule = ruleCreated });
         }
 
         internal async Task OnAutoModerationRuleUpdatedAsync(DiscordAutoModerationRule ruleUpdated)
         {
+            ruleUpdated.Discord = this;
             await this._autoModerationRuleUpdated.InvokeAsync(this, new AutoModerationRuleUpdateEventArgs { Rule = ruleUpdated });
         }
 
         internal async Task OnAutoModerationRuleDeletedAsync(DiscordAutoModerationRule ruleDeleted)
         {
+            ruleDeleted.Discord = this;
             await this._autoModerationRuleDeleted.InvokeAsync(this, new AutoModerationRuleDeleteEventArgs { Rule = ruleDeleted });
         }
 


### PR DESCRIPTION
# Summary
Fixes an issue reported on the discord ([here](https://discord.com/channels/379378609942560770/379386901725052928/1130160232857870439))
# Details
All `AutoModerationRule` related events missed to set the `Discord` field on the rule instance 