### PR TITLE
Added a public constructor to DiscordMessageFile

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageFile.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageFile.cs
@@ -39,6 +39,15 @@ namespace DSharpPlus.Entities
             this.ResetPositionTo = resetPositionTo;
         }
 
+        public DiscordMessageFile(string fileName, Stream stream, bool resetPosition = false)
+        {
+            this.FileName = fileName;
+            this.Stream = stream;
+            this.FileType = null;
+            this.ContentType = null;
+            this.ResetPositionTo = resetPosition ? 0 : null;
+        }
+
         /// <summary>
         /// Gets the FileName of the File.
         /// </summary>


### PR DESCRIPTION
# Summary
Adds a public constructor to DiscordMessageFile

# Details
I noticed that DiscordMessageFile has no public constructor but is used in one of the IDiscordMessageBuilder methods.  
I feel like if it should be able to be used by the user to add a file. It should be constructable by the user.