### PR TITLE
Add a constructor to DefaultReaction and fix incorrect DefaultReaction JsonProperty name

### DIFF
--- a/DSharpPlus/Entities/Channel/Thread/Forum/DefaultReaction.cs
+++ b/DSharpPlus/Entities/Channel/Thread/Forum/DefaultReaction.cs
@@ -47,6 +47,10 @@ namespace DSharpPlus.Entities
         /// <param name="emoji">The <see cref="DiscordEmoji"/>.</param>
         /// <returns>Create <see cref="DefaultReaction"/> object.</returns>
         public static DefaultReaction FromEmoji(DiscordEmoji emoji)
-            => new DefaultReaction { EmojiId = emoji.Id, EmojiName = emoji.Name};
+        {
+            return emoji.Id == 0
+                ? new DefaultReaction { EmojiName = emoji.Name }
+                : new DefaultReaction { EmojiId = emoji.Id };
+        }
     }
 }

--- a/DSharpPlus/Entities/Channel/Thread/Forum/DefaultReaction.cs
+++ b/DSharpPlus/Entities/Channel/Thread/Forum/DefaultReaction.cs
@@ -42,15 +42,19 @@ namespace DSharpPlus.Entities
         public string EmojiName { get; internal set; }
         
         /// <summary>
-        /// Creates a DefaultReaction object from an emoji.
+        /// Constructs a new DefaultReaction from an emoji.
         /// </summary>
         /// <param name="emoji">The <see cref="DiscordEmoji"/>.</param>
-        /// <returns>Create <see cref="DefaultReaction"/> object.</returns>
-        public static DefaultReaction FromEmoji(DiscordEmoji emoji)
+        public DefaultReaction(DiscordEmoji emoji)
         {
-            return emoji.Id == 0
-                ? new DefaultReaction { EmojiName = emoji.Name }
-                : new DefaultReaction { EmojiId = emoji.Id };
+            if (emoji.Id == 0)
+            {
+                EmojiName = emoji.Name;
+            }
+            else
+            {
+                EmojiId = emoji.Id;
+            }
         }
     }
 }

--- a/DSharpPlus/Entities/Channel/Thread/Forum/DefaultReaction.cs
+++ b/DSharpPlus/Entities/Channel/Thread/Forum/DefaultReaction.cs
@@ -40,5 +40,13 @@ namespace DSharpPlus.Entities
         /// </summary>
         [JsonProperty("emoji_name")]
         public string EmojiName { get; internal set; }
+        
+        /// <summary>
+        /// Creates a DefaultReaction object from an emoji.
+        /// </summary>
+        /// <param name="emoji">The <see cref="DiscordEmoji"/>.</param>
+        /// <returns>Create <see cref="DefaultReaction"/> object.</returns>
+        public static DefaultReaction FromEmoji(DiscordEmoji emoji)
+            => new DefaultReaction { EmojiId = emoji.Id, EmojiName = emoji.Name};
     }
 }

--- a/DSharpPlus/Entities/Channel/Thread/Forum/DiscordForumChannel.cs
+++ b/DSharpPlus/Entities/Channel/Thread/Forum/DiscordForumChannel.cs
@@ -59,7 +59,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// The default reaction shown on posts when they are created.
         /// </summary>
-        [JsonProperty("default_reaction", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("default_reaction_emoji", NullValueHandling = NullValueHandling.Ignore)]
         public DefaultReaction? DefaultReaction { get; internal set; }
 
         /// <summary>


### PR DESCRIPTION
# Summary
Added a constructor to the DefaultReaction class.
Fixed incorrect JsonProperty name (https://discord.com/developers/docs/resources/channel)

# Details
Introduced a new constructor to the DefaultReaction class to provide a way of creating a DefaultReaction object from a DiscordEmoji. This enables to set a DefaultReaction to a DiscordForumChannel, which would not be possible otherwise.
Fixed the JSonProperty name of DefaultReaction in the DiscordForumChannel class. Before this fix it was always null.

# Changes proposed
* Added a constructor to the DefaultReaction class, allowing the creation of a DefaultReaction object from a DiscordEmoji.
* Added in gerneral a way to create a DefaultReaction object.
* Fixed the DefaultReaction in DiscordForumChannel to not be always null.