### PR TITLE
Fixes forum channel parsing when channel uses custom emojis

### DIFF
--- a/DSharpPlus/Entities/Channel/Thread/Forum/DefaultReaction.cs
+++ b/DSharpPlus/Entities/Channel/Thread/Forum/DefaultReaction.cs
@@ -36,25 +36,9 @@ namespace DSharpPlus.Entities
         public ulong? EmojiId { get; internal set; }
 
         /// <summary>
-        /// The unicoide emoji, if applicable.
+        /// The unicode emoji, if applicable.
         /// </summary>
         [JsonProperty("emoji_name")]
-        public string EmojiName { get; internal set; }
-        
-        /// <summary>
-        /// Constructs a new DefaultReaction from an emoji.
-        /// </summary>
-        /// <param name="emoji">The <see cref="DiscordEmoji"/>.</param>
-        public DefaultReaction(DiscordEmoji emoji)
-        {
-            if (emoji.Id == 0)
-            {
-                EmojiName = emoji.Name;
-            }
-            else
-            {
-                EmojiId = emoji.Id;
-            }
-        }
+        public string? EmojiName { get; internal set; }
     }
 }


### PR DESCRIPTION
# Details
The [constructor in the DefaultReaction object](https://github.com/DSharpPlus/DSharpPlus/blob/68c7574fab7331202e2354c5edce1de959094043/DSharpPlus/Entities/Channel/Thread/Forum/DefaultReaction.cs#L48) receives `null` as the parameter when the channel uses a custom emoji. 

# Changes proposed
* Removes the constructor from DefaultReaction
* Makes the EmojiName nullable, as it is null when a custom emoji is used
* fixes a very important typo

# Notes
can someone please fix the TestBot.cs under DSharpPlus.Test? it refuses to build