### PR TITLE
fix: not converting guild emoji correctly from DiscordEmoji argument option type

### DIFF
--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -1018,7 +1018,19 @@ namespace DSharpPlus.SlashCommands
                         if (DiscordEmoji.TryFromUnicode(this.Client, value, out var emoji) || DiscordEmoji.TryFromName(this.Client, value, out emoji))
                             args.Add(emoji);
                         else
-                            throw new ArgumentException("Error parsing emoji parameter.");
+                        {
+                            //try regex <:EmojiName:EmojiId>
+                            const string regex = @"<:[^:]+:(\d+)>";
+                            var match = Regex.Match(value, regex);
+                            if (match.Success && ulong.TryParse(match.Groups[1].Value, out var emojiId) && DiscordEmoji.TryFromGuildEmote(this.Client, emojiId, out emoji))
+                            {
+                                args.Add(emoji);
+                            }
+                            else
+                            {
+                                throw new ArgumentException("Error parsing emoji parameter.");
+                            }
+                        }
                     }
                     else if (parameter.ParameterType == typeof(DiscordAttachment))
                     {


### PR DESCRIPTION
# Summary
Fix ApplicationCommandOptionType.String convertion to DiscordEmoji for guild emojis.

# Details
For my tests the value of [`var value = option.Value.ToString()`](https://github.com/Omnyseus/DSharpPlus/blob/576c31a1ffc6f9bfd93d73eba0674afc693084e4/DSharpPlus.SlashCommands/SlashCommandsExtension.cs#L1016C25-L1016C61) have been:
* Using a default emoji: The emoji as unicode (in rider displayed as `?`)
* Using a guild emoji i receive a string with the following structure: `<:EmojiName:EmojiId>`

maybe [`|| DiscordEmoji.TryFromName(this.Client, value, out emoji)`](https://github.com/Omnyseus/DSharpPlus/blob/576c31a1ffc6f9bfd93d73eba0674afc693084e4/DSharpPlus.SlashCommands/SlashCommandsExtension.cs#L1018C1-L1018C1) isn't used anymore - at least in my test cases

# Notes
How to reproduce:
* Create a SlashCommand with a DiscordEmoji Option
* Use the command