### PR TITLE
Simplified and fixed logic of `DiscordMessage.PopulateMentions`

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -388,18 +388,18 @@ namespace DSharpPlus.Entities
             this._mentionedRoles ??= new List<DiscordRole>();
             this._mentionedChannels ??= new List<DiscordChannel>();
 
-            // Create a Hashset that will replace '_mentionedUsers'.
+            // Create a Hashset that will replace 'this._mentionedUsers'.
             var mentionedUsers = new HashSet<DiscordUser>(new DiscordUserComparer());
 
             foreach (var usr in this._mentionedUsers)
             {
-                // Assign Discord instance and update user cache.
+                // Assign the Discord instance and update the user cache.
                 usr.Discord = this.Discord;
                 this.Discord.UpdateUserCache(usr);
 
                 if (guild != null && usr is not DiscordMember && guild._members.TryGetValue(usr.Id, out var cachedMember))
                 {
-                    // If message is from guild, but a discord member isn't passed, try to get member out of guild members cache.
+                    // If the message is from a guild, but a discord member isn't provided, try to get the discord member out of guild members cache.
                     mentionedUsers.Add(cachedMember);
                 }
                 else
@@ -409,7 +409,7 @@ namespace DSharpPlus.Entities
                 }
             }
 
-            // Replace '_mentionedUsers'.
+            // Replace 'this._mentionedUsers'.
             this._mentionedUsers = mentionedUsers.ToList();
 
             if (guild != null && !string.IsNullOrWhiteSpace(this.Content))

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -389,53 +389,21 @@ namespace DSharpPlus.Entities
             this._mentionedChannels ??= new List<DiscordChannel>();
 
             var mentionedUsers = new HashSet<DiscordUser>(new DiscordUserComparer());
-            if (guild != null)
+            foreach (var usr in this._mentionedUsers)
             {
-                foreach (var usr in this._mentionedUsers)
-                {
-                    var member = usr as DiscordMember;
-                    if (member != null)
-                    {
-                        this.Discord.UpdateUserCache(new DiscordUser()
-                        {
-                            Id = member.Id,
-                            Username = member.Username,
-                            Discriminator = member.Discriminator,
-                            AvatarHash = member.AvatarHash,
-                            _bannerColor = member._bannerColor,
-                            BannerHash = member.BannerHash,
-                            IsBot = member.IsBot,
-                            MfaEnabled = member.MfaEnabled,
-                            Verified = member.Verified,
-                            Email = member.Email,
-                            PremiumType = member.PremiumType,
-                            Locale = member.Locale,
-                            Flags = member.Flags,
-                            OAuthFlags = member.OAuthFlags,
-                            Discord = this.Discord
-                        });
-                    }
-                    else
-                    {
-                        usr.Discord = this.Discord;
-                        this.Discord.UpdateUserCache(usr);
-                    }
+                usr.Discord = this.Discord;
+                this.Discord.UpdateUserCache(usr);
 
-                    mentionedUsers.Add(member ?? (guild._members.TryGetValue(usr.Id, out var cachedMember) ? cachedMember : usr));
-                }
+                mentionedUsers.Add(usr);
             }
-            if (!string.IsNullOrWhiteSpace(this.Content))
+            if (guild != null && !string.IsNullOrWhiteSpace(this.Content))
             {
+                this._mentionedChannels = this._mentionedChannels.Union(Utilities.GetChannelMentions(this).Select(xid => guild.GetChannel(xid))).ToList();
+                this._mentionedRoles = this._mentionedRoles.Union(this._mentionedRoleIds.Select(xid => guild.GetRole(xid))).ToList();
+
                 //uncomment if this breaks
                 //mentionedUsers.UnionWith(Utilities.GetUserMentions(this).Select(this.Discord.GetCachedOrEmptyUserInternal));
-
-                if (guild != null)
-                {
-                    //uncomment if this breaks
-                    //this._mentionedRoles = this._mentionedRoles.Union(Utilities.GetRoleMentions(this).Select(xid => guild.GetRole(xid))).ToList();
-                    this._mentionedRoles = this._mentionedRoles.Union(this._mentionedRoleIds.Select(xid => guild.GetRole(xid))).ToList();
-                    this._mentionedChannels = this._mentionedChannels.Union(Utilities.GetChannelMentions(this).Select(xid => guild.GetChannel(xid))).ToList();
-                }
+                //this._mentionedRoles = this._mentionedRoles.Union(Utilities.GetRoleMentions(this).Select(xid => guild.GetRole(xid))).ToList();
             }
             this._mentionedUsers = mentionedUsers.ToList();
         }

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -388,14 +388,12 @@ namespace DSharpPlus.Entities
             this._mentionedRoles ??= new List<DiscordRole>();
             this._mentionedChannels ??= new List<DiscordChannel>();
 
-            var mentionedUsers = new HashSet<DiscordUser>(new DiscordUserComparer());
             foreach (var usr in this._mentionedUsers)
             {
                 usr.Discord = this.Discord;
                 this.Discord.UpdateUserCache(usr);
-
-                mentionedUsers.Add(usr);
             }
+
             if (guild != null && !string.IsNullOrWhiteSpace(this.Content))
             {
                 this._mentionedChannels = this._mentionedChannels.Union(Utilities.GetChannelMentions(this).Select(xid => guild.GetChannel(xid))).ToList();
@@ -405,7 +403,6 @@ namespace DSharpPlus.Entities
                 //mentionedUsers.UnionWith(Utilities.GetUserMentions(this).Select(this.Discord.GetCachedOrEmptyUserInternal));
                 //this._mentionedRoles = this._mentionedRoles.Union(Utilities.GetRoleMentions(this).Select(xid => guild.GetRole(xid))).ToList();
             }
-            this._mentionedUsers = mentionedUsers.ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary
Rewrote `DiscordMessage.PopulateMentions` and fixed its logic so `MentionedUsers` gets populated in DMs as it previously did not.