### PR TITLE
Add None to DiscordIntents enum

### DIFF
--- a/DSharpPlus/DiscordIntents.cs
+++ b/DSharpPlus/DiscordIntents.cs
@@ -65,6 +65,10 @@ public static class DiscordIntentExtensions
 public enum DiscordIntents
 {
     /// <summary>
+    /// By default, no Discord Intents are requested from the Discord gateway.
+    /// </summary>
+    None = 0,
+    /// <summary>
     /// Whether to include general guild events.
     /// <para>These include <see cref="DiscordClient.GuildCreated"/>, <see cref="DiscordClient.GuildDeleted"/>, <see cref="DiscordClient.GuildAvailable"/>, <see cref="DiscordClient.GuildDownloadCompleted"/>,</para>
     /// <para><see cref="DiscordClient.GuildRoleCreated"/>, <see cref="DiscordClient.GuildRoleUpdated"/>, <see cref="DiscordClient.GuildRoleDeleted"/>,</para>

--- a/DSharpPlus/DiscordIntents.cs
+++ b/DSharpPlus/DiscordIntents.cs
@@ -68,6 +68,7 @@ public enum DiscordIntents
     /// By default, no Discord Intents are requested from the Discord gateway.
     /// </summary>
     None = 0,
+
     /// <summary>
     /// Whether to include general guild events.
     /// <para>These include <see cref="DiscordClient.GuildCreated"/>, <see cref="DiscordClient.GuildDeleted"/>, <see cref="DiscordClient.GuildAvailable"/>, <see cref="DiscordClient.GuildDownloadCompleted"/>,</para>


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Adds None to DiscordIntents enum, because without it we had to do (DiscordIntents)0 or 0

# Notes
Any additional notes go here.