### PR TITLE
Remove misleading xml doc

### DIFF
--- a/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
@@ -133,7 +133,7 @@ namespace DSharpPlus.Entities
         /// <summary>
         /// Gets the original interaction response.
         /// </summary>
-        /// <returns>The original message that was sent. This <b>does not work on ephemeral messages.</b></returns>
+        /// <returns>The original message that was sent.</returns>
         public Task<DiscordMessage> GetOriginalResponseAsync() =>
             this.Discord.ApiClient.GetOriginalInteractionResponseAsync(this.Discord.CurrentApplication.Id, this.Token);
 


### PR DESCRIPTION
# Summary
GetOriginalResponse works for all responses and this documentation is not found in the offical docs