### PR TITLE
Added support for sending messages in Stage type channels

### DIFF
--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -203,6 +203,7 @@ namespace DSharpPlus
                 ChannelType.PrivateThread => true,
                 ChannelType.NewsThread => true,
                 ChannelType.News => true,
+                ChannelType.Stage => true,
                 _ => false,
             };
 


### PR DESCRIPTION
# Summary
Fixes ArgumentException Stage channels do not support sending text messages issue. when trying to send a message in a Stage type channel

# Details
I added ChannelType.Stage in the IsTextableChannel check

# Notes
Change tested and message being sent successfully on the channel.