### PR TITLE
Yet another infrastructure update

### DIFF
--- a/.github/workflows/publish_nightly_master.yml
+++ b/.github/workflows/publish_nightly_master.yml
@@ -33,27 +33,20 @@ jobs:
         with:
           dotnet-version: 7
       - name: Package
-        run: |
-          mkdir build
-          # If the package version does not comply with SemVer, it will be set as a pre-release version automatically.
-          # We add 1195 since it's the last build number AppVeyor used.
-          dotnet pack \
-            -o build \
-            --include-source \
-            -p:VersionSuffix='nightly' \
-            -p:BuildNumber=$(printf \"%0*d\" 5 $(( 1195 + ${{ github.run_number }} )))
+        # If the package version does not comply with SemVer, it will be set as a pre-release version automatically.
+        # We add 1195 since it's the last build number AppVeyor used.
+        run: dotnet pack -o build -p:Nightly=$(printf \"%0*d\" 5 $(( 1195 + ${{ github.run_number }} )))
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: DSharpPlus-Nightly-${{ github.run_number }}∕${{ github.run_attempt }}.zip
+          name: DSharpPlus-Nightly-${{ github.run_number }}-${{ github.run_attempt }}.zip
           path: ./build/*
       - name: Publish nightly NuGet packages
-        if: ${{ github.event_name == 'push' }} # Ensure we don't push nightlies to the nuget feed on PRs.
+        # Ensure we don't push nightlies to the nuget feed on PRs.
+        if: github.event.pull_request == null
         run: |
           echo LATEST_STABLE_VERSION=$(git describe --tags $(git rev-list --tags --max-count=1)) >> $GITHUB_ENV
-          dotnet nuget push "build/*" -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json
-
-          # Update channel topic
+          dotnet nuget push "build/*" --skip-duplicate -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json
           dotnet run --project ./tools/AutoUpdateChannelDescription -p:VersionSuffix='nightly' -p:BuildNumber=$(printf \"%0*d\" 5 $(( 1195 + ${{ github.run_number }} )))
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}

--- a/.github/workflows/publish_release_master.yml
+++ b/.github/workflows/publish_release_master.yml
@@ -22,12 +22,12 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.103
+          dotnet-version: 7
       - name: Publish NuGet packages
         run: |
           mkdir build
           dotnet pack -c Release -o build
-          dotnet nuget push \"build/*\" -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json
+          dotnet nuget push \"build/*\" --skip-duplicate -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json
       - name: Upload NuGet packages to GitHub Actions
         uses: actions/upload-artifact@v3
         with:

--- a/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
+++ b/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
@@ -6,7 +6,9 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj" />
+    <ProjectReference Include="$(ProjectRoot)\DSharpPlus\DSharpPlus.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>

--- a/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
+++ b/DSharpPlus.CommandsNext/DSharpPlus.CommandsNext.csproj
@@ -1,24 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <AssemblyName>DSharpPlus.CommandsNext</AssemblyName>
-    <RootNamespace>DSharpPlus.CommandsNext</RootNamespace>
-    <OutputType>Library</OutputType>
-  </PropertyGroup>
-
   <PropertyGroup>
     <PackageId>DSharpPlus.CommandsNext</PackageId>
     <Description>Advanced command framework for DSharpPlus.</Description>
-    <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, commands, commandsnext</PackageTags>
+    <PackageTags>$(PackageTags), commands, commandsnext</PackageTags>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
+    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/DSharpPlus.Interactivity/DSharpPlus.Interactivity.csproj
+++ b/DSharpPlus.Interactivity/DSharpPlus.Interactivity.csproj
@@ -6,7 +6,9 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj" />
+    <ProjectReference Include="$(ProjectRoot)\DSharpPlus\DSharpPlus.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="ConcurrentHashSet"/>
   </ItemGroup>
 </Project>

--- a/DSharpPlus.Interactivity/DSharpPlus.Interactivity.csproj
+++ b/DSharpPlus.Interactivity/DSharpPlus.Interactivity.csproj
@@ -1,22 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyName>DSharpPlus.Interactivity</AssemblyName>
-    <RootNamespace>DSharpPlus.Interactivity</RootNamespace>
-    <OutputType>Library</OutputType>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <PackageId>DSharpPlus.Interactivity</PackageId>
     <Description>An addon that adds interactivity capabilities to commands.</Description>
-    <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, interactive, pagination, reactions</PackageTags>
+    <PackageTags>$(PackageTags), interactive, pagination, reactions</PackageTags>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="ConcurrentHashSet"/>
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj" />
+    <PackageReference Include="ConcurrentHashSet"/>
   </ItemGroup>
-
 </Project>

--- a/DSharpPlus.Lavalink/DSharpPlus.Lavalink.csproj
+++ b/DSharpPlus.Lavalink/DSharpPlus.Lavalink.csproj
@@ -3,7 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>DSharpPlus.Lavalink</PackageId>
     <Description>Lavalink implementation for DSharpPlus. Lavalink is an easy and lightweight method of streaming audio to Discord.</Description>
-    <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, audio, voice, radio, music, lavalink, lavaplayer</PackageTags>
+    <PackageTags>$(PackageTags), audio, voice, radio, music, lavalink, lavaplayer</PackageTags>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>

--- a/DSharpPlus.Lavalink/DSharpPlus.Lavalink.csproj
+++ b/DSharpPlus.Lavalink/DSharpPlus.Lavalink.csproj
@@ -6,6 +6,6 @@
     <PackageTags>$(PackageTags), audio, voice, radio, music, lavalink, lavaplayer</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>
+    <ProjectReference Include="$(ProjectRoot)\DSharpPlus\DSharpPlus.csproj" />
   </ItemGroup>
 </Project>

--- a/DSharpPlus.Lavalink/DSharpPlus.Lavalink.csproj
+++ b/DSharpPlus.Lavalink/DSharpPlus.Lavalink.csproj
@@ -1,19 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <AssemblyName>DSharpPlus.Lavalink</AssemblyName>
-        <RootNamespace>DSharpPlus.Lavalink</RootNamespace>
-        <OutputType>Library</OutputType>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <PackageId>DSharpPlus.Lavalink</PackageId>
-        <Description>Lavalink implementation for DSharpPlus. Lavalink is an easy and lightweight method of streaming audio to Discord.</Description>
-        <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, audio, voice, radio, music, lavalink, lavaplayer</PackageTags>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>
-    </ItemGroup>
-
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PackageId>DSharpPlus.Lavalink</PackageId>
+    <Description>Lavalink implementation for DSharpPlus. Lavalink is an easy and lightweight method of streaming audio to Discord.</Description>
+    <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, audio, voice, radio, music, lavalink, lavaplayer</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>
+  </ItemGroup>
 </Project>

--- a/DSharpPlus.Rest/DSharpPlus.Rest.csproj
+++ b/DSharpPlus.Rest/DSharpPlus.Rest.csproj
@@ -6,6 +6,6 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>
+    <ProjectReference Include="$(ProjectRoot)\DSharpPlus\DSharpPlus.csproj" />
   </ItemGroup>
 </Project>

--- a/DSharpPlus.Rest/DSharpPlus.Rest.csproj
+++ b/DSharpPlus.Rest/DSharpPlus.Rest.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <AssemblyName>DSharpPlus.Rest</AssemblyName>
-        <RootNamespace>DSharpPlus.Rest</RootNamespace>
-        <OutputType>Library</OutputType>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <PackageId>DSharpPlus.Rest</PackageId>
-        <Description>A Rest-only client for DSharpPlus.</Description>
-        <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, rest-api, oauth2</PackageTags>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>
-    </ItemGroup>
-
+  <PropertyGroup>
+    <PackageId>DSharpPlus.Rest</PackageId>
+    <Description>A Rest-only client for DSharpPlus.</Description>
+    <PackageTags>$(PackageTags), rest-api, oauth2</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>
+  </ItemGroup>
 </Project>

--- a/DSharpPlus.SlashCommands/DSharpPlus.SlashCommands.csproj
+++ b/DSharpPlus.SlashCommands/DSharpPlus.SlashCommands.csproj
@@ -1,23 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <AssemblyName>DSharpPlus.SlashCommands</AssemblyName>
-        <RootNamespace>DSharpPlus.SlashCommands</RootNamespace>
-        <OutputType>Library</OutputType>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <PackageId>DSharpPlus.SlashCommands</PackageId>
-        <Description>An extension for DSharpPlus to make slash commands easy</Description>
-        <PackageTags>discord, discord-api, bots, discord-bots, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, commands, slash-commands, interactions</PackageTags>
-        <Authors>IDoEverything, Epictek, SakuraIsayeki, sssvt-drabek-stepan, tygore587, VelvetThePanda, OoLunar</Authors>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>
-    </ItemGroup>
-
+  <PropertyGroup>
+    <PackageId>DSharpPlus.SlashCommands</PackageId>
+    <Description>An extension for DSharpPlus to make slash commands easy</Description>
+    <PackageTags>$(PackageTags), commands, slash-commands, interactions</PackageTags>
+    <Authors>IDoEverything, Epictek, SakuraIsayeki, sssvt-drabek-stepan, tygore587, VelvetThePanda, OoLunar</Authors>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
+  </ItemGroup>
 </Project>

--- a/DSharpPlus.SlashCommands/DSharpPlus.SlashCommands.csproj
+++ b/DSharpPlus.SlashCommands/DSharpPlus.SlashCommands.csproj
@@ -6,7 +6,9 @@
     <Authors>IDoEverything, Epictek, SakuraIsayeki, sssvt-drabek-stepan, tygore587, VelvetThePanda, OoLunar</Authors>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>
+    <ProjectReference Include="$(ProjectRoot)\DSharpPlus\DSharpPlus.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
   </ItemGroup>
 </Project>

--- a/DSharpPlus.VoiceNext/DSharpPlus.VoiceNext.csproj
+++ b/DSharpPlus.VoiceNext/DSharpPlus.VoiceNext.csproj
@@ -1,23 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <AssemblyName>DSharpPlus.VoiceNext</AssemblyName>
-        <RootNamespace>DSharpPlus.VoiceNext</RootNamespace>
-        <OutputType>Library</OutputType>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <PackageId>DSharpPlus.VoiceNext</PackageId>
-        <Description>Voice implementation for DSharpPlus.</Description>
-        <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, audio, voice, radio, music</PackageTags>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="DSharpPlus.VoiceNext.Natives"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>
-    </ItemGroup>
-
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PackageId>DSharpPlus.VoiceNext</PackageId>
+    <Description>Voice implementation for DSharpPlus.</Description>
+    <PackageTags>$(PackageTags), audio, voice, radio, music</PackageTags>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>
+    <PackageReference Include="DSharpPlus.VoiceNext.Natives"/>
+  </ItemGroup>
 </Project>

--- a/DSharpPlus.VoiceNext/DSharpPlus.VoiceNext.csproj
+++ b/DSharpPlus.VoiceNext/DSharpPlus.VoiceNext.csproj
@@ -7,7 +7,9 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>
+    <ProjectReference Include="$(ProjectRoot)\DSharpPlus\DSharpPlus.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="DSharpPlus.VoiceNext.Natives"/>
   </ItemGroup>
 </Project>

--- a/DSharpPlus/DSharpPlus.csproj
+++ b/DSharpPlus/DSharpPlus.csproj
@@ -1,22 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <AssemblyName>DSharpPlus</AssemblyName>
-    <RootNamespace>DSharpPlus</RootNamespace>
-    <OutputType>Library</OutputType>
-  </PropertyGroup>
-
-  <PropertyGroup>
+    <PackageId>DSharpPlus</PackageId>
     <Description>A C# API for Discord based off DiscordSharp, but rewritten to fit the API standards.</Description>
-    <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp, webhooks</PackageTags>
+    <PackageTags>$(PackageTags), webhooks</PackageTags>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
-    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
-
-
-
 </Project>

--- a/DSharpPlus/DSharpPlus.csproj.DotSettings
+++ b/DSharpPlus/DSharpPlus.csproj.DotSettings
@@ -1,2 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=entities_005Cinteraction_005Ccomponents_005Cselects/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,11 +8,12 @@
     <NoWarn>CS1591</NoWarn>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
-    <ProjectRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), "*.sln"))</ProjectRoot>
+    <ProjectRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), "DSharpPlus.sln"))</ProjectRoot>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <TargetFramework>net7.0</TargetFramework>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <Version>5.0.0</Version>
+    <Version Condition="'$(Nightly)' != ''">$(Version)-nightly-$(Nightly)</Version>
   </PropertyGroup>
   <!-- Nuget -->
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,8 +11,6 @@
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
     <ProjectRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), "DSharpPlus.sln"))</ProjectRoot>
-    <!-- Remove the 'JSImportGenerator' analyzer by default to improve compilation time. +200ms is apparently enough to require this change. -->
-    <RemoveAnalyzer Include="Microsoft.Interop.JavaScript.JSImportGenerator" />
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <TargetFramework>net7.0</TargetFramework>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
@@ -46,6 +44,8 @@
     <None Include="$(ProjectRoot)/LICENSE" Pack="true" PackagePath=""/>
     <None Include="$(ProjectRoot)/README.md" Pack="true" PackagePath=""/>
     <None Include="$(ProjectRoot)/logo/dsharpplus.png" Pack="true" PackagePath=""/>
+    <!-- Remove the 'JSImportGenerator' analyzer by default to improve compilation time. +200ms is apparently enough to require this change. -->
+    <RemoveAnalyzer Include="Microsoft.Interop.JavaScript.JSImportGenerator" />
   </ItemGroup>
 
   <Target Name="_DisableAnalyzers" DependsOnTargets="ResolveTargetingPackAssets" Inputs="@(RemoveAnalyzer)" Outputs="|%(Identity)|">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,73 +1,36 @@
 <Project>
-    <PropertyGroup>
-        <!-- general properties -->
-        <VersionPrefix>5.0.0</VersionPrefix>
-        <TargetFramework>net7.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <LangVersion>Latest</LangVersion>
-        <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
-        <Authors>Naamloos, afroraydude, DrCreo, Death, TiaqoY0, Axiom, Emzi0767, IDoEverything, Velvet, OoLunar, akiraveliara, DSharpPlus contributors</Authors>
-        <Company>DSharpPlus developers</Company>
-        <PackageProjectUrl>https://github.com/DSharpPlus/DSharpPlus</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/DSharpPlus/DSharpPlus</RepositoryUrl>
-        <RepositoryType>Git</RepositoryType>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageIcon>dsharpplus.png</PackageIcon>
-        <PackageIconUrl>https://raw.githubusercontent.com/DSharpPlus/DSharpPlus/master/logo/dsharpplus.png</PackageIconUrl>
-        <GenerateDocumentationFile>True</GenerateDocumentationFile>
-        <NoWarn>CS1591</NoWarn>
-        <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
-        <ManagePackageVersionsCentrally>True</ManagePackageVersionsCentrally>
-
-        <!-- SourceLink -->
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-        <Optimize>False</Optimize>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">
-        <Version>$(VersionPrefix)-$(VersionSuffix)-$(BuildNumber)</Version>
-        <AssemblyVersion>$(VersionPrefix).$(BuildNumber)</AssemblyVersion>
-        <FileVersion>$(VersionPrefix).$(BuildNumber)</FileVersion>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' == ''">
-        <Version>$(VersionPrefix)-$(VersionSuffix)</Version>
-        <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
-        <FileVersion>$(VersionPrefix).0</FileVersion>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(VersionSuffix)' == ''">
-        <Version>$(VersionPrefix)</Version>
-        <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
-        <FileVersion>$(VersionPrefix).0</FileVersion>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <None Include="../logo/dsharpplus.png" Pack="true" PackagePath="/"/>
-    </ItemGroup>
-
-  <ItemGroup>
-    <!-- We want to remove JSImportGenerator by default, becuase it takes a good deal of compilation time -->
-    <RemoveAnalyzer Include="Microsoft.Interop.JavaScript.JSImportGenerator" />
-  </ItemGroup>
-
+  <!-- Build -->
   <PropertyGroup>
-    <CoreCompileDependsOn>$(CoreCompileDependsOn);_DisableAnalyzers</CoreCompileDependsOn>
+    <OutputType>Library</OutputType>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+    <LangVersion>Latest</LangVersion>
+    <ManagePackageVersionsCentrally>True</ManagePackageVersionsCentrally>
+    <NoWarn>CS1591</NoWarn>
+    <Nullable>enable</Nullable>
+    <ProjectRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), "*.sln"))</ProjectRoot>
+    <TargetFramework>net7.0</TargetFramework>
+    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
   </PropertyGroup>
-
-  <Target Name="_DisableAnalyzers" DependsOnTargets="ResolveTargetingPackAssets" Inputs="@(RemoveAnalyzer)" Outputs="|%(Identity)|">
-    <PropertyGroup>
-      <_RemoveAnalyzer>%(RemoveAnalyzer.Identity)</_RemoveAnalyzer>
-    </PropertyGroup>
-    <ItemGroup>
-      <Analyzer Remove="$(_RemoveAnalyzer)"/>
-      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.Filename)' == '$(_RemoveAnalyzer)'"/>
-    </ItemGroup>
-  </Target>
+  <!-- Nuget -->
+  <PropertyGroup>
+    <Authors>Naamloos, afroraydude, DrCreo, Death, TiaqoY0, Axiom, Emzi0767, IDoEverything, Velvet, OoLunar, akiraveliara, DSharpPlus contributors</Authors>
+    <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp</PackageTags>
+    <Company>DSharpPlus developers</Company>
+    <PackageIcon>dsharpplus.png</PackageIcon>
+    <PackageIconUrl>https://raw.githubusercontent.com/DSharpPlus/DSharpPlus/master/logo/dsharpplus.png</PackageIconUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/DSharpPlus/DSharpPlus</PackageProjectUrl>
+    <RepositoryType>Git</RepositoryType>
+    <RepositoryUrl>https://github.com/DSharpPlus/DSharpPlus</RepositoryUrl>
+    <VersionPrefix>5.0.0</VersionPrefix>
+    <!-- SourceLink -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="$(ProjectRoot)/logo/dsharpplus.png" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,8 @@
 <Project>
   <!-- Build -->
   <PropertyGroup>
+    <!-- Add '_DisableAnalyzers' to the list of compilation dependencies -->
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);_DisableAnalyzers</CoreCompileDependsOn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
     <LangVersion>Latest</LangVersion>
@@ -9,13 +11,14 @@
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
     <ProjectRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), "DSharpPlus.sln"))</ProjectRoot>
+    <!-- Remove the 'JSImportGenerator' analyzer by default to improve compilation time. +200ms is apparently enough to require this change. -->
+    <RemoveAnalyzer Include="Microsoft.Interop.JavaScript.JSImportGenerator" />
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <TargetFramework>net7.0</TargetFramework>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Version>5.0.0</Version>
     <Version Condition="'$(Nightly)' != ''">$(Version)-nightly-$(Nightly)</Version>
   </PropertyGroup>
-
   <!-- Nuget -->
   <PropertyGroup>
     <Authors>Naamloos, afroraydude, DrCreo, Death, TiaqoY0, Axiom, Emzi0767, IDoEverything, Velvet, OoLunar, akiraveliara, DSharpPlus contributors</Authors>
@@ -28,7 +31,6 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/DSharpPlus/DSharpPlus</RepositoryUrl>
   </PropertyGroup>
-
   <!-- SourceLink -->
   <PropertyGroup>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -36,10 +38,15 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
-
   <ItemGroup>
     <None Include="$(ProjectRoot)/LICENSE" Pack="true" PackagePath=""/>
     <None Include="$(ProjectRoot)/README.md" Pack="true" PackagePath=""/>
     <None Include="$(ProjectRoot)/logo/dsharpplus.png" Pack="true" PackagePath=""/>
   </ItemGroup>
+  <Target Name="_DisableAnalyzers" DependsOnTargets="ResolveTargetingPackAssets" Inputs="@(RemoveAnalyzer)" Outputs="|%(Identity)|">
+    <ItemGroup>
+      <!-- Remove the analyzer specified in 'RemoveAnalyzer' from the list of analyzers -->
+      <Analyzer Remove="@(Analyzer)" Condition="'%(Analyzer.Identity)' == '$(RemoveAnalyzer)'"/>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,7 @@
     <Version>5.0.0</Version>
     <Version Condition="'$(Nightly)' != ''">$(Version)-nightly-$(Nightly)</Version>
   </PropertyGroup>
+
   <!-- Nuget -->
   <PropertyGroup>
     <Authors>Naamloos, afroraydude, DrCreo, Death, TiaqoY0, Axiom, Emzi0767, IDoEverything, Velvet, OoLunar, akiraveliara, DSharpPlus contributors</Authors>
@@ -27,6 +28,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/DSharpPlus/DSharpPlus</RepositoryUrl>
   </PropertyGroup>
+
   <!-- SourceLink -->
   <PropertyGroup>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -34,6 +36,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
   <ItemGroup>
     <None Include="$(ProjectRoot)/LICENSE" Pack="true" PackagePath=""/>
     <None Include="$(ProjectRoot)/README.md" Pack="true" PackagePath=""/>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,7 @@
     <Version>5.0.0</Version>
     <Version Condition="'$(Nightly)' != ''">$(Version)-nightly-$(Nightly)</Version>
   </PropertyGroup>
+
   <!-- Nuget -->
   <PropertyGroup>
     <Authors>Naamloos, afroraydude, DrCreo, Death, TiaqoY0, Axiom, Emzi0767, IDoEverything, Velvet, OoLunar, akiraveliara, DSharpPlus contributors</Authors>
@@ -31,6 +32,7 @@
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/DSharpPlus/DSharpPlus</RepositoryUrl>
   </PropertyGroup>
+
   <!-- SourceLink -->
   <PropertyGroup>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -38,11 +40,14 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <!-- Resource Files -->
   <ItemGroup>
     <None Include="$(ProjectRoot)/LICENSE" Pack="true" PackagePath=""/>
     <None Include="$(ProjectRoot)/README.md" Pack="true" PackagePath=""/>
     <None Include="$(ProjectRoot)/logo/dsharpplus.png" Pack="true" PackagePath=""/>
   </ItemGroup>
+
   <Target Name="_DisableAnalyzers" DependsOnTargets="ResolveTargetingPackAssets" Inputs="@(RemoveAnalyzer)" Outputs="|%(Identity)|">
     <ItemGroup>
       <!-- Remove the analyzer specified in 'RemoveAnalyzer' from the list of analyzers -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,36 +1,41 @@
 <Project>
   <!-- Build -->
   <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
     <LangVersion>Latest</LangVersion>
-    <ManagePackageVersionsCentrally>True</ManagePackageVersionsCentrally>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NoWarn>CS1591</NoWarn>
     <Nullable>enable</Nullable>
+    <OutputType>Library</OutputType>
     <ProjectRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), "*.sln"))</ProjectRoot>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <TargetFramework>net7.0</TargetFramework>
-    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <VersionPrefix>5.0.0</VersionPrefix>
   </PropertyGroup>
   <!-- Nuget -->
   <PropertyGroup>
     <Authors>Naamloos, afroraydude, DrCreo, Death, TiaqoY0, Axiom, Emzi0767, IDoEverything, Velvet, OoLunar, akiraveliara, DSharpPlus contributors</Authors>
-    <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp</PackageTags>
     <Company>DSharpPlus developers</Company>
     <PackageIcon>dsharpplus.png</PackageIcon>
-    <PackageIconUrl>https://raw.githubusercontent.com/DSharpPlus/DSharpPlus/master/logo/dsharpplus.png</PackageIconUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/DSharpPlus/DSharpPlus</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp</PackageTags>
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/DSharpPlus/DSharpPlus</RepositoryUrl>
-    <VersionPrefix>5.0.0</VersionPrefix>
-    <!-- SourceLink -->
+  </PropertyGroup>
+  <!-- SourceLink -->
+  <PropertyGroup>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="$(ProjectRoot)/logo/dsharpplus.png" Pack="true" PackagePath="/"/>
+    <None Include="$(ProjectRoot)/LICENSE" Pack="true" PackagePath=""/>
+    <None Include="$(ProjectRoot)/README.md" Pack="true" PackagePath=""/>
+    <None Include="$(ProjectRoot)/logo/dsharpplus.png" Pack="true" PackagePath=""/>
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0"/>
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0"/>
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="7.0.0"/>
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1"/>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all"/>
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3"/>
     <PackageVersion Include="System.Text.Json" Version="8.0.0-preview.2.23128.3"/>

--- a/tools/AutoUpdateChannelDescription/DSharpPlus.Tools.AutoUpdateChannelDescription.csproj
+++ b/tools/AutoUpdateChannelDescription/DSharpPlus.Tools.AutoUpdateChannelDescription.csproj
@@ -1,11 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="../../DSharpPlus/DSharpPlus.csproj" />
+    <ProjectReference Include="$(ProjectRoot)/DSharpPlus/DSharpPlus.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update csproj settings
- Generate reference assemblies once more
- Begone deprecated PackageIconUrl
- Remove default behavior
- Remove complicated targets to disable the js import
- Sort all XML keys alphabetically
- Make all csproj not packable by default
- Use project root due to MSBuild's non-existant concept of relative files
- Update MSE.Logging.Abstractions from 7.0.0 to 7.0.1
- Remove unused DotSettings file