### PR TITLE
Add overloads for AddFile to support additional scenarios

### DIFF
--- a/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
@@ -388,9 +388,6 @@ namespace DSharpPlus.Entities
     /// <summary>
     /// Additional flags for files added to a message builder.
     /// </summary>
-    /// <remarks>
-    /// If used, disposal of the message builder is expected.
-    /// </remarks>
     [Flags]
     public enum AddFileOptions
     {

--- a/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace DSharpPlus.Entities
 {
@@ -185,21 +186,7 @@ namespace DSharpPlus.Entities
         /// <param name="stream">The Stream to the file.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The current builder to be chained.</returns>
-        public T AddFile(string fileName, Stream stream, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count >= 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            if (this._files.Any(x => x.FileName == fileName))
-                throw new ArgumentException("A File with that filename already exists");
-
-            if (resetStreamPosition)
-                this._files.Add(new DiscordMessageFile(fileName, stream, stream.Position));
-            else
-                this._files.Add(new DiscordMessageFile(fileName, stream, null));
-
-            return this as T;
-        }
+        public T AddFile(string fileName, Stream stream, bool resetStreamPosition = false) => this.AddFile(fileName, stream, resetStreamPosition ? AddFileOptions.ResetStream : AddFileOptions.None);
 
         /// <summary>
         /// Sets if the message has files to be sent.
@@ -207,21 +194,7 @@ namespace DSharpPlus.Entities
         /// <param name="stream">The Stream to the file.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The current builder to be chained.</returns>
-        public T AddFile(FileStream stream, bool resetStreamPosition = false)
-        {
-            if (this.Files.Count >= 10)
-                throw new ArgumentException("Cannot send more than 10 files with a single message.");
-
-            if (this._files.Any(x => x.FileName == stream.Name))
-                throw new ArgumentException("A File with that filename already exists");
-
-            if (resetStreamPosition)
-                this._files.Add(new DiscordMessageFile(stream.Name, stream, stream.Position));
-            else
-                this._files.Add(new DiscordMessageFile(stream.Name, stream, null));
-
-            return this as T;
-        }
+        public T AddFile(FileStream stream, bool resetStreamPosition = false) => this.AddFile(stream, resetStreamPosition ? AddFileOptions.ResetStream : AddFileOptions.None);
 
         /// <summary>
         /// Sets if the message has files to be sent.
@@ -229,7 +202,45 @@ namespace DSharpPlus.Entities
         /// <param name="files">The Files that should be sent.</param>
         /// <param name="resetStreamPosition">Tells the API Client to reset the stream position to what it was after the file is sent.</param>
         /// <returns>The current builder to be chained.</returns>
-        public T AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false)
+        public T AddFiles(IDictionary<string, Stream> files, bool resetStreamPosition = false) => this.AddFiles(files, resetStreamPosition ? AddFileOptions.ResetStream : AddFileOptions.None);
+
+        /// <summary>
+        /// Attaches a file to this message.
+        /// </summary>
+        /// <param name="fileName">Name of the file to attach.</param>
+        /// <param name="stream">Stream containing said file's contents.</param>
+        /// <param name="fileOptions">Additional flags for the handling of the file stream.</param>
+        /// <returns>The current builder to be chained.</returns>
+        public T AddFile(string fileName, Stream stream, AddFileOptions fileOptions)
+        {
+            if (this.Files.Count >= 10)
+                throw new ArgumentException("Cannot send more than 10 files with a single message.");
+
+            if (this._files.Any(x => x.FileName == fileName))
+                throw new ArgumentException("A File with that filename already exists");
+
+            stream = ResolveStream(stream, fileOptions);
+            long? resetPosition = fileOptions.HasFlag(AddFileOptions.ResetStream) ? stream.Position : null;
+            this._files.Add(new DiscordMessageFile(fileName, stream, resetPosition, fileOptions: fileOptions));
+
+            return this as T;
+        }
+
+        /// <summary>
+        /// Attaches a file to this message.
+        /// </summary>
+        /// <param name="stream">FileStream pointing to the file to attach.</param>
+        /// <param name="fileOptions">Additional flags for the handling of the file stream.</param>
+        /// <returns>The current builder to be chained.</returns>
+        public T AddFile(FileStream stream, AddFileOptions fileOptions) => this.AddFile(stream.Name, stream, fileOptions);
+
+        /// <summary>
+        /// Attaches multiple files to this message.
+        /// </summary>
+        /// <param name="files">Dictionary of files to add, where <see cref="string"/> is a file name and <see cref="Stream"/> is a stream containing the file's contents.</param>
+        /// <param name="fileOptions">Additional flags for the handling of the file streams.</param>
+        /// <returns>The current builder to be chained.</returns>
+        public T AddFiles(IDictionary<string, Stream> files, AddFileOptions fileOptions)
         {
             if (this.Files.Count + files.Count > 10)
                 throw new ArgumentException("Cannot send more than 10 files with a single message.");
@@ -239,10 +250,9 @@ namespace DSharpPlus.Entities
                 if (this._files.Any(x => x.FileName == file.Key))
                     throw new ArgumentException("A File with that filename already exists");
 
-                if (resetStreamPosition)
-                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, file.Value.Position));
-                else
-                    this._files.Add(new DiscordMessageFile(file.Key, file.Value, null));
+                var stream = ResolveStream(file.Value, fileOptions);
+                long? resetPosition = fileOptions.HasFlag(AddFileOptions.ResetStream) ? stream.Position : null;
+                this._files.Add(new DiscordMessageFile(file.Key, stream, resetPosition, fileOptions: fileOptions));
             }
 
             return this as T;
@@ -294,6 +304,68 @@ namespace DSharpPlus.Entities
             this._components.Clear();
         }
 
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            // We don't bother to fully implement the dispose pattern
+            // since deriving from this type outside this assembly is unusual.
+
+            foreach (var file in _files)
+            {
+                if (file.FileOptions.HasFlag(AddFileOptions.CloseStream))
+                    file.Stream.Dispose();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc/>
+        public async ValueTask DisposeAsync()
+        {
+            foreach (var file in _files)
+            {
+                if (file.FileOptions.HasFlag(AddFileOptions.CloseStream))
+                    await file.Stream.DisposeAsync();
+            }
+
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Helper method to reset stream positions used several times by the API client.
+        /// </summary>
+        internal void ResetFileStreamPositions()
+        {
+            foreach (var file in _files)
+            {
+                if (file.ResetPositionTo is long pos)
+                    file.Stream.Position = pos;
+            }
+        }
+
+        /// <summary>
+        /// Helper method to resolve stream copies depending on the file mode parameter.
+        /// </summary>
+        private static Stream ResolveStream(Stream stream, AddFileOptions fileOptions)
+        {
+            if (fileOptions.HasFlag(AddFileOptions.CopyStream))
+            {
+                Stream originalStream = stream;
+                MemoryStream newStream = new();
+                originalStream.CopyTo(newStream);
+                newStream.Position = 0;
+
+                if (fileOptions.HasFlag(AddFileOptions.CloseStream))
+                {
+                    originalStream.Dispose();
+                }
+
+                stream = newStream;
+            }
+
+            return stream;
+        }
+
         IDiscordMessageBuilder IDiscordMessageBuilder.SuppressNotifications() => this.SuppressNotifications();
         IDiscordMessageBuilder IDiscordMessageBuilder.WithContent(string content) => this.WithContent(content);
         IDiscordMessageBuilder IDiscordMessageBuilder.AddComponents(params DiscordComponent[] components) => this.AddComponents(components);
@@ -306,11 +378,58 @@ namespace DSharpPlus.Entities
         IDiscordMessageBuilder IDiscordMessageBuilder.AddFile(FileStream stream, bool resetStream) => this.AddFile(stream, resetStream);
         IDiscordMessageBuilder IDiscordMessageBuilder.AddFiles(IDictionary<string, Stream> files, bool resetStreams) => this.AddFiles(files, resetStreams);
         IDiscordMessageBuilder IDiscordMessageBuilder.AddFiles(IEnumerable<DiscordMessageFile> files) => this.AddFiles(files);
+        IDiscordMessageBuilder IDiscordMessageBuilder.AddFile(string fileName, Stream stream, AddFileOptions fileOptions) => this.AddFile(fileName, stream, fileOptions);
+        IDiscordMessageBuilder IDiscordMessageBuilder.AddFile(FileStream stream, AddFileOptions fileOptions) => this.AddFile(stream, fileOptions);
+        IDiscordMessageBuilder IDiscordMessageBuilder.AddFiles(IDictionary<string, Stream> files, AddFileOptions fileOptions) => this.AddFiles(files, fileOptions);
         IDiscordMessageBuilder IDiscordMessageBuilder.AddMention(IMention mention) => this.AddMention(mention);
         IDiscordMessageBuilder IDiscordMessageBuilder.AddMentions(IEnumerable<IMention> mentions) => this.AddMentions(mentions);
     }
 
-    public interface IDiscordMessageBuilder
+    /// <summary>
+    /// Additional flags for files added to a message builder.
+    /// </summary>
+    /// <remarks>
+    /// If used, disposal of the message builder is expected.
+    /// </remarks>
+    [Flags]
+    public enum AddFileOptions
+    {
+        /// <summary>
+        /// No additional behavior. The stream will read to completion and is left at that position after sending.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Resets the stream to its original position after sending.
+        /// </summary>
+        ResetStream = 0x1,
+
+        /// <summary>
+        /// Closes the stream upon disposal of the message builder.
+        /// </summary>
+        /// <remarks>
+        /// Streams will not be disposed upon sending. Disposal of the message builder is necessary.
+        /// </remarks>
+        CloseStream = 0x2,
+
+        /// <summary>
+        /// Immediately reads the stream to completion and copies its contents to an in-memory stream.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Note that this incurs an additional memory overhead and may perform synchronous I/O and should only be used if the source stream cannot be kept open any longer.
+        /// </para>
+        /// <para>
+        /// If specified together with <see cref="CloseStream"/>, the stream will closed immediately after the copy.
+        /// </para>
+        /// </remarks>
+        CopyStream = 0x4,
+    }
+
+    /// <summary>
+    /// Base interface for any discord message builder.
+    /// </summary>
+    public interface IDiscordMessageBuilder : IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// Getter / setter for message content.
@@ -417,6 +536,31 @@ namespace DSharpPlus.Entities
         /// <param name="resetStreams">Whether to reset all stream positions to 0 after sending.</param>
         /// <returns></returns>
         IDiscordMessageBuilder AddFiles(IDictionary<string, Stream> files, bool resetStreams = false);
+
+        /// <summary>
+        /// Attaches a file to this message.
+        /// </summary>
+        /// <param name="fileName">Name of the file to attach.</param>
+        /// <param name="stream">Stream containing said file's contents.</param>
+        /// <param name="fileOptions">Additional flags for the handling of the file stream.</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder AddFile(string fileName, Stream stream, AddFileOptions fileOptions);
+
+        /// <summary>
+        /// Attaches a file to this message.
+        /// </summary>
+        /// <param name="stream">FileStream pointing to the file to attach.</param>
+        /// <param name="fileOptions">Additional flags for the handling of the file stream.</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder AddFile(FileStream stream, AddFileOptions fileOptions);
+
+        /// <summary>
+        /// Attaches multiple files to this message.
+        /// </summary>
+        /// <param name="files">Dictionary of files to add, where <see cref="string"/> is a file name and <see cref="Stream"/> is a stream containing the file's contents.</param>
+        /// <param name="fileOptions">Additional flags for the handling of the file streams.</param>
+        /// <returns></returns>
+        IDiscordMessageBuilder AddFiles(IDictionary<string, Stream> files, AddFileOptions fileOptions);
 
         /// <summary>
         /// Attaches previously used files to this file stream.

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageFile.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageFile.cs
@@ -7,11 +7,12 @@ namespace DSharpPlus.Entities
     /// </summary>
     public class DiscordMessageFile
     {
-        internal DiscordMessageFile(string fileName, Stream stream, long? resetPositionTo, string fileType = null, string contentType = null)
+        internal DiscordMessageFile(string fileName, Stream stream, long? resetPositionTo, string fileType = null, string contentType = null, AddFileOptions fileOptions = AddFileOptions.None)
         {
             this.FileName = fileName ?? "file";
             this.FileType = fileType;
             this.ContentType = contentType;
+            this.FileOptions = fileOptions;
             this.Stream = stream;
             this.ResetPositionTo = resetPositionTo;
         }
@@ -34,5 +35,6 @@ namespace DSharpPlus.Entities
         /// Gets the position the File should be reset to.
         /// </summary>
         internal long? ResetPositionTo { get; set; }
+        internal AddFileOptions FileOptions { get; set; }
     }
 }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1449,10 +1449,7 @@ namespace DSharpPlus.Net
 
                 var ret = this.PrepareMessage(JObject.Parse(res.Response));
 
-                foreach (var file in builder._files.Where(x => x.ResetPositionTo.HasValue))
-                {
-                    file.Stream.Position = file.ResetPositionTo.Value;
-                }
+                builder.ResetFileStreamPositions();
 
                 return ret;
             }
@@ -2907,10 +2904,7 @@ namespace DSharpPlus.Net
             var res = await this.DoMultipartAsync(this._discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
 
-            foreach (var file in builder.Files.Where(x => x.ResetPositionTo.HasValue))
-            {
-                file.Stream.Position = file.ResetPositionTo.Value;
-            }
+            builder.ResetFileStreamPositions();
 
             ret.Discord = this._discord;
             return ret;
@@ -2969,8 +2963,7 @@ namespace DSharpPlus.Net
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
             ret.Discord = this._discord;
 
-            foreach (var file in builder.Files.Where(x => x.ResetPositionTo.HasValue))
-                file.Stream.Position = file.ResetPositionTo.Value;
+            builder.ResetFileStreamPositions();
 
             return ret;
         }
@@ -3495,10 +3488,7 @@ namespace DSharpPlus.Net
             {
                 await this.DoMultipartAsync(this._discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files);
 
-                foreach (var file in builder.Files.Where(x => x.ResetPositionTo.HasValue))
-                {
-                    file.Stream.Position = file.ResetPositionTo.Value;
-                }
+                builder.ResetFileStreamPositions();
             }
             else
             {
@@ -3557,10 +3547,7 @@ namespace DSharpPlus.Net
             var res = await this.DoMultipartAsync(this._discord, bucket, url, RestRequestMethod.POST, route, values: values, files: builder.Files);
             var ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response);
 
-            foreach (var file in builder.Files.Where(x => x.ResetPositionTo.HasValue))
-            {
-                file.Stream.Position = file.ResetPositionTo.Value;
-            }
+            builder.ResetFileStreamPositions();
 
             ret.Discord = this._discord;
             return ret;


### PR DESCRIPTION
# Summary
This adds additional overloads for AddFile(s) to every message builder that allow specifying additional options for handling the provided streams. The old overloads with the `resetStreamPosition` parameter now delegate to these new overloads.

# Details
In specific, 3 options exist, that can be combined in any way:
- `ResetStream`: This behaves as if `resetStreamPosition` was set to true on the existing overloads and resets the stream position after sending.
- `CloseStream`: This closes the stream upon disposal of the builder. This does not close them on send currently.
- `CopyStream`: Immediately reads the stream to completion and copies it to a `MemoryStream` that is then added to the builder instead.

As an aside, code that resets stream positions in the API client code now calls into a unified helper.

# Notes
`CloseStream` doesn't close the stream on send due to how the code around message edits is written (the builder isn't passed down entirely). Disposal of the builder instead should be a fine compromise.

Technically, adding `IDisposable` to the message builders can be considered a breaking change, however it'd be a no-op for every existing case and should therefore be a non-issue.

~~Why did I write this.~~