### PR TITLE
Return the source exception within the CommandErrored event.

### DIFF
--- a/DSharpPlus.CommandsNext/Entities/Command.cs
+++ b/DSharpPlus.CommandsNext/Entities/Command.cs
@@ -1,194 +1,204 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using DSharpPlus.CommandsNext.Attributes;
+using DSharpPlus.CommandsNext.Converters;
 using DSharpPlus.CommandsNext.Entities;
 
-namespace DSharpPlus.CommandsNext
+namespace DSharpPlus.CommandsNext;
+
+/// <summary>
+/// Represents a command.
+/// </summary>
+public class Command
 {
     /// <summary>
-    /// Represents a command.
+    /// Gets this command's name.
     /// </summary>
-    public class Command
+    public string Name { get; internal set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the category this command belongs to.
+    /// </summary>
+    public string? Category { get; internal set; } = null;
+
+    /// <summary>
+    /// Gets this command's qualified name (i.e. one that includes all module names).
+    /// </summary>
+    public string QualifiedName => this.Parent is not null ? string.Concat(this.Parent.QualifiedName, " ", this.Name) : this.Name;
+
+    /// <summary>
+    /// Gets this command's aliases.
+    /// </summary>
+    public IReadOnlyList<string> Aliases { get; internal set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets this command's parent module, if any.
+    /// </summary>
+    public CommandGroup? Parent { get; internal set; }
+
+    /// <summary>
+    /// Gets this command's description.
+    /// </summary>
+    public string? Description { get; internal set; }
+
+    /// <summary>
+    /// Gets whether this command is hidden.
+    /// </summary>
+    public bool IsHidden { get; internal set; }
+
+    /// <summary>
+    /// Gets a collection of pre-execution checks for this command.
+    /// </summary>
+    public IReadOnlyList<CheckBaseAttribute> ExecutionChecks { get; internal set; } = Array.Empty<CheckBaseAttribute>();
+
+    /// <summary>
+    /// Gets a collection of this command's overloads.
+    /// </summary>
+    public IReadOnlyList<CommandOverload> Overloads { get; internal set; } = Array.Empty<CommandOverload>();
+
+    /// <summary>
+    /// Gets the module in which this command is defined.
+    /// </summary>
+    public ICommandModule? Module { get; internal set; }
+
+    /// <summary>
+    /// Gets the custom attributes defined on this command.
+    /// </summary>
+    public IReadOnlyList<Attribute> CustomAttributes { get; internal set; } = Array.Empty<Attribute>();
+
+    internal Command() { }
+
+    /// <summary>
+    /// Executes this command with specified context.
+    /// </summary>
+    /// <param name="ctx">Context to execute the command in.</param>
+    /// <returns>Command's execution results.</returns>
+    public virtual async Task<CommandResult> ExecuteAsync(CommandContext ctx)
     {
-        /// <summary>
-        /// Gets this command's name.
-        /// </summary>
-        public string Name { get; internal set; } = string.Empty;
-
-        /// <summary>
-        /// Gets the category this command belongs to.
-        /// </summary>
-        public string? Category { get; internal set; } = null;
-
-        /// <summary>
-        /// Gets this command's qualified name (i.e. one that includes all module names).
-        /// </summary>
-        public string QualifiedName => this.Parent is not null ? string.Concat(this.Parent.QualifiedName, " ", this.Name) : this.Name;
-
-        /// <summary>
-        /// Gets this command's aliases.
-        /// </summary>
-        public IReadOnlyList<string> Aliases { get; internal set; } = Array.Empty<string>();
-
-        /// <summary>
-        /// Gets this command's parent module, if any.
-        /// </summary>
-        public CommandGroup? Parent { get; internal set; }
-
-        /// <summary>
-        /// Gets this command's description.
-        /// </summary>
-        public string? Description { get; internal set; }
-
-        /// <summary>
-        /// Gets whether this command is hidden.
-        /// </summary>
-        public bool IsHidden { get; internal set; }
-
-        /// <summary>
-        /// Gets a collection of pre-execution checks for this command.
-        /// </summary>
-        public IReadOnlyList<CheckBaseAttribute> ExecutionChecks { get; internal set; } = Array.Empty<CheckBaseAttribute>();
-
-        /// <summary>
-        /// Gets a collection of this command's overloads.
-        /// </summary>
-        public IReadOnlyList<CommandOverload> Overloads { get; internal set; } = Array.Empty<CommandOverload>();
-
-        /// <summary>
-        /// Gets the module in which this command is defined.
-        /// </summary>
-        public ICommandModule? Module { get; internal set; }
-
-        /// <summary>
-        /// Gets the custom attributes defined on this command.
-        /// </summary>
-        public IReadOnlyList<Attribute> CustomAttributes { get; internal set; } = Array.Empty<Attribute>();
-
-        internal Command() { }
-
-        /// <summary>
-        /// Executes this command with specified context.
-        /// </summary>
-        /// <param name="ctx">Context to execute the command in.</param>
-        /// <returns>Command's execution results.</returns>
-        public virtual async Task<CommandResult> ExecuteAsync(CommandContext ctx)
+        try
         {
-            CommandResult res = default;
-            try
+            foreach (CommandOverload? overload in this.Overloads.OrderByDescending(x => x.Priority))
             {
-                var executed = false;
-                foreach (var ovl in this.Overloads.OrderByDescending(x => x.Priority))
+                ctx.Overload = overload;
+
+                // Attempt to match the arguments to the overload
+                ArgumentBindingResult args = await CommandsNextUtilities.BindArgumentsAsync(ctx, ctx.Config.IgnoreExtraArguments);
+                if (!args.IsSuccessful)
                 {
-                    ctx.Overload = ovl;
-                    var args = await CommandsNextUtilities.BindArgumentsAsync(ctx, ctx.Config.IgnoreExtraArguments);
-
-                    if (!args.IsSuccessful)
-                        continue;
-
-                    ctx.RawArguments = args.Raw;
-
-                    var mdl = ovl._invocationTarget ?? this.Module?.GetInstance(ctx.Services);
-                    if (mdl is BaseCommandModule bcmBefore)
-                        await bcmBefore.BeforeExecutionAsync(ctx);
-
-                    args.Converted[0] = mdl;
-                    var ret = (Task)ovl._callable.DynamicInvoke(args.Converted);
-                    await ret;
-                    executed = true;
-                    res = new CommandResult
-                    {
-                        IsSuccessful = true,
-                        Context = ctx
-                    };
-
-                    if (mdl is BaseCommandModule bcmAfter)
-                        await bcmAfter.AfterExecutionAsync(ctx);
-                    break;
+                    continue;
                 }
 
-                if (!executed)
-                    throw new ArgumentException("Could not find a suitable overload for the command.");
-            }
-            catch (Exception ex)
-            {
-                res = new CommandResult
+                ctx.RawArguments = args.Raw;
+
+                // From... what I can gather, this seems to be support for executing commands that don't inherit from BaseCommandModule.
+                // But, that can never be the case since all Commands must inherit from BaseCommandModule.
+                // Regardless, I'm not removing this legacy code in case if it's actually used and I'm just not seeing it.
+                BaseCommandModule? commandModule = this.Module?.GetInstance(ctx.Services);
+                if (commandModule is not null)
                 {
-                    IsSuccessful = false,
-                    Exception = ex,
+                    await commandModule.BeforeExecutionAsync(ctx);
+                }
+
+                args.Converted[0] = overload._invocationTarget ?? commandModule;
+                await (Task)overload._callable.DynamicInvoke(args.Converted)!;
+
+                if (commandModule is not null)
+                {
+                    await commandModule.AfterExecutionAsync(ctx);
+                }
+
+                return new CommandResult
+                {
+                    IsSuccessful = true,
                     Context = ctx
                 };
             }
 
-            return res;
+            throw new ArgumentException("Could not find a suitable overload for the command.");
         }
-
-        /// <summary>
-        /// Runs pre-execution checks for this command and returns any that fail for given context.
-        /// </summary>
-        /// <param name="ctx">Context in which the command is executed.</param>
-        /// <param name="help">Whether this check is being executed from help or not. This can be used to probe whether command can be run without setting off certain fail conditions (such as cooldowns).</param>
-        /// <returns>Pre-execution checks that fail for given context.</returns>
-        public async Task<IEnumerable<CheckBaseAttribute>> RunChecksAsync(CommandContext ctx, bool help)
+        catch (Exception error)
         {
-            var fchecks = new List<CheckBaseAttribute>();
-            if (this.ExecutionChecks.Any())
-                foreach (var ec in this.ExecutionChecks)
-                    if (!await ec.ExecuteCheckAsync(ctx, help))
-                        fchecks.Add(ec);
+            if (error is TargetInvocationException targetInvocationError)
+            {
+                error = ExceptionDispatchInfo.Capture(targetInvocationError.InnerException!).SourceException;
+            }
 
-            return fchecks;
+            return new CommandResult
+            {
+                IsSuccessful = false,
+                Exception = error,
+                Context = ctx
+            };
         }
+    }
 
-        /// <summary>
-        /// Checks whether this command is equal to another one.
-        /// </summary>
-        /// <param name="cmd1">Command to compare to.</param>
-        /// <param name="cmd2">Command to compare.</param>
-        /// <returns>Whether the two commands are equal.</returns>
-        public static bool operator ==(Command? cmd1, Command? cmd2)
-        {
-            var o1 = cmd1 as object;
-            var o2 = cmd2 as object;
-            return (o1 != null || o2 == null) && (o1 == null || o2 != null) && ((o1 == null && o2 == null) || cmd1!.QualifiedName == cmd2!.QualifiedName);
-        }
+    /// <summary>
+    /// Runs pre-execution checks for this command and returns any that fail for given context.
+    /// </summary>
+    /// <param name="ctx">Context in which the command is executed.</param>
+    /// <param name="help">Whether this check is being executed from help or not. This can be used to probe whether command can be run without setting off certain fail conditions (such as cooldowns).</param>
+    /// <returns>Pre-execution checks that fail for given context.</returns>
+    public async Task<IEnumerable<CheckBaseAttribute>> RunChecksAsync(CommandContext ctx, bool help)
+    {
+        var fchecks = new List<CheckBaseAttribute>();
+        if (this.ExecutionChecks.Any())
+            foreach (var ec in this.ExecutionChecks)
+                if (!await ec.ExecuteCheckAsync(ctx, help))
+                    fchecks.Add(ec);
 
-        /// <summary>
-        /// Checks whether this command is not equal to another one.
-        /// </summary>
-        /// <param name="cmd1">Command to compare to.</param>
-        /// <param name="cmd2">Command to compare.</param>
-        /// <returns>Whether the two commands are not equal.</returns>
-        public static bool operator !=(Command? cmd1, Command? cmd2) => !(cmd1 == cmd2);
+        return fchecks;
+    }
 
-        /// <summary>
-        /// Checks whether this command equals another object.
-        /// </summary>
-        /// <param name="obj">Object to compare to.</param>
-        /// <returns>Whether this command is equal to another object.</returns>
-        public override bool Equals(object? obj)
-        {
-            var o2 = this as object;
-            return (obj != null || o2 == null) && (obj == null || o2 != null) && ((obj == null && o2 == null) || (obj is Command cmd && cmd.QualifiedName == this.QualifiedName));
-        }
+    /// <summary>
+    /// Checks whether this command is equal to another one.
+    /// </summary>
+    /// <param name="cmd1">Command to compare to.</param>
+    /// <param name="cmd2">Command to compare.</param>
+    /// <returns>Whether the two commands are equal.</returns>
+    public static bool operator ==(Command? cmd1, Command? cmd2)
+    {
+        var o1 = cmd1 as object;
+        var o2 = cmd2 as object;
+        return (o1 != null || o2 == null) && (o1 == null || o2 != null) && ((o1 == null && o2 == null) || cmd1!.QualifiedName == cmd2!.QualifiedName);
+    }
 
-        /// <summary>
-        /// Gets this command's hash code.
-        /// </summary>
-        /// <returns>This command's hash code.</returns>
-        public override int GetHashCode() => this.QualifiedName.GetHashCode();
+    /// <summary>
+    /// Checks whether this command is not equal to another one.
+    /// </summary>
+    /// <param name="cmd1">Command to compare to.</param>
+    /// <param name="cmd2">Command to compare.</param>
+    /// <returns>Whether the two commands are not equal.</returns>
+    public static bool operator !=(Command? cmd1, Command? cmd2) => !(cmd1 == cmd2);
 
-        /// <summary>
-        /// Returns a string representation of this command.
-        /// </summary>
-        /// <returns>String representation of this command.</returns>
-        public override string ToString()
-        {
-            return this is CommandGroup g
-                ? $"Command Group: {this.QualifiedName}, {g.Children.Count} top-level children"
-                : $"Command: {this.QualifiedName}";
-        }
+    /// <summary>
+    /// Checks whether this command equals another object.
+    /// </summary>
+    /// <param name="obj">Object to compare to.</param>
+    /// <returns>Whether this command is equal to another object.</returns>
+    public override bool Equals(object? obj)
+    {
+        var o2 = this as object;
+        return (obj != null || o2 == null) && (obj == null || o2 != null) && ((obj == null && o2 == null) || (obj is Command cmd && cmd.QualifiedName == this.QualifiedName));
+    }
+
+    /// <summary>
+    /// Gets this command's hash code.
+    /// </summary>
+    /// <returns>This command's hash code.</returns>
+    public override int GetHashCode() => this.QualifiedName.GetHashCode();
+
+    /// <summary>
+    /// Returns a string representation of this command.
+    /// </summary>
+    /// <returns>String representation of this command.</returns>
+    public override string ToString()
+    {
+        return this is CommandGroup g
+            ? $"Command Group: {this.QualifiedName}, {g.Children.Count} top-level children"
+            : $"Command: {this.QualifiedName}";
     }
 }


### PR DESCRIPTION
# Summary
Return the source exception within the CommandErrored event.

# Details
Currently the `CommandsNextExtension.CommandErrored` returns a `TargetInvocationException` from `Delegate.DynamicInvoke`. As much as it pains me, I've done my best to clean up the logic to continue have no changes in behavior, see the comment inside the code.

As stated above, a `TargetInvocationException` isn't the most helpful exception to work with, especially since this is the exception given in `CommandErrorEventArgs.Exception`. What the user would've expected was the source exception that initially caused the issue inside of the user-code. 

My solution is a `if(error is TargetInvocationException)` check, which get rids of the wrapping `TargetInvocationException` via `ExceptionDispatchInfo.Capture`.

# Notes
Briefly tested.