### PR TITLE
Add missing clients to threadChannelMember

### DIFF
--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -3120,6 +3120,12 @@ public sealed class DiscordApiClient
         RestResponse response = await this._rest.ExecuteRequestAsync(request);
 
         List<DiscordThreadChannelMember> threadMembers = JsonConvert.DeserializeObject<List<DiscordThreadChannelMember>>(response.Response!)!;
+        
+        foreach (DiscordThreadChannelMember member in threadMembers)
+        {
+            member.Discord = this._discord!;
+        }
+        
         return new ReadOnlyCollection<DiscordThreadChannelMember>(threadMembers);
     }
 


### PR DESCRIPTION
# Summary
There were some NRE because of missing DiscordClients in the return list