### PR TITLE
ApiClient QA

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -906,7 +906,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
         }
 
         // Sort the roles by position and create skeleton roles for the payload.
-        DiscordRole[] returnedRoles = await this.Discord.ApiClient.ModifyGuildRolePositionsAsync(this.Id, roles.Select(x => new RestGuildRoleReorderPayload() { RoleId = x.Value.Id, Position = x.Key }), reason);
+        IReadOnlyList<DiscordRole> returnedRoles = await this.Discord.ApiClient.ModifyGuildRolePositionsAsync(this.Id, roles.Select(x => new RestGuildRoleReorderPayload() { RoleId = x.Value.Id, Position = x.Key }), reason);
 
         // Update the cache as the endpoint returns all roles in the order they were sent.
         this._roles = new(returnedRoles.Select(x => new KeyValuePair<ulong, DiscordRole>(x.Id, x)));

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -426,7 +426,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordBan> bansRaw = JsonConvert.DeserializeObject<IEnumerable<DiscordBan>>(res.Response!)!
+        IEnumerable<DiscordBan> bansRaw = DiscordJson.ToDiscordObject<IEnumerable<DiscordBan>>(res.Response!)!
         .Select(xb =>
         {
             if (!this._discord!.TryGetCachedUserInternal(xb.RawUser.Id, out DiscordUser? user))
@@ -545,7 +545,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        TransportMember transport = JsonConvert.DeserializeObject<TransportMember>(res.Response!)!;
+        TransportMember transport = DiscordJson.ToDiscordObject<TransportMember>(res.Response!)!;
 
         return new DiscordMember(transport) { Discord = this._discord!, _guild_id = guildId };
     }
@@ -578,7 +578,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        List<TransportMember> rawMembers = JsonConvert.DeserializeObject<List<TransportMember>>(res.Response!)!;
+        List<TransportMember> rawMembers = DiscordJson.ToDiscordObject<List<TransportMember>>(res.Response!)!;
         return new ReadOnlyCollection<TransportMember>(rawMembers);
     }
 
@@ -678,7 +678,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordRole[] ret = JsonConvert.DeserializeObject<DiscordRole[]>(res.Response!)!;
+        DiscordRole[] ret = DiscordJson.ToDiscordObject<DiscordRole[]>(res.Response!)!;
         foreach (DiscordRole role in ret)
         {
             role.Discord = this._discord!;
@@ -731,7 +731,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        return JsonConvert.DeserializeObject<AuditLog>(res.Response!)!;
+        return DiscordJson.ToDiscordObject<AuditLog>(res.Response!)!;
     }
 
     internal async ValueTask<DiscordInvite> GetGuildVanityUrlAsync
@@ -748,7 +748,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        return JsonConvert.DeserializeObject<DiscordInvite>(res.Response!)!;
+        return DiscordJson.ToDiscordObject<DiscordInvite>(res.Response!)!;
     }
 
     internal async ValueTask<DiscordWidget> GetGuildWidgetAsync
@@ -804,7 +804,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordWidgetSettings ret = JsonConvert.DeserializeObject<DiscordWidgetSettings>(res.Response!)!;
+        DiscordWidgetSettings ret = DiscordJson.ToDiscordObject<DiscordWidgetSettings>(res.Response!)!;
         ret.Guild = this._discord!.Guilds[guildId];
 
         return ret;
@@ -840,7 +840,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordWidgetSettings ret = JsonConvert.DeserializeObject<DiscordWidgetSettings>(res.Response!)!;
+        DiscordWidgetSettings ret = DiscordJson.ToDiscordObject<DiscordWidgetSettings>(res.Response!)!;
         ret.Guild = this._discord!.Guilds[guildId];
 
         return ret;
@@ -861,7 +861,7 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         IEnumerable<DiscordGuildTemplate> templates = 
-            JsonConvert.DeserializeObject<IEnumerable<DiscordGuildTemplate>>(res.Response!)!;
+            DiscordJson.ToDiscordObject<IEnumerable<DiscordGuildTemplate>>(res.Response!)!;
 
         return new ReadOnlyCollection<DiscordGuildTemplate>(new List<DiscordGuildTemplate>(templates));
     }
@@ -889,7 +889,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        return JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response!)!;
+        return DiscordJson.ToDiscordObject<DiscordGuildTemplate>(res.Response!)!;
     }
 
     internal async ValueTask<DiscordGuildTemplate> SyncGuildTemplateAsync
@@ -907,7 +907,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        return JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response!)!;
+        return DiscordJson.ToDiscordObject<DiscordGuildTemplate>(res.Response!)!;
     }
 
     internal async ValueTask<DiscordGuildTemplate> ModifyGuildTemplateAsync
@@ -934,7 +934,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        return JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response!)!;
+        return DiscordJson.ToDiscordObject<DiscordGuildTemplate>(res.Response!)!;
     }
 
     internal async ValueTask<DiscordGuildTemplate> DeleteGuildTemplateAsync
@@ -952,7 +952,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        return JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response!)!;
+        return DiscordJson.ToDiscordObject<DiscordGuildTemplate>(res.Response!)!;
     }
 
     internal async ValueTask<DiscordGuildMembershipScreening> GetGuildMembershipScreeningFormAsync
@@ -969,7 +969,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        return JsonConvert.DeserializeObject<DiscordGuildMembershipScreening>(res.Response!)!;
+        return DiscordJson.ToDiscordObject<DiscordGuildMembershipScreening>(res.Response!)!;
     }
 
     internal async ValueTask<DiscordGuildMembershipScreening> ModifyGuildMembershipScreeningFormAsync
@@ -997,7 +997,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        return JsonConvert.DeserializeObject<DiscordGuildMembershipScreening>(res.Response!)!;
+        return DiscordJson.ToDiscordObject<DiscordGuildMembershipScreening>(res.Response!)!;
     }
 
     internal async ValueTask<DiscordGuildWelcomeScreen> GetGuildWelcomeScreenAsync
@@ -1014,7 +1014,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        return JsonConvert.DeserializeObject<DiscordGuildWelcomeScreen>(res.Response!)!;
+        return DiscordJson.ToDiscordObject<DiscordGuildWelcomeScreen>(res.Response!)!;
     }
 
     internal async ValueTask<DiscordGuildWelcomeScreen> ModifyGuildWelcomeScreenAsync
@@ -1049,7 +1049,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        return JsonConvert.DeserializeObject<DiscordGuildWelcomeScreen>(res.Response!)!;
+        return DiscordJson.ToDiscordObject<DiscordGuildWelcomeScreen>(res.Response!)!;
     }
 
     internal async ValueTask UpdateCurrentUserVoiceStateAsync
@@ -1406,7 +1406,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordChannel ret = JsonConvert.DeserializeObject<DiscordChannel>(res.Response!)!;
+        DiscordChannel ret = DiscordJson.ToDiscordObject<DiscordChannel>(res.Response!)!;
         ret.Discord = this._discord!;
 
         foreach (DiscordOverwrite xo in ret._permissionOverwrites)
@@ -1582,7 +1582,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordScheduledGuildEvent[] ret = JsonConvert.DeserializeObject<DiscordScheduledGuildEvent[]>(res.Response!)!;
+        DiscordScheduledGuildEvent[] ret = DiscordJson.ToDiscordObject<DiscordScheduledGuildEvent[]>(res.Response!)!;
         
         foreach (DiscordScheduledGuildEvent? scheduledGuildEvent in ret)
         {
@@ -1641,7 +1641,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordScheduledGuildEvent ret = JsonConvert.DeserializeObject<DiscordScheduledGuildEvent>(res.Response!)!;
+        DiscordScheduledGuildEvent ret = DiscordJson.ToDiscordObject<DiscordScheduledGuildEvent>(res.Response!)!;
 
         ret.Discord = this._discord!;
 
@@ -1738,7 +1738,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordScheduledGuildEvent ret = JsonConvert.DeserializeObject<DiscordScheduledGuildEvent>(res.Response!)!;
+        DiscordScheduledGuildEvent ret = DiscordJson.ToDiscordObject<DiscordScheduledGuildEvent>(res.Response!)!;
 
         ret.Discord = this._discord!;
 
@@ -1799,7 +1799,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordScheduledGuildEvent ret = JsonConvert.DeserializeObject<DiscordScheduledGuildEvent>(res.Response!)!;
+        DiscordScheduledGuildEvent ret = DiscordJson.ToDiscordObject<DiscordScheduledGuildEvent>(res.Response!)!;
 
         ret.Discord = this._discord!;
 
@@ -2119,7 +2119,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         
-        IEnumerable<DiscordChannel> channelsRaw = JsonConvert.DeserializeObject<IEnumerable<DiscordChannel>>(res.Response!)!
+        IEnumerable<DiscordChannel> channelsRaw = DiscordJson.ToDiscordObject<IEnumerable<DiscordChannel>>(res.Response!)!
             .Select
             (
                 xc => 
@@ -2384,7 +2384,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordInvite> invitesRaw = JsonConvert.DeserializeObject<IEnumerable<DiscordInvite>>(res.Response!)!
+        IEnumerable<DiscordInvite> invitesRaw = DiscordJson.ToDiscordObject<IEnumerable<DiscordInvite>>(res.Response!)!
             .Select
             (
                 xi => 
@@ -2441,7 +2441,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         
-        DiscordInvite ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response!)!;
+        DiscordInvite ret = DiscordJson.ToDiscordObject<DiscordInvite>(res.Response!)!;
         ret.Discord = this._discord!;
 
         return ret;
@@ -2664,7 +2664,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         
-        DiscordDmChannel ret = JsonConvert.DeserializeObject<DiscordDmChannel>(res.Response!)!;
+        DiscordDmChannel ret = DiscordJson.ToDiscordObject<DiscordDmChannel>(res.Response!)!;
         ret.Discord = this._discord!;
         
         if (this._discord is DiscordClient dc)
@@ -2697,7 +2697,7 @@ public sealed class DiscordApiClient
         };
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        DiscordDmChannel ret = JsonConvert.DeserializeObject<DiscordDmChannel>(res.Response!)!;
+        DiscordDmChannel ret = DiscordJson.ToDiscordObject<DiscordDmChannel>(res.Response!)!;
         ret.Discord = this._discord!;
 
         if (this._discord is DiscordClient dc)
@@ -2732,7 +2732,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         
-        return JsonConvert.DeserializeObject<DiscordFollowedChannel>(res.Response!)!;
+        return DiscordJson.ToDiscordObject<DiscordFollowedChannel>(res.Response!)!;
     }
 
     internal async ValueTask<DiscordMessage> CrosspostMessageAsync
@@ -2793,7 +2793,7 @@ public sealed class DiscordApiClient
         
         RestResponse response = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordStageInstance stage = JsonConvert.DeserializeObject<DiscordStageInstance>(response.Response!)!;
+        DiscordStageInstance stage = DiscordJson.ToDiscordObject<DiscordStageInstance>(response.Response!)!;
         stage.Discord = this._discord!;
 
         return stage;
@@ -2816,7 +2816,7 @@ public sealed class DiscordApiClient
         
         RestResponse response = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordStageInstance stage = JsonConvert.DeserializeObject<DiscordStageInstance>(response.Response!)!;
+        DiscordStageInstance stage = DiscordJson.ToDiscordObject<DiscordStageInstance>(response.Response!)!;
         stage.Discord = this._discord!;
 
         return stage;
@@ -2855,7 +2855,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse response = await this._rest.ExecuteRequestAsync(request);
-        DiscordStageInstance stage = JsonConvert.DeserializeObject<DiscordStageInstance>(response.Response!)!;
+        DiscordStageInstance stage = DiscordJson.ToDiscordObject<DiscordStageInstance>(response.Response!)!;
         stage.Discord = this._discord!;
 
         return stage;
@@ -2960,7 +2960,7 @@ public sealed class DiscordApiClient
         
         RestResponse response = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordThreadChannel thread = JsonConvert.DeserializeObject<DiscordThreadChannel>(response.Response!)!;
+        DiscordThreadChannel thread = DiscordJson.ToDiscordObject<DiscordThreadChannel>(response.Response!)!;
         thread.Discord = this._discord!;
 
         return thread;
@@ -3002,7 +3002,7 @@ public sealed class DiscordApiClient
         
         RestResponse response = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordThreadChannel thread = JsonConvert.DeserializeObject<DiscordThreadChannel>(response.Response!)!;
+        DiscordThreadChannel thread = DiscordJson.ToDiscordObject<DiscordThreadChannel>(response.Response!)!;
         thread.Discord = this._discord!;
 
         return thread;
@@ -3062,7 +3062,7 @@ public sealed class DiscordApiClient
         
         RestResponse response = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordThreadChannelMember ret = JsonConvert.DeserializeObject<DiscordThreadChannelMember>(response.Response!)!;
+        DiscordThreadChannelMember ret = DiscordJson.ToDiscordObject<DiscordThreadChannelMember>(response.Response!)!;
         
         ret.Discord = this._discord!;
         
@@ -3124,7 +3124,7 @@ public sealed class DiscordApiClient
         
         RestResponse response = await this._rest.ExecuteRequestAsync(request);
 
-        List<DiscordThreadChannelMember> threadMembers = JsonConvert.DeserializeObject<List<DiscordThreadChannelMember>>(response.Response!)!;
+        List<DiscordThreadChannelMember> threadMembers = DiscordJson.ToDiscordObject<List<DiscordThreadChannelMember>>(response.Response!)!;
         
         foreach (DiscordThreadChannelMember member in threadMembers)
         {
@@ -3151,7 +3151,7 @@ public sealed class DiscordApiClient
         
         RestResponse response = await this._rest.ExecuteRequestAsync(request);
 
-        ThreadQueryResult result = JsonConvert.DeserializeObject<ThreadQueryResult>(response.Response!)!;
+        ThreadQueryResult result = DiscordJson.ToDiscordObject<ThreadQueryResult>(response.Response!)!;
         result.HasMore = false;
 
         foreach (DiscordThreadChannel thread in result.Threads)
@@ -3205,7 +3205,7 @@ public sealed class DiscordApiClient
 
         RestResponse response = await this._rest.ExecuteRequestAsync(request);
 
-        ThreadQueryResult result = JsonConvert.DeserializeObject<ThreadQueryResult>(response.Response!)!;
+        ThreadQueryResult result = DiscordJson.ToDiscordObject<ThreadQueryResult>(response.Response!)!;
 
         foreach (DiscordThreadChannel thread in result.Threads)
         {
@@ -3256,7 +3256,7 @@ public sealed class DiscordApiClient
         
         RestResponse response = await this._rest.ExecuteRequestAsync(request);
 
-        ThreadQueryResult result = JsonConvert.DeserializeObject<ThreadQueryResult>(response.Response!)!;
+        ThreadQueryResult result = DiscordJson.ToDiscordObject<ThreadQueryResult>(response.Response!)!;
 
         foreach (DiscordThreadChannel thread in result.Threads)
         {
@@ -3307,7 +3307,7 @@ public sealed class DiscordApiClient
         
         RestResponse response = await this._rest.ExecuteRequestAsync(request);
 
-        ThreadQueryResult result = JsonConvert.DeserializeObject<ThreadQueryResult>(response.Response!)!;
+        ThreadQueryResult result = DiscordJson.ToDiscordObject<ThreadQueryResult>(response.Response!)!;
 
         foreach (DiscordThreadChannel thread in result.Threads)
         {
@@ -3351,7 +3351,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        TransportUser userRaw = JsonConvert.DeserializeObject<TransportUser>(res.Response!)!;
+        TransportUser userRaw = DiscordJson.ToDiscordObject<TransportUser>(res.Response!)!;
         DiscordUser user = new(userRaw) 
         { 
             Discord = this._discord! 
@@ -3378,7 +3378,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        TransportMember tm = JsonConvert.DeserializeObject<TransportMember>(res.Response!)!;
+        TransportMember tm = DiscordJson.ToDiscordObject<TransportMember>(res.Response!)!;
 
         DiscordUser usr = new(tm.User) 
         { 
@@ -3444,7 +3444,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        TransportUser userRaw = JsonConvert.DeserializeObject<TransportUser>(res.Response!)!;
+        TransportUser userRaw = DiscordJson.ToDiscordObject<TransportUser>(res.Response!)!;
 
         return userRaw;
     }
@@ -3481,7 +3481,7 @@ public sealed class DiscordApiClient
 
         if (this._discord is DiscordClient)
         {
-            IEnumerable<RestUserGuild> guildsRaw = JsonConvert.DeserializeObject<IEnumerable<RestUserGuild>>(res.Response!)!;
+            IEnumerable<RestUserGuild> guildsRaw = DiscordJson.ToDiscordObject<IEnumerable<RestUserGuild>>(res.Response!)!;
             IEnumerable<DiscordGuild> guilds = guildsRaw.Select
             (
                 xug => (this._discord as DiscordClient)?._guilds[xug.Id]
@@ -3497,7 +3497,7 @@ public sealed class DiscordApiClient
         }
         else
         {
-            return new ReadOnlyCollection<DiscordGuild>(JsonConvert.DeserializeObject<List<DiscordGuild>>(res.Response!)!);
+            return new ReadOnlyCollection<DiscordGuild>(DiscordJson.ToDiscordObject<List<DiscordGuild>>(res.Response!)!);
         }
     }
 
@@ -3597,7 +3597,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordRole> rolesRaw = JsonConvert.DeserializeObject<IEnumerable<DiscordRole>>(res.Response!)!
+        IEnumerable<DiscordRole> rolesRaw = DiscordJson.ToDiscordObject<IEnumerable<DiscordRole>>(res.Response!)!
             .Select
             (
                 xr => 
@@ -3707,7 +3707,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordRole ret = JsonConvert.DeserializeObject<DiscordRole>(res.Response!)!;
+        DiscordRole ret = DiscordJson.ToDiscordObject<DiscordRole>(res.Response!)!;
         ret.Discord = this._discord!;
         ret._guild_id = guildId;
 
@@ -3793,7 +3793,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordRole ret = JsonConvert.DeserializeObject<DiscordRole>(res.Response!)!;
+        DiscordRole ret = DiscordJson.ToDiscordObject<DiscordRole>(res.Response!)!;
         ret.Discord = this._discord!;
         ret._guild_id = guildId;
 
@@ -3841,7 +3841,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        RestGuildPruneResultPayload pruned = JsonConvert.DeserializeObject<RestGuildPruneResultPayload>(res.Response!)!;
+        RestGuildPruneResultPayload pruned = DiscordJson.ToDiscordObject<RestGuildPruneResultPayload>(res.Response!)!;
 
         return pruned.Pruned!.Value;
     }
@@ -3892,7 +3892,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        RestGuildPruneResultPayload pruned = JsonConvert.DeserializeObject<RestGuildPruneResultPayload>(res.Response!)!;
+        RestGuildPruneResultPayload pruned = DiscordJson.ToDiscordObject<RestGuildPruneResultPayload>(res.Response!)!;
 
         return pruned.Pruned;
     }
@@ -3916,7 +3916,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordGuildTemplate templatesRaw = JsonConvert.DeserializeObject<DiscordGuildTemplate>(res.Response!)!;
+        DiscordGuildTemplate templatesRaw = DiscordJson.ToDiscordObject<DiscordGuildTemplate>(res.Response!)!;
 
         return templatesRaw;
     }
@@ -3939,7 +3939,7 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         IEnumerable<DiscordIntegration> integrationsRaw = 
-            JsonConvert.DeserializeObject<IEnumerable<DiscordIntegration>>(res.Response!)!
+            DiscordJson.ToDiscordObject<IEnumerable<DiscordIntegration>>(res.Response!)!
             .Select
             (
                 xi => 
@@ -3969,7 +3969,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordGuildPreview ret = JsonConvert.DeserializeObject<DiscordGuildPreview>(res.Response!)!;
+        DiscordGuildPreview ret = DiscordJson.ToDiscordObject<DiscordGuildPreview>(res.Response!)!;
         ret.Discord = this._discord!;
 
         return ret;
@@ -4001,7 +4001,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordIntegration ret = JsonConvert.DeserializeObject<DiscordIntegration>(res.Response!)!;
+        DiscordIntegration ret = DiscordJson.ToDiscordObject<DiscordIntegration>(res.Response!)!;
         ret.Discord = this._discord!;
 
         return ret;
@@ -4035,7 +4035,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        DiscordIntegration ret = JsonConvert.DeserializeObject<DiscordIntegration>(res.Response!)!;
+        DiscordIntegration ret = DiscordJson.ToDiscordObject<DiscordIntegration>(res.Response!)!;
         ret.Discord = this._discord!;
 
         return ret;
@@ -4104,7 +4104,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordVoiceRegion> regionsRaw = JsonConvert.DeserializeObject<IEnumerable<DiscordVoiceRegion>>(res.Response!)!;
+        IEnumerable<DiscordVoiceRegion> regionsRaw = DiscordJson.ToDiscordObject<IEnumerable<DiscordVoiceRegion>>(res.Response!)!;
 
         return new ReadOnlyCollection<DiscordVoiceRegion>(new List<DiscordVoiceRegion>(regionsRaw));
     }
@@ -4127,7 +4127,7 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         IEnumerable<DiscordInvite> invitesRaw = 
-            JsonConvert.DeserializeObject<IEnumerable<DiscordInvite>>(res.Response!)!
+            DiscordJson.ToDiscordObject<IEnumerable<DiscordInvite>>(res.Response!)!
             .Select
             (
                 xi => 
@@ -4168,7 +4168,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordInvite ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response!)!;
+        DiscordInvite ret = DiscordJson.ToDiscordObject<DiscordInvite>(res.Response!)!;
         ret.Discord = this._discord!;
 
         return ret;
@@ -4199,7 +4199,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordInvite ret = JsonConvert.DeserializeObject<DiscordInvite>(res.Response!)!;
+        DiscordInvite ret = DiscordJson.ToDiscordObject<DiscordInvite>(res.Response!)!;
         ret.Discord = this._discord!;
 
         return ret;
@@ -4222,7 +4222,7 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         IEnumerable<DiscordConnection> connectionsRaw = 
-            JsonConvert.DeserializeObject<IEnumerable<DiscordConnection>>(res.Response!)!
+            DiscordJson.ToDiscordObject<IEnumerable<DiscordConnection>>(res.Response!)!
             .Select
             (
                 xc => 
@@ -4252,7 +4252,7 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         IEnumerable<DiscordVoiceRegion> regions = 
-            JsonConvert.DeserializeObject<IEnumerable<DiscordVoiceRegion>>(res.Response!)!;
+            DiscordJson.ToDiscordObject<IEnumerable<DiscordVoiceRegion>>(res.Response!)!;
 
         return new ReadOnlyCollection<DiscordVoiceRegion>(new List<DiscordVoiceRegion>(regions));
     }
@@ -4294,7 +4294,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordWebhook ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response!)!;
+        DiscordWebhook ret = DiscordJson.ToDiscordObject<DiscordWebhook>(res.Response!)!;
         ret.Discord = this._discord!;
         ret.ApiClient = this;
 
@@ -4384,7 +4384,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordWebhook ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response!)!;
+        DiscordWebhook ret = DiscordJson.ToDiscordObject<DiscordWebhook>(res.Response!)!;
         ret.Discord = this._discord!;
         ret.ApiClient = this;
 
@@ -4411,7 +4411,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordWebhook ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response!)!;
+        DiscordWebhook ret = DiscordJson.ToDiscordObject<DiscordWebhook>(res.Response!)!;
         ret.Token = webhookToken;
         ret.Id = webhookId;
         ret.Discord = this._discord!;
@@ -4440,7 +4440,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
+        DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
         ret.Discord = this._discord!;
         return ret;
     }
@@ -4482,7 +4482,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordWebhook ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response!)!;
+        DiscordWebhook ret = DiscordJson.ToDiscordObject<DiscordWebhook>(res.Response!)!;
         ret.Discord = this._discord!;
         ret.ApiClient = this;
 
@@ -4525,7 +4525,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordWebhook ret = JsonConvert.DeserializeObject<DiscordWebhook>(res.Response!)!;
+        DiscordWebhook ret = DiscordJson.ToDiscordObject<DiscordWebhook>(res.Response!)!;
         ret.Discord = this._discord!;
         ret.ApiClient = this;
 
@@ -4648,7 +4648,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
+        DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
 
         builder.ResetFileStreamPositions();
 
@@ -4677,7 +4677,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         
-        DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
+        DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
         ret.Discord = this._discord!;
         return ret;
     }
@@ -4703,7 +4703,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
+        DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
         ret.Discord = this._discord!;
         return ret;
     }
@@ -4877,7 +4877,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<TransportUser> usersRaw = JsonConvert.DeserializeObject<IEnumerable<TransportUser>>(res.Response!)!;
+        IEnumerable<TransportUser> usersRaw = DiscordJson.ToDiscordObject<IEnumerable<TransportUser>>(res.Response!)!;
         List<DiscordUser> users = new();
         foreach (TransportUser xr in usersRaw)
         {
@@ -4959,7 +4959,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<JObject> emojisRaw = JsonConvert.DeserializeObject<IEnumerable<JObject>>(res.Response!)!;
+        IEnumerable<JObject> emojisRaw = DiscordJson.ToDiscordObject<IEnumerable<JObject>>(res.Response!)!;
 
         this._discord!.Guilds.TryGetValue(guildId, out DiscordGuild? guild);
         Dictionary<ulong, DiscordUser> users = new();
@@ -5190,7 +5190,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordApplicationCommand> ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response!)!;
+        IEnumerable<DiscordApplicationCommand> ret = DiscordJson.ToDiscordObject<IEnumerable<DiscordApplicationCommand>>(res.Response!)!;
         foreach (DiscordApplicationCommand app in ret)
         {
             app.Discord = this._discord!;
@@ -5236,7 +5236,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordApplicationCommand> ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response!)!;
+        IEnumerable<DiscordApplicationCommand> ret = DiscordJson.ToDiscordObject<IEnumerable<DiscordApplicationCommand>>(res.Response!)!;
         foreach (DiscordApplicationCommand app in ret)
         {
             app.Discord = this._discord!;
@@ -5278,7 +5278,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordApplicationCommand ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response!)!;
+        DiscordApplicationCommand ret = DiscordJson.ToDiscordObject<DiscordApplicationCommand>(res.Response!)!;
         ret.Discord = this._discord!;
 
         return ret;
@@ -5302,7 +5302,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordApplicationCommand ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response!)!;
+        DiscordApplicationCommand ret = DiscordJson.ToDiscordObject<DiscordApplicationCommand>(res.Response!)!;
         ret.Discord = this._discord!;
 
         return ret;
@@ -5349,7 +5349,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordApplicationCommand ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response!)!;
+        DiscordApplicationCommand ret = DiscordJson.ToDiscordObject<DiscordApplicationCommand>(res.Response!)!;
         ret.Discord = this._discord!;
 
         return ret;
@@ -5392,7 +5392,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordApplicationCommand> ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response!)!;
+        IEnumerable<DiscordApplicationCommand> ret = DiscordJson.ToDiscordObject<IEnumerable<DiscordApplicationCommand>>(res.Response!)!;
         foreach (DiscordApplicationCommand app in ret)
         {
             app.Discord = this._discord!;
@@ -5439,7 +5439,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordApplicationCommand> ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response!)!;
+        IEnumerable<DiscordApplicationCommand> ret = DiscordJson.ToDiscordObject<IEnumerable<DiscordApplicationCommand>>(res.Response!)!;
         foreach (DiscordApplicationCommand app in ret)
         {
             app.Discord = this._discord!;
@@ -5482,7 +5482,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordApplicationCommand ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response!)!;
+        DiscordApplicationCommand ret = DiscordJson.ToDiscordObject<DiscordApplicationCommand>(res.Response!)!;
         ret.Discord = this._discord!;
 
         return ret;
@@ -5507,7 +5507,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordApplicationCommand ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response!)!;
+        DiscordApplicationCommand ret = DiscordJson.ToDiscordObject<DiscordApplicationCommand>(res.Response!)!;
         ret.Discord = this._discord!;
 
         return ret;
@@ -5555,7 +5555,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordApplicationCommand ret = JsonConvert.DeserializeObject<DiscordApplicationCommand>(res.Response!)!;
+        DiscordApplicationCommand ret = DiscordJson.ToDiscordObject<DiscordApplicationCommand>(res.Response!)!;
         ret.Discord = this._discord!;
 
         return ret;
@@ -5680,7 +5680,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
+        DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
 
         ret.Discord = this._discord!;
         return ret;
@@ -5728,7 +5728,7 @@ public sealed class DiscordApiClient
 
             RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-            DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
+            DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
             ret.Discord = this._discord!;
 
             foreach (DiscordMessageFile? file in builder.Files.Where(x => x.ResetPositionTo.HasValue))
@@ -5814,7 +5814,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
+        DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
 
         builder.ResetFileStreamPositions();
 
@@ -5860,7 +5860,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        IEnumerable<DiscordGuildApplicationCommandPermissions> ret = JsonConvert.DeserializeObject<IEnumerable<DiscordGuildApplicationCommandPermissions>>(res.Response!)!;
+        IEnumerable<DiscordGuildApplicationCommandPermissions> ret = DiscordJson.ToDiscordObject<IEnumerable<DiscordGuildApplicationCommandPermissions>>(res.Response!)!;
 
         foreach (DiscordGuildApplicationCommandPermissions perm in ret)
         {
@@ -5888,7 +5888,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        DiscordGuildApplicationCommandPermissions ret = JsonConvert.DeserializeObject<DiscordGuildApplicationCommandPermissions>(res.Response!)!;
+        DiscordGuildApplicationCommandPermissions ret = DiscordJson.ToDiscordObject<DiscordGuildApplicationCommandPermissions>(res.Response!)!;
 
         ret.Discord = this._discord!;
         return ret;
@@ -5921,7 +5921,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         DiscordGuildApplicationCommandPermissions ret = 
-            JsonConvert.DeserializeObject<DiscordGuildApplicationCommandPermissions>(res.Response!)!;
+            DiscordJson.ToDiscordObject<DiscordGuildApplicationCommandPermissions>(res.Response!)!;
 
         ret.Discord = this._discord!;
         return ret;
@@ -5947,7 +5947,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         IEnumerable<DiscordGuildApplicationCommandPermissions> ret = 
-            JsonConvert.DeserializeObject<IEnumerable<DiscordGuildApplicationCommandPermissions>>(res.Response!)!;
+            DiscordJson.ToDiscordObject<IEnumerable<DiscordGuildApplicationCommandPermissions>>(res.Response!)!;
 
         foreach (DiscordGuildApplicationCommandPermissions perm in ret)
         {
@@ -5985,7 +5985,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        return JsonConvert.DeserializeObject<TransportApplication>(res.Response!)!;
+        return DiscordJson.ToDiscordObject<TransportApplication>(res.Response!)!;
     }
 
     internal async ValueTask<IReadOnlyList<DiscordApplicationAsset>> GetApplicationAssetsAsync
@@ -6005,7 +6005,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordApplicationAsset> assets = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationAsset>>(res.Response!)!;
+        IEnumerable<DiscordApplicationAsset> assets = DiscordJson.ToDiscordObject<IEnumerable<DiscordApplicationAsset>>(res.Response!)!;
         foreach (DiscordApplicationAsset asset in assets)
         {
             asset.Discord = application.Discord;
@@ -6178,7 +6178,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        DiscordAutoModerationRule rule = JsonConvert.DeserializeObject<DiscordAutoModerationRule>(res.Response!)!;
+        DiscordAutoModerationRule rule = DiscordJson.ToDiscordObject<DiscordAutoModerationRule>(res.Response!)!;
         rule.Discord = this._discord!;
         
         return rule;
@@ -6207,7 +6207,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        DiscordAutoModerationRule rule = JsonConvert.DeserializeObject<DiscordAutoModerationRule>(res.Response!)!;
+        DiscordAutoModerationRule rule = DiscordJson.ToDiscordObject<DiscordAutoModerationRule>(res.Response!)!;
         rule.Discord = this._discord!;
         
         return rule;
@@ -6234,7 +6234,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        IReadOnlyList<DiscordAutoModerationRule> rules = JsonConvert.DeserializeObject<IReadOnlyList<DiscordAutoModerationRule>>(res.Response!)!;
+        IReadOnlyList<DiscordAutoModerationRule> rules = DiscordJson.ToDiscordObject<IReadOnlyList<DiscordAutoModerationRule>>(res.Response!)!;
         
         foreach (DiscordAutoModerationRule rule in rules)
         {
@@ -6302,7 +6302,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        DiscordAutoModerationRule rule = JsonConvert.DeserializeObject<DiscordAutoModerationRule>(res.Response!)!;
+        DiscordAutoModerationRule rule = DiscordJson.ToDiscordObject<DiscordAutoModerationRule>(res.Response!)!;
         rule.Discord = this._discord!;
         
         return rule;

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -107,9 +107,8 @@ public sealed class DiscordApiClient
                 {
                     Discord = this._discord
                 };
+                this._discord.UserCache[author.Id] = user;
             }
-
-            this._discord.UserCache[author.Id] = user;
 
             // get the member object if applicable, if not set the message author to an user
             if (guild is not null)
@@ -4319,8 +4318,8 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         IEnumerable<DiscordWebhook> webhooksRaw = 
-            JsonConvert
-                .DeserializeObject<IEnumerable<DiscordWebhook>>(res.Response!)!
+            DiscordJson
+                .ToDiscordObject<IEnumerable<DiscordWebhook>>(res.Response!)!
                 .Select
                 (
                     xw => 
@@ -4352,8 +4351,8 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         IEnumerable<DiscordWebhook> webhooksRaw = 
-            JsonConvert
-                .DeserializeObject<IEnumerable<DiscordWebhook>>(res.Response!)!
+            DiscordJson
+                .ToDiscordObject<IEnumerable<DiscordWebhook>>(res.Response!)!
                 .Select
                 (
                     xw => 
@@ -4440,7 +4439,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
+        DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
         ret.Discord = this._discord!;
         return ret;
     }
@@ -4648,7 +4647,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
+        DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
 
         builder.ResetFileStreamPositions();
 
@@ -4677,7 +4676,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         
-        DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
+        DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
         ret.Discord = this._discord!;
         return ret;
     }
@@ -4703,7 +4702,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
+        DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
         ret.Discord = this._discord!;
         return ret;
     }
@@ -5680,7 +5679,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
+        DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
 
         ret.Discord = this._discord!;
         return ret;
@@ -5728,7 +5727,7 @@ public sealed class DiscordApiClient
 
             RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-            DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
+            DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
             ret.Discord = this._discord!;
 
             foreach (DiscordMessageFile? file in builder.Files.Where(x => x.ResetPositionTo.HasValue))
@@ -5814,7 +5813,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        DiscordMessage ret = DiscordJson.ToDiscordObject<DiscordMessage>(res.Response!)!;
+        DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
 
         builder.ResetFileStreamPositions();
 

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1828,13 +1828,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordChannel ret = JsonConvert.DeserializeObject<DiscordChannel>(res.Response!)!;
-
-        // this is really weird, we should consider doing this better
-        if (ret.IsThread)
-        {
-            ret = JsonConvert.DeserializeObject<DiscordThreadChannel>(res.Response!)!;
-        }
+        DiscordChannel ret = DiscordJson.ToDiscordObject<DiscordThreadChannel>(res.Response!)!;
 
         ret.Discord = this._discord!;
         foreach (DiscordOverwrite xo in ret._permissionOverwrites)
@@ -2672,6 +2666,11 @@ public sealed class DiscordApiClient
         
         DiscordDmChannel ret = JsonConvert.DeserializeObject<DiscordDmChannel>(res.Response!)!;
         ret.Discord = this._discord!;
+        
+        if (this._discord is DiscordClient dc)
+        {
+            _ = dc._privateChannels.TryAdd(ret.Id, ret);
+        }
 
         return ret;
     }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -24,6 +24,9 @@ namespace DSharpPlus.Net;
 
 // huge credits to dvoraks 8th symphony for being a source of sanity in the trying times of 
 // fixing this absolute catastrophy up at least somewhat
+// - akiraveliara
+// also credits given to starwars lofi to keep my sanity while working on this
+// - plerx
 
 public sealed class DiscordApiClient
 {
@@ -425,8 +428,8 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordBan> bansRaw = DiscordJson
-            .ToDiscordObject<IEnumerable<DiscordBan>>(JObject.Parse(res.Response!))!
+        IEnumerable<DiscordBan> bansRaw = JArray.Parse(res.Response!)
+            .ToDiscordObject<IEnumerable<DiscordBan>>()!
             .Select(xb =>
             {
                 if (!this._discord!.TryGetCachedUserInternal(xb.RawUser.Id, out DiscordUser? user))
@@ -2120,7 +2123,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         
-        IEnumerable<DiscordChannel> channelsRaw = JObject.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordChannel>>()!
+        IEnumerable<DiscordChannel> channelsRaw = JArray.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordChannel>>()!
             .Select
             (
                 xc => 
@@ -2385,7 +2388,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordInvite> invitesRaw = JObject.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordInvite>>()!
+        IEnumerable<DiscordInvite> invitesRaw = JArray.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordInvite>>()!
             .Select
             (
                 xi => 
@@ -3482,7 +3485,7 @@ public sealed class DiscordApiClient
 
         if (this._discord is DiscordClient)
         {
-            IEnumerable<RestUserGuild> guildsRaw = JObject.Parse(res.Response!).ToDiscordObject<IEnumerable<RestUserGuild>>()!;
+            IEnumerable<RestUserGuild> guildsRaw = JArray.Parse(res.Response!).ToDiscordObject<IEnumerable<RestUserGuild>>()!;
             IEnumerable<DiscordGuild> guilds = guildsRaw.Select
             (
                 xug => (this._discord as DiscordClient)?._guilds[xug.Id]
@@ -3598,7 +3601,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordRole> rolesRaw = JObject.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordRole>>()!
+        IEnumerable<DiscordRole> rolesRaw = JArray.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordRole>>()!
             .Select
             (
                 xr => 
@@ -3940,7 +3943,7 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         List<DiscordIntegration> integrationsRaw = 
-            JObject.Parse(res.Response!)
+            JArray.Parse(res.Response!)
                 .ToDiscordObject<IEnumerable<DiscordIntegration>>()!
                 .Select
                 (
@@ -4108,7 +4111,7 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         List<DiscordVoiceRegion> regionsRaw = 
-            JObject.Parse(res.Response!)
+            JArray.Parse(res.Response!)
                 .ToDiscordObject<IEnumerable<DiscordVoiceRegion>>()
                 .ToList();
 
@@ -4133,7 +4136,7 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         List<DiscordInvite> invitesRaw = 
-            JObject.Parse(res.Response!)
+            JArray.Parse(res.Response!)
                 .ToDiscordObject<IEnumerable<DiscordInvite>>()!
                 .Select
                 (
@@ -4230,7 +4233,7 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         List<DiscordConnection> connectionsRaw = 
-            JObject.Parse(res.Response!)
+            JArray.Parse(res.Response!)
                 .ToDiscordObject<IEnumerable<DiscordConnection>>()!
                 .Select
                 (
@@ -4262,7 +4265,7 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         List<DiscordVoiceRegion> regions = 
-            JObject.Parse(res.Response!)
+            JArray.Parse(res.Response!)
                 .ToDiscordObject<IEnumerable<DiscordVoiceRegion>>()
                 .ToList();
 
@@ -4331,7 +4334,7 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         List<DiscordWebhook> webhooksRaw = 
-            JObject.Parse(res.Response!)
+            JArray.Parse(res.Response!)
                 .ToDiscordObject<IEnumerable<DiscordWebhook>>()!
                 .Select
                 (
@@ -4365,7 +4368,7 @@ public sealed class DiscordApiClient
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
         List<DiscordWebhook> webhooksRaw = 
-            JObject.Parse(res.Response!)
+            JArray.Parse(res.Response!)
                 .ToDiscordObject<IEnumerable<DiscordWebhook>>()!
                 .Select
                 (
@@ -4891,7 +4894,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<TransportUser> usersRaw = JObject.Parse(res.Response!).ToDiscordObject<IEnumerable<TransportUser>>()!;
+        IEnumerable<TransportUser> usersRaw = JArray.Parse(res.Response!).ToDiscordObject<IEnumerable<TransportUser>>()!;
         List<DiscordUser> users = new();
         foreach (TransportUser xr in usersRaw)
         {
@@ -4973,7 +4976,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<JObject> emojisRaw = JObject.Parse(res.Response!).ToDiscordObject<IEnumerable<JObject>>()!;
+        IEnumerable<JObject> emojisRaw = JArray.Parse(res.Response!).ToDiscordObject<IEnumerable<JObject>>()!;
 
         this._discord!.Guilds.TryGetValue(guildId, out DiscordGuild? guild);
         Dictionary<ulong, DiscordUser> users = new();
@@ -5204,7 +5207,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordApplicationCommand> ret = JObject.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordApplicationCommand>>()!;
+        IEnumerable<DiscordApplicationCommand> ret = JArray.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordApplicationCommand>>()!;
         foreach (DiscordApplicationCommand app in ret)
         {
             app.Discord = this._discord!;
@@ -5250,7 +5253,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordApplicationCommand> ret = JObject.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordApplicationCommand>>()!;
+        IEnumerable<DiscordApplicationCommand> ret = JArray.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordApplicationCommand>>()!;
         foreach (DiscordApplicationCommand app in ret)
         {
             app.Discord = this._discord!;
@@ -5406,7 +5409,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordApplicationCommand> ret = JObject.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordApplicationCommand>>()!;
+        IEnumerable<DiscordApplicationCommand> ret = JArray.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordApplicationCommand>>()!;
         foreach (DiscordApplicationCommand app in ret)
         {
             app.Discord = this._discord!;
@@ -5453,7 +5456,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordApplicationCommand> ret = JObject.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordApplicationCommand>>()!;
+        IEnumerable<DiscordApplicationCommand> ret = JArray.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordApplicationCommand>>()!;
         foreach (DiscordApplicationCommand app in ret)
         {
             app.Discord = this._discord!;
@@ -5874,7 +5877,7 @@ public sealed class DiscordApiClient
         };
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
-        IEnumerable<DiscordGuildApplicationCommandPermissions> ret = JObject.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordGuildApplicationCommandPermissions>>()!;
+        IEnumerable<DiscordGuildApplicationCommandPermissions> ret = JArray.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordGuildApplicationCommandPermissions>>()!;
 
         foreach (DiscordGuildApplicationCommandPermissions perm in ret)
         {
@@ -5961,7 +5964,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         IEnumerable<DiscordGuildApplicationCommandPermissions> ret = 
-            JObject.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordGuildApplicationCommandPermissions>>()!;
+            JArray.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordGuildApplicationCommandPermissions>>()!;
 
         foreach (DiscordGuildApplicationCommandPermissions perm in ret)
         {
@@ -6019,7 +6022,7 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        IEnumerable<DiscordApplicationAsset> assets = JObject.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordApplicationAsset>>()!;
+        IEnumerable<DiscordApplicationAsset> assets = JArray.Parse(res.Response!).ToDiscordObject<IEnumerable<DiscordApplicationAsset>>()!;
         foreach (DiscordApplicationAsset asset in assets)
         {
             asset.Discord = application.Discord;

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1832,7 +1832,7 @@ public sealed class DiscordApiClient
 
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
 
-        DiscordChannel ret = JObject.Parse(res.Response!).ToDiscordObject<DiscordThreadChannel>()!;
+        DiscordChannel ret = JObject.Parse(res.Response!).ToDiscordObject<DiscordChannel>()!;
 
         ret.Discord = this._discord!;
         foreach (DiscordOverwrite xo in ret._permissionOverwrites)

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -252,6 +252,8 @@ public sealed class DiscordApiClient
             // this looks wrong. TODO: investigate double-fired event?
             await dc.OnGuildCreateEventAsync(guild, rawMembers, null!);
         }
+        
+        guild.Discord = this._discord!;
 
         return guild;
     }
@@ -287,6 +289,8 @@ public sealed class DiscordApiClient
         {
             await dc.OnGuildCreateEventAsync(guild, rawMembers, null!);
         }
+        
+        guild.Discord = this._discord!;
 
         return guild;
     }
@@ -2750,7 +2754,9 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         
-        return JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
+        DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
+        
+        return ret;
     }
 
     internal async ValueTask<DiscordStageInstance> CreateStageInstanceAsync
@@ -3482,6 +3488,12 @@ public sealed class DiscordApiClient
                 xug => (this._discord as DiscordClient)?._guilds[xug.Id]
             )
             .Where(static guild => guild is not null)!;
+
+            foreach (DiscordGuild guild in guilds)
+            {
+                guild.Discord = this._discord!;
+            }
+            
             return new ReadOnlyCollection<DiscordGuild>(new List<DiscordGuild>(guilds));
         }
         else
@@ -4639,7 +4651,7 @@ public sealed class DiscordApiClient
 
         DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
 
-            builder.ResetFileStreamPositions();
+        builder.ResetFileStreamPositions();
 
         ret.Discord = this._discord!;
         return ret;
@@ -4973,6 +4985,8 @@ public sealed class DiscordApiClient
 
                 discordGuildEmoji.User = users[rawUser.Id];
             }
+            
+            discordGuildEmoji.Discord = this._discord!;
 
             emojis.Add(discordGuildEmoji);
         }
@@ -5013,6 +5027,8 @@ public sealed class DiscordApiClient
         {
             emoji.User = guild is not null && guild.Members.TryGetValue(rawUser.Id, out DiscordMember? member) ? member : new DiscordUser(rawUser);
         }
+        
+        emoji.Discord = this._discord!;
 
         return emoji;
     }
@@ -5067,6 +5083,8 @@ public sealed class DiscordApiClient
         emoji.User = rawUser != null
             ? guild is not null && guild.Members.TryGetValue(rawUser.Id, out DiscordMember? member) ? member : new DiscordUser(rawUser)
             : this._discord.CurrentUser;
+        
+        emoji.Discord = this._discord!;
 
         return emoji;
     }
@@ -5121,6 +5139,8 @@ public sealed class DiscordApiClient
         {
             emoji.User = guild is not null && guild.Members.TryGetValue(rawUser.Id, out DiscordMember? member) ? member : new DiscordUser(rawUser);
         }
+        
+        emoji.Discord = this._discord!;
 
         return emoji;
     }
@@ -6160,7 +6180,8 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         DiscordAutoModerationRule rule = JsonConvert.DeserializeObject<DiscordAutoModerationRule>(res.Response!)!;
-
+        rule.Discord = this._discord!;
+        
         return rule;
     }
 
@@ -6188,7 +6209,8 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         DiscordAutoModerationRule rule = JsonConvert.DeserializeObject<DiscordAutoModerationRule>(res.Response!)!;
-
+        rule.Discord = this._discord!;
+        
         return rule;
     }
 
@@ -6214,7 +6236,12 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         IReadOnlyList<DiscordAutoModerationRule> rules = JsonConvert.DeserializeObject<IReadOnlyList<DiscordAutoModerationRule>>(res.Response!)!;
-
+        
+        foreach (DiscordAutoModerationRule rule in rules)
+        {
+            rule.Discord = this._discord!;
+        }
+        
         return rules;
     }
 
@@ -6277,7 +6304,8 @@ public sealed class DiscordApiClient
         
         RestResponse res = await this._rest.ExecuteRequestAsync(request);
         DiscordAutoModerationRule rule = JsonConvert.DeserializeObject<DiscordAutoModerationRule>(res.Response!)!;
-
+        rule.Discord = this._discord!;
+        
         return rule;
     }
 


### PR DESCRIPTION
# Summary
After we got serveral issues about NREs which were often caused by missing clients i did another full review on the ApiClient

# Details
Adds serveral missing clients, use PrepareMessage everytime suitable, add groupDm to the dm cache

# Notes
Things i had questions about:
- [x]  2 Methods return TransportUser instead of DiscordUser:
   - [x]  `internal async ValueTask<IReadOnlyList<TransportMember>> ListGuildMembersAsync`
   - [x] `internal async ValueTask<TransportUser> ModifyCurrentUserAsync`
 - [x] Line 1833: There is a check for threadChannels. Shouldnt this be handled by the custom jsonserializer?
 - [x] Line 2707: When we create a DmChannel we add it to the client but we dont do it for groupDms. Is this correct?
 - [x] Most of the time we use the method to prepare messages but there are some exceptions. Are those old and should be exchanged or is this intended?