### PR TITLE
embed titles can, in fact, be missing

### DIFF
--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1921,7 +1921,7 @@ public sealed class DiscordApiClient
         {
             foreach (DiscordEmbed embed in embeds)
             {
-                if (embed.Title.Length > 256)
+                if (embed.Title?.Length > 256)
                 {
                     throw new ArgumentException("Embed title length must not exceed 256 characters.");
                 }
@@ -1963,7 +1963,7 @@ public sealed class DiscordApiClient
                 }
                 
                 int totalCharacter = 0;
-                totalCharacter += embed.Title.Length;
+                totalCharacter += embed.Title?.Length ?? 0;
                 totalCharacter += embed.Description?.Length ?? 0;
                 totalCharacter += embed.Fields?.Sum(xf => xf.Name.Length + xf.Value.Length) ?? 0;
                 totalCharacter += embed.Footer?.Text.Length ?? 0;


### PR DESCRIPTION
for some reason we treated embed titles as required when they are, in fact, not. cc @Plerx2493 