### PR TITLE
DiscordShardedClient startup bug

### DIFF
--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -259,13 +259,13 @@ public sealed partial class DiscordShardedClient
 
     private async Task<GatewayInfo> GetGatewayInfoAsync()
     {
-        string url = $"{Utilities.GetApiBaseUri()}{Endpoints.GATEWAY}{Endpoints.BOT}";
+        string url = $"{Utilities.GetApiBaseUri()}/{Endpoints.GATEWAY}/{Endpoints.BOT}";
         HttpClient http = new HttpClient();
 
         http.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", Utilities.GetUserAgent());
         http.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", Utilities.GetFormattedToken(this.Configuration));
 
-        this.Logger.LogDebug(LoggerEvents.ShardRest, $"Obtaining gateway information from GET {Endpoints.GATEWAY}{Endpoints.BOT}...");
+        this.Logger.LogDebug(LoggerEvents.ShardRest, $"Obtaining gateway information from GET {Endpoints.GATEWAY}/{Endpoints.BOT}...");
         HttpResponseMessage resp = await http.GetAsync(url);
 
         http.Dispose();


### PR DESCRIPTION
# Summary
Malformed url in `GetGatewayInfoAsync`