### PR TITLE
fix: rest request headers are not escaped

### DIFF
--- a/DSharpPlus/Net/Rest/MultipartRestRequest.cs
+++ b/DSharpPlus/Net/Rest/MultipartRestRequest.cs
@@ -76,7 +76,7 @@ internal readonly record struct MultipartRestRequest : IRestRequest
         {
             foreach (KeyValuePair<string, string> header in this.Headers)
             {
-                request.Headers.Add(header.Key, header.Value);
+                request.Headers.Add(header.Key, Uri.EscapeDataString(header.Value));
             }
         }
 

--- a/DSharpPlus/Net/Rest/RestRequest.cs
+++ b/DSharpPlus/Net/Rest/RestRequest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -52,7 +53,7 @@ internal readonly record struct RestRequest : IRestRequest
         {
             foreach (KeyValuePair<string, string> header in this.Headers)
             {
-                request.Headers.Add(header.Key, header.Value);
+                request.Headers.Add(header.Key, Uri.EscapeDataString(header.Value));
             }
         }
 


### PR DESCRIPTION
Closes #1657 

Header encoding got lost in https://github.com/DSharpPlus/DSharpPlus/commit/851632ea316655d8509f5d9c208b5de8eaf187c1