### PR TITLE
[ci skip] Fix links in articles

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -15,7 +15,7 @@
       "filter": "filter_config.yml",
       "shouldSkipMarkup": true,
       "memberLayout": "separatePages"
-    }
+    } 
   ],
   "build": {
     "content": [

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -14,7 +14,8 @@
       "dest": "api",
       "filter": "filter_config.yml",
       "shouldSkipMarkup": true,
-      "memberLayout": "separatePages"
+      "memberLayout": "separatePages",
+      "outputFormat": "apiPage"
     }
   ],
   "build": {

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -14,8 +14,7 @@
       "dest": "api",
       "filter": "filter_config.yml",
       "shouldSkipMarkup": true,
-      "memberLayout": "separatePages",
-      "outputFormat": "apiPage"
+      "memberLayout": "separatePages"
     }
   ],
   "build": {


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Fixes links to API documentation in docs, by disabling a docfx feature, that i enabled without testing. Oops.

# Notes
kaboom