### PR TITLE
Fix NRE within `Optional<T>.GetHashCode` method

### DIFF
--- a/DSharpPlus/Entities/Optional.cs
+++ b/DSharpPlus/Entities/Optional.cs
@@ -124,8 +124,21 @@ public readonly struct Optional<T> : IEquatable<Optional<T>>, IEquatable<T>, IOp
     /// Gets the hash code for this <see cref="Optional{T}"/>.
     /// </summary>
     /// <returns>The hash code for this <see cref="Optional{T}"/>.</returns>
+    [SuppressMessage("Formatting", "IDE0046", Justification = "Do not fall into the ternary trap")]
     public override int GetHashCode()
-        => this.IsDefined(out T? value) ? value.GetHashCode() : 0;
+    {
+        if (this.HasValue)
+        {
+            if (this._val is not null)
+            {
+                return this._val.GetHashCode();
+            }
+
+            return 0;
+        }
+
+        return -1;
+    }
 
     public static implicit operator Optional<T>(T val)
         => new(val);

--- a/DSharpPlus/Entities/Optional.cs
+++ b/DSharpPlus/Entities/Optional.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using DSharpPlus.Net.Serialization;
@@ -79,7 +80,7 @@ public readonly struct Optional<T> : IEquatable<Optional<T>>, IEquatable<T>, IOp
     /// </summary>
     /// <param name="value">The value contained within the optional.</param>
     /// <returns>True if the value is set, and is not null, otherwise false.</returns>
-    public bool IsDefined(out T? value)
+    public bool IsDefined([NotNullWhen(true)] out T? value)
         => (value = this._val) != null;
 
     /// <summary>
@@ -124,7 +125,7 @@ public readonly struct Optional<T> : IEquatable<Optional<T>>, IEquatable<T>, IOp
     /// </summary>
     /// <returns>The hash code for this <see cref="Optional{T}"/>.</returns>
     public override int GetHashCode()
-        => this.HasValue ? this.Value.GetHashCode() : 0;
+        => this.IsDefined(out T? value) ? value.GetHashCode() : 0;
 
     public static implicit operator Optional<T>(T val)
         => new(val);


### PR DESCRIPTION
When `Optional<T>.Value` is null, `GetHashCode` will throw an NRE. Currently `GetHashCode` returns `0` for an empty `Optional<T>`, and the hashcode of the internal value otherwise.

This PR changes `GetHashCode`'s behavior to return `-1` for an empty `Optional<T>`, `0` for a `Optional<T>` with a `null` value, or the value's internal hashcode for a non-null `Optional<T>`.