### PR TITLE
annotate audit logs for nullability

### DIFF
--- a/DSharpPlus/Entities/AuditLogs/AuditLogActionCategory.cs
+++ b/DSharpPlus/Entities/AuditLogs/AuditLogActionCategory.cs
@@ -26,7 +26,7 @@ namespace DSharpPlus.Entities.AuditLogs;
 /// <summary>
 /// Indicates audit log action category.
 /// </summary>
-public enum AuditLogActionCategory
+public enum DiscordAuditLogActionCategory
 {
     /// <summary>
     /// Indicates that this action resulted in creation or addition of an object.

--- a/DSharpPlus/Entities/AuditLogs/AuditLogActionType.cs
+++ b/DSharpPlus/Entities/AuditLogs/AuditLogActionType.cs
@@ -29,7 +29,7 @@ namespace DSharpPlus.Entities.AuditLogs;
 /// <summary>
 /// Represents type of the action that was taken in given audit log event.
 /// </summary>
-public enum AuditLogActionType : int
+public enum DiscordAuditLogActionType
 {
     /// <summary>
     /// Indicates that the guild was updated.

--- a/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
+++ b/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
@@ -144,23 +144,23 @@ internal static class AuditLogParser
         DiscordAuditLogEntry? entry = null;
         switch (auditLogAction.ActionType)
         {
-            case AuditLogActionType.GuildUpdate:
+            case DiscordAuditLogActionType.GuildUpdate:
                 entry = await ParseGuildUpdateAsync(guild, auditLogAction);
                 break;
 
-            case AuditLogActionType.ChannelCreate:
-            case AuditLogActionType.ChannelDelete:
-            case AuditLogActionType.ChannelUpdate:
+            case DiscordAuditLogActionType.ChannelCreate:
+            case DiscordAuditLogActionType.ChannelDelete:
+            case DiscordAuditLogActionType.ChannelUpdate:
                 entry = ParseChannelEntry(guild, auditLogAction);
                 break;
 
-            case AuditLogActionType.OverwriteCreate:
-            case AuditLogActionType.OverwriteDelete:
-            case AuditLogActionType.OverwriteUpdate:
+            case DiscordAuditLogActionType.OverwriteCreate:
+            case DiscordAuditLogActionType.OverwriteDelete:
+            case DiscordAuditLogActionType.OverwriteUpdate:
                 entry = ParseOverwriteEntry(guild, auditLogAction);
                 break;
 
-            case AuditLogActionType.Kick:
+            case DiscordAuditLogActionType.Kick:
                 entry = new DiscordAuditLogKickEntry
                 {
                     Target = members.TryGetValue(auditLogAction.TargetId!.Value, out DiscordMember? kickMember)
@@ -174,7 +174,7 @@ internal static class AuditLogParser
                 };
                 break;
 
-            case AuditLogActionType.Prune:
+            case DiscordAuditLogActionType.Prune:
                 entry = new DiscordAuditLogPruneEntry
                 {
                     Days = auditLogAction.Options.DeleteMemberDays,
@@ -182,8 +182,8 @@ internal static class AuditLogParser
                 };
                 break;
 
-            case AuditLogActionType.Ban:
-            case AuditLogActionType.Unban:
+            case DiscordAuditLogActionType.Ban:
+            case DiscordAuditLogActionType.Unban:
                 entry = new DiscordAuditLogBanEntry
                 {
                     Target = members.TryGetValue(auditLogAction.TargetId!.Value, out DiscordMember? unbanMember)
@@ -197,32 +197,32 @@ internal static class AuditLogParser
                 };
                 break;
 
-            case AuditLogActionType.MemberUpdate:
-            case AuditLogActionType.MemberRoleUpdate:
+            case DiscordAuditLogActionType.MemberUpdate:
+            case DiscordAuditLogActionType.MemberRoleUpdate:
                 entry = ParseMemberUpdateEntry(guild, auditLogAction);
                 break;
 
-            case AuditLogActionType.RoleCreate:
-            case AuditLogActionType.RoleDelete:
-            case AuditLogActionType.RoleUpdate:
+            case DiscordAuditLogActionType.RoleCreate:
+            case DiscordAuditLogActionType.RoleDelete:
+            case DiscordAuditLogActionType.RoleUpdate:
                 entry = ParseRoleUpdateEntry(guild, auditLogAction);
                 break;
 
-            case AuditLogActionType.InviteCreate:
-            case AuditLogActionType.InviteDelete:
-            case AuditLogActionType.InviteUpdate:
+            case DiscordAuditLogActionType.InviteCreate:
+            case DiscordAuditLogActionType.InviteDelete:
+            case DiscordAuditLogActionType.InviteUpdate:
                 entry = ParseInviteUpdateEntry(guild, auditLogAction);
                 break;
 
-            case AuditLogActionType.WebhookCreate:
-            case AuditLogActionType.WebhookDelete:
-            case AuditLogActionType.WebhookUpdate:
+            case DiscordAuditLogActionType.WebhookCreate:
+            case DiscordAuditLogActionType.WebhookDelete:
+            case DiscordAuditLogActionType.WebhookUpdate:
                 entry = ParseWebhookUpdateEntry(guild, auditLogAction, webhooks);
                 break;
 
-            case AuditLogActionType.EmojiCreate:
-            case AuditLogActionType.EmojiDelete:
-            case AuditLogActionType.EmojiUpdate:
+            case DiscordAuditLogActionType.EmojiCreate:
+            case DiscordAuditLogActionType.EmojiDelete:
+            case DiscordAuditLogActionType.EmojiUpdate:
                 entry = new DiscordAuditLogEmojiEntry
                 {
                     Target = guild._emojis.TryGetValue(auditLogAction.TargetId!.Value, out DiscordEmoji? target)
@@ -253,14 +253,14 @@ internal static class AuditLogParser
 
                 break;
 
-            case AuditLogActionType.StickerCreate:
-            case AuditLogActionType.StickerDelete:
-            case AuditLogActionType.StickerUpdate:
+            case DiscordAuditLogActionType.StickerCreate:
+            case DiscordAuditLogActionType.StickerDelete:
+            case DiscordAuditLogActionType.StickerUpdate:
                 entry = ParseStickerUpdateEntry(guild, auditLogAction);
                 break;
 
-            case AuditLogActionType.MessageDelete:
-            case AuditLogActionType.MessageBulkDelete:
+            case DiscordAuditLogActionType.MessageDelete:
+            case DiscordAuditLogActionType.MessageBulkDelete:
                 {
                     entry = new DiscordAuditLogMessageEntry();
 
@@ -290,8 +290,8 @@ internal static class AuditLogParser
                     break;
                 }
 
-            case AuditLogActionType.MessagePin:
-            case AuditLogActionType.MessageUnpin:
+            case DiscordAuditLogActionType.MessagePin:
+            case DiscordAuditLogActionType.MessageUnpin:
                 {
                     entry = new DiscordAuditLogMessagePinEntry();
 
@@ -334,7 +334,7 @@ internal static class AuditLogParser
                     break;
                 }
 
-            case AuditLogActionType.BotAdd:
+            case DiscordAuditLogActionType.BotAdd:
                 {
                     entry = new DiscordAuditLogBotAddEntry();
 
@@ -354,7 +354,7 @@ internal static class AuditLogParser
                     break;
                 }
 
-            case AuditLogActionType.MemberMove:
+            case DiscordAuditLogActionType.MemberMove:
                 entry = new DiscordAuditLogMemberMoveEntry();
 
                 if (auditLogAction.Options == null)
@@ -373,29 +373,29 @@ internal static class AuditLogParser
                 };
                 break;
 
-            case AuditLogActionType.MemberDisconnect:
+            case DiscordAuditLogActionType.MemberDisconnect:
                 entry = new DiscordAuditLogMemberDisconnectEntry { UserCount = auditLogAction.Options?.Count ?? 0 };
                 break;
 
-            case AuditLogActionType.IntegrationCreate:
-            case AuditLogActionType.IntegrationDelete:
-            case AuditLogActionType.IntegrationUpdate:
+            case DiscordAuditLogActionType.IntegrationCreate:
+            case DiscordAuditLogActionType.IntegrationDelete:
+            case DiscordAuditLogActionType.IntegrationUpdate:
                 entry = ParseIntegrationUpdateEntry(guild, auditLogAction);
                 break;
 
-            case AuditLogActionType.GuildScheduledEventCreate:
-            case AuditLogActionType.GuildScheduledEventDelete:
-            case AuditLogActionType.GuildScheduledEventUpdate:
+            case DiscordAuditLogActionType.GuildScheduledEventCreate:
+            case DiscordAuditLogActionType.GuildScheduledEventDelete:
+            case DiscordAuditLogActionType.GuildScheduledEventUpdate:
                 entry = ParseGuildScheduledEventUpdateEntry(guild, auditLogAction, events);
                 break;
 
-            case AuditLogActionType.ThreadCreate:
-            case AuditLogActionType.ThreadDelete:
-            case AuditLogActionType.ThreadUpdate:
+            case DiscordAuditLogActionType.ThreadCreate:
+            case DiscordAuditLogActionType.ThreadDelete:
+            case DiscordAuditLogActionType.ThreadUpdate:
                 entry = ParseThreadUpdateEntry(guild, auditLogAction, threads);
                 break;
 
-            case AuditLogActionType.ApplicationCommandPermissionUpdate:
+            case DiscordAuditLogActionType.ApplicationCommandPermissionUpdate:
                 entry = new DiscordAuditLogApplicationCommandPermissionEntry();
                 DiscordAuditLogApplicationCommandPermissionEntry permissionEntry =
                     (DiscordAuditLogApplicationCommandPermissionEntry)entry;
@@ -429,9 +429,9 @@ internal static class AuditLogParser
 
                 break;
 
-            case AuditLogActionType.AutoModerationBlockMessage:
-            case AuditLogActionType.AutoModerationFlagToChannel:
-            case AuditLogActionType.AutoModerationUserCommunicationDisabled:
+            case DiscordAuditLogActionType.AutoModerationBlockMessage:
+            case DiscordAuditLogActionType.AutoModerationFlagToChannel:
+            case DiscordAuditLogActionType.AutoModerationUserCommunicationDisabled:
                 entry = new DiscordAuditLogAutoModerationExecutedEntry();
 
                 DiscordAuditLogAutoModerationExecutedEntry autoModerationEntry =
@@ -455,9 +455,9 @@ internal static class AuditLogParser
                     (RuleTriggerType)int.Parse(auditLogAction.Options.AutoModerationRuleTriggerType);
                 break;
 
-            case AuditLogActionType.AutoModerationRuleCreate:
-            case AuditLogActionType.AutoModerationRuleUpdate:
-            case AuditLogActionType.AutoModerationRuleDelete:
+            case DiscordAuditLogActionType.AutoModerationRuleCreate:
+            case DiscordAuditLogActionType.AutoModerationRuleUpdate:
+            case DiscordAuditLogActionType.AutoModerationRuleDelete:
                 entry = ParseAutoModerationRuleUpdateEntry(guild, auditLogAction);
                 break;
 
@@ -479,26 +479,26 @@ internal static class AuditLogParser
 
         entry.ActionCategory = auditLogAction.ActionType switch
         {
-            AuditLogActionType.ChannelCreate or AuditLogActionType.EmojiCreate or AuditLogActionType.InviteCreate
-                or AuditLogActionType.OverwriteCreate or AuditLogActionType.RoleCreate
-                or AuditLogActionType.WebhookCreate or AuditLogActionType.IntegrationCreate
-                or AuditLogActionType.StickerCreate
-                or AuditLogActionType.AutoModerationRuleCreate => AuditLogActionCategory.Create,
+            DiscordAuditLogActionType.ChannelCreate or DiscordAuditLogActionType.EmojiCreate or DiscordAuditLogActionType.InviteCreate
+                or DiscordAuditLogActionType.OverwriteCreate or DiscordAuditLogActionType.RoleCreate
+                or DiscordAuditLogActionType.WebhookCreate or DiscordAuditLogActionType.IntegrationCreate
+                or DiscordAuditLogActionType.StickerCreate
+                or DiscordAuditLogActionType.AutoModerationRuleCreate => DiscordAuditLogActionCategory.Create,
 
-            AuditLogActionType.ChannelDelete or AuditLogActionType.EmojiDelete or AuditLogActionType.InviteDelete
-                or AuditLogActionType.MessageDelete or AuditLogActionType.MessageBulkDelete
-                or AuditLogActionType.OverwriteDelete or AuditLogActionType.RoleDelete
-                or AuditLogActionType.WebhookDelete or AuditLogActionType.IntegrationDelete
-                or AuditLogActionType.StickerDelete
-                or AuditLogActionType.AutoModerationRuleDelete => AuditLogActionCategory.Delete,
+            DiscordAuditLogActionType.ChannelDelete or DiscordAuditLogActionType.EmojiDelete or DiscordAuditLogActionType.InviteDelete
+                or DiscordAuditLogActionType.MessageDelete or DiscordAuditLogActionType.MessageBulkDelete
+                or DiscordAuditLogActionType.OverwriteDelete or DiscordAuditLogActionType.RoleDelete
+                or DiscordAuditLogActionType.WebhookDelete or DiscordAuditLogActionType.IntegrationDelete
+                or DiscordAuditLogActionType.StickerDelete
+                or DiscordAuditLogActionType.AutoModerationRuleDelete => DiscordAuditLogActionCategory.Delete,
 
-            AuditLogActionType.ChannelUpdate or AuditLogActionType.EmojiUpdate or AuditLogActionType.InviteUpdate
-                or AuditLogActionType.MemberRoleUpdate or AuditLogActionType.MemberUpdate
-                or AuditLogActionType.OverwriteUpdate or AuditLogActionType.RoleUpdate
-                or AuditLogActionType.WebhookUpdate or AuditLogActionType.IntegrationUpdate
-                or AuditLogActionType.StickerUpdate
-                or AuditLogActionType.AutoModerationRuleUpdate => AuditLogActionCategory.Update,
-            _ => AuditLogActionCategory.Other,
+            DiscordAuditLogActionType.ChannelUpdate or DiscordAuditLogActionType.EmojiUpdate or DiscordAuditLogActionType.InviteUpdate
+                or DiscordAuditLogActionType.MemberRoleUpdate or DiscordAuditLogActionType.MemberUpdate
+                or DiscordAuditLogActionType.OverwriteUpdate or DiscordAuditLogActionType.RoleUpdate
+                or DiscordAuditLogActionType.WebhookUpdate or DiscordAuditLogActionType.IntegrationUpdate
+                or DiscordAuditLogActionType.StickerUpdate
+                or DiscordAuditLogActionType.AutoModerationRuleUpdate => DiscordAuditLogActionCategory.Update,
+            _ => DiscordAuditLogActionCategory.Other,
         };
         entry.ActionType = auditLogAction.ActionType;
         entry.Id = auditLogAction.Id;

--- a/DSharpPlus/Entities/AuditLogs/DiscordAuditLogEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/DiscordAuditLogEntry.cs
@@ -36,12 +36,12 @@ public abstract class DiscordAuditLogEntry : SnowflakeObject
     /// <summary>
     /// Gets the user responsible for the action.
     /// </summary>
-    public DiscordUser UserResponsible { get; internal set; }
+    public DiscordUser? UserResponsible { get; internal set; }
 
     /// <summary>
     /// Gets the reason defined in the action.
     /// </summary>
-    public string Reason { get; internal set; }
+    public string? Reason { get; internal set; }
 
     /// <summary>
     /// Gets the category under which the action falls.

--- a/DSharpPlus/Entities/AuditLogs/DiscordAuditLogEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/DiscordAuditLogEntry.cs
@@ -31,7 +31,7 @@ public abstract class DiscordAuditLogEntry : SnowflakeObject
     /// <summary>
     /// Gets the entry's action type.
     /// </summary>
-    public AuditLogActionType ActionType { get; internal set; }
+    public DiscordAuditLogActionType ActionType { get; internal set; }
 
     /// <summary>
     /// Gets the user responsible for the action.
@@ -46,5 +46,5 @@ public abstract class DiscordAuditLogEntry : SnowflakeObject
     /// <summary>
     /// Gets the category under which the action falls.
     /// </summary>
-    public AuditLogActionCategory ActionCategory { get; internal set; }
+    public DiscordAuditLogActionCategory ActionCategory { get; internal set; }
 }

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogApplicationCommandPermissionEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogApplicationCommandPermissionEntry.cs
@@ -40,5 +40,5 @@ public sealed class DiscordAuditLogApplicationCommandPermissionEntry : DiscordAu
     /// <summary>
     /// Permissions changed
     /// </summary>
-    public IEnumerable<PropertyChange<DiscordApplicationCommandPermission>> PermissionChanges { get; internal set; }
+    public IEnumerable<PropertyChange<DiscordApplicationCommandPermission>> PermissionChanges { get; internal set; } = default!;
 }

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogAutoModerationExecutedEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogAutoModerationExecutedEntry.cs
@@ -30,12 +30,12 @@ public sealed class DiscordAuditLogAutoModerationExecutedEntry : DiscordAuditLog
     /// <summary>
     /// Name of the rule that was executed
     /// </summary>
-    public string ResponsibleRule { get; internal set; }
+    public string ResponsibleRule { get; internal set; } = default!;
 
     /// <summary>
     /// User that was affected by the rule
     /// </summary>
-    public DiscordUser TargetUser { get; internal set; }
+    public DiscordUser TargetUser { get; internal set; } = default!;
 
     /// <summary>
     /// Type of the trigger that was executed
@@ -45,5 +45,5 @@ public sealed class DiscordAuditLogAutoModerationExecutedEntry : DiscordAuditLog
     /// <summary>
     /// Channel where the rule was executed
     /// </summary>
-    public DiscordChannel Channel { get; internal set; }
+    public DiscordChannel Channel { get; internal set; } = default!;
 }

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogAutoModerationRuleEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogAutoModerationRuleEntry.cs
@@ -22,6 +22,7 @@
 // SOFTWARE.
 
 using System.Collections.Generic;
+
 using DSharpPlus.Enums;
 
 namespace DSharpPlus.Entities.AuditLogs;

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogBanEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogBanEntry.cs
@@ -28,7 +28,7 @@ public sealed class DiscordAuditLogBanEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the banned member.
     /// </summary>
-    public DiscordMember Target { get; internal set; }
+    public DiscordMember Target { get; internal set; } = default!;
 
     internal DiscordAuditLogBanEntry() { }
 }

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogBotAddEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogBotAddEntry.cs
@@ -28,5 +28,5 @@ public sealed class DiscordAuditLogBotAddEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the bot that has been added to the guild.
     /// </summary>
-    public DiscordUser TargetBot { get; internal set; }
+    public DiscordUser TargetBot { get; internal set; } = default!;
 }

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogChannelEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogChannelEntry.cs
@@ -30,7 +30,7 @@ public sealed class DiscordAuditLogChannelEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the affected channel.
     /// </summary>
-    public DiscordChannel Target { get; internal set; }
+    public DiscordChannel Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the description of channel's name change.

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogEmojiEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogEmojiEntry.cs
@@ -28,7 +28,7 @@ public sealed class DiscordAuditLogEmojiEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the affected emoji.
     /// </summary>
-    public DiscordEmoji Target { get; internal set; }
+    public DiscordEmoji Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the description of emoji's name change.

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogGuildEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogGuildEntry.cs
@@ -28,7 +28,7 @@ public sealed class DiscordAuditLogGuildEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the affected guild.
     /// </summary>
-    public DiscordGuild Target { get; internal set; }
+    public DiscordGuild Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the description of guild name's change.

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogGuildScheduledEventEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogGuildScheduledEventEntry.cs
@@ -33,7 +33,7 @@ public sealed class DiscordAuditLogGuildScheduledEventEntry : DiscordAuditLogEnt
     /// <summary>
     /// Gets the target event. Note that this will only have the ID specified if it is not cached.
     /// </summary>
-    public DiscordScheduledGuildEvent Target { get; internal set; }
+    public DiscordScheduledGuildEvent Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the channel the event was changed to.

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogInviteEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogInviteEntry.cs
@@ -28,7 +28,7 @@ public sealed class DiscordAuditLogInviteEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the affected invite.
     /// </summary>
-    public DiscordInvite Target { get; internal set; }
+    public DiscordInvite Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the description of invite's max age change.

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogKickEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogKickEntry.cs
@@ -28,7 +28,7 @@ public sealed class DiscordAuditLogKickEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the kicked member.
     /// </summary>
-    public DiscordMember Target { get; internal set; }
+    public DiscordMember Target { get; internal set; } = default!;
 
     internal DiscordAuditLogKickEntry() { }
 }

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogMemberMoveEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogMemberMoveEntry.cs
@@ -28,7 +28,7 @@ public sealed class DiscordAuditLogMemberMoveEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the channel the members were moved in.
     /// </summary>
-    public DiscordChannel Channel { get; internal set; }
+    public DiscordChannel Channel { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the amount of users that were moved out from the voice channel.

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogMemberUpdateEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogMemberUpdateEntry.cs
@@ -30,7 +30,7 @@ public sealed class DiscordAuditLogMemberUpdateEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the affected member.
     /// </summary>
-    public DiscordMember Target { get; internal set; }
+    public DiscordMember Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the description of member's nickname change.
@@ -40,12 +40,12 @@ public sealed class DiscordAuditLogMemberUpdateEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the roles that were removed from the member.
     /// </summary>
-    public IReadOnlyList<DiscordRole> RemovedRoles { get; internal set; }
+    public IReadOnlyList<DiscordRole>? RemovedRoles { get; internal set; }
 
     /// <summary>
     /// Gets the roles that were added to the member.
     /// </summary>
-    public IReadOnlyList<DiscordRole> AddedRoles { get; internal set; }
+    public IReadOnlyList<DiscordRole>? AddedRoles { get; internal set; }
 
     /// <summary>
     /// Gets the description of member's mute status change.

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogMessageEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogMessageEntry.cs
@@ -28,7 +28,7 @@ public sealed class DiscordAuditLogMessageEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the affected User.
     /// </summary>
-    public DiscordUser Target { get; internal set; }
+    public DiscordUser Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the affected Member. This is null if the action was performed on a user that is not in the member cache.
@@ -38,7 +38,7 @@ public sealed class DiscordAuditLogMessageEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the channel in which the action occurred.
     /// </summary>
-    public DiscordChannel Channel { get; internal set; }
+    public DiscordChannel Channel { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the number of messages that were affected.

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogMessagePinEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogMessagePinEntry.cs
@@ -28,17 +28,17 @@ public sealed class DiscordAuditLogMessagePinEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the affected message's user.
     /// </summary>
-    public DiscordUser Target { get; internal set; }
+    public DiscordUser Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the channel the message is in.
     /// </summary>
-    public DiscordChannel Channel { get; internal set; }
+    public DiscordChannel Channel { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the message the pin action was for.
     /// </summary>
-    public DiscordMessage Message { get; internal set; }
+    public DiscordMessage Message { get; internal set; } = default!;
 
     internal DiscordAuditLogMessagePinEntry() { }
 }

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogOverwriteEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogOverwriteEntry.cs
@@ -28,12 +28,12 @@ public sealed class DiscordAuditLogOverwriteEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the affected overwrite.
     /// </summary>
-    public DiscordOverwrite Target { get; internal set; }
+    public DiscordOverwrite Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the channel for which the overwrite was changed.
     /// </summary>
-    public DiscordChannel Channel { get; internal set; }
+    public DiscordChannel Channel { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the description of overwrite's allow value change.

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogRoleUpdateEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogRoleUpdateEntry.cs
@@ -5,7 +5,7 @@ public sealed class DiscordAuditLogRoleUpdateEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the affected role.
     /// </summary>
-    public DiscordRole Target { get; internal set; }
+    public DiscordRole Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the description of role's name change.

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogStickerEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogStickerEntry.cs
@@ -28,7 +28,7 @@ public sealed class DiscordAuditLogStickerEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the affected sticker.
     /// </summary>
-    public DiscordMessageSticker Target { get; internal set; }
+    public DiscordMessageSticker Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the description of sticker's name change.

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogThreadEventEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogThreadEventEntry.cs
@@ -28,7 +28,7 @@ public sealed class DiscordAuditLogThreadEventEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the target thread.
     /// </summary>
-    public DiscordThreadChannel Target { get; internal set; }
+    public DiscordThreadChannel Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets a change in the thread's name.

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogWebhookEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogWebhookEntry.cs
@@ -28,7 +28,7 @@ public sealed class DiscordAuditLogWebhookEntry : DiscordAuditLogEntry
     /// <summary>
     /// Gets the affected webhook.
     /// </summary>
-    public DiscordWebhook Target { get; internal set; }
+    public DiscordWebhook Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the description of webhook's name change.

--- a/DSharpPlus/Entities/AuditLogs/PropertyChange.cs
+++ b/DSharpPlus/Entities/AuditLogs/PropertyChange.cs
@@ -34,21 +34,21 @@ public readonly record struct PropertyChange<T>
     /// <summary>
     /// The property's value before it was changed.
     /// </summary>
-    public T Before { get; internal init; }
+    public T? Before { get; internal init; }
 
     /// <summary>
     /// The property's value after it was changed.
     /// </summary>
-    public T After { get; internal init; }
+    public T? After { get; internal init; }
 
     /// <summary>
     /// Create a new <see cref="PropertyChange{T}"/> from the given before and after values.
     /// </summary>
-    public static PropertyChange<T> From(object before, object after) =>
+    public static PropertyChange<T> From(object? before, object? after) =>
         new()
         {
-            Before = before is not null && before is T ? (T)before : default,
-            After = after is not null && after is T ? (T)after : default
+            Before = before is not null and T ? (T)before : default,
+            After = after is not null and T ? (T)after : default
         };
 
     /// <summary>

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -1529,7 +1529,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     (
         int? limit = 100,
         DiscordMember byMember = null,
-        AuditLogActionType? actionType = null
+        DiscordAuditLogActionType? actionType = null
     )
     {
         //Get all entries from api

--- a/DSharpPlus/Entities/Invite/DiscordInviteChannel.cs
+++ b/DSharpPlus/Entities/Invite/DiscordInviteChannel.cs
@@ -11,7 +11,7 @@ public class DiscordInviteChannel : SnowflakeObject
     /// Gets the name of the channel.
     /// </summary>
     [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
-    public string Name { get; internal set; }
+    public string Name { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the type of the channel.

--- a/DSharpPlus/Net/Abstractions/AuditLogAbstractions.cs
+++ b/DSharpPlus/Net/Abstractions/AuditLogAbstractions.cs
@@ -110,7 +110,7 @@ internal sealed class AuditLogAction
     public ulong Id { get; set; }
 
     [JsonProperty("action_type")]
-    public AuditLogActionType ActionType { get; set; }
+    public DiscordAuditLogActionType ActionType { get; set; }
 
     [JsonProperty("changes")]
     public IEnumerable<AuditLogActionChange> Changes { get; set; }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -691,7 +691,7 @@ public sealed class DiscordApiClient
         ulong? after = null,
         ulong? before = null,
         ulong? userId = null,
-        AuditLogActionType? actionType = null
+        DiscordAuditLogActionType? actionType = null
     )
     {
         QueryUriBuilder builder = new($"{Endpoints.GUILDS}/{guildId}/{Endpoints.AUDIT_LOGS}");


### PR DESCRIPTION
with regards to #1653 , this should check off the entire audit log category - 5/however many there are

also changed the two enums, AuditLogActionType and AuditLogActionCategory