### PR TITLE
Fix NRE in DiscordSpotifyAsset ctor

### DIFF
--- a/DSharpPlus/Entities/Application/DiscordSpotifyAsset.cs
+++ b/DSharpPlus/Entities/Application/DiscordSpotifyAsset.cs
@@ -12,8 +12,9 @@ public sealed class DiscordSpotifyAsset : DiscordAsset
 
     private readonly Uri _url;
 
-    public DiscordSpotifyAsset()
+    public DiscordSpotifyAsset(string pId)
     {
+        this.Id = pId;
         string[] ids = this.Id.Split(':');
         string id = ids[1];
 

--- a/DSharpPlus/Entities/User/DiscordActivity.cs
+++ b/DSharpPlus/Entities/User/DiscordActivity.cs
@@ -379,7 +379,7 @@ public sealed class DiscordRichPresence
         {
             if (lid.StartsWith("spotify:"))
             {
-                this.LargeImage = new DiscordSpotifyAsset { Id = lid };
+                this.LargeImage = new DiscordSpotifyAsset(lid);
             }
             else if (ulong.TryParse(lid, NumberStyles.Number, CultureInfo.InvariantCulture, out ulong ulid))
             {
@@ -392,11 +392,11 @@ public sealed class DiscordRichPresence
         {
             if (sid.StartsWith("spotify:"))
             {
-                this.SmallImage = new DiscordSpotifyAsset { Id = sid };
+                this.SmallImage = new DiscordSpotifyAsset(sid);
             }
             else if (ulong.TryParse(sid, NumberStyles.Number, CultureInfo.InvariantCulture, out ulong usid))
             {
-                this.SmallImage = new DiscordApplicationAsset { Id = sid, Application = this.Application, Type = DiscordApplicationAssetType.LargeImage };
+                this.SmallImage = new DiscordApplicationAsset { Id = sid, Application = this.Application, Type = DiscordApplicationAssetType.SmallImage };
             }
         }
     }

--- a/DSharpPlus/Entities/User/DiscordActivity.cs
+++ b/DSharpPlus/Entities/User/DiscordActivity.cs
@@ -383,7 +383,13 @@ public sealed class DiscordRichPresence
             }
             else if (ulong.TryParse(lid, NumberStyles.Number, CultureInfo.InvariantCulture, out ulong ulid))
             {
-                this.LargeImage = new DiscordApplicationAsset { Id = lid, Application = this.Application, Type = DiscordApplicationAssetType.LargeImage };
+                this.LargeImage =
+                    new DiscordApplicationAsset
+                    {
+                        Id = lid,
+                        Application = this.Application,
+                        Type = DiscordApplicationAssetType.LargeImage
+                    };
             }
         }
 
@@ -396,7 +402,13 @@ public sealed class DiscordRichPresence
             }
             else if (ulong.TryParse(sid, NumberStyles.Number, CultureInfo.InvariantCulture, out ulong usid))
             {
-                this.SmallImage = new DiscordApplicationAsset { Id = sid, Application = this.Application, Type = DiscordApplicationAssetType.SmallImage };
+                this.SmallImage =
+                    new DiscordApplicationAsset
+                    {
+                        Id = sid,
+                        Application = this.Application,
+                        Type = DiscordApplicationAssetType.SmallImage
+                    };
             }
         }
     }


### PR DESCRIPTION
# Summary
The id of the asset is used in the constructor and therefore musst provided as a parameter. Also there was a little "bug" because we gave a small image the large image enum value