### PR TITLE
Add ResetStreamPosition handling for exceptions

### DIFF
--- a/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using DSharpPlus.Net;
 
 namespace DSharpPlus.Entities;
 
@@ -366,7 +367,7 @@ public abstract class BaseDiscordMessageBuilder<T> : IDiscordMessageBuilder wher
         {
             if (file.ResetPositionTo is long pos)
             {
-                file.Stream.Position = pos;
+                file.Stream.Seek(pos, SeekOrigin.Begin);
             }
         }
     }
@@ -388,10 +389,12 @@ public abstract class BaseDiscordMessageBuilder<T> : IDiscordMessageBuilder wher
                 originalStream.Dispose();
             }
 
-            stream = newStream;
+            return newStream;
         }
-
-        return stream;
+        else
+        {
+            return new RequestStreamWrapper(stream);
+        }
     }
 
     IDiscordMessageBuilder IDiscordMessageBuilder.SuppressNotifications() => this.SuppressNotifications();

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -2098,7 +2098,8 @@ public sealed class DiscordApiClient
             try
             {
                 res = await this._rest.ExecuteRequestAsync(request);
-            }catch(Exception)
+            }
+            catch(Exception)
             {
                 builder.ResetFileStreamPositions();
                 throw;
@@ -4640,8 +4641,17 @@ public sealed class DiscordApiClient
             IsExemptFromGlobalLimit = true
         };
 
-        RestResponse res = await this._rest.ExecuteRequestAsync(request);
-
+        RestResponse res;
+        try
+        {
+            res = await this._rest.ExecuteRequestAsync(request);
+        }
+        catch (Exception)
+        {
+            builder.ResetFileStreamPositions();
+            throw;
+        }
+        
         DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
 
         builder.ResetFileStreamPositions();
@@ -4742,7 +4752,16 @@ public sealed class DiscordApiClient
             IsExemptFromGlobalLimit = true
         };
 
-        RestResponse res = await this._rest.ExecuteRequestAsync(request);
+        RestResponse res;
+        try
+        {
+            res = await this._rest.ExecuteRequestAsync(request);
+        }
+        catch (Exception)
+        {
+            builder.ResetFileStreamPositions();
+            throw;
+        }
 
         DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
 
@@ -5630,7 +5649,15 @@ public sealed class DiscordApiClient
                 IsExemptFromGlobalLimit = true
             };
 
-            await this._rest.ExecuteRequestAsync(request);
+            try
+            {
+                await this._rest.ExecuteRequestAsync(request);
+            }
+            catch (Exception)
+            {
+                builder.ResetFileStreamPositions();
+                throw;
+            }
 
             builder.ResetFileStreamPositions();
         }
@@ -5799,7 +5826,17 @@ public sealed class DiscordApiClient
             IsExemptFromGlobalLimit = true
         };
 
-        RestResponse res = await this._rest.ExecuteRequestAsync(request);
+        RestResponse res;
+        try
+        {
+            res = await this._rest.ExecuteRequestAsync(request);
+        }
+        catch (Exception)
+        {
+            builder.ResetFileStreamPositions();
+            throw;
+        }
+        
         DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
 
         builder.ResetFileStreamPositions();

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -2098,7 +2098,7 @@ public sealed class DiscordApiClient
             try
             {
                 res = await this._rest.ExecuteRequestAsync(request);
-            }catch(Exception ex)
+            }catch(Exception)
             {
                 builder.ResetFileStreamPositions();
                 throw;

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -2094,7 +2094,16 @@ public sealed class DiscordApiClient
                 Files = builder.Files
             };
 
-            RestResponse res = await this._rest.ExecuteRequestAsync(request);
+            RestResponse res;
+            try
+            {
+                res = await this._rest.ExecuteRequestAsync(request);
+            }catch(Exception ex)
+            {
+                builder.ResetFileStreamPositions();
+                throw;
+            }
+            
 
             DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
 

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -2099,17 +2099,12 @@ public sealed class DiscordApiClient
             {
                 res = await this._rest.ExecuteRequestAsync(request);
             }
-            catch(Exception)
+            finally
             {
                 builder.ResetFileStreamPositions();
-                throw;
             }
-            
-
             DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
-
-            builder.ResetFileStreamPositions();
-
+            
             return ret;
         }
     }
@@ -4646,15 +4641,11 @@ public sealed class DiscordApiClient
         {
             res = await this._rest.ExecuteRequestAsync(request);
         }
-        catch (Exception)
+        finally
         {
             builder.ResetFileStreamPositions();
-            throw;
         }
-        
         DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
-
-        builder.ResetFileStreamPositions();
 
         ret.Discord = this._discord!;
         return ret;
@@ -4757,16 +4748,12 @@ public sealed class DiscordApiClient
         {
             res = await this._rest.ExecuteRequestAsync(request);
         }
-        catch (Exception)
+        finally
         {
             builder.ResetFileStreamPositions();
-            throw;
         }
-
         DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
-
-        builder.ResetFileStreamPositions();
-
+        
         return ret;
     }
 
@@ -5653,13 +5640,10 @@ public sealed class DiscordApiClient
             {
                 await this._rest.ExecuteRequestAsync(request);
             }
-            catch (Exception)
+            finally
             {
                 builder.ResetFileStreamPositions();
-                throw;
             }
-
-            builder.ResetFileStreamPositions();
         }
         else
         {
@@ -5831,15 +5815,11 @@ public sealed class DiscordApiClient
         {
             res = await this._rest.ExecuteRequestAsync(request);
         }
-        catch (Exception)
+        finally
         {
             builder.ResetFileStreamPositions();
-            throw;
         }
-        
         DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
-
-        builder.ResetFileStreamPositions();
 
         ret.Discord = this._discord!;
         return ret;

--- a/DSharpPlus/Net/Rest/RequestStreamWrapper.cs
+++ b/DSharpPlus/Net/Rest/RequestStreamWrapper.cs
@@ -1,0 +1,73 @@
+﻿namespace DSharpPlus.Net;
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+// this class is a clusterfuck to prevent the RestClient from disposing streams we dont want to dispose
+// only god, aaron and i know what a psychosis it was to fix this issue (#1677)
+public class RequestStreamWrapper : Stream, IDisposable
+{
+    private readonly Stream _refStream;
+
+    private void CheckDisposed()
+    {
+        if (this._refStream is null)
+        {
+            throw new ObjectDisposedException(nameof(RequestStreamWrapper));
+        }
+    }
+
+    //basically these two methods are the whole purpose of this class
+    protected override void Dispose(bool disposing){ /* NOT TODAY MY FRIEND */ }
+    protected void Dispose() => this.Dispose(true);
+
+    public RequestStreamWrapper(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        this._refStream = stream;
+    }
+
+    public override bool CanRead => this._refStream.CanRead;
+
+    public override bool CanSeek => this._refStream.CanSeek;
+
+    public override bool CanWrite => this._refStream.CanWrite;
+    
+    public override void Flush() => this._refStream.Flush();
+
+    public override long Length
+    {
+        get
+        {
+            this.CheckDisposed();
+            return this._refStream.Length;
+        }
+    }
+
+    public override long Position
+    {
+        get => this._refStream.Position;
+        set => this._refStream.Position = value;
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        CheckDisposed();
+        return this._refStream.Read(buffer, offset, count);
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        CheckDisposed();
+        return this._refStream.Seek(offset, origin);
+    }
+
+    public override void SetLength(long value) => this._refStream.SetLength(value);
+
+    public override void Write(byte[] buffer, int offset, int count) => this._refStream.Write(buffer, offset, count);
+
+    void IDisposable.Dispose() => Dispose(false);
+}


### PR DESCRIPTION
# Summary
All apiClient methods which uses the `ResetFileStreamPositions()` now have a try-catch block surrounding the request and on exception resets the stream bevor throwing the exception

# Related issues
closes #1677 