### PR TITLE
improve ImageTool performance

### DIFF
--- a/DSharpPlus/ImageTool.cs
+++ b/DSharpPlus/ImageTool.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Buffers;
+using System.Buffers.Text;
 using System.IO;
 using System.Text;
 
@@ -26,8 +28,7 @@ public sealed class ImageTool : IDisposable
     /// </summary>
     public Stream SourceStream { get; }
 
-    private ImageFormat _ifcache;
-    private string _b64cache;
+    private ImageFormat format;
 
     /// <summary>
     /// Creates a new image tool from given stream.
@@ -35,10 +36,7 @@ public sealed class ImageTool : IDisposable
     /// <param name="stream">Stream to work with.</param>
     public ImageTool(Stream stream)
     {
-        if (stream == null)
-        {
-            throw new ArgumentNullException(nameof(stream));
-        }
+        ArgumentNullException.ThrowIfNull(stream);
 
         if (!stream.CanRead || !stream.CanSeek)
         {
@@ -48,8 +46,7 @@ public sealed class ImageTool : IDisposable
         this.SourceStream = stream;
         this.SourceStream.Seek(0, SeekOrigin.Begin);
 
-        this._ifcache = 0;
-        this._b64cache = null;
+        this.format = 0;
     }
 
     /// <summary>
@@ -58,29 +55,29 @@ public sealed class ImageTool : IDisposable
     /// <returns>Detected format.</returns>
     public ImageFormat GetFormat()
     {
-        if (this._ifcache != ImageFormat.Unknown)
+        if (this.format != ImageFormat.Unknown)
         {
-            return this._ifcache;
+            return this.format;
         }
 
-        using (BinaryReader br = new BinaryReader(this.SourceStream, Utilities.UTF8, true))
+        using (BinaryReader br = new(this.SourceStream, Utilities.UTF8, true))
         {
             ulong bgn64 = br.ReadUInt64();
             if (bgn64 == PNG_MAGIC)
             {
-                return this._ifcache = ImageFormat.Png;
+                return this.format = ImageFormat.Png;
             }
 
             bgn64 &= GIF_MASK;
             if (bgn64 == GIF_MAGIC_1 || bgn64 == GIF_MAGIC_2)
             {
-                return this._ifcache = ImageFormat.Gif;
+                return this.format = ImageFormat.Gif;
             }
 
             uint bgn32 = (uint)(bgn64 & MASK32);
             if (bgn32 == WEBP_MAGIC_1 && br.ReadUInt32() == WEBP_MAGIC_2)
             {
-                return this._ifcache = ImageFormat.WebP;
+                return this.format = ImageFormat.WebP;
             }
 
             ushort bgn16 = (ushort)(bgn32 & MASK16);
@@ -89,7 +86,7 @@ public sealed class ImageTool : IDisposable
                 this.SourceStream.Seek(-2, SeekOrigin.End);
                 if (br.ReadUInt16() == JPEG_MAGIC_2)
                 {
-                    return this._ifcache = ImageFormat.Jpeg;
+                    return this.format = ImageFormat.Jpeg;
                 }
             }
         }
@@ -103,29 +100,52 @@ public sealed class ImageTool : IDisposable
     /// <returns>Data-scheme base64 string.</returns>
     public string GetBase64()
     {
-        if (this._b64cache != null)
-        {
-            return this._b64cache;
-        }
-
         ImageFormat fmt = this.GetFormat();
-        StringBuilder sb = new StringBuilder();
 
-        sb.Append("data:image/")
-            .Append(fmt.ToString().ToLowerInvariant())
-            .Append(";base64,");
+        int contentLength = Base64.GetMaxEncodedToUtf8Length((int)this.SourceStream.Length);
 
-        this.SourceStream.Seek(0, SeekOrigin.Begin);
-        byte[] buff = new byte[this.SourceStream.Length];
-        int br = 0;
-        while (br < buff.Length)
+        int formatLength = (int)fmt switch
         {
-            br += this.SourceStream.Read(buff, br, (int)this.SourceStream.Length - br);
+            < 2 => 3,
+            < 5 => 4,
+            _ => 7
+        };
+
+        byte[] b64Buffer = ArrayPool<byte>.Shared.Rent(formatLength + contentLength + 19);
+        byte[] readBuffer = ArrayPool<byte>.Shared.Rent(3072);
+
+        int processed = 0;
+        int totalWritten = 0;
+
+        "data:image/"u8.CopyTo(b64Buffer);
+        Encoding.UTF8.GetBytes(fmt.ToString().ToLowerInvariant()).CopyTo(b64Buffer, 11);
+        ";base64,"u8.CopyTo(b64Buffer.AsSpan()[(11 + formatLength)..]);
+
+        totalWritten += 19;
+        totalWritten += formatLength;
+
+        while (processed < this.SourceStream.Length - 3072)
+        {
+            this.SourceStream.Read(readBuffer);
+
+            Base64.EncodeToUtf8(readBuffer, b64Buffer.AsSpan().Slice(totalWritten, 4096), out int _, out int written, false);
+
+            processed += 3072;
+            totalWritten += written;
         }
 
-        sb.Append(Convert.ToBase64String(buff));
+        int remainingLength = (int)this.SourceStream.Length - processed;
 
-        return this._b64cache = sb.ToString();
+        this.SourceStream.Read(readBuffer, 0, remainingLength);
+
+        Base64.EncodeToUtf8(readBuffer.AsSpan()[..remainingLength], b64Buffer.AsSpan()[totalWritten..], out int _, out int lastWritten);
+
+        string value = Encoding.UTF8.GetString(b64Buffer.AsSpan()[..(totalWritten + lastWritten)]);
+
+        ArrayPool<byte>.Shared.Return(b64Buffer);
+        ArrayPool<byte>.Shared.Return(readBuffer);
+
+        return value;
     }
 
     /// <summary>
@@ -139,10 +159,10 @@ public sealed class ImageTool : IDisposable
 /// </summary>
 public enum ImageFormat : int
 {
-    Unknown = 0,
-    Jpeg = 1,
-    Png = 2,
-    Gif = 3,
-    WebP = 4,
-    Auto = 5
+    Png,
+    Gif,
+    Jpeg,
+    WebP,
+    Auto,
+    Unknown,
 }


### PR DESCRIPTION
with #1686 supporting scheduled event images, ImageTool has come under my focus.

## explanation

the ImageTool shipped in v4 reads the provided stream to a string builder, then returns the contents of that string. this incurs a huge string allocation at the end that we can't avoid (more details on that later), *but it also incurs an intermediary allocation for the data conversion*, as this conversion happens using `Convert.ToBase64String`, thereby creating one string of just the b64'ed data *and another of the b64'ed data and the format information prepended*, which is then returned; and it incurs another allocation for the data before b64'ing, as it reads the entire stream into an allocated byte array

this new ImageTool uses a pooled array of 3KB to read from the stream, then immediately converts that to b64 and writes to the also pooled output buffer. thus, the only allocations incurred are for the initial pooled arrays, which can be quite substantial (an 8mb image incurs a 16mb `ArrayPool` allocation, since it normalizes array sizes to the next higher power of two - though even if we pooled this ourselves, the allocation would still be ~11mb), and for the inevitable string allocation. this, in turn, drastically reduces allocations per iteration, though CPU time stays in unacceptable ranges (see performance section).

the string allocation mentioned several times is, in fact, required by our serialization infrastructure. there may be ways to adapt our infrastructure to handle this better, but they are not explored in this pull request, thus, we are forced to provide a `System.String` containing image data. while Newtonsoft.Json *does* support `byte[]` serialization into base64, we need to prepend a small amount of plaintext data according to the scheme laid out in [the API docs](https://discord.com/developers/docs/reference#image-data) - `data:image/FORMAT;base64,B64_IMAGE_DATA`, and were we to use `byte[]`, this format information would also get converted to b64.

## performance


| Method     | Mean     | Error    | StdDev   | Ratio | Gen0     | Gen1     | Gen2     | Allocated | Alloc Ratio |
|----------- |---------:|---------:|---------:|------:|---------:|---------:|---------:|----------:|------------:|
| V4-STABLE | 14.75 ms | 0.294 ms | 0.245 ms |  1.00 | 828.1250 | 828.1250 | 828.1250 |  65.01 MB |        1.00 |
| V5-PR1687      | 13.90 ms | 0.072 ms | 0.060 ms |  0.94 | 953.1250 | 953.1250 | 953.1250 |  19.27 MB |        0.30 |

data obtained from a PNG with a size of 7,574,458 bytes.

here, it is noteworthy that some allocations in v5-PR1687 are pooled, meaning the allocations per iteration actually only amount to 16MB.
conversion time has also improved, but only marginally - in fact, ~95% of the total iteration time is spent purely on allocating and populating the string.

these measures further jump up considerably when sending the data as HTTP request, to up to ~85MB for v4-stable and ~27MB for v5-pr1687, which is unavoidable with our current rest/serialization infrastructure.