### PR TITLE
potentially fix ClearComponents if components is null

### DIFF
--- a/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
@@ -312,7 +312,7 @@ public abstract class BaseDiscordMessageBuilder<T> : IDiscordMessageBuilder wher
     /// Clears all message components on this builder.
     /// </summary>
     public virtual void ClearComponents()
-        => this._components.Clear();
+        => this._components = [];
 
     /// <summary>
     /// Allows for clearing the Message Builder so that it can be used again to send a new message.


### PR DESCRIPTION
BaseDiscordMessageBuilder.ClearComponents doesn't clear components when editing if the builders components field is null. this overwrites it with an empty array, which should theoretically fix that