### PR TITLE
Expose `RequestStreamWrapper.UnderlyingStream`

### DIFF
--- a/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
@@ -377,24 +377,21 @@ public abstract class BaseDiscordMessageBuilder<T> : IDiscordMessageBuilder wher
     /// </summary>
     private static Stream ResolveStream(Stream stream, AddFileOptions fileOptions)
     {
-        if (fileOptions.HasFlag(AddFileOptions.CopyStream))
-        {
-            Stream originalStream = stream;
-            MemoryStream newStream = new();
-            originalStream.CopyTo(newStream);
-            newStream.Position = 0;
-
-            if (fileOptions.HasFlag(AddFileOptions.CloseStream))
-            {
-                originalStream.Dispose();
-            }
-
-            return newStream;
-        }
-        else
+        if (!fileOptions.HasFlag(AddFileOptions.CopyStream))
         {
             return new RequestStreamWrapper(stream);
         }
+
+        Stream originalStream = stream;
+        MemoryStream newStream = new();
+        originalStream.CopyTo(newStream);
+        newStream.Position = 0;
+        if (fileOptions.HasFlag(AddFileOptions.CloseStream))
+        {
+            originalStream.Dispose();
+        }
+
+        return newStream;
     }
 
     IDiscordMessageBuilder IDiscordMessageBuilder.SuppressNotifications() => this.SuppressNotifications();

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -22,7 +22,7 @@ using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.Net;
 
-// huge credits to dvoraks 8th symphony for being a source of sanity in the trying times of 
+// huge credits to dvoraks 8th symphony for being a source of sanity in the trying times of
 // fixing this absolute catastrophy up at least somewhat
 
 public sealed class DiscordApiClient
@@ -2120,9 +2120,8 @@ public sealed class DiscordApiClient
             {
                 builder.ResetFileStreamPositions();
             }
-            DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
-            
-            return ret;
+
+            return this.PrepareMessage(JObject.Parse(res.Response!));
         }
     }
 
@@ -4769,9 +4768,8 @@ public sealed class DiscordApiClient
         {
             builder.ResetFileStreamPositions();
         }
-        DiscordMessage ret = this.PrepareMessage(JObject.Parse(res.Response!));
-        
-        return ret;
+
+        return this.PrepareMessage(JObject.Parse(res.Response!));
     }
 
     internal async ValueTask DeleteWebhookMessageAsync


### PR DESCRIPTION
# Summary
- Expose `RequestStreamWrapper.UnderlyingStream`
- Addresses nitpicks within #1678
- Inherit documentation from Stream

# Notes
Requested by @NycroV: https://github.com/DSharpPlus/DSharpPlus/pull/1678#issuecomment-1820138785

Untested :)