### PR TITLE
Add missing DiscordClient on ForumPostStarter channel

### DIFF
--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -6134,6 +6134,7 @@ public sealed class DiscordApiClient
         DiscordMessage msg = this.PrepareMessage(msgToken!);
         // We know the return type; deserialize directly.
         DiscordThreadChannel chn = ret.ToDiscordObject<DiscordThreadChannel>();
+        chn.Discord = this._discord!;
 
         return new DiscordForumPostStarter(chn, msg);
     }


### PR DESCRIPTION
# Summary
Fixes NREs due to a missing DiscordClient on the returned DiscordThreadChannel when creating a forumpost