### PR TITLE
Fix auditlog parsing when a ChannelPermissionOverwrite was deleted

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -36,3 +36,10 @@ jobs:
             7
       - name: Build Project
         run: dotnet build
+      - name: Build and Package Project
+        run: dotnet pack --include-symbols --include-source -o build -p:Nightly="PR-${{ github.event.pull_request.number }}"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: DSharpPlus-PR-${{ github.event.pull_request.number }}
+          path: ./build/*

--- a/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
+++ b/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
@@ -1094,7 +1094,7 @@ internal static class AuditLogParser
             Target = guild
                 .GetChannel(auditLogAction.TargetId!.Value)
                 .PermissionOverwrites
-                .First(xo => xo.Id == auditLogAction.Options.Id),
+                .FirstOrDefault(xo => xo.Id == auditLogAction.Options.Id),
             Channel = guild.GetChannel(auditLogAction.TargetId.Value)
         };
 

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogOverwriteEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogOverwriteEntry.cs
@@ -26,9 +26,9 @@ namespace DSharpPlus.Entities.AuditLogs;
 public sealed class DiscordAuditLogOverwriteEntry : DiscordAuditLogEntry
 {
     /// <summary>
-    /// Gets the affected overwrite.
+    /// Gets the affected overwrite. Null if the overwrite was deleted or not in cache.
     /// </summary>
-    public DiscordOverwrite Target { get; internal set; } = default!;
+    public DiscordOverwrite? Target { get; internal set; } = default!;
 
     /// <summary>
     /// Gets the channel for which the overwrite was changed.


### PR DESCRIPTION
# Summary
Target is null when overwrite was deleted. Currently throwing because the overwrite is not found in the guild (because it was deleted)