### PR TITLE
fix oversized reads causing issues with certain (most) (almost all) stream implementations

### DIFF
--- a/DSharpPlus/ImageTool.cs
+++ b/DSharpPlus/ImageTool.cs
@@ -135,7 +135,7 @@ public sealed class ImageTool : IDisposable
 
             Base64.EncodeToUtf8(readBuffer, b64Buffer.AsSpan().Slice(totalWritten, writeLength), out int _, out int written, false);
 
-            processed += 3072;
+            processed += readLength;
             totalWritten += written;
         }
 


### PR DESCRIPTION
make sure we account for the arraypool allocating in powers of two by slicing off the bytes we don't need
12288 as magic number chosen also nicely corresponds to three memory pages on amd64 - not that it really matters, realistically