### PR TITLE
PR Artifacts now have unique names per commit

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -36,10 +36,13 @@ jobs:
             7
       - name: Build Project
         run: dotnet build
+      - name: Get PR Version
+        id: pr
+        run: printf "version=%0*d" 5 ${{ github.run_number }} >> "$GITHUB_OUTPUT"
       - name: Build and Package Project
-        run: dotnet pack --include-symbols --include-source -o build -p:PR="${{ github.event.pull_request.number }}-$(printf "%0*d" 5 ${{ github.run_number }})"
+        run: dotnet pack --include-symbols --include-source -o build -p:PR="${{ github.event.pull_request.number }}-${{ steps.pr.outputs.version }}"
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: DSharpPlus-PR-${{ github.event.pull_request.number }}
+          name: DSharpPlus-PR-${{ github.event.pull_request.number }}-${{ steps.pr.outputs.version }}
           path: ./build/*

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build Project
         run: dotnet build
       - name: Build and Package Project
-        run: dotnet pack --include-symbols --include-source -o build -p:Nightly="PR-${{ github.event.pull_request.number }}"
+        run: dotnet pack --include-symbols --include-source -o build -p:PR="${{ github.event.pull_request.number }}-$(printf "%0*d" 5 ${{ github.run_number }})"
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,7 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Version>5.0.0</Version>
     <Version Condition="'$(Nightly)' != ''">$(Version)-nightly-$(Nightly)</Version>
+    <Version Condition="'$(PR)' != ''">$(Version)-pr-$(PR)</Version>
   </PropertyGroup>
 
   <!-- Nuget -->


### PR DESCRIPTION
# Summary
Before:
- `<package>.<version>-nightly-PR-${{ github.event.pull_request.number }}`
- `DSharpPlus.5.0.0-nightly-PR-1680.nupkg`
After:
- `<package>.<version>-pr-${{ github.event.pull_request.number }}-$(printf "%0*d" 5 ${{ github.run_number }})`
- `DSharpPlus.5.0.0-pr-1680-000044.nupkg`