### PR TITLE
Check size of returned autocompletions

### DIFF
--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -1259,6 +1259,13 @@ public sealed class SlashCommandsExtension : BaseExtension
             object providerInstance = ActivatorUtilities.CreateInstance(this._configuration.Services, provider);
 
             IEnumerable<DiscordAutoCompleteChoice> choices = await (Task<IEnumerable<DiscordAutoCompleteChoice>>)providerMethod.Invoke(providerInstance, new[] { context });
+            
+            if (choices.Count() > 25)
+            {
+                choices = choices.Take(25);
+                this.Client.Logger.LogWarning("""Autocomplete provider "{provider}" returned more than 25 choices. Only the first 25 are passed to Discord.""", nameof(provider));
+            }
+            
             await interaction.CreateResponseAsync(InteractionResponseType.AutoCompleteResult, new DiscordInteractionResponseBuilder().AddAutoCompleteChoices(choices));
 
             await this._autocompleteExecuted.InvokeAsync(this,


### PR DESCRIPTION
# Summary
At the moment we dont check how many autocompletions are return. This pr adds a check and only takes the first 25 to send them to discord. Additionally it sends a warning to the user

