### PR TITLE
Remove explicit support for Sourcelink

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,14 +32,6 @@
     <RepositoryUrl>https://github.com/DSharpPlus/DSharpPlus</RepositoryUrl>
   </PropertyGroup>
 
-  <!-- SourceLink -->
-  <PropertyGroup>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
-
   <!-- Resource Files -->
   <ItemGroup>
     <None Include="$(ProjectRoot)/LICENSE" Pack="true" PackagePath=""/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,6 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageVersion Include="ConcurrentHashSet" Version="1.3.0" />
     <PackageVersion Include="DSharpPlus.VoiceNext.Natives" Version="1.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
# Summary
As of .NET 8, sourcelink is enabled by default. I'm not actually sure if we had sourcelink setup correctly to begin with. Regardless, we no longer need to explicitly enable it.

# Notes
Untested.