### PR TITLE
Fix/sharded shared rest

### DIFF
--- a/DSharpPlus/Clients/BaseDiscordClient.cs
+++ b/DSharpPlus/Clients/BaseDiscordClient.cs
@@ -66,7 +66,7 @@ public abstract class BaseDiscordClient : IDisposable
     /// Initializes this Discord API client.
     /// </summary>
     /// <param name="config">Configuration for this client.</param>
-    protected BaseDiscordClient(DiscordConfiguration config)
+    internal BaseDiscordClient(DiscordConfiguration config, RestClient? rest_client = null)
     {
         this.Configuration = new DiscordConfiguration(config);
 
@@ -77,7 +77,7 @@ public abstract class BaseDiscordClient : IDisposable
         }
         this.Logger = this.Configuration.LoggerFactory.CreateLogger<BaseDiscordClient>();
 
-        this.ApiClient = new DiscordApiClient(this);
+        this.ApiClient = new DiscordApiClient(this, rest_client);
         this.UserCache = new ConcurrentDictionary<ulong, DiscordUser>();
         this.InternalVoiceRegions = new ConcurrentDictionary<string, DiscordVoiceRegion>();
         this._voice_regions_lazy = new Lazy<IReadOnlyDictionary<string, DiscordVoiceRegion>>(() => new ReadOnlyDictionary<string, DiscordVoiceRegion>(this.InternalVoiceRegions));

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -125,6 +125,27 @@ public sealed partial class DiscordClient : BaseDiscordClient
         this.Guilds = new ReadOnlyConcurrentDictionary<ulong, DiscordGuild>(this._guilds);
         this.PrivateChannels = new ReadOnlyConcurrentDictionary<ulong, DiscordDmChannel>(this._privateChannels);
     }
+    
+    /// <summary>
+    /// This constructor is used when constructing a sharded client to use a shared rest client.
+    /// </summary>
+    /// <param name="config">Specifies configuration parameters.</param>
+    /// <param name="restClient">Restclient which will be used for the underlying ApiClients</param>
+    internal DiscordClient(DiscordConfiguration config, RestClient restClient)
+        : base(config, restClient)
+    {
+        DiscordIntents intents = this.Configuration.Intents;
+        if (intents.HasIntent(DiscordIntents.GuildMessages) || intents.HasIntent(DiscordIntents.DirectMessages))
+        {
+            this.MessageCache = this.Configuration.MessageCacheProvider
+                                ?? (this.Configuration.MessageCacheSize > 0 ? new MessageCache(this.Configuration.MessageCacheSize) : null);
+        }
+
+        this.InternalSetup();
+
+        this.Guilds = new ReadOnlyConcurrentDictionary<ulong, DiscordGuild>(this._guilds);
+        this.PrivateChannels = new ReadOnlyConcurrentDictionary<ulong, DiscordDmChannel>(this._privateChannels);
+    }
 
     internal void InternalSetup()
     {

--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -234,6 +234,7 @@ public sealed partial class DiscordShardedClient
         this.GatewayInfo = await this.GetGatewayInfoAsync();
         int shardc = this.Configuration.ShardCount == 1 ? this.GatewayInfo.ShardCount : this.Configuration.ShardCount;
         ShardedLoggerFactory lf = new ShardedLoggerFactory(this.Logger);
+        RestClient rc = new RestClient(this.Configuration, lf.CreateLogger("Rest"));
         for (int i = 0; i < shardc; i++)
         {
             DiscordConfiguration cfg = new DiscordConfiguration(this.Configuration)

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -32,10 +32,11 @@ public sealed class DiscordApiClient
     internal BaseDiscordClient? _discord { get; }
     internal RestClient _rest { get; }
 
-    internal DiscordApiClient(BaseDiscordClient client)
+    internal DiscordApiClient(BaseDiscordClient client, RestClient? rest = null)
     {
         this._discord = client;
-        this._rest = new RestClient(client);
+        rest ??= new RestClient(client.Configuration, client.Logger);
+        this._rest = rest;
     }
 
     internal DiscordApiClient

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -30,20 +30,18 @@ internal sealed partial class RestClient : IDisposable
     private BaseDiscordClient? Discord { get; }
     private ILogger Logger { get; }
     private AsyncManualResetEvent GlobalRateLimitEvent { get; }
-
     private AsyncPolicyWrap<HttpResponseMessage> RateLimitPolicy { get; }
 
     private volatile bool _disposed;
 
-    internal RestClient(BaseDiscordClient client)
+    internal RestClient(DiscordConfiguration config, ILogger logger)
         : this
         (
-            client.Configuration.Proxy,
-            client.Configuration.HttpTimeout,
-            client.Logger
+            config.Proxy,
+            config.HttpTimeout,
+            logger
         )
     {
-        this.Discord = client;
         this.HttpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", Utilities.GetFormattedToken(client));
         this.HttpClient.BaseAddress = new(Endpoints.BASE_URI);
     }

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -42,7 +42,7 @@ internal sealed partial class RestClient : IDisposable
             logger
         )
     {
-        this.HttpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", Utilities.GetFormattedToken(client));
+        this.HttpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", Utilities.GetFormattedToken(config));
         this.HttpClient.BaseAddress = new(Endpoints.BASE_URI);
     }
 


### PR DESCRIPTION
# Summary
At the moment each DiscordClient in a sharded client has their own restclient which will result in incorrect ratelimiting. This pr adds a new internal constructor to the discordclient which allows to pass a Restclient for the DiscordApiClient