### PR TITLE
Remove restriction from ShardedLoggerFactory

### DIFF
--- a/DSharpPlus/Clients/DiscordShardedClient.cs
+++ b/DSharpPlus/Clients/DiscordShardedClient.cs
@@ -233,7 +233,7 @@ public sealed partial class DiscordShardedClient
 
         this.GatewayInfo = await this.GetGatewayInfoAsync();
         int shardCount = this.Configuration.ShardCount == 1 ? this.GatewayInfo.ShardCount : this.Configuration.ShardCount;
-        ShardedLoggerFactory loggerFactory = new ShardedLoggerFactory(this.Logger);
+        ShardedLoggerFactory loggerFactory = new ShardedLoggerFactory(this.Configuration.LoggerFactory);
         RestClient restClient = new RestClient(this.Configuration, loggerFactory.CreateLogger("Rest"));
         for (int i = 0; i < shardCount; i++)
         {

--- a/DSharpPlus/Logging/DefaultLoggerFactory.cs
+++ b/DSharpPlus/Logging/DefaultLoggerFactory.cs
@@ -11,14 +11,10 @@ internal class DefaultLoggerFactory : ILoggerFactory
 
     public void AddProvider(ILoggerProvider provider) => this.Providers.Add(provider);
 
-    public ILogger CreateLogger(string categoryName)
-    {
-        return this._isDisposed
+    public ILogger CreateLogger(string categoryName) =>
+        this._isDisposed
             ? throw new InvalidOperationException("This logger factory is already disposed.")
-            : (ILogger)(categoryName != typeof(BaseDiscordClient).FullName && categoryName != typeof(DiscordWebhookClient).FullName
-            ? throw new ArgumentException($"This factory can only provide instances of loggers for {typeof(BaseDiscordClient).FullName} or {typeof(DiscordWebhookClient).FullName}.", nameof(categoryName))
-            : new CompositeDefaultLogger(this.Providers));
-    }
+            : new CompositeDefaultLogger(this.Providers);
 
     public void Dispose()
     {

--- a/DSharpPlus/Logging/ShardedLoggerFactory.cs
+++ b/DSharpPlus/Logging/ShardedLoggerFactory.cs
@@ -3,20 +3,18 @@ using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus;
 
+using System.Collections.Concurrent;
+
 internal class ShardedLoggerFactory : ILoggerFactory
 {
-    private ILogger<BaseDiscordClient> Logger { get; }
+    private ConcurrentDictionary<string, ILogger> Loggers { get; } = new();
+    private ILoggerFactory Factory { get; }
 
-    public ShardedLoggerFactory(ILogger<BaseDiscordClient> instance) => this.Logger = instance;
+    public ShardedLoggerFactory(ILoggerFactory factory) => this.Factory = factory;
 
     public void AddProvider(ILoggerProvider provider) => throw new InvalidOperationException("This is a passthrough logger container, it cannot register new providers.");
 
-    public ILogger CreateLogger(string categoryName)
-    {
-        return categoryName != typeof(BaseDiscordClient).FullName
-            ? throw new ArgumentException($"This factory can only provide instances of loggers for {typeof(BaseDiscordClient).FullName}.", nameof(categoryName))
-            : this.Logger;
-    }
+    public ILogger CreateLogger(string categoryName) => this.Loggers.GetOrAdd(categoryName, this.Factory.CreateLogger(categoryName));
 
     public void Dispose()
     { }


### PR DESCRIPTION
# Summary
ShardedLoggerFactory was restricted to only create a logger for a BaseDiscordClient