### PR TITLE
address TimeSpan Too Long errors thrown from using absolute instead of relative resets

### DIFF
--- a/DSharpPlus/Net/Rest/RateLimitBucket.cs
+++ b/DSharpPlus/Net/Rest/RateLimitBucket.cs
@@ -81,7 +81,7 @@ internal record struct RateLimitBucket
             (
                 !headers.TryGetValues("X-RateLimit-Limit", out IEnumerable<string>? limitRaw)
                 || !headers.TryGetValues("X-RateLimit-Remaining", out IEnumerable<string>? remainingRaw)
-                || !headers.TryGetValues("X-RateLimit-Reset", out IEnumerable<string>? ratelimitResetRaw)
+                || !headers.TryGetValues("X-RateLimit-Reset-After", out IEnumerable<string>? ratelimitResetRaw)
             )
             {
                 return false;
@@ -97,7 +97,7 @@ internal record struct RateLimitBucket
                 return false;
             }
 
-            DateTime reset = (DateTimeOffset.UnixEpoch + TimeSpan.FromSeconds(ratelimitReset)).UtcDateTime;
+            DateTime reset = (DateTimeOffset.UtcNow + TimeSpan.FromSeconds(ratelimitReset)).UtcDateTime;
 
             bucket = new(limit, remaining, reset);
             return true;

--- a/DSharpPlus/Net/Rest/RateLimitBucket.cs
+++ b/DSharpPlus/Net/Rest/RateLimitBucket.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http.Headers;
 
@@ -89,9 +90,9 @@ internal record struct RateLimitBucket
 
             if
             (
-                !int.TryParse(limitRaw.SingleOrDefault(), out int limit)
-                || !int.TryParse(remainingRaw.SingleOrDefault(), out int remaining)
-                || !double.TryParse(ratelimitResetRaw.SingleOrDefault(), out double ratelimitReset)
+                !int.TryParse(limitRaw.SingleOrDefault(), CultureInfo.InvariantCulture, out int limit)
+                || !int.TryParse(remainingRaw.SingleOrDefault(), CultureInfo.InvariantCulture, out int remaining)
+                || !double.TryParse(ratelimitResetRaw.SingleOrDefault(), CultureInfo.InvariantCulture, out double ratelimitReset)
             )
             {
                 return false;


### PR DESCRIPTION
it appears that we're running into some length limit, potentially system-specific, here. cc @Aaron2550 does this fix the issue