### PR TITLE
Mark `VoiceNextExtension.GetConnection` return as possible `null` value

### DIFF
--- a/DSharpPlus.VoiceNext/DiscordClientExtensions.cs
+++ b/DSharpPlus.VoiceNext/DiscordClientExtensions.cs
@@ -109,7 +109,7 @@ public static class DiscordClientExtensions
         }
 
         VoiceNextExtension vnext = discord.GetVoiceNext() ?? throw new InvalidOperationException("VoiceNext is not initialized for this Discord client.");
-        VoiceNextConnection vnc = vnext.GetConnection(channel.Guild);
+        VoiceNextConnection? vnc = vnext.GetConnection(channel.Guild);
         return vnc != null
             ? throw new InvalidOperationException("VoiceNext is already connected in this guild.")
             : vnext.ConnectAsync(channel);

--- a/DSharpPlus.VoiceNext/VoiceNextExtension.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextExtension.cs
@@ -127,7 +127,7 @@ public sealed class VoiceNextExtension : BaseExtension
     /// </summary>
     /// <param name="guild">Guild to get VoiceNext connection for.</param>
     /// <returns>VoiceNext connection for the specified guild.</returns>
-    public VoiceNextConnection GetConnection(DiscordGuild guild)
+    public VoiceNextConnection? GetConnection(DiscordGuild guild)
         => this.ActiveConnections.ContainsKey(guild.Id) ? this.ActiveConnections[guild.Id] : null;
 
     private async Task Vnc_VoiceDisconnected(DiscordGuild guild)


### PR DESCRIPTION
# Summary
Adds `?` to the return type of `VoiceNextExtension.GetConnection`, since this has the possibility of returning `null`

# Notes
I don't know if this is a breaking change or even wanted. I was confused by this function not having a "failing" path hinted by my IDE, so i looked into the code and realized this might return `null`.