### PR TITLE
let users defer ephemerally

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandContext.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandContext.cs
@@ -49,6 +49,8 @@ public record SlashCommandContext : CommandContext
         this.State |= InteractionStatus.ResponseDelayed;
     }
 
+    /// <inheritdoc cref="DeferResponseAsync()"/>
+    /// <param name="ephemeral">Specifies whether this response should be ephemeral.</param>
     public async ValueTask DeferResponseAsync(bool ephemeral)
     {
         await this.Interaction.CreateResponseAsync

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandContext.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandContext.cs
@@ -49,6 +49,17 @@ public record SlashCommandContext : CommandContext
         this.State |= InteractionStatus.ResponseDelayed;
     }
 
+    public async ValueTask DeferResponseAsync(bool ephemeral)
+    {
+        await this.Interaction.CreateResponseAsync
+        (
+            InteractionResponseType.DeferredChannelMessageWithSource,
+            new DiscordInteractionResponseBuilder().AsEphemeral(ephemeral)
+        );
+
+        this.State |= InteractionStatus.ResponseDelayed;
+    }
+
     /// <inheritdoc />
     public override async ValueTask EditResponseAsync(IDiscordMessageBuilder builder)
     {


### PR DESCRIPTION
ephemerality of an original response needs to be specified when creating the response and cannot be edited in, so, here we go.