### PR TITLE
Update AUCD to reload DocBot

### DIFF
--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -66,6 +66,8 @@ jobs:
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
           DISCORD_CHANNEL_ID: ${{ secrets.DISCORD_CHANNEL_ID }}
           DISCORD_CHANNEL_TOPIC: ${{ secrets.DISCORD_CHANNEL_TOPIC }}
+          DISCORD_DOC_BOT_USER_ID: ${{ secrets.DISCORD_DOC_BOT_USER_ID }}
+          DISCORD_BOT_USAGE_CHANNEL_ID: ${{ secrets.DISCORD_BOT_USAGE_CHANNEL_ID }}
           NUGET_URL: ${{ secrets.NUGET_URL }}
           GITHUB_URL : ${{ github.server_url }}/${{ github.repository }}
       - name: Upload Artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}
           DISCORD_CHANNEL_ID: ${{ secrets.DISCORD_CHANNEL_ID }}
           DISCORD_CHANNEL_TOPIC: ${{ secrets.DISCORD_CHANNEL_TOPIC }}
+          DISCORD_DOC_BOT_USER_ID: ${{ secrets.DISCORD_DOC_BOT_USER_ID }}
+          DISCORD_BOT_USAGE_CHANNEL_ID: ${{ secrets.DISCORD_BOT_USAGE_CHANNEL_ID }}
           NUGET_URL: ${{ secrets.NUGET_URL }}
           GITHUB_URL : ${{ github.server_url }}/${{ github.repository }}
       - name: Upload Artifact

--- a/tools/AutoUpdateChannelDescription/Program.cs
+++ b/tools/AutoUpdateChannelDescription/Program.cs
@@ -17,6 +17,8 @@ public sealed class Program
         string guildId = Environment.GetEnvironmentVariable("DISCORD_GUILD_ID") ?? throw new InvalidOperationException("DISCORD_GUILD_ID environment variable is not set.");
         string channelId = Environment.GetEnvironmentVariable("DISCORD_CHANNEL_ID") ?? throw new InvalidOperationException("DISCORD_CHANNEL_ID environment variable is not set.");
         string channelTopic = Environment.GetEnvironmentVariable("DISCORD_CHANNEL_TOPIC") ?? throw new InvalidOperationException("DISCORD_DESCRIPTION environment variable is not set.");
+        string docBotUserId = Environment.GetEnvironmentVariable("DISCORD_DOC_BOT_USER_ID") ?? throw new InvalidOperationException("DISCORD_DOC_BOT_USER_ID environment variable is not set.");
+        string botUsageChannelId = Environment.GetEnvironmentVariable("DISCORD_BOT_USAGE_CHANNEL_ID") ?? throw new InvalidOperationException("DISCORD_BOT_USAGE_CHANNEL_ID environment variable is not set.");
         string nugetUrl = Environment.GetEnvironmentVariable("NUGET_URL") ?? throw new InvalidOperationException("NUGET_URL environment variable is not set.");
         string githubUrl = Environment.GetEnvironmentVariable("GITHUB_URL") ?? throw new InvalidOperationException("GITHUB_URL environment variable is not set.");
         string? latestStableVersion = Environment.GetEnvironmentVariable("LATEST_STABLE_VERSION");
@@ -57,6 +59,15 @@ public sealed class Program
 
             // Update the channel topic with the latest nightly version.
             builder.AppendLine(Formatter.Bold("Latest preview version") + ": " + nugetUrl + "/" + nightlyVersion);
+
+            try
+            {
+                await channel.SendMessageAsync($"<@{docBotUserId}> reload");
+            }
+            catch (DiscordException error)
+            {
+                Console.WriteLine($"Error: HTTP {error.Response!.StatusCode}, {await error.Response.Content.ReadAsStringAsync()}");
+            }
 
             try
             {


### PR DESCRIPTION
# Summary
When a new commit is pushed, this tool will ping DocBot (itself) and execute the reload command via text. Even though the bot is restarted everyday at midnight CST, this should still be helpful to ensure the bot's documentation is always up-to-date.

# Details
This should work for the following reasons:
- By default, DSharpPlus.Commands do not ignore commands from bots. This could be considered a security issue, however I personally consider bots should be treated the same as a user. Save this debate for a different GitHub issue.
- DocBot uses a custom `RequireOwnerAttribute` which checks to see if it's the bot itself that executed the command. `Client.CurrentApplication.Owners` does not include the bot itself but rather just the application team members.