### PR TITLE
Add fetching guilds over rest

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -840,7 +840,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
     /// <summary>
     /// Returns a list of guilds before a certain guild.
     /// <param name="limit">The amount of guilds to fetch.</param>
-    /// <param name="before">guild to fetch before from.</param>
+    /// <param name="before">Id of the guild before which we fetch the guilds</param>
     /// <param name="withCount">Whether to include approximate member and presence counts in the returned guilds.</param>
     /// </summary>
     /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
@@ -851,7 +851,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
     /// <summary>
     /// Returns a list of guilds after a certain guild.
     /// <param name="limit">The amount of guilds to fetch.</param>
-    /// <param name="after">guild to fetch after from.</param>
+    /// <param name="after">Id of the guild after which we fetch the guilds.</param>
     /// <param name="withCount">Whether to include approximate member and presence counts in the returned guilds.</param>
     /// </summary>
     /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
@@ -902,9 +902,9 @@ public sealed partial class DiscordClient : BaseDiscordClient
 
             if (!isbefore)
             {
-                foreach (DiscordGuild msg in sortedGuildsArray)
+                foreach (DiscordGuild guild in sortedGuildsArray)
                 {
-                    yield return msg;
+                    yield return guild;
                 }
                 last = sortedGuildsArray.LastOrDefault()?.Id;
             }

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -856,7 +856,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
     /// </summary>
     /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
     /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-    public IAsyncEnumerable<DiscordGuild> GetMessagesAfterAsync(ulong after, int limit = 100, bool? withCount = null)
+    public IAsyncEnumerable<DiscordGuild> GetGuildsAfterAsync(ulong after, int limit = 100, bool? withCount = null)
         => this.GetGuildsInternalAsync(limit, null, after, null);
     
     /// <summary>
@@ -866,7 +866,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
     /// </summary>
     /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
     /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-    public IAsyncEnumerable<DiscordGuild> GetMessagesAsync(int limit = 100, bool? withCount = null) =>
+    public IAsyncEnumerable<DiscordGuild> GetGuildsAsync(int limit = 100, bool? withCount = null) =>
         this.GetGuildsInternalAsync(limit, null, null, withCount);
     
     private async IAsyncEnumerable<DiscordGuild> GetGuildsInternalAsync(int limit = 200, ulong? before = null, ulong? after = null, bool? withCount = null)

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -835,6 +835,91 @@ public sealed partial class DiscordClient : BaseDiscordClient
     /// <param name="commandId">The ID of the command.</param>
     public async Task DeleteGuildApplicationCommandAsync(ulong guildId, ulong commandId) =>
         await this.ApiClient.DeleteGuildApplicationCommandAsync(this.CurrentApplication.Id, guildId, commandId);
+    
+    
+    /// <summary>
+    /// Returns a list of guilds before a certain guild.
+    /// <param name="limit">The amount of guilds to fetch.</param>
+    /// <param name="before">guild to fetch before from.</param>
+    /// <param name="withCount">Whether to include approximate member and presence counts in the returned guilds.</param>
+    /// </summary>
+    /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
+    /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+    public IAsyncEnumerable<DiscordGuild> GetGuildsBeforeAsync(ulong before, int limit = 200, bool? withCount = null)
+        => this.GetGuildsInternalAsync(limit, before, null, null);
+
+    /// <summary>
+    /// Returns a list of guilds after a certain guild.
+    /// <param name="limit">The amount of guilds to fetch.</param>
+    /// <param name="after">guild to fetch after from.</param>
+    /// <param name="withCount">Whether to include approximate member and presence counts in the returned guilds.</param>
+    /// </summary>
+    /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
+    /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+    public IAsyncEnumerable<DiscordGuild> GetMessagesAfterAsync(ulong after, int limit = 100, bool? withCount = null)
+        => this.GetGuildsInternalAsync(limit, null, after, null);
+    
+    /// <summary>
+    /// Returns a list of guilds the bot is in.
+    /// <param name="limit">The amount of guilds to fetch.</param>
+    /// <param name="withCount">Whether to include approximate member and presence counts in the returned guilds.</param>
+    /// </summary>
+    /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
+    /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+    public IAsyncEnumerable<DiscordGuild> GetMessagesAsync(int limit = 100, bool? withCount = null) =>
+        this.GetGuildsInternalAsync(limit, null, null, withCount);
+    
+    private async IAsyncEnumerable<DiscordGuild> GetGuildsInternalAsync(int limit = 200, ulong? before = null, ulong? after = null, bool? withCount = null)
+    {
+        if (limit < 0)
+        {
+            throw new ArgumentException("Cannot get a negative number of guilds.");
+        }
+
+        if (limit == 0)
+        {
+            yield break;
+        }
+        
+        List<DiscordGuild> guilds = new(limit);
+        int remaining = limit;
+        ulong? last = null;
+        bool isbefore = before != null;
+
+        int lastCount;
+        do
+        {
+            int fetchSize = remaining > 100 ? 100 : remaining;
+            IReadOnlyList<DiscordGuild> fetchedGuilds = await this.ApiClient.GetGuildsAsync( fetchSize, isbefore ? last ?? before : null, !isbefore ? last ?? after : null, withCount);
+
+            lastCount = fetchedGuilds.Count;
+            remaining -= lastCount;
+            
+            //We sort the returned guilds by ID so that they are in order in case Discord switches the order AGAIN.
+            DiscordGuild[] sortedGuildsArray = fetchedGuilds.ToArray();
+            Array.Sort(sortedGuildsArray, (x, y) => x.Id.CompareTo(y.Id));
+            
+
+            if (!isbefore)
+            {
+                foreach (DiscordGuild msg in sortedGuildsArray)
+                {
+                    yield return msg;
+                }
+                last = sortedGuildsArray.LastOrDefault()?.Id;
+            }
+            else
+            {
+                for (int i = sortedGuildsArray.Length - 1; i >= 0; i--)
+                {
+                    yield return sortedGuildsArray[i];
+                }
+                last = sortedGuildsArray.FirstOrDefault()?.Id;
+            }
+        }
+        while (remaining > 0 && lastCount is > 0 and 100);
+    }
+    
     #endregion
 
     #region Internal Caching Methods

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -840,7 +840,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
     /// <summary>
     /// Returns a list of guilds before a certain guild.
     /// <param name="limit">The amount of guilds to fetch.</param>
-    /// <param name="before">Id of the guild before which we fetch the guilds</param>
+    /// <param name="before">The ID of the guild before which we fetch the guilds</param>
     /// <param name="withCount">Whether to include approximate member and presence counts in the returned guilds.</param>
     /// </summary>
     /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
@@ -851,7 +851,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
     /// <summary>
     /// Returns a list of guilds after a certain guild.
     /// <param name="limit">The amount of guilds to fetch.</param>
-    /// <param name="after">Id of the guild after which we fetch the guilds.</param>
+    /// <param name="after">The ID of the guild after which we fetch the guilds.</param>
     /// <param name="withCount">Whether to include approximate member and presence counts in the returned guilds.</param>
     /// </summary>
     /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -194,12 +194,16 @@ public sealed class DiscordApiClient
         foreach (JToken token in jArray)
         {
             DiscordGuild guildRest = token.ToDiscordObject<DiscordGuild>();
-            foreach (DiscordRole role in guildRest._roles.Values)
-            {
-                role._guild_id = guildRest.Id;
-                role.Discord = this._discord!;
-            }
 
+            if (guildRest._roles is not null)
+            {
+                foreach (DiscordRole role in guildRest._roles.Values)
+                {
+                    role._guild_id = guildRest.Id;
+                    role.Discord = this._discord!;
+                }
+            }
+            
             guildRest.Discord = this._discord!;
             guilds.Add(guildRest);
         }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -146,6 +146,67 @@ public sealed class DiscordApiClient
 
     #region Guild
 
+    internal async ValueTask<IReadOnlyList<DiscordGuild>> GetGuildsAsync
+    (
+        int? limit = null,
+        ulong? before = null,
+        ulong? after = null,
+        bool? withCounts = null
+    )
+    {
+        QueryUriBuilder builder = new($"{Endpoints.USERS}/@me/{Endpoints.GUILDS}");
+
+        if (limit is not null)
+        {
+            if (limit < 1 || limit > 200)
+            {
+                throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be a number between 1 and 200.");
+            }
+            builder.AddParameter("limit", limit.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (before is not null)
+        {
+            builder.AddParameter("before", before.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (after is not null)
+        {
+            builder.AddParameter("after", after.Value.ToString(CultureInfo.InvariantCulture));
+        }
+        
+        if (withCounts is not null)
+        {
+            builder.AddParameter("with_counts", withCounts.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        RestRequest request = new()
+        {
+            Route = $"/{Endpoints.USERS}/@me/{Endpoints.GUILDS}", Url = builder.Build(), Method = HttpMethod.Get
+        };
+
+        RestResponse response = await this._rest.ExecuteRequestAsync(request);
+
+        JArray jArray = JArray.Parse(response.Response!);
+
+        List<DiscordGuild> guilds = new(200);
+
+        foreach (JToken token in jArray)
+        {
+            DiscordGuild guildRest = token.ToDiscordObject<DiscordGuild>();
+            foreach (DiscordRole role in guildRest._roles.Values)
+            {
+                role._guild_id = guildRest.Id;
+                role.Discord = this._discord!;
+            }
+
+            guildRest.Discord = this._discord!;
+            guilds.Add(guildRest);
+        }
+
+        return guilds;
+    }
+
     internal async ValueTask<IReadOnlyList<DiscordMember>> SearchMembersAsync
     (
         ulong guildId,


### PR DESCRIPTION
# Summary
Adds the `/users/@me/guilds` endpoint to the DiscordApiClient and exposes a `IAsyncEnumerable<DiscordGuild>` through `DiscordClient#GetGuilds*Async`