### PR TITLE
Send Flags when creating a message with a Messagebuilder

### DIFF
--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -2134,7 +2134,8 @@ public sealed class DiscordApiClient
             IsTTS = builder.IsTTS,
             HasEmbed = builder.Embeds != null,
             Embeds = builder.Embeds,
-            Components = builder.Components
+            Components = builder.Components,
+            Flags = builder.Flags
         };
 
         if (builder.ReplyId != null)


### PR DESCRIPTION
# Summary
We didnt send the flags from the MessageBuilder when creating a message

# Notes
fixes #1740 