### PR TITLE
send default member permissions as strings

### DIFF
--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
+
+using DSharpPlus.Net.Serialization;
+
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities;
@@ -46,6 +49,7 @@ public sealed class DiscordApplicationCommand : SnowflakeObject, IEquatable<Disc
     /// Gets whether the command is enabled by default when the application is added to a guild.
     /// </summary>
     [JsonProperty("default_permission")]
+    [JsonConverter(typeof(DiscordPermissionsAsStringJsonConverter))]
     public bool? DefaultPermission { get; internal set; }
 
     /// <summary>

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
@@ -49,7 +49,6 @@ public sealed class DiscordApplicationCommand : SnowflakeObject, IEquatable<Disc
     /// Gets whether the command is enabled by default when the application is added to a guild.
     /// </summary>
     [JsonProperty("default_permission")]
-    [JsonConverter(typeof(DiscordPermissionsAsStringJsonConverter))]
     public bool? DefaultPermission { get; internal set; }
 
     /// <summary>
@@ -62,6 +61,7 @@ public sealed class DiscordApplicationCommand : SnowflakeObject, IEquatable<Disc
     /// What permissions this command requires to be invoked.
     /// </summary>
     [JsonProperty("default_member_permissions")]
+    [JsonConverter(typeof(DiscordPermissionsAsStringJsonConverter))]
     public Permissions? DefaultMemberPermissions { get; internal set; }
 
     /// <summary>

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
@@ -4,8 +4,6 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 
-using DSharpPlus.Net.Serialization;
-
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities;
@@ -61,7 +59,6 @@ public sealed class DiscordApplicationCommand : SnowflakeObject, IEquatable<Disc
     /// What permissions this command requires to be invoked.
     /// </summary>
     [JsonProperty("default_member_permissions")]
-    [JsonConverter(typeof(DiscordPermissionsAsStringJsonConverter))]
     public Permissions? DefaultMemberPermissions { get; internal set; }
 
     /// <summary>

--- a/DSharpPlus/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using DSharpPlus.Entities;
+using DSharpPlus.Net.Serialization;
+
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Net.Abstractions;
@@ -31,6 +33,7 @@ internal class RestApplicationCommandCreatePayload
     public bool? AllowDMUsage { get; set; }
 
     [JsonProperty("default_member_permissions", NullValueHandling = NullValueHandling.Ignore)]
+    [JsonConverter(typeof(DiscordPermissionsAsStringJsonConverter))]
     public Permissions? DefaultMemberPermissions { get; set; }
 
     [JsonProperty("nsfw", NullValueHandling = NullValueHandling.Ignore)]

--- a/DSharpPlus/Net/Serialization/DiscordPermissionsAsStringJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/DiscordPermissionsAsStringJsonConverter.cs
@@ -25,5 +25,14 @@ internal sealed class DiscordPermissionsAsStringJsonConverter : JsonConverter<Pe
     }
 
     public override void WriteJson(JsonWriter writer, Permissions value, JsonSerializer serializer)
-        => writer.WriteValue(((ulong)value).ToString(CultureInfo.InvariantCulture));
+    {
+        if ((ulong)value == 0)
+        {
+            writer.WriteNull();
+        }
+        else
+        {
+            writer.WriteValue(((ulong)value).ToString(CultureInfo.InvariantCulture));
+        }
+    }
 }

--- a/DSharpPlus/Net/Serialization/DiscordPermissionsAsStringJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/DiscordPermissionsAsStringJsonConverter.cs
@@ -1,0 +1,29 @@
+namespace DSharpPlus.Net.Serialization;
+
+using System;
+using System.Globalization;
+
+using Newtonsoft.Json;
+
+/// <summary>
+/// Facilitates serializing permissions as string.
+/// </summary>
+internal sealed class DiscordPermissionsAsStringJsonConverter : JsonConverter<Permissions>
+{
+    public override Permissions ReadJson
+    (
+        JsonReader reader,
+        Type objectType,
+        Permissions existingValue,
+        bool hasExistingValue,
+        JsonSerializer serializer
+    )
+    {
+        string? value = reader.ReadAsString();
+
+        return value is not null ? (Permissions)ulong.Parse(value) : existingValue;
+    }
+
+    public override void WriteJson(JsonWriter writer, Permissions value, JsonSerializer serializer)
+        => writer.WriteValue(((ulong)value).ToString(CultureInfo.InvariantCulture));
+}


### PR DESCRIPTION
discord, in their [docs](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure), specifies that `default_member_permissions` should be sent as string, but we currently send it as integer. this is suspected to cause problems with the new commands extension.

fixes #1743 