### PR TITLE
Pass the parameter description instead of the command description

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -391,7 +391,7 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
 
         if (!descriptionLocalizations.TryGetValue("en-US", out string? description))
         {
-            description = command.Description;
+            description = parameter.Description;
         }
 
         if (string.IsNullOrWhiteSpace(description))


### PR DESCRIPTION
# Summary
Previously slash commands passed the command description as the parameter description. Now they do not.

Before:
![image](https://github.com/DSharpPlus/DSharpPlus/assets/46751150/f65a33fd-64f9-4f4d-9e2f-406a8c600455)

After:
![image](https://github.com/DSharpPlus/DSharpPlus/assets/46751150/16ae905b-cd98-4a80-8b73-70e02930fa3b)
