### PR TITLE
DiscordMessageBuilder: MentionedUsers is not null on copy

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -104,7 +104,7 @@ public sealed class DiscordMessageBuilder : BaseDiscordMessageBuilder<DiscordMes
         this._stickers = [.. baseMessage.Stickers];
         this._mentions = [];
 
-        if (baseMessage._mentionedRoles != null)
+        if (baseMessage._mentionedUsers != null)
         {
             foreach (DiscordUser user in baseMessage._mentionedUsers)
             {


### PR DESCRIPTION
# Summary
Currently when copying a Discord message through the Discord Message Builder, it checks for mentioned roles before copying the mentioned users. Now it does not.

# Notes
Untested.