### PR TITLE
fixes one potential edge case in ratelimiting

### DIFF
--- a/DSharpPlus/Net/Rest/RateLimitBucket.cs
+++ b/DSharpPlus/Net/Rest/RateLimitBucket.cs
@@ -113,7 +113,13 @@ internal record struct RateLimitBucket
     {
         if (this.Remaining <= 0)
         {
-            return this.Reset < DateTime.UtcNow;
+            if (this.Reset < DateTime.UtcNow)
+            {
+                this._remaining = this.Maximum - 1;
+                return true;
+            }
+
+            return false;
         }
 
         this._remaining--;


### PR DESCRIPTION
hypothetically, if we were querying an expired bucket, we wouldn't locally decrement the remaining limit. this would lead to the limit being unknown and unchecked for brief timespans normally, unless we get scheduled away from working, which would allow a series of 429s to happen.

this is not a case we have concrete evidence of being hit in the open, but i don't think it can hurt to fix anyway