### PR TITLE
Nuke `DiscordConfiguration#UseRelativeRatelimits`

### DIFF
--- a/DSharpPlus/Clients/DiscordWebhookClient.cs
+++ b/DSharpPlus/Clients/DiscordWebhookClient.cs
@@ -63,7 +63,7 @@ public class DiscordWebhookClient
     /// <param name="loggerFactory">The optional logging factory to use for this client.</param>
     /// <param name="minimumLogLevel">The minimum logging level for messages.</param>
     /// <param name="logTimestampFormat">The timestamp format to use for the logger.</param>
-    public DiscordWebhookClient(IWebProxy proxy = null, TimeSpan? timeout = null, bool useRelativeRateLimit = true,
+    public DiscordWebhookClient(IWebProxy proxy = null, TimeSpan? timeout = null,
         ILoggerFactory loggerFactory = null, LogLevel minimumLogLevel = LogLevel.Information, string logTimestampFormat = "yyyy-MM-dd HH:mm:ss zzz")
     {
         this._minimumLogLevel = minimumLogLevel;

--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -43,14 +43,6 @@ public sealed class DiscordConfiguration
     public LogLevel MinimumLogLevel { internal get; set; } = LogLevel.Information;
 
     /// <summary>
-    /// <para>Sets whether to rely on Discord for NTP (Network Time Protocol) synchronization with the "X-Ratelimit-Reset-After" header.</para>
-    /// <para>If the system clock is not synced, setting this to true will ensure ratelimits are synced with Discord and reduce the risk of hitting one.</para>
-    /// <para>This should only be set to false if the system clock is synced with NTP.</para>
-    /// <para>Defaults to true.</para>
-    /// </summary>
-    public bool UseRelativeRatelimit { internal get; set; } = true;
-
-    /// <summary>
     /// <para>Allows you to overwrite the time format used by the internal debug logger.</para>
     /// <para>Only applicable when <see cref="LoggerFactory"/> is set left at default value. Defaults to ISO 8601-like format.</para>
     /// </summary>
@@ -194,7 +186,6 @@ public sealed class DiscordConfiguration
         this.Token = other.Token;
         this.TokenType = other.TokenType;
         this.MinimumLogLevel = other.MinimumLogLevel;
-        this.UseRelativeRatelimit = other.UseRelativeRatelimit;
         this.LogTimestampFormat = other.LogTimestampFormat;
         this.LargeThreshold = other.LargeThreshold;
         this.AutoReconnect = other.AutoReconnect;


### PR DESCRIPTION
# Summary
`DiscordConfiguration#UseRelativeRatelimit` isnt used since our Rest update (#1624) and since #1718 the defacto standard. 