### PR TITLE
Wait for response when we dont have a hash for a route

### DIFF
--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -80,8 +80,9 @@ public sealed class DiscordConfiguration
     public GatewayCompressionLevel GatewayCompressionLevel { internal get; set; } = GatewayCompressionLevel.Stream;
     
     /// <summary>
-    /// <para>Specifies the probing interval in ms to use when first making requests to the API. Should be slightly higher than your average ping to the discord rest api.</para>
-    /// <para>Defaults to 200 ms</para>
+    /// Specifies the probing interval in ms to use when first making requests to the API. This should be slightly higher than your average ping to the discord rest api.
+    /// <br/>
+    /// Defaults to 200 ms
     /// </summary>
     public int TimeoutForInitialApiRequest { internal get; set; } = 200;
 

--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -78,6 +78,12 @@ public sealed class DiscordConfiguration
     /// <para>Defaults to <see cref="Stream"/>.</para>
     /// </summary>
     public GatewayCompressionLevel GatewayCompressionLevel { internal get; set; } = GatewayCompressionLevel.Stream;
+    
+    /// <summary>
+    /// <para>Specifies the probing interval in ms to use when first making requests to the API. Should be slightly higher than your average ping to the discord rest api.</para>
+    /// <para>Defaults to 200 ms</para>
+    /// </summary>
+    public int TimeoutForInitialApiRequest { internal get; set; } = 200;
 
     /// <summary>
     /// <para>Sets the size of the global message cache.</para>

--- a/DSharpPlus/Net/Rest/RateLimitPolicy.cs
+++ b/DSharpPlus/Net/Rest/RateLimitPolicy.cs
@@ -22,6 +22,18 @@ internal class RateLimitPolicy : AsyncPolicy<HttpResponseMessage>
     private readonly MemoryCache cache;
     private readonly ILogger logger;
     private readonly ConcurrentDictionary<string, string> routeHashes;
+    
+    /// <summary>
+    /// Collection of routes we are waiting for a hash. This is the case when we have a request for which we dont know the
+    /// hash but are waiting for a response to get it.
+    /// </summary>
+    private List<string> waitingForHashRoutes;
+    private SemaphoreSlim waitingForHashListSemaphore = new(1, 1);
+    
+    /// <summary>
+    /// Time to wait for a response to set the hash for a route.
+    /// </summary>
+    private readonly int waitingForHashMilliseconds = 200;
     private static readonly TimeSpan second = TimeSpan.FromSeconds(1);
 
     public RateLimitPolicy(ILogger logger)
@@ -117,6 +129,48 @@ internal class RateLimitPolicy : AsyncPolicy<HttpResponseMessage>
                     return synthesizedResponse;
                 }
             }
+            else
+            {
+                this.logger.LogTrace
+                (
+                    LoggerEvents.RatelimitDiag,
+                    "Route has no known bucket: {Route}.",
+                    route
+                );
+            }
+        }
+        else
+        {
+            this.logger.LogTrace
+            (
+                LoggerEvents.RatelimitPreemptive,
+                "Route has no known hash: {Route}.",
+                route
+            );
+            
+            //We dont know the hash of the route, so we check if we have a request where we will get the hash. Otherwise
+            //we will add the route to our list of routes we are waiting for a hash.
+            await this.waitingForHashListSemaphore.WaitAsync(cancellationToken);
+            if (this.waitingForHashRoutes.Contains(route))
+            {
+                HttpResponseMessage synthesizedResponse = new(HttpStatusCode.TooManyRequests);
+                
+                DateTimeOffset reset = instant.AddMilliseconds(this.waitingForHashMilliseconds);
+
+                synthesizedResponse.Headers.RetryAfter = new RetryConditionHeaderValue(reset);
+                synthesizedResponse.Headers.Add("DSharpPlus-Internal-Response", "waitingOnHash");
+
+                this.logger.LogWarning
+                (
+                    LoggerEvents.RatelimitPreemptive,
+                    "Pre-emptive ratelimit triggered, waiting for route hash until {reset:yyyy-MM-dd HH:mm:ss zzz}.",
+                    reset
+                );
+                waitingForHashRoutes.Add(route);
+                return synthesizedResponse;
+            }
+            
+            this.waitingForHashListSemaphore.Release();
         }
 
         // make the actual request
@@ -126,6 +180,14 @@ internal class RateLimitPolicy : AsyncPolicy<HttpResponseMessage>
 
         if (!exemptFromGlobalLimit && hasBucketHeader)
         {
+            // the request had no known hash, we remove the route from the waiting list because we got a hash now
+            if (!hashPresent)
+            {
+                await this.waitingForHashListSemaphore.WaitAsync(cancellationToken);
+                this.waitingForHashRoutes.Remove(route);
+                this.waitingForHashListSemaphore.Release();
+            }
+            
             hash = hashHeader?.Single();
 
             if(!RateLimitBucket.TryExtractRateLimitBucket(response.Headers, out RateLimitBucket? extracted))

--- a/DSharpPlus/Net/Rest/RateLimitPolicy.cs
+++ b/DSharpPlus/Net/Rest/RateLimitPolicy.cs
@@ -36,7 +36,7 @@ internal class RateLimitPolicy : AsyncPolicy<HttpResponseMessage>
     private readonly int waitingForHashMilliseconds = 200;
     private static readonly TimeSpan second = TimeSpan.FromSeconds(1);
 
-    public RateLimitPolicy(ILogger logger)
+    public RateLimitPolicy(ILogger logger, int waitingForHashMilliseconds = 200)
     {
         this.globalBucket = new(50, 50, DateTime.UtcNow.AddSeconds(1));
 
@@ -51,6 +51,8 @@ internal class RateLimitPolicy : AsyncPolicy<HttpResponseMessage>
 
         this.logger = logger;
         this.routeHashes = new();
+        this.waitingForHashRoutes = new();
+        this.waitingForHashMilliseconds = waitingForHashMilliseconds;
     }
 
     protected override async Task<HttpResponseMessage> ImplementationAsync

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -39,7 +39,8 @@ internal sealed partial class RestClient : IDisposable
         (
             config.Proxy,
             config.HttpTimeout,
-            logger
+            logger,
+            config.TimeoutForInitialApiRequest
         )
     {
         this.HttpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", Utilities.GetFormattedToken(config));
@@ -51,7 +52,8 @@ internal sealed partial class RestClient : IDisposable
     (
         IWebProxy proxy,
         TimeSpan timeout,
-        ILogger logger
+        ILogger logger,
+        int waitingForHashMilliseconds = 200
     )
     {
         this.Logger = logger;


### PR DESCRIPTION
# Summary
Fixes issue with ratelimiting. When we dont know a routes ratelimiting hash we will wait for the response to be complete to update our routes-to-hash table and prevent further request to this route until we got the response for the first call to the route