### PR TITLE
kills an allocation in parsing the response for good measure

### DIFF
--- a/DSharpPlus/Net/Rest/RateLimitBucket.cs
+++ b/DSharpPlus/Net/Rest/RateLimitBucket.cs
@@ -75,11 +75,10 @@ internal sealed class RateLimitBucket
     (
         HttpResponseHeaders headers,
 
-        [NotNullWhen(true)]
-        out RateLimitBucket? bucket
+        out RateLimitCandidateBucket bucket
     )
     {
-        bucket = null!;
+        bucket = default;
 
         try
         {

--- a/DSharpPlus/Net/Rest/RateLimitCandidateBucket.cs
+++ b/DSharpPlus/Net/Rest/RateLimitCandidateBucket.cs
@@ -1,0 +1,12 @@
+namespace DSharpPlus.Net;
+
+using System;
+
+/// <summary>
+/// A value-type variant of <seealso cref="RateLimitBucket"/> for extraction, in case we don't need the object.
+/// </summary>
+internal readonly record struct RateLimitCandidateBucket(int Maximum, int Remaining, DateTime Reset)
+{
+    public RateLimitBucket ToFullBucket() 
+        => new(this.Maximum, this.Remaining, this.Reset);
+}

--- a/DSharpPlus/Net/Rest/RateLimitStrategy.cs
+++ b/DSharpPlus/Net/Rest/RateLimitStrategy.cs
@@ -175,23 +175,23 @@ internal class RateLimitStrategy : ResilienceStrategy<HttpResponseMessage>, IDis
         {
             string newHash = hashHeader?.Single()!;
 
-            if (!RateLimitBucket.TryExtractRateLimitBucket(response.Headers, out RateLimitBucket? extracted))
+            if (!RateLimitBucket.TryExtractRateLimitBucket(response.Headers, out RateLimitCandidateBucket extracted))
             {
                 return;
             }
             else if (oldHash != newHash)
             {
-                this.buckets.AddOrUpdate(newHash, _ => extracted, (_, _) => extracted);
+                this.buckets.AddOrUpdate(newHash, _ => extracted.ToFullBucket(), (_, _) => extracted.ToFullBucket());
             }
             else
             {
                 if (this.buckets.TryGetValue(newHash, out RateLimitBucket? oldBucket))
                 {
-                    oldBucket.UpdateBucket(extracted.maximum, extracted.remaining, extracted.Reset);
+                    oldBucket.UpdateBucket(extracted.Maximum, extracted.Remaining, extracted.Reset);
                 }
                 else
                 {
-                    this.buckets.AddOrUpdate(newHash, _ => extracted, (_, _) => extracted);
+                    this.buckets.AddOrUpdate(newHash, _ => extracted.ToFullBucket(), (_, _) => extracted.ToFullBucket());
                 }
             }
 


### PR DESCRIPTION
we used to always allocate a new bucket for extraction, now we dont :)