### PR TITLE
fixes checks in general and RequireApplicationOwnerCheck in specific

### DIFF
--- a/DSharpPlus.Commands/ContextChecks/RequireApplicationOwnerCheck.cs
+++ b/DSharpPlus.Commands/ContextChecks/RequireApplicationOwnerCheck.cs
@@ -9,9 +9,9 @@ internal sealed class RequireApplicationOwnerCheck : IContextCheck<RequireApplic
     {
         return ValueTask.FromResult
         (
-            context.Client.CurrentApplication.Owners?.Contains(context.User) ?? context.User.Id == context.Client.CurrentUser.Id
-                ? "This command must be executed by an owner of the application."
-                : null
+            context.Client.CurrentApplication.Owners?.Contains(context.User) == true || context.User.Id == context.Client.CurrentUser.Id
+                ? null    
+                : "This command must be executed by an owner of the application."
         );
     }
 }


### PR DESCRIPTION
the Unsafe.As is fine because it down-casts the generic parameters to a less specific type, it doesn't actually influence the object types