### PR TITLE
Polly dont support -1 as infinite

### DIFF
--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -51,7 +51,7 @@ internal sealed partial class RestClient : IDisposable
         IWebProxy proxy,
         TimeSpan timeout,
         ILogger logger,
-        int maxRetries = -1,
+        int maxRetries = int.MaxValue,
         double retryDelayFallback = 2.5,
         int waitingForHashMilliseconds = 200
     )


### PR DESCRIPTION
# Summary
Polly does not support using -1 as infinite which was the default value used for "meta clients" (webhookclient, DSP.Rest)