### PR TITLE
fix the global bucket

### DIFF
--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -192,6 +192,16 @@ public sealed class DiscordConfiguration
     public double RatelimitRetryDelayFallback { internal get; set; } = 2.5;
 
     /// <summary>
+    /// Specifies the maximum rest requests to attempt per second. Defaults to 15.
+    /// </summary>
+    /// <remarks>
+    /// This is a band-aid for large bots and will be removed in a future version. Do not set this value above 50 unless Discord has
+    /// approved you for an increase, and only increase it if your bot is flooding many different endpoints on different guilds and
+    /// channels. If your bot is heavily flooding very few endpoints, you may even reduce this limit.
+    /// </remarks>
+    public int MaximumRestRequestsPerSecond { internal get; set; } = 15;
+
+    /// <summary>
     /// Creates a new configuration with default values.
     /// </summary>
     public DiscordConfiguration()
@@ -223,5 +233,8 @@ public sealed class DiscordConfiguration
         this.LogUnknownEvents = other.LogUnknownEvents;
         this.LogUnknownAuditlogs = other.LogUnknownAuditlogs;
         this.MessageCacheProvider = other.MessageCacheProvider;
+        this.MaximumRatelimitRetries = other.MaximumRatelimitRetries;
+        this.RatelimitRetryDelayFallback = other.RatelimitRetryDelayFallback;
+        this.MaximumRestRequestsPerSecond = other.MaximumRestRequestsPerSecond;
     }
 }

--- a/DSharpPlus/Net/Rest/RateLimitBucket.cs
+++ b/DSharpPlus/Net/Rest/RateLimitBucket.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http.Headers;
@@ -135,23 +134,42 @@ internal sealed class RateLimitBucket
     {
         Interlocked.Exchange(ref this.maximum, maximum);
         Interlocked.Exchange(ref this.remaining, remaining);
-        Interlocked.Decrement(ref this.reserved);
+
+        if (this.reserved > 0)
+        {
+            Interlocked.Decrement(ref this.reserved);
+        }
+
         this.Reset = reset;
     }
 
-    internal void CancelReservation() 
-        => Interlocked.Decrement(ref this.reserved);
+    internal void CancelReservation()
+    {
+        if (this.reserved > 0)
+        {
+            Interlocked.Decrement(ref this.reserved);
+        }
+    }
 
     internal void CompleteReservation()
     {
         if (this.Reset < DateTime.UtcNow)
         {
             this.ResetLimit(DateTime.UtcNow + TimeSpan.FromSeconds(1));
-            Interlocked.Decrement(ref this.reserved);
+
+            if (this.reserved > 0)
+            {
+                Interlocked.Decrement(ref this.reserved);
+            }
+
             return;
         }
 
-        Interlocked.Decrement(ref this.remaining);
-        Interlocked.Decrement(ref this.reserved);
+        Interlocked.Decrement(ref this.remaining); 
+        
+        if (this.reserved > 0)
+        {
+            Interlocked.Decrement(ref this.reserved);
+        }
     }
 }

--- a/DSharpPlus/Net/Rest/RateLimitBucket.cs
+++ b/DSharpPlus/Net/Rest/RateLimitBucket.cs
@@ -141,4 +141,17 @@ internal sealed class RateLimitBucket
 
     internal void CancelReservation() 
         => Interlocked.Decrement(ref this.reserved);
+
+    internal void CompleteReservation()
+    {
+        if (this.Reset < DateTime.UtcNow)
+        {
+            this.ResetLimit(DateTime.UtcNow + TimeSpan.FromSeconds(1));
+            Interlocked.Decrement(ref this.reserved);
+            return;
+        }
+
+        Interlocked.Decrement(ref this.remaining);
+        Interlocked.Decrement(ref this.reserved);
+    }
 }

--- a/DSharpPlus/Net/Rest/RateLimitStrategy.cs
+++ b/DSharpPlus/Net/Rest/RateLimitStrategy.cs
@@ -106,7 +106,7 @@ internal class RateLimitStrategy : ResilienceStrategy<HttpResponseMessage>, IDis
         {
             if (!exemptFromGlobalLimit)
             {
-                this.globalBucket.CompleteReservation();
+                this.globalBucket.CancelReservation();
             }
 
             return this.SynthesizeInternalResponse

--- a/DSharpPlus/Net/Rest/RateLimitStrategy.cs
+++ b/DSharpPlus/Net/Rest/RateLimitStrategy.cs
@@ -201,6 +201,8 @@ internal class RateLimitStrategy : ResilienceStrategy<HttpResponseMessage>, IDis
         {
             traceIdString = $"Request ID:{traceId}: ";
         }
+
+        DateTime retryJittered = retry + TimeSpan.FromMilliseconds(Random.Shared.NextInt64(100));
         
         logger.LogDebug
         (
@@ -210,11 +212,11 @@ internal class RateLimitStrategy : ResilienceStrategy<HttpResponseMessage>, IDis
             global,
             route,
             waitingForRoute,
-            retry
+            retryJittered
         );
 
         return Outcome.FromException<HttpResponseMessage>(
-            new PreemptiveRatelimitException(scope, retry - DateTime.UtcNow));
+            new PreemptiveRatelimitException(scope, retryJittered - DateTime.UtcNow));
     }
 
     private void UpdateRateLimitBuckets(HttpResponseMessage response, string oldHash, string route)

--- a/DSharpPlus/Net/Rest/RateLimitStrategy.cs
+++ b/DSharpPlus/Net/Rest/RateLimitStrategy.cs
@@ -178,7 +178,7 @@ internal class RateLimitStrategy : ResilienceStrategy<HttpResponseMessage>, IDis
             {
                 if (!exemptFromGlobalLimit)
                 {
-                    this.globalBucket.CancelReservation();
+                    this.globalBucket.CompleteReservation();
                 }
             }
 

--- a/DSharpPlus/Net/Rest/RateLimitStrategy.cs
+++ b/DSharpPlus/Net/Rest/RateLimitStrategy.cs
@@ -90,7 +90,7 @@ internal class RateLimitStrategy : ResilienceStrategy<HttpResponseMessage>, IDis
 
             if (!exemptFromGlobalLimit)
             {
-                this.globalBucket.CancelReservation();
+                this.globalBucket.CompleteReservation();
             }
 
             if (outcome.Result is null)
@@ -114,7 +114,7 @@ internal class RateLimitStrategy : ResilienceStrategy<HttpResponseMessage>, IDis
         {
             if (!exemptFromGlobalLimit)
             {
-                this.globalBucket.CancelReservation();
+                this.globalBucket.CompleteReservation();
             }
 
             return this.SynthesizeInternalResponse

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -38,7 +38,8 @@ internal sealed partial class RestClient : IDisposable
             logger,
             config.MaximumRatelimitRetries,
             config.RatelimitRetryDelayFallback,
-            config.TimeoutForInitialApiRequest
+            config.TimeoutForInitialApiRequest,
+            config.MaximumRestRequestsPerSecond
         )
     {
         this.httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", Utilities.GetFormattedToken(config));
@@ -53,7 +54,8 @@ internal sealed partial class RestClient : IDisposable
         ILogger logger,
         int maxRetries = int.MaxValue,
         double retryDelayFallback = 2.5,
-        int waitingForHashMilliseconds = 200
+        int waitingForHashMilliseconds = 200,
+        int maximumRequestsPerSecond = 15
     )
     {
         this.logger = logger;
@@ -77,7 +79,7 @@ internal sealed partial class RestClient : IDisposable
 
         this.globalRateLimitEvent = new AsyncManualResetEvent(true);
 
-        this.rateLimitStrategy = new(logger, waitingForHashMilliseconds);
+        this.rateLimitStrategy = new(logger, waitingForHashMilliseconds, maximumRequestsPerSecond);
 
         ResiliencePipelineBuilder<HttpResponseMessage> builder = new();
 


### PR DESCRIPTION
this fixes the global bucket never releasing allocated requests, leading to too aggressive preemptive ratelimiting

there's still issues remaining with the global bucket, such as letting the occasional request pass because our understanding of seconds doesn't match discord's (no idea how to approach that), or the fact it doesn't correctly cover all kinds of requests (subject for a future PR)

we might also want to consider letting extremely large bots that have their global limit increased configure the default value of 50 reqs/s, also for a future PR