### PR TITLE
Add client to guilds for RestClients

### DIFF
--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -3575,7 +3575,13 @@ public sealed class DiscordApiClient
         }
         else
         {
-            return new ReadOnlyCollection<DiscordGuild>(JsonConvert.DeserializeObject<List<DiscordGuild>>(res.Response!)!);
+            List<DiscordGuild> guildsRaw = JsonConvert.DeserializeObject<List<DiscordGuild>>(res.Response!)!.ToList();
+            foreach (DiscordGuild guild in guildsRaw)
+            {
+                guild.Discord = this._discord!;
+
+            }
+            return new ReadOnlyCollection<DiscordGuild>(guildsRaw);
         }
     }
 


### PR DESCRIPTION
# Summary
When getting all guild for the current user, we dont add a client to the guilds when the client is not a DiscordClient

# Notes
tested