### PR TITLE
Fix Autocomplete

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "dotnet.defaultSolution": "DSharpPlus.sln"
-}

--- a/DSharpPlus.Commands/Converters/ByteConverter.cs
+++ b/DSharpPlus.Commands/Converters/ByteConverter.cs
@@ -13,10 +13,10 @@ public class ByteConverter : ISlashArgumentConverter<byte>, ITextArgumentConvert
     public bool RequiresText { get; init; } = true;
 
     public Task<Optional<byte>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => byte.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out byte result)
-            ? Task.FromResult(Optional.FromValue(result))
-            : Task.FromResult(Optional.FromNoValue<byte>());
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<byte>());
 
-    public Task<Optional<byte>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => context.As<InteractionConverterContext>().Argument.Value is int number && number >= byte.MinValue && number <= byte.MaxValue
-            ? Task.FromResult(Optional.FromValue((byte)number))
-            : Task.FromResult(Optional.FromNoValue<byte>());
+    public Task<Optional<byte>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => byte.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out byte result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<byte>());
 }

--- a/DSharpPlus.Commands/Converters/DateTimeOffsetConverter.cs
+++ b/DSharpPlus.Commands/Converters/DateTimeOffsetConverter.cs
@@ -13,10 +13,11 @@ public class DateTimeOffsetConverter : ISlashArgumentConverter<DateTimeOffset>, 
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.String;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<DateTimeOffset>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => ConvertAsync(context.As<TextConverterContext>().Argument);
-    public Task<Optional<DateTimeOffset>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync(context.As<InteractionConverterContext>().Argument.ToString());
-    public static Task<Optional<DateTimeOffset>> ConvertAsync(string? value) =>
-        DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, out DateTimeOffset result)
-            ? Task.FromResult(Optional.FromValue(result.ToUniversalTime()))
-            : Task.FromResult(Optional.FromNoValue<DateTimeOffset>());
+    public Task<Optional<DateTimeOffset>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => DateTimeOffset.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out DateTimeOffset result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<DateTimeOffset>());
+
+    public Task<Optional<DateTimeOffset>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => DateTimeOffset.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out DateTimeOffset result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<DateTimeOffset>());
 }

--- a/DSharpPlus.Commands/Converters/DiscordAttachmentConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordAttachmentConverter.cs
@@ -1,5 +1,6 @@
 namespace DSharpPlus.Commands.Converters;
 
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using DSharpPlus.Commands.Processors.SlashCommands;
@@ -48,9 +49,19 @@ public class AttachmentConverter : ISlashArgumentConverter<DiscordAttachment>, I
             // Too many parameters, not enough attachments
             return Task.FromResult(Optional.FromNoValue<DiscordAttachment>());
         }
+        else if (!ulong.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out ulong attachmentId))
+        {
+            // Invalid attachment ID
+            return Task.FromResult(Optional.FromNoValue<DiscordAttachment>());
+        }
+        else if (!eventArgs.Interaction.Data.Resolved.Attachments.TryGetValue(attachmentId, out DiscordAttachment? attachment))
+        {
+            // Attachment not found
+            return Task.FromResult(Optional.FromNoValue<DiscordAttachment>());
+        }
         else
         {
-            return Task.FromResult(Optional.FromValue(eventArgs.Interaction.Data.Resolved.Attachments[(ulong)context.As<InteractionConverterContext>().Argument.Value]));
+            return Task.FromResult(Optional.FromValue(attachment));
         }
     }
 }

--- a/DSharpPlus.Commands/Converters/DiscordAttachmentConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordAttachmentConverter.cs
@@ -38,8 +38,19 @@ public class AttachmentConverter : ISlashArgumentConverter<DiscordAttachment>, I
     public Task<Optional<DiscordAttachment>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
     {
         int currentAttachmentArgumentIndex = context.Command.Parameters.Where(argument => argument.Type == typeof(DiscordAttachment)).IndexOf(context.Parameter);
-        return eventArgs.Interaction.Data.Options.Count(argument => argument.Type == ApplicationCommandOptionType.Attachment) < currentAttachmentArgumentIndex
-            ? Task.FromResult(Optional.FromNoValue<DiscordAttachment>()) // Too many parameters, not enough attachments
-            : Task.FromResult(Optional.FromValue(eventArgs.Interaction.Data.Resolved.Attachments[(ulong)context.As<InteractionConverterContext>().Argument.Value]));
+        if (eventArgs.Interaction.Data.Resolved is null)
+        {
+            // Resolved can be null on autocomplete contexts
+            return Task.FromResult(Optional.FromNoValue<DiscordAttachment>());
+        }
+        else if (eventArgs.Interaction.Data.Options.Count(argument => argument.Type == ApplicationCommandOptionType.Attachment) < currentAttachmentArgumentIndex)
+        {
+            // Too many parameters, not enough attachments
+            return Task.FromResult(Optional.FromNoValue<DiscordAttachment>());
+        }
+        else
+        {
+            return Task.FromResult(Optional.FromValue(eventArgs.Interaction.Data.Resolved.Attachments[(ulong)context.As<InteractionConverterContext>().Argument.Value]));
+        }
     }
 }

--- a/DSharpPlus.Commands/Converters/DiscordChannelConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordChannelConverter.cs
@@ -43,6 +43,8 @@ public partial class DiscordChannelConverter : ISlashArgumentConverter<DiscordCh
     public Task<Optional<DiscordChannel>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
     {
         InteractionConverterContext slashContext = context.As<InteractionConverterContext>();
-        return Task.FromResult(Optional.FromValue(slashContext.Interaction.Data.Resolved.Channels[(ulong)slashContext.Argument.Value]));
+        return slashContext.Interaction.Data.Resolved is null || !slashContext.Interaction.Data.Resolved.Channels.TryGetValue((ulong)slashContext.Argument.Value, out DiscordChannel? channel)
+            ? Task.FromResult(Optional.FromNoValue<DiscordChannel>())
+            : Task.FromResult(Optional.FromValue(channel));
     }
 }

--- a/DSharpPlus.Commands/Converters/DiscordChannelConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordChannelConverter.cs
@@ -43,7 +43,7 @@ public partial class DiscordChannelConverter : ISlashArgumentConverter<DiscordCh
     public Task<Optional<DiscordChannel>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
     {
         InteractionConverterContext slashContext = context.As<InteractionConverterContext>();
-        return slashContext.Interaction.Data.Resolved is null || !slashContext.Interaction.Data.Resolved.Channels.TryGetValue((ulong)slashContext.Argument.Value, out DiscordChannel? channel)
+        return slashContext.Interaction.Data.Resolved is null || !ulong.TryParse(slashContext.Argument.RawValue, CultureInfo.InvariantCulture, out ulong channelId) || !slashContext.Interaction.Data.Resolved.Channels.TryGetValue(channelId, out DiscordChannel? channel)
             ? Task.FromResult(Optional.FromNoValue<DiscordChannel>())
             : Task.FromResult(Optional.FromValue(channel));
     }

--- a/DSharpPlus.Commands/Converters/DiscordEmojiConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordEmojiConverter.cs
@@ -12,7 +12,7 @@ public class DiscordEmojiConverter : ISlashArgumentConverter<DiscordEmoji>, ITex
     public bool RequiresText { get; init; } = true;
 
     public Task<Optional<DiscordEmoji>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => ConvertAsync(context, context.As<TextConverterContext>().Argument);
-    public Task<Optional<DiscordEmoji>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync(context, context.As<InteractionConverterContext>().Argument.Value.ToString());
+    public Task<Optional<DiscordEmoji>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync(context, context.As<InteractionConverterContext>().Argument.RawValue);
     public static Task<Optional<DiscordEmoji>> ConvertAsync(ConverterContext context, string? value) => !string.IsNullOrWhiteSpace(value) && (DiscordEmoji.TryFromUnicode(context.Client, value, out DiscordEmoji? emoji) || DiscordEmoji.TryFromName(context.Client, value, out emoji))
         ? Task.FromResult(Optional.FromValue(emoji))
         : Task.FromResult(Optional.FromNoValue<DiscordEmoji>());

--- a/DSharpPlus.Commands/Converters/DiscordMemberConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordMemberConverter.cs
@@ -58,6 +58,8 @@ public partial class DiscordMemberConverter : ISlashArgumentConverter<DiscordMem
     public Task<Optional<DiscordMember>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
     {
         InteractionConverterContext slashContext = context.As<InteractionConverterContext>();
-        return Task.FromResult(Optional.FromValue(slashContext.Interaction.Data.Resolved.Members[(ulong)slashContext.Argument.Value]));
+        return slashContext.Interaction.Data.Resolved is null || !slashContext.Interaction.Data.Resolved.Members.TryGetValue((ulong)slashContext.Argument.Value, out DiscordMember? member)
+            ? Task.FromResult(Optional.FromNoValue<DiscordMember>())
+            : Task.FromResult(Optional.FromValue(member));
     }
 }

--- a/DSharpPlus.Commands/Converters/DiscordMemberConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordMemberConverter.cs
@@ -58,7 +58,7 @@ public partial class DiscordMemberConverter : ISlashArgumentConverter<DiscordMem
     public Task<Optional<DiscordMember>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
     {
         InteractionConverterContext slashContext = context.As<InteractionConverterContext>();
-        return slashContext.Interaction.Data.Resolved is null || !slashContext.Interaction.Data.Resolved.Members.TryGetValue((ulong)slashContext.Argument.Value, out DiscordMember? member)
+        return slashContext.Interaction.Data.Resolved is null || !ulong.TryParse(slashContext.Argument.RawValue, CultureInfo.InvariantCulture, out ulong memberId) || !slashContext.Interaction.Data.Resolved.Members.TryGetValue(memberId, out DiscordMember? member)
             ? Task.FromResult(Optional.FromNoValue<DiscordMember>())
             : Task.FromResult(Optional.FromValue(member));
     }

--- a/DSharpPlus.Commands/Converters/DiscordMessageConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordMessageConverter.cs
@@ -18,7 +18,7 @@ public partial class DiscordMessageConverter : ISlashArgumentConverter<DiscordMe
     public bool RequiresText { get; init; } = true;
 
     public Task<Optional<DiscordMessage>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => ConvertAsync(context, context.As<TextConverterContext>().Argument);
-    public Task<Optional<DiscordMessage>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync(context, context.As<InteractionConverterContext>().Argument.Value.ToString());
+    public Task<Optional<DiscordMessage>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync(context, context.As<InteractionConverterContext>().Argument.RawValue);
 
     public static async Task<Optional<DiscordMessage>> ConvertAsync(ConverterContext context, string? value)
     {

--- a/DSharpPlus.Commands/Converters/DiscordRoleConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordRoleConverter.cs
@@ -46,6 +46,8 @@ public partial class DiscordRoleConverter : ISlashArgumentConverter<DiscordRole>
     public Task<Optional<DiscordRole>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
     {
         InteractionConverterContext slashContext = context.As<InteractionConverterContext>();
-        return Task.FromResult(Optional.FromValue(slashContext.Interaction.Data.Resolved.Roles[(ulong)slashContext.Argument.Value]));
+        return slashContext.Interaction.Data.Resolved is null || !slashContext.Interaction.Data.Resolved.Roles.TryGetValue((ulong)slashContext.Argument.Value, out DiscordRole? role)
+            ? Task.FromResult(Optional.FromNoValue<DiscordRole>())
+            : Task.FromResult(Optional.FromValue(role));
     }
 }

--- a/DSharpPlus.Commands/Converters/DiscordRoleConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordRoleConverter.cs
@@ -46,7 +46,7 @@ public partial class DiscordRoleConverter : ISlashArgumentConverter<DiscordRole>
     public Task<Optional<DiscordRole>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
     {
         InteractionConverterContext slashContext = context.As<InteractionConverterContext>();
-        return slashContext.Interaction.Data.Resolved is null || !slashContext.Interaction.Data.Resolved.Roles.TryGetValue((ulong)slashContext.Argument.Value, out DiscordRole? role)
+        return slashContext.Interaction.Data.Resolved is null || !ulong.TryParse(slashContext.Argument.RawValue, CultureInfo.InvariantCulture, out ulong roleId) || !slashContext.Interaction.Data.Resolved.Roles.TryGetValue(roleId, out DiscordRole? role)
             ? Task.FromResult(Optional.FromNoValue<DiscordRole>())
             : Task.FromResult(Optional.FromValue(role));
     }

--- a/DSharpPlus.Commands/Converters/DiscordThreadChannelConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordThreadChannelConverter.cs
@@ -46,6 +46,8 @@ public partial class DiscordThreadChannelConverter : ISlashArgumentConverter<Dis
     public Task<Optional<DiscordThreadChannel>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
     {
         InteractionConverterContext slashContext = context.As<InteractionConverterContext>();
-        return Task.FromResult(Optional.FromValue((DiscordThreadChannel)slashContext.Interaction.Data.Resolved.Channels[(ulong)slashContext.Argument.Value]));
+        return slashContext.Interaction.Data.Resolved is null || !slashContext.Interaction.Data.Resolved.Channels.TryGetValue((ulong)slashContext.Argument.Value, out DiscordChannel? channel)
+            ? Task.FromResult(Optional.FromNoValue<DiscordThreadChannel>())
+            : Task.FromResult(Optional.FromValue((DiscordThreadChannel)channel));
     }
 }

--- a/DSharpPlus.Commands/Converters/DiscordThreadChannelConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordThreadChannelConverter.cs
@@ -46,7 +46,7 @@ public partial class DiscordThreadChannelConverter : ISlashArgumentConverter<Dis
     public Task<Optional<DiscordThreadChannel>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
     {
         InteractionConverterContext slashContext = context.As<InteractionConverterContext>();
-        return slashContext.Interaction.Data.Resolved is null || !slashContext.Interaction.Data.Resolved.Channels.TryGetValue((ulong)slashContext.Argument.Value, out DiscordChannel? channel)
+        return slashContext.Interaction.Data.Resolved is null || !ulong.TryParse(slashContext.Argument.RawValue, CultureInfo.InvariantCulture, out ulong channelId) || !slashContext.Interaction.Data.Resolved.Channels.TryGetValue(channelId, out DiscordChannel? channel)
             ? Task.FromResult(Optional.FromNoValue<DiscordThreadChannel>())
             : Task.FromResult(Optional.FromValue((DiscordThreadChannel)channel));
     }

--- a/DSharpPlus.Commands/Converters/DiscordUserConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordUserConverter.cs
@@ -69,6 +69,8 @@ public partial class DiscordUserConverter : ISlashArgumentConverter<DiscordUser>
     public Task<Optional<DiscordUser>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
     {
         InteractionConverterContext slashContext = context.As<InteractionConverterContext>();
-        return Task.FromResult(Optional.FromValue(slashContext.Interaction.Data.Resolved.Users[(ulong)slashContext.Argument.Value]));
+        return slashContext.Interaction.Data.Resolved is null || !slashContext.Interaction.Data.Resolved.Users.TryGetValue((ulong)slashContext.Argument.Value, out DiscordUser? user)
+            ? Task.FromResult(Optional.FromNoValue<DiscordUser>())
+            : Task.FromResult(Optional.FromValue(user));
     }
 }

--- a/DSharpPlus.Commands/Converters/DiscordUserConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordUserConverter.cs
@@ -69,7 +69,7 @@ public partial class DiscordUserConverter : ISlashArgumentConverter<DiscordUser>
     public Task<Optional<DiscordUser>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
     {
         InteractionConverterContext slashContext = context.As<InteractionConverterContext>();
-        return slashContext.Interaction.Data.Resolved is null || !slashContext.Interaction.Data.Resolved.Users.TryGetValue((ulong)slashContext.Argument.Value, out DiscordUser? user)
+        return slashContext.Interaction.Data.Resolved is null || !ulong.TryParse(slashContext.Argument.RawValue, CultureInfo.InvariantCulture, out ulong memberId) || !slashContext.Interaction.Data.Resolved.Users.TryGetValue(memberId, out DiscordUser? user)
             ? Task.FromResult(Optional.FromNoValue<DiscordUser>())
             : Task.FromResult(Optional.FromValue(user));
     }

--- a/DSharpPlus.Commands/Converters/DoubleConverter.cs
+++ b/DSharpPlus.Commands/Converters/DoubleConverter.cs
@@ -12,10 +12,11 @@ public class DoubleConverter : ISlashArgumentConverter<double>, ITextArgumentCon
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Number;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<double>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) =>
-        double.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out double result)
-            ? Task.FromResult(Optional.FromValue(result))
-            : Task.FromResult(Optional.FromNoValue<double>());
+    public Task<Optional<double>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => double.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out double result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<double>());
 
-    public Task<Optional<double>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => Task.FromResult(Optional.FromValue((double)context.As<InteractionConverterContext>().Argument.Value));
+    public Task<Optional<double>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => double.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out double result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<double>());
 }

--- a/DSharpPlus.Commands/Converters/FloatConverter.cs
+++ b/DSharpPlus.Commands/Converters/FloatConverter.cs
@@ -12,10 +12,11 @@ public class FloatConverter : ISlashArgumentConverter<float>, ITextArgumentConve
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Number;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<float>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) =>
-        float.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out float result)
-            ? Task.FromResult(Optional.FromValue(result))
-            : Task.FromResult(Optional.FromNoValue<float>());
+    public Task<Optional<float>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => float.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out float result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<float>());
 
-    public Task<Optional<float>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => Task.FromResult(Optional.FromValue((float)context.As<InteractionConverterContext>().Argument.Value));
+    public Task<Optional<float>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => float.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out float result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<float>());
 }

--- a/DSharpPlus.Commands/Converters/Int16Converter.cs
+++ b/DSharpPlus.Commands/Converters/Int16Converter.cs
@@ -12,12 +12,11 @@ public class Int16Converter : ISlashArgumentConverter<short>, ITextArgumentConve
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Integer;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<short>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) =>
-        short.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out short result)
-            ? Task.FromResult(Optional.FromValue(result))
-            : Task.FromResult(Optional.FromNoValue<short>());
+    public Task<Optional<short>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => short.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out short result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<short>());
 
-    public Task<Optional<short>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => context.As<InteractionConverterContext>().Argument.Value is int number && number >= short.MinValue && number <= short.MaxValue
-        ? Task.FromResult(Optional.FromValue((short)number))
+    public Task<Optional<short>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => short.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out short result)
+        ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<short>());
 }

--- a/DSharpPlus.Commands/Converters/Int32Converter.cs
+++ b/DSharpPlus.Commands/Converters/Int32Converter.cs
@@ -12,10 +12,11 @@ public class Int32Converter : ISlashArgumentConverter<int>, ITextArgumentConvert
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Integer;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<int>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) =>
-        int.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out int result)
-            ? Task.FromResult(Optional.FromValue(result))
-            : Task.FromResult(Optional.FromNoValue<int>());
+    public Task<Optional<int>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => int.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out int result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<int>());
 
-    public Task<Optional<int>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => Task.FromResult(Optional.FromValue((int)context.As<InteractionConverterContext>().Argument.Value));
+    public Task<Optional<int>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => int.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out int result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<int>());
 }

--- a/DSharpPlus.Commands/Converters/Int64Converter.cs
+++ b/DSharpPlus.Commands/Converters/Int64Converter.cs
@@ -15,10 +15,11 @@ public class Int64Converter : ISlashArgumentConverter<long>, ITextArgumentConver
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.String;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<long>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => ConvertAsync(context.As<TextConverterContext>().Argument);
-    public Task<Optional<long>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync((string)context.As<InteractionConverterContext>().Argument.Value);
-    public static Task<Optional<long>> ConvertAsync(string? value) =>
-        long.TryParse(value, CultureInfo.InvariantCulture, out long result)
-            ? Task.FromResult(Optional.FromValue(result))
-            : Task.FromResult(Optional.FromNoValue<long>());
+    public Task<Optional<long>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => long.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out long result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<long>());
+
+    public Task<Optional<long>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => long.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out long result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<long>());
 }

--- a/DSharpPlus.Commands/Converters/SByteConverter.cs
+++ b/DSharpPlus.Commands/Converters/SByteConverter.cs
@@ -13,10 +13,10 @@ public class SByteConverter : ISlashArgumentConverter<sbyte>, ITextArgumentConve
     public bool RequiresText { get; init; } = true;
 
     public Task<Optional<sbyte>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => sbyte.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out sbyte result)
-            ? Task.FromResult(Optional.FromValue(result))
-            : Task.FromResult(Optional.FromNoValue<sbyte>());
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<sbyte>());
 
-    public Task<Optional<sbyte>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => context.As<InteractionConverterContext>().Argument.Value is int number && number >= sbyte.MinValue && number <= sbyte.MaxValue
-            ? Task.FromResult(Optional.FromValue((sbyte)number))
-            : Task.FromResult(Optional.FromNoValue<sbyte>());
+    public Task<Optional<sbyte>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => sbyte.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out sbyte result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<sbyte>());
 }

--- a/DSharpPlus.Commands/Converters/StringConverter.cs
+++ b/DSharpPlus.Commands/Converters/StringConverter.cs
@@ -25,5 +25,5 @@ public class StringConverter : ISlashArgumentConverter<string>, ITextArgumentCon
         return Task.FromResult(Optional.FromValue(textConverterContext.RawArguments[textConverterContext.CurrentArgumentIndex..]));
     }
 
-    public Task<Optional<string>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => Task.FromResult(Optional.FromValue((string)context.As<InteractionConverterContext>().Argument.Value));
+    public Task<Optional<string>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => Task.FromResult(Optional.FromValue(context.As<InteractionConverterContext>().Argument.RawValue));
 }

--- a/DSharpPlus.Commands/Converters/TimeSpanConverter.cs
+++ b/DSharpPlus.Commands/Converters/TimeSpanConverter.cs
@@ -18,7 +18,7 @@ public partial class TimeSpanConverter : ISlashArgumentConverter<TimeSpan>, ITex
     public bool RequiresText { get; init; } = true;
 
     public Task<Optional<TimeSpan>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => ConvertAsync(context, context.As<TextConverterContext>().Argument);
-    public Task<Optional<TimeSpan>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync(context, context.As<InteractionConverterContext>().Argument.Value.ToString());
+    public Task<Optional<TimeSpan>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync(context, context.As<InteractionConverterContext>().Argument.RawValue);
 
     public static Task<Optional<TimeSpan>> ConvertAsync(ConverterContext context, string? value)
     {

--- a/DSharpPlus.Commands/Converters/UInt16Converter.cs
+++ b/DSharpPlus.Commands/Converters/UInt16Converter.cs
@@ -12,12 +12,11 @@ public class UInt16Converter : ISlashArgumentConverter<ushort>, ITextArgumentCon
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Integer;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<ushort>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) =>
-        ushort.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out ushort result)
-            ? Task.FromResult(Optional.FromValue(result))
-            : Task.FromResult(Optional.FromNoValue<ushort>());
+    public Task<Optional<ushort>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => ushort.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out ushort result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<ushort>());
 
-    public Task<Optional<ushort>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => context.As<InteractionConverterContext>().Argument.Value is int number && number >= ushort.MinValue && number <= ushort.MaxValue
-        ? Task.FromResult(Optional.FromValue((ushort)number))
+    public Task<Optional<ushort>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ushort.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out ushort result)
+        ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<ushort>());
 }

--- a/DSharpPlus.Commands/Converters/UInt32Converter.cs
+++ b/DSharpPlus.Commands/Converters/UInt32Converter.cs
@@ -12,10 +12,11 @@ public class UInt32Converter : ISlashArgumentConverter<uint>, ITextArgumentConve
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Integer;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<uint>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) =>
-        uint.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out uint result)
-            ? Task.FromResult(Optional.FromValue(result))
-            : Task.FromResult(Optional.FromNoValue<uint>());
+    public Task<Optional<uint>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => uint.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out uint result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<uint>());
 
-    public Task<Optional<uint>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => Task.FromResult(Optional.FromValue((uint)context.As<InteractionConverterContext>().Argument.Value));
+    public Task<Optional<uint>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => uint.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out uint result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<uint>());
 }

--- a/DSharpPlus.Commands/Converters/UInt64Converter.cs
+++ b/DSharpPlus.Commands/Converters/UInt64Converter.cs
@@ -15,10 +15,11 @@ public class UInt64Converter : ISlashArgumentConverter<ulong>, ITextArgumentConv
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.String;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<ulong>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => ConvertAsync(context.As<TextConverterContext>().Argument);
-    public Task<Optional<ulong>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync((string)context.As<InteractionConverterContext>().Argument.Value);
-    public static Task<Optional<ulong>> ConvertAsync(string? value) =>
-        ulong.TryParse(value, CultureInfo.InvariantCulture, out ulong result)
-            ? Task.FromResult(Optional.FromValue(result))
-            : Task.FromResult(Optional.FromNoValue<ulong>());
+    public Task<Optional<ulong>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => ulong.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out ulong result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<ulong>());
+
+    public Task<Optional<ulong>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ulong.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out ulong result)
+        ? Task.FromResult(Optional.FromValue(result))
+        : Task.FromResult(Optional.FromNoValue<ulong>());
 }

--- a/DSharpPlus.Commands/Processors/SlashCommands/Attributes/SlashAutoCompleteProviderAttribute.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/Attributes/SlashAutoCompleteProviderAttribute.cs
@@ -41,5 +41,5 @@ public sealed class SlashAutoCompleteProviderAttribute<T> : SlashAutoCompletePro
 
 public interface IAutoCompleteProvider
 {
-    public ValueTask<Dictionary<string, object>> AutoCompleteAsync(AutoCompleteContext context);
+    public ValueTask<IReadOnlyDictionary<string, object>> AutoCompleteAsync(AutoCompleteContext context);
 }

--- a/DSharpPlus.Commands/Processors/SlashCommands/AutoCompleteContext.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/AutoCompleteContext.cs
@@ -10,5 +10,5 @@ public sealed record AutoCompleteContext : AbstractContext
     public required IEnumerable<DiscordInteractionDataOption> Options { get; init; }
     public required IReadOnlyDictionary<CommandParameter, object?> Arguments { get; init; }
     public required CommandParameter AutoCompleteArgument { get; init; }
-    public required object UserInput { get; init; }
+    public required string UserInput { get; init; }
 }

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
@@ -28,7 +28,7 @@ public sealed class DiscordInteractionDataOption
     public bool Focused { get; internal set; }
 
     [JsonProperty("value")]
-    internal string InternalValue { get; set; }
+    public string RawValue { get; internal set; }
 
     /// <summary>
     /// Gets the value of this interaction parameter.
@@ -37,16 +37,16 @@ public sealed class DiscordInteractionDataOption
     [JsonIgnore]
     public object Value => this.Type switch
     {
-        ApplicationCommandOptionType.Boolean => bool.Parse(this.InternalValue),
-        ApplicationCommandOptionType.Integer => long.Parse(this.InternalValue),
-        ApplicationCommandOptionType.String => this.InternalValue,
-        ApplicationCommandOptionType.Channel => ulong.Parse(this.InternalValue),
-        ApplicationCommandOptionType.User => ulong.Parse(this.InternalValue),
-        ApplicationCommandOptionType.Role => ulong.Parse(this.InternalValue),
-        ApplicationCommandOptionType.Mentionable => ulong.Parse(this.InternalValue),
-        ApplicationCommandOptionType.Number => double.Parse(this.InternalValue, CultureInfo.InvariantCulture),
-        ApplicationCommandOptionType.Attachment => ulong.Parse(this.InternalValue, CultureInfo.InvariantCulture),
-        _ => this.InternalValue,
+        ApplicationCommandOptionType.Boolean => bool.Parse(this.RawValue),
+        ApplicationCommandOptionType.Integer => long.Parse(this.RawValue),
+        ApplicationCommandOptionType.String => this.RawValue,
+        ApplicationCommandOptionType.Channel => ulong.Parse(this.RawValue),
+        ApplicationCommandOptionType.User => ulong.Parse(this.RawValue),
+        ApplicationCommandOptionType.Role => ulong.Parse(this.RawValue),
+        ApplicationCommandOptionType.Mentionable => ulong.Parse(this.RawValue),
+        ApplicationCommandOptionType.Number => double.Parse(this.RawValue, CultureInfo.InvariantCulture),
+        ApplicationCommandOptionType.Attachment => ulong.Parse(this.RawValue, CultureInfo.InvariantCulture),
+        _ => this.RawValue,
     };
 
     /// <summary>


### PR DESCRIPTION
# Summary
There were as many bugs as there were headaches. Fixes the following:
- Autocomplete always assumed that it was the first parameter that held the autocomplete attribute.
- Discord does not send any `Resolved` information on autocomplete requests
- Discord does not validate or provide client verification on a parameter's type

# Details
The biggest change (and issue) here is that Discord will provide `string` information for `DiscordInteractionDataOption.InternalValue` (`value` in JSON) regardless of what `DiscordInteractionDataOption.Type` specifies. This means that we will receive string information on numeric parameters. Unfortunately the user will not have any way to access the value as `DiscordInteractionDataOption.Value` will *always*  throw since it attempts to return the object type that matches `DiscordInteractionDataOption.Type`. While this issue is still present, I've since renamed `InternalValue` to `RawValue` and exposed the getter as a temporary or possible permanent solution. Having `RawValue` available could future proof any other new argument types that are introduced while also allowing autocomplete values to become accessible.

![image](https://github.com/DSharpPlus/DSharpPlus/assets/46751150/394be04f-d416-4422-991d-e7970f266fb8)


![image](https://github.com/DSharpPlus/DSharpPlus/assets/46751150/c332a083-ee7d-4286-b0ca-f5d6b238393c)


![image](https://github.com/DSharpPlus/DSharpPlus/assets/46751150/55c67de4-df3a-45b2-904b-6e984369cf0c)

All converters have been updated to use `RawValue` over `Value` for both efficiency and safety, as converters are used within autocomplete contexts. Additionally all converters now check if `DiscordInteractionData.Resolved` is `null` or not instead of directly indexing.

# Notes
Autocomplete has been tested, most converters have been tested.