### PR TITLE
Do not register event handlers twice

### DIFF
--- a/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandProcessor.cs
@@ -27,8 +27,12 @@ public sealed class MessageCommandProcessor : ICommandProcessor<InteractionCreat
 
     public async ValueTask ConfigureAsync(CommandsExtension extension)
     {
+        if (this._extension is null)
+        {
+            extension.Client.ContextMenuInteractionCreated += this.ExecuteInteractionAsync;
+        }
+
         this._extension = extension;
-        this._extension.Client.ContextMenuInteractionCreated += this.ExecuteInteractionAsync;
         this._slashCommandProcessor = this._extension.GetProcessor<SlashCommandProcessor>() ?? new SlashCommandProcessor();
         await this._slashCommandProcessor.ConfigureAsync(this._extension);
 

--- a/DSharpPlus.Commands/Processors/UserCommands/UserCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/UserCommands/UserCommandProcessor.cs
@@ -27,8 +27,12 @@ public sealed class UserCommandProcessor : ICommandProcessor<InteractionCreateEv
 
     public async ValueTask ConfigureAsync(CommandsExtension extension)
     {
+        if (this._extension is null)
+        {
+            extension.Client.ContextMenuInteractionCreated += this.ExecuteInteractionAsync;
+        }
+
         this._extension = extension;
-        this._extension.Client.ContextMenuInteractionCreated += this.ExecuteInteractionAsync;
         this._slashCommandProcessor = this._extension.GetProcessor<SlashCommandProcessor>() ?? new SlashCommandProcessor();
         await this._slashCommandProcessor.ConfigureAsync(this._extension);
 


### PR DESCRIPTION
# Summary
`ICommandProcessor<T>.ConfigureAsync` was being called twice:
- `AddProcessorAsync`
- `RefreshAsync`

The processor did not correctly check to see if it was already configured, which lead to the event handler being executed twice due to the double registration.

# Notes
Tested. Closes #1787