### PR TITLE
DebugGuildId is no longer nullable

### DIFF
--- a/DSharpPlus.Commands/CommandsConfiguration.cs
+++ b/DSharpPlus.Commands/CommandsConfiguration.cs
@@ -13,9 +13,9 @@ public sealed record CommandsConfiguration
     public required IServiceProvider ServiceProvider { get; set; }
 
     /// <summary>
-    /// The guild id to use for debugging.
+    /// The guild id to use for debugging. Leave as 0 to disable.
     /// </summary>
-    public ulong? DebugGuildId { get; set; }
+    public ulong DebugGuildId { get; set; }
 
     /// <summary>
     /// Whether to enable the default command error handler.

--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -41,7 +41,7 @@ public sealed class CommandsExtension : BaseExtension
     public IServiceProvider ServiceProvider { get; init; }
 
     /// <inheritdoc cref="CommandsConfiguration.DebugGuildId"/>
-    public ulong? DebugGuildId { get; init; }
+    public ulong DebugGuildId { get; init; }
 
     /// <inheritdoc cref="CommandsConfiguration.UseDefaultCommandErrorHandler"/>
     public bool UseDefaultCommandErrorHandler { get; init; }

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -191,9 +191,9 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
             applicationCommands.Add(await this.ToApplicationCommandAsync(command));
         }
 
-        IReadOnlyList<DiscordApplicationCommand> discordCommands = extension.DebugGuildId is null
+        IReadOnlyList<DiscordApplicationCommand> discordCommands = extension.DebugGuildId is 0
             ? await extension.Client.BulkOverwriteGlobalApplicationCommandsAsync(applicationCommands)
-            : await extension.Client.BulkOverwriteGuildApplicationCommandsAsync(extension.DebugGuildId.Value, applicationCommands);
+            : await extension.Client.BulkOverwriteGuildApplicationCommandsAsync(extension.DebugGuildId, applicationCommands);
 
         Dictionary<ulong, Command> commandsDictionary = [];
         foreach (DiscordApplicationCommand discordCommand in discordCommands)

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -47,7 +47,7 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
         }
         else if (string.IsNullOrWhiteSpace(eventArgs.Message.Content)
             || (eventArgs.Author.IsBot && this.Configuration.IgnoreBots)
-            || (this._extension.DebugGuildId == 0 && eventArgs.Guild?.Id != this._extension.DebugGuildId))
+            || (this._extension.DebugGuildId != 0 && this._extension.DebugGuildId != eventArgs.Guild?.Id))
         {
             return;
         }

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -47,7 +47,7 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
         }
         else if (string.IsNullOrWhiteSpace(eventArgs.Message.Content)
             || (eventArgs.Author.IsBot && this.Configuration.IgnoreBots)
-            || (this._extension.DebugGuildId.HasValue && eventArgs.Guild?.Id != this._extension.DebugGuildId))
+            || (this._extension.DebugGuildId == 0 && eventArgs.Guild?.Id != this._extension.DebugGuildId))
         {
             return;
         }


### PR DESCRIPTION
# Summary
Converts `DebugGuildId` from a `ulong?` to a `ulong`. Instead of being `null` to disable, you should now use `0`. Those who did `DebugGuildId == default` should remain unaffected.

# Notes
Untested.