### PR TITLE
Use processor specific converter context

### DIFF
--- a/DSharpPlus.Commands/Converters/BooleanConverter.cs
+++ b/DSharpPlus.Commands/Converters/BooleanConverter.cs
@@ -11,14 +11,14 @@ public class BooleanConverter : ISlashArgumentConverter<bool>, ITextArgumentConv
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Boolean;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<bool>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => Task.FromResult(context.As<TextConverterContext>().Argument.ToLowerInvariant() switch
+    public Task<Optional<bool>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => Task.FromResult(context.Argument.ToLowerInvariant() switch
     {
         "true" or "yes" or "y" or "1" or "on" or "enable" or "enabled" or "t" => Optional.FromValue(true),
         "false" or "no" or "n" or "0" or "off" or "disable" or "disabled" or "f" => Optional.FromValue(false),
         _ => Optional.FromNoValue<bool>()
     });
 
-    public Task<Optional<bool>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => bool.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, out bool result)
+    public Task<Optional<bool>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => bool.TryParse(context.Argument.RawValue, out bool result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<bool>());
 }

--- a/DSharpPlus.Commands/Converters/ByteConverter.cs
+++ b/DSharpPlus.Commands/Converters/ByteConverter.cs
@@ -12,11 +12,11 @@ public class ByteConverter : ISlashArgumentConverter<byte>, ITextArgumentConvert
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Integer;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<byte>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => byte.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out byte result)
+    public Task<Optional<byte>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => byte.TryParse(context.Argument, CultureInfo.InvariantCulture, out byte result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<byte>());
 
-    public Task<Optional<byte>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => byte.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out byte result)
+    public Task<Optional<byte>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => byte.TryParse(context.Argument.RawValue, CultureInfo.InvariantCulture, out byte result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<byte>());
 }

--- a/DSharpPlus.Commands/Converters/DateTimeOffsetConverter.cs
+++ b/DSharpPlus.Commands/Converters/DateTimeOffsetConverter.cs
@@ -13,11 +13,11 @@ public class DateTimeOffsetConverter : ISlashArgumentConverter<DateTimeOffset>, 
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.String;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<DateTimeOffset>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => DateTimeOffset.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out DateTimeOffset result)
+    public Task<Optional<DateTimeOffset>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => DateTimeOffset.TryParse(context.Argument, CultureInfo.InvariantCulture, out DateTimeOffset result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<DateTimeOffset>());
 
-    public Task<Optional<DateTimeOffset>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => DateTimeOffset.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out DateTimeOffset result)
+    public Task<Optional<DateTimeOffset>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => DateTimeOffset.TryParse(context.Argument.RawValue, CultureInfo.InvariantCulture, out DateTimeOffset result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<DateTimeOffset>());
 }

--- a/DSharpPlus.Commands/Converters/DiscordAttachmentConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordAttachmentConverter.cs
@@ -14,7 +14,7 @@ public class AttachmentConverter : ISlashArgumentConverter<DiscordAttachment>, I
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Attachment;
     public bool RequiresText { get; init; }
 
-    public Task<Optional<DiscordAttachment>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs)
+    public Task<Optional<DiscordAttachment>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs)
     {
         DiscordMessage message = eventArgs.Message;
         int currentAttachmentArgumentIndex = context.Command.Parameters.Where(argument => argument.Type == typeof(DiscordAttachment)).IndexOf(context.Parameter);
@@ -36,7 +36,7 @@ public class AttachmentConverter : ISlashArgumentConverter<DiscordAttachment>, I
             : Task.FromResult(Optional.FromValue(message.Attachments[currentAttachmentArgumentIndex]));
     }
 
-    public Task<Optional<DiscordAttachment>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
+    public Task<Optional<DiscordAttachment>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs)
     {
         int currentAttachmentArgumentIndex = context.Command.Parameters.Where(argument => argument.Type == typeof(DiscordAttachment)).IndexOf(context.Parameter);
         if (eventArgs.Interaction.Data.Resolved is null)
@@ -49,7 +49,7 @@ public class AttachmentConverter : ISlashArgumentConverter<DiscordAttachment>, I
             // Too many parameters, not enough attachments
             return Task.FromResult(Optional.FromNoValue<DiscordAttachment>());
         }
-        else if (!ulong.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out ulong attachmentId))
+        else if (!ulong.TryParse(context.Argument.RawValue, CultureInfo.InvariantCulture, out ulong attachmentId))
         {
             // Invalid attachment ID
             return Task.FromResult(Optional.FromNoValue<DiscordAttachment>());

--- a/DSharpPlus.Commands/Converters/DiscordEmojiConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordEmojiConverter.cs
@@ -11,9 +11,10 @@ public class DiscordEmojiConverter : ISlashArgumentConverter<DiscordEmoji>, ITex
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.String;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<DiscordEmoji>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => ConvertAsync(context, context.As<TextConverterContext>().Argument);
-    public Task<Optional<DiscordEmoji>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync(context, context.As<InteractionConverterContext>().Argument.RawValue);
-    public static Task<Optional<DiscordEmoji>> ConvertAsync(ConverterContext context, string? value) => !string.IsNullOrWhiteSpace(value) && (DiscordEmoji.TryFromUnicode(context.Client, value, out DiscordEmoji? emoji) || DiscordEmoji.TryFromName(context.Client, value, out emoji))
-        ? Task.FromResult(Optional.FromValue(emoji))
-        : Task.FromResult(Optional.FromNoValue<DiscordEmoji>());
+    public Task<Optional<DiscordEmoji>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => ConvertAsync(context, context.Argument);
+    public Task<Optional<DiscordEmoji>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync(context, context.Argument.RawValue);
+    public static Task<Optional<DiscordEmoji>> ConvertAsync(ConverterContext context, string? value) => !string.IsNullOrWhiteSpace(value)
+        && (DiscordEmoji.TryFromUnicode(context.Client, value, out DiscordEmoji? emoji) || DiscordEmoji.TryFromName(context.Client, value, out emoji))
+            ? Task.FromResult(Optional.FromValue(emoji))
+            : Task.FromResult(Optional.FromNoValue<DiscordEmoji>());
 }

--- a/DSharpPlus.Commands/Converters/DiscordMessageConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordMessageConverter.cs
@@ -17,8 +17,8 @@ public partial class DiscordMessageConverter : ISlashArgumentConverter<DiscordMe
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.String;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<DiscordMessage>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => ConvertAsync(context, context.As<TextConverterContext>().Argument);
-    public Task<Optional<DiscordMessage>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync(context, context.As<InteractionConverterContext>().Argument.RawValue);
+    public Task<Optional<DiscordMessage>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => ConvertAsync(context, context.Argument);
+    public Task<Optional<DiscordMessage>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync(context, context.Argument.RawValue);
 
     public static async Task<Optional<DiscordMessage>> ConvertAsync(ConverterContext context, string? value)
     {

--- a/DSharpPlus.Commands/Converters/DoubleConverter.cs
+++ b/DSharpPlus.Commands/Converters/DoubleConverter.cs
@@ -12,11 +12,11 @@ public class DoubleConverter : ISlashArgumentConverter<double>, ITextArgumentCon
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Number;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<double>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => double.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out double result)
+    public Task<Optional<double>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => double.TryParse(context.Argument, CultureInfo.InvariantCulture, out double result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<double>());
 
-    public Task<Optional<double>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => double.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out double result)
+    public Task<Optional<double>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => double.TryParse(context.Argument.RawValue, CultureInfo.InvariantCulture, out double result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<double>());
 }

--- a/DSharpPlus.Commands/Converters/EnumArgumentConverter.cs
+++ b/DSharpPlus.Commands/Converters/EnumArgumentConverter.cs
@@ -13,18 +13,13 @@ public class EnumConverter : ISlashArgumentConverter<Enum>, ITextArgumentConvert
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Integer;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<Enum>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs)
-    {
-        string value = context.As<TextConverterContext>().Argument;
-        return Task.FromResult(Enum.TryParse(context.Parameter.Type, value, true, out object? result)
-            ? Optional.FromValue((Enum)result)
-            : Optional.FromNoValue<Enum>());
-    }
+    public Task<Optional<Enum>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => Task.FromResult(Enum.TryParse(context.Parameter.Type, context.Argument, true, out object? result)
+        ? Optional.FromValue((Enum)result)
+        : Optional.FromNoValue<Enum>());
 
-    public Task<Optional<Enum>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
+    public Task<Optional<Enum>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs)
     {
-        InteractionConverterContext slashConverterContext = context.As<InteractionConverterContext>();
-        object value = Convert.ChangeType(slashConverterContext.Argument.Value, Enum.GetUnderlyingType(context.Parameter.Type), CultureInfo.InvariantCulture);
+        object value = Convert.ChangeType(context.Argument.Value, Enum.GetUnderlyingType(context.Parameter.Type), CultureInfo.InvariantCulture);
         return Enum.IsDefined(context.Parameter.Type, value)
             ? Task.FromResult(Optional.FromValue((Enum)Enum.ToObject(context.Parameter.Type, value)))
             : Task.FromResult(Optional.FromNoValue<Enum>());

--- a/DSharpPlus.Commands/Converters/FloatConverter.cs
+++ b/DSharpPlus.Commands/Converters/FloatConverter.cs
@@ -12,11 +12,11 @@ public class FloatConverter : ISlashArgumentConverter<float>, ITextArgumentConve
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Number;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<float>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => float.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out float result)
+    public Task<Optional<float>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => float.TryParse(context.Argument, CultureInfo.InvariantCulture, out float result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<float>());
 
-    public Task<Optional<float>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => float.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out float result)
+    public Task<Optional<float>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => float.TryParse(context.Argument.RawValue, CultureInfo.InvariantCulture, out float result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<float>());
 }

--- a/DSharpPlus.Commands/Converters/IArgumentConverter.cs
+++ b/DSharpPlus.Commands/Converters/IArgumentConverter.cs
@@ -6,7 +6,9 @@ using DSharpPlus.Entities;
 
 public interface IArgumentConverter { }
 
-public interface IArgumentConverter<TEventArgs, TOutput> : IArgumentConverter where TEventArgs : AsyncEventArgs
+public interface IArgumentConverter<TConverterContext, TEventArgs, TOutput> : IArgumentConverter
+    where TConverterContext : ConverterContext
+    where TEventArgs : AsyncEventArgs
 {
-    public Task<Optional<TOutput>> ConvertAsync(ConverterContext context, TEventArgs eventArgs);
+    public Task<Optional<TOutput>> ConvertAsync(TConverterContext context, TEventArgs eventArgs);
 }

--- a/DSharpPlus.Commands/Converters/Int16Converter.cs
+++ b/DSharpPlus.Commands/Converters/Int16Converter.cs
@@ -12,11 +12,11 @@ public class Int16Converter : ISlashArgumentConverter<short>, ITextArgumentConve
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Integer;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<short>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => short.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out short result)
+    public Task<Optional<short>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => short.TryParse(context.Argument, CultureInfo.InvariantCulture, out short result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<short>());
 
-    public Task<Optional<short>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => short.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out short result)
+    public Task<Optional<short>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => short.TryParse(context.Argument.RawValue, CultureInfo.InvariantCulture, out short result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<short>());
 }

--- a/DSharpPlus.Commands/Converters/Int32Converter.cs
+++ b/DSharpPlus.Commands/Converters/Int32Converter.cs
@@ -12,11 +12,11 @@ public class Int32Converter : ISlashArgumentConverter<int>, ITextArgumentConvert
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Integer;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<int>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => int.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out int result)
+    public Task<Optional<int>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => int.TryParse(context.Argument, CultureInfo.InvariantCulture, out int result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<int>());
 
-    public Task<Optional<int>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => int.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out int result)
+    public Task<Optional<int>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => int.TryParse(context.Argument.RawValue, CultureInfo.InvariantCulture, out int result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<int>());
 }

--- a/DSharpPlus.Commands/Converters/Int64Converter.cs
+++ b/DSharpPlus.Commands/Converters/Int64Converter.cs
@@ -15,11 +15,11 @@ public class Int64Converter : ISlashArgumentConverter<long>, ITextArgumentConver
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.String;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<long>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => long.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out long result)
+    public Task<Optional<long>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => long.TryParse(context.Argument, CultureInfo.InvariantCulture, out long result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<long>());
 
-    public Task<Optional<long>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => long.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out long result)
+    public Task<Optional<long>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => long.TryParse(context.Argument.RawValue, CultureInfo.InvariantCulture, out long result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<long>());
 }

--- a/DSharpPlus.Commands/Converters/SByteConverter.cs
+++ b/DSharpPlus.Commands/Converters/SByteConverter.cs
@@ -12,11 +12,11 @@ public class SByteConverter : ISlashArgumentConverter<sbyte>, ITextArgumentConve
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Integer;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<sbyte>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => sbyte.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out sbyte result)
+    public Task<Optional<sbyte>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => sbyte.TryParse(context.Argument, CultureInfo.InvariantCulture, out sbyte result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<sbyte>());
 
-    public Task<Optional<sbyte>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => sbyte.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out sbyte result)
+    public Task<Optional<sbyte>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => sbyte.TryParse(context.Argument.RawValue, CultureInfo.InvariantCulture, out sbyte result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<sbyte>());
 }

--- a/DSharpPlus.Commands/Converters/StringConverter.cs
+++ b/DSharpPlus.Commands/Converters/StringConverter.cs
@@ -16,31 +16,29 @@ public class StringConverter : ISlashArgumentConverter<string>, ITextArgumentCon
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.String;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<string>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs)
+    public Task<Optional<string>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs)
     {
-        TextConverterContext textContext = context.As<TextConverterContext>();
         foreach (Attribute attribute in context.Parameter.Attributes)
         {
             if (attribute is RemainingTextAttribute)
             {
-                return Task.FromResult(Optional.FromValue(textContext.Argument));
+                return Task.FromResult(Optional.FromValue(context.Argument));
             }
             else if (attribute is FromCodeAttribute codeAttribute)
             {
-                return TryGetCodeBlock(textContext.Argument, codeAttribute.CodeType, out string? code)
+                return TryGetCodeBlock(context.Argument, codeAttribute.CodeType, out string? code)
                     ? Task.FromResult(Optional.FromValue(code))
                     : Task.FromResult(Optional.FromNoValue<string>());
             }
         }
 
-        TextConverterContext textConverterContext = context.As<TextConverterContext>();
-        return Task.FromResult(Optional.FromValue(textConverterContext.RawArguments[textConverterContext.CurrentArgumentIndex..]));
+        return Task.FromResult(Optional.FromValue(context.RawArguments[context.CurrentArgumentIndex..]));
     }
 
     [SuppressMessage("Roslyn", "IDE0046", Justification = "Ternary rabbit hole.")]
-    public Task<Optional<string>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs)
+    public Task<Optional<string>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs)
     {
-        string? value = (string)context.As<InteractionConverterContext>().Argument.Value;
+        string value = (string)context.Argument.Value;
         if (context.Parameter.Attributes.FirstOrDefault(x => x is FromCodeAttribute) is not FromCodeAttribute codeAttribute)
         {
             return Task.FromResult(Optional.FromValue(context.As<InteractionConverterContext>().Argument.RawValue));

--- a/DSharpPlus.Commands/Converters/TimeSpanConverter.cs
+++ b/DSharpPlus.Commands/Converters/TimeSpanConverter.cs
@@ -17,8 +17,8 @@ public partial class TimeSpanConverter : ISlashArgumentConverter<TimeSpan>, ITex
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.String;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<TimeSpan>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => ConvertAsync(context, context.As<TextConverterContext>().Argument);
-    public Task<Optional<TimeSpan>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync(context, context.As<InteractionConverterContext>().Argument.RawValue);
+    public Task<Optional<TimeSpan>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => ConvertAsync(context, context.Argument);
+    public Task<Optional<TimeSpan>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => ConvertAsync(context, context.Argument.RawValue);
 
     public static Task<Optional<TimeSpan>> ConvertAsync(ConverterContext context, string? value)
     {

--- a/DSharpPlus.Commands/Converters/UInt16Converter.cs
+++ b/DSharpPlus.Commands/Converters/UInt16Converter.cs
@@ -12,11 +12,11 @@ public class UInt16Converter : ISlashArgumentConverter<ushort>, ITextArgumentCon
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Integer;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<ushort>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => ushort.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out ushort result)
+    public Task<Optional<ushort>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => ushort.TryParse(context.Argument, CultureInfo.InvariantCulture, out ushort result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<ushort>());
 
-    public Task<Optional<ushort>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ushort.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out ushort result)
+    public Task<Optional<ushort>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => ushort.TryParse(context.Argument.RawValue, CultureInfo.InvariantCulture, out ushort result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<ushort>());
 }

--- a/DSharpPlus.Commands/Converters/UInt32Converter.cs
+++ b/DSharpPlus.Commands/Converters/UInt32Converter.cs
@@ -12,11 +12,11 @@ public class UInt32Converter : ISlashArgumentConverter<uint>, ITextArgumentConve
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.Integer;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<uint>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => uint.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out uint result)
+    public Task<Optional<uint>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => uint.TryParse(context.Argument, CultureInfo.InvariantCulture, out uint result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<uint>());
 
-    public Task<Optional<uint>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => uint.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out uint result)
+    public Task<Optional<uint>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => uint.TryParse(context.Argument.RawValue, CultureInfo.InvariantCulture, out uint result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<uint>());
 }

--- a/DSharpPlus.Commands/Converters/UInt64Converter.cs
+++ b/DSharpPlus.Commands/Converters/UInt64Converter.cs
@@ -15,11 +15,11 @@ public class UInt64Converter : ISlashArgumentConverter<ulong>, ITextArgumentConv
     public ApplicationCommandOptionType ParameterType { get; init; } = ApplicationCommandOptionType.String;
     public bool RequiresText { get; init; } = true;
 
-    public Task<Optional<ulong>> ConvertAsync(ConverterContext context, MessageCreateEventArgs eventArgs) => ulong.TryParse(context.As<TextConverterContext>().Argument, CultureInfo.InvariantCulture, out ulong result)
+    public Task<Optional<ulong>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => ulong.TryParse(context.Argument, CultureInfo.InvariantCulture, out ulong result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<ulong>());
 
-    public Task<Optional<ulong>> ConvertAsync(ConverterContext context, InteractionCreateEventArgs eventArgs) => ulong.TryParse(context.As<InteractionConverterContext>().Argument.RawValue, CultureInfo.InvariantCulture, out ulong result)
+    public Task<Optional<ulong>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs) => ulong.TryParse(context.Argument.RawValue, CultureInfo.InvariantCulture, out ulong result)
         ? Task.FromResult(Optional.FromValue(result))
         : Task.FromResult(Optional.FromNoValue<ulong>());
 }

--- a/DSharpPlus.Commands/Processors/SlashCommands/ISlashArgumentConverter.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/ISlashArgumentConverter.cs
@@ -8,4 +8,4 @@ public interface ISlashArgumentConverter : IArgumentConverter
     public ApplicationCommandOptionType ParameterType { get; init; }
 }
 
-public interface ISlashArgumentConverter<T> : ISlashArgumentConverter, IArgumentConverter<InteractionCreateEventArgs, T>;
+public interface ISlashArgumentConverter<T> : ISlashArgumentConverter, IArgumentConverter<InteractionConverterContext, InteractionCreateEventArgs, T>;

--- a/DSharpPlus.Commands/Processors/TextCommands/ITextArgumentConverter.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/ITextArgumentConverter.cs
@@ -8,4 +8,4 @@ public interface ITextArgumentConverter : IArgumentConverter
     public bool RequiresText { get; init; }
 }
 
-public interface ITextArgumentConverter<T> : ITextArgumentConverter, IArgumentConverter<MessageCreateEventArgs, T>;
+public interface ITextArgumentConverter<T> : ITextArgumentConverter, IArgumentConverter<TextConverterContext, MessageCreateEventArgs, T>;


### PR DESCRIPTION
# Summary
This changes argument converters to use their respective converter context instead of a generalized `ConverterContext`.

# Notes
Tested.