### PR TITLE
Allow the command executor to be reassigned

### DIFF
--- a/DSharpPlus.Commands/CommandsConfiguration.cs
+++ b/DSharpPlus.Commands/CommandsConfiguration.cs
@@ -30,4 +30,12 @@ public sealed record CommandsConfiguration
     /// as this configuration option will only add the default processors if they're not found in the list.
     /// </remarks>
     public bool RegisterDefaultCommandProcessors { get; set; } = true;
+
+    /// <summary>
+    /// The command executor to use for command execution.
+    /// </summary>
+    /// <remarks>
+    /// The command executor is responsible for executing context checks, making full use of the dependency injection system, executing the command method itself, and handling errors.
+    /// </remarks>
+    public ICommandExecutor CommandExecutor { get; set; } = new CommandExecutor();
 }

--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -53,7 +53,7 @@ public sealed class CommandsExtension : BaseExtension
     /// <inheritdoc cref="CommandsConfiguration.RegisterDefaultCommandProcessors"/>
     public bool RegisterDefaultCommandProcessors { get; init; }
 
-    public CommandExecutor CommandExecutor { get; init; } = new();
+    public ICommandExecutor CommandExecutor { get; init; }
 
     /// <summary>
     /// The registered commands that the users can execute.
@@ -98,6 +98,8 @@ public sealed class CommandsExtension : BaseExtension
         this.ServiceProvider = configuration.ServiceProvider;
         this.DebugGuildId = configuration.DebugGuildId;
         this.UseDefaultCommandErrorHandler = configuration.UseDefaultCommandErrorHandler;
+        this.RegisterDefaultCommandProcessors = configuration.RegisterDefaultCommandProcessors;
+        this.CommandExecutor = configuration.CommandExecutor;
         if (this.UseDefaultCommandErrorHandler)
         {
             this.CommandErrored += DefaultCommandErrorHandlerAsync;


### PR DESCRIPTION
# Summary
Previously the command executor was forced to be the default command executor. This is no longer the case.

Additionally this PR fixes `RegisterDefaultCommandProcessors` never being assigned the correct value. I'm unsure how this previously passed testing.

# Notes
Untested.