### PR TITLE
[Commands] Fix accidental reversal of remaining text logic

### DIFF
--- a/DSharpPlus.Commands/Converters/StringConverter.cs
+++ b/DSharpPlus.Commands/Converters/StringConverter.cs
@@ -22,7 +22,7 @@ public class StringConverter : ISlashArgumentConverter<string>, ITextArgumentCon
         {
             if (attribute is RemainingTextAttribute)
             {
-                return Task.FromResult(Optional.FromValue(context.Argument));
+                return Task.FromResult(Optional.FromValue(context.RawArguments[context.CurrentArgumentIndex..]));
             }
             else if (attribute is FromCodeAttribute codeAttribute)
             {
@@ -32,7 +32,7 @@ public class StringConverter : ISlashArgumentConverter<string>, ITextArgumentCon
             }
         }
 
-        return Task.FromResult(Optional.FromValue(context.RawArguments[context.CurrentArgumentIndex..]));
+        return Task.FromResult(Optional.FromValue(context.Argument));
     }
 
     [SuppressMessage("Roslyn", "IDE0046", Justification = "Ternary rabbit hole.")]


### PR DESCRIPTION
# Summary
The logic behind the remaining text attribute within the string converter was entirely backwards and caused numerous bugs. Now they do not.

# Notes
Tested.