### PR TITLE
Use a more sane default commandexecutor in cnext

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
@@ -119,7 +119,7 @@ public sealed class CommandsNextConfiguration
     /// <para>Gets or sets the default command executor.</para>
     /// <para>This alters the behaviour, execution, and scheduling method of command execution.</para>
     /// </summary>
-    public ICommandExecutor CommandExecutor { internal get; set; } = new SynchronousCommandExecutor();
+    public ICommandExecutor CommandExecutor { internal get; set; } = new AsynchronousCommandExecutor();
 
     /// <summary>
     /// Creates a new instance of <see cref="CommandsNextConfiguration"/>.

--- a/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
@@ -119,7 +119,7 @@ public sealed class CommandsNextConfiguration
     /// <para>Gets or sets the default command executor.</para>
     /// <para>This alters the behaviour, execution, and scheduling method of command execution.</para>
     /// </summary>
-    public ICommandExecutor CommandExecutor { internal get; set; } = new ParallelQueuedCommandExecutor();
+    public ICommandExecutor CommandExecutor { internal get; set; } = new AsynchronousCommandExecutor();
 
     /// <summary>
     /// Creates a new instance of <see cref="CommandsNextConfiguration"/>.

--- a/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextConfiguration.cs
@@ -119,7 +119,7 @@ public sealed class CommandsNextConfiguration
     /// <para>Gets or sets the default command executor.</para>
     /// <para>This alters the behaviour, execution, and scheduling method of command execution.</para>
     /// </summary>
-    public ICommandExecutor CommandExecutor { internal get; set; } = new AsynchronousCommandExecutor();
+    public ICommandExecutor CommandExecutor { internal get; set; } = new SynchronousCommandExecutor();
 
     /// <summary>
     /// Creates a new instance of <see cref="CommandsNextConfiguration"/>.

--- a/DSharpPlus.CommandsNext/Executors/AsynchronousCommandExecutor.cs
+++ b/DSharpPlus.CommandsNext/Executors/AsynchronousCommandExecutor.cs
@@ -10,7 +10,7 @@ public sealed class AsynchronousCommandExecutor : ICommandExecutor
 {
     Task ICommandExecutor.ExecuteAsync(CommandContext ctx)
     {
-        _ = Task.Run(() => ctx.CommandsNext.ExecuteCommandAsync(ctx));
+        _ = ctx.CommandsNext.ExecuteCommandAsync(ctx);
         return Task.CompletedTask;
     }
 

--- a/DSharpPlus.CommandsNext/Executors/SynchronousCommandExecutor.cs
+++ b/DSharpPlus.CommandsNext/Executors/SynchronousCommandExecutor.cs
@@ -8,8 +8,8 @@ namespace DSharpPlus.CommandsNext.Executors;
 /// </summary>
 public sealed class SynchronousCommandExecutor : ICommandExecutor
 {
-    async Task ICommandExecutor.ExecuteAsync(CommandContext ctx)
-        => await ctx.CommandsNext.ExecuteCommandAsync(ctx);
+    Task ICommandExecutor.ExecuteAsync(CommandContext ctx)
+        => ctx.CommandsNext.ExecuteCommandAsync(ctx);
 
     void IDisposable.Dispose()
     { }


### PR DESCRIPTION
# Summary
Just throw commandexecutions at the .Net threadpool