### PR TITLE
Fixes beginning whitespace being passed to the argument

### DIFF
--- a/DSharpPlus.Commands/Converters/StringConverter.cs
+++ b/DSharpPlus.Commands/Converters/StringConverter.cs
@@ -22,7 +22,7 @@ public class StringConverter : ISlashArgumentConverter<string>, ITextArgumentCon
         {
             if (attribute is RemainingTextAttribute)
             {
-                return Task.FromResult(Optional.FromValue(context.RawArguments[context.CurrentArgumentIndex..]));
+                return Task.FromResult(Optional.FromValue(context.RawArguments[context.CurrentArgumentIndex..].TrimStart()));
             }
             else if (attribute is FromCodeAttribute codeAttribute)
             {


### PR DESCRIPTION
# Summary
Yet another bug within the string converter.

![" Testing"](https://github.com/DSharpPlus/DSharpPlus/assets/46751150/7bd669d1-010a-4f68-b7ae-9f954db4d1b1)

# Notes
Tested