### PR TITLE
Fix type and default for DiscordApplicationCommand's Contexts and IntegrationTypes

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -285,8 +285,8 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
             allowDMUsage: command.Attributes.Any(x => x is AllowDMUsageAttribute),
             defaultMemberPermissions: command.Attributes.OfType<RequirePermissionsAttribute>().FirstOrDefault()?.UserPermissions ?? Permissions.None,
             nsfw: command.Attributes.Any(x => x is RequireNsfwAttribute),
-            contexts: command.Attributes.OfType<SlashAllowedContextsAttribute>().FirstOrDefault()?.AllowedContexts ?? [],
-            integrationTypes: command.Attributes.OfType<SlashInstallTypeAttribute>().FirstOrDefault()?.InstallTypes ?? []
+            contexts: command.Attributes.OfType<SlashAllowedContextsAttribute>().FirstOrDefault()?.AllowedContexts ?? [InteractionContextType.Guild | InteractionContextType.BotDM],
+            integrationTypes: command.Attributes.OfType<SlashInstallTypeAttribute>().FirstOrDefault()?.InstallTypes ?? [ApplicationIntegrationType.GuildInstall]
         );
     }
 

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
@@ -83,13 +83,13 @@ public sealed class DiscordApplicationCommand : SnowflakeObject, IEquatable<Disc
     /// Contexts in which this command can be invoked.
     /// </summary>
     [JsonProperty("contexts")]
-    public IReadOnlyList<InteractionContextType> Contexts { get; internal set; }
+    public IReadOnlyList<InteractionContextType>? Contexts { get; internal set; }
     
     /// <summary>
     /// Contexts in which this command can be installed.
     /// </summary>
     [JsonProperty("integration_types")]
-    public IReadOnlyList<ApplicationIntegrationType> IntegrationTypes { get; internal set; }
+    public IReadOnlyList<ApplicationIntegrationType>? IntegrationTypes { get; internal set; }
 
     /// <summary>
     /// Gets the command's mention string.
@@ -171,8 +171,8 @@ public sealed class DiscordApplicationCommand : SnowflakeObject, IEquatable<Disc
         this.AllowDMUsage = allowDMUsage;
         this.DefaultMemberPermissions = defaultMemberPermissions;
         this.NSFW = nsfw;
-        this.Contexts = contexts ?? new List<InteractionContextType>();
-        this.IntegrationTypes = integrationTypes ?? new List<ApplicationIntegrationType>();
+        this.Contexts = contexts ?? [InteractionContextType.Guild | InteractionContextType.BotDM];
+        this.IntegrationTypes = integrationTypes ?? [ApplicationIntegrationType.GuildInstall];
     }
 
     /// <summary>


### PR DESCRIPTION
- Fix the issue where if DiscordApplicationCommand's Contexts and IntegrationTypes were not set, it would initialize as an empty array, which would throw an error on command registration.