### PR TITLE
enable localizing application command choices

### DIFF
--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOptionChoice.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommandOptionChoice.cs
@@ -1,40 +1,57 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities;
 
 /// <summary>
-/// Represents a command parameter choice for a <see cref="DiscordApplicationCommandOption"/>.
+/// Represents a choice for a <see cref="DiscordApplicationCommandOption"/> parameter.
 /// </summary>
 public sealed class DiscordApplicationCommandOptionChoice
 {
     /// <summary>
-    /// Gets the name of this choice parameter.
+    /// Gets the name of this choice.
     /// </summary>
     [JsonProperty("name")]
     public string Name { get; set; }
 
     /// <summary>
-    /// Gets the value of this choice parameter. This will either be a type of <see cref="int"/> / <see cref="long"/>, <see cref="double"/> or <see cref="string"/>.
+    /// Gets the value of this choice. This will either be a type of <see cref="int"/> / <see cref="long"/>, <see cref="double"/> or <see cref="string"/>.
     /// </summary>
     [JsonProperty("value")]
     public object Value { get; set; }
 
+    [JsonProperty("name_localizations")]
+    public IReadOnlyDictionary<string, string>? NameLocalizations { get; set; }
+
     /// <summary>
     /// Creates a new instance of a <see cref="DiscordApplicationCommandOptionChoice"/>.
     /// </summary>
-    /// <param name="name">The name of the parameter choice.</param>
-    /// <param name="value">The value of the parameter choice.</param>
-    public DiscordApplicationCommandOptionChoice(string name, object value)
+    /// <param name="name">The name of this choice.</param>
+    /// <param name="value">The value of this choice.</param>
+    /// <param name="localizations">
+    /// Localized names for this choice. The keys must be appropriate locales as documented by Discord:
+    /// <seealso href="https://discord.com/developers/docs/reference#locales"/>.
+    /// </param>
+    public DiscordApplicationCommandOptionChoice(string name, object value, IReadOnlyDictionary<string, string>? localizations = null)
     {
-        if (!(value is string || value is long || value is int || value is double))
+        if (value is not (string or long or int or double or float))
         {
-            throw new InvalidOperationException($"Only {typeof(string)}, {typeof(long)}, {typeof(double)} or {typeof(int)} types may be passed to a command option choice.");
+            throw new InvalidOperationException
+            (
+                "Only strings, floating point and integer types may be passed to a command option choice."
+            );
         }
 
-        if (name.Length > 100)
+        if (name.Length is < 1 or > 100)
         {
-            throw new ArgumentException("Application command choice name cannot exceed 100 characters.", nameof(name));
+            throw new ArgumentException
+            (
+                "Application command choice name cannot be empty or longer than 100 characters.", 
+                nameof(name)
+            );
         }
 
         if (value is string val && val.Length > 100)
@@ -42,7 +59,17 @@ public sealed class DiscordApplicationCommandOptionChoice
             throw new ArgumentException("Application command choice value cannot exceed 100 characters.", nameof(value));
         }
 
+        if (localizations is not null && localizations.Values.Any(localized => localized.Length is < 1 or > 100))
+        {
+            throw new ArgumentException
+            (
+                "Localized application command choice names cannot be empty or longer than 100 characters.",
+                nameof(localizations)
+            );
+        }
+
         this.Name = name;
         this.Value = value;
+        this.NameLocalizations = localizations;
     }
 }


### PR DESCRIPTION
should work ootb for DSharpPlus.Commands, which makes choice providers return the choice objects, can't speak for DSharpPlus.SlashCommands (not that I particularly care, anyway)

we might want to rework the type check for value even more, but i've now added `float` to the list of allowed types since that's still relatively common in code compared to short/byte; on a future note, we could consider supporting argument conversion on choices in DSharpPlus.Commands, which would make for pretty fun programming