### PR TITLE
Make command registeration behavior more consistent

### DIFF
--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -135,13 +135,14 @@ public sealed class CommandsExtension : BaseExtension
         this.AddCheck<TextMessageReplyCheck>();
     }
 
+    public void AddCommand(Type type) => this._commandBuilders.Add(CommandBuilder.From(type));
     public void AddCommand(CommandBuilder command) => this._commandBuilders.Add(command);
     public void AddCommand(Delegate commandDelegate) => this._commandBuilders.Add(CommandBuilder.From(commandDelegate));
     public void AddCommands(IEnumerable<CommandBuilder> commands) => this._commandBuilders.AddRange(commands);
     public void AddCommands(Assembly assembly) => this.AddCommands(assembly.GetTypes());
-    public void AddCommands(params CommandBuilder[] commands) => this._commandBuilders.AddRange(commands);
-    public void AddCommands(Type type) => this._commandBuilders.Add(CommandBuilder.From(type));
+    public void AddCommands(Type type) => this.AddCommands([type]);
     public void AddCommands<T>() => this._commandBuilders.Add(CommandBuilder.From<T>());
+    public void AddCommands(params CommandBuilder[] commands) => this._commandBuilders.AddRange(commands);
     public void AddCommands(IEnumerable<Type> types)
     {
         foreach (Type type in types)


### PR DESCRIPTION
# Summary
Add `AddCommand(Type type)` overload and modify `AddCommands(Type type)` to accept multiple commands from one type

# Notes
Untested. Closes #1826