### PR TITLE
Add cancellation tokens to IAsyncEnumerables

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -839,7 +839,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
     
     
     /// <summary>
-    /// Returns a list of guilds before a certain guild. One api request per 200 guilds
+    /// Returns a list of guilds before a certain guild. This will execute one API request per 200 guilds.
     /// <param name="limit">The amount of guilds to fetch.</param>
     /// <param name="before">The ID of the guild before which we fetch the guilds</param>
     /// <param name="withCount">Whether to include approximate member and presence counts in the returned guilds.</param>
@@ -851,7 +851,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
         => this.GetGuildsInternalAsync(limit, before, withCount: withCount, cancellationToken: cancellationToken);
 
     /// <summary>
-    /// Returns a list of guilds after a certain guild. One api request per 200 guilds
+    /// Returns a list of guilds after a certain guild. This will execute one API request per 200 guilds.
     /// <param name="limit">The amount of guilds to fetch.</param>
     /// <param name="after">The ID of the guild after which we fetch the guilds.</param>
     /// <param name="withCount">Whether to include approximate member and presence counts in the returned guilds.</param>
@@ -863,7 +863,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
         => this.GetGuildsInternalAsync(limit, after: after, withCount: withCount, cancellationToken: cancellationToken);
     
     /// <summary>
-    /// Returns a list of guilds the bot is in. One api request per 200 guilds
+    /// Returns a list of guilds the bot is in. This will execute one API request per 200 guilds.
     /// <param name="limit">The amount of guilds to fetch.</param>
     /// <param name="withCount">Whether to include approximate member and presence counts in the returned guilds.</param>
     /// <param name="cancellationToken">Cancels the enumeration before doing the next api request</param>
@@ -901,7 +901,10 @@ public sealed partial class DiscordClient : BaseDiscordClient
         int lastCount;
         do
         {
-            if (cancellationToken.IsCancellationRequested) yield break;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                yield break;
+            }
             
             int fetchSize = remaining > 200 ? 200 : remaining;
             IReadOnlyList<DiscordGuild> fetchedGuilds = await this.ApiClient.GetGuildsAsync( fetchSize, isbefore ? last ?? before : null, !isbefore ? last ?? after : null, withCount);

--- a/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
+++ b/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 using DSharpPlus.Net.Abstractions;
@@ -14,8 +16,6 @@ using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.Entities.AuditLogs;
 
-using System.Runtime.CompilerServices;
-using System.Threading;
 
 internal static class AuditLogParser
 {

--- a/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
+++ b/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
@@ -14,6 +14,9 @@ using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.Entities.AuditLogs;
 
+using System.Runtime.CompilerServices;
+using System.Threading;
+
 internal static class AuditLogParser
 {
     /// <summary>
@@ -25,7 +28,9 @@ internal static class AuditLogParser
     internal static async IAsyncEnumerable<DiscordAuditLogEntry> ParseAuditLogToEntriesAsync
     (
         DiscordGuild guild,
-        AuditLog auditLog
+        AuditLog auditLog,
+        [EnumeratorCancellation]
+        CancellationToken cancellationToken = default
     )
     {
         BaseDiscordClient client = guild.Discord;
@@ -96,6 +101,7 @@ internal static class AuditLogParser
         IOrderedEnumerable<AuditLogAction>? auditLogActions = auditLog.Entries.OrderByDescending(xa => xa.Id);
         foreach (AuditLogAction? auditLogAction in auditLogActions)
         {
+            if (cancellationToken.IsCancellationRequested) yield break;
             DiscordAuditLogEntry? entry =
                 await ParseAuditLogEntryAsync(guild, auditLogAction, members, threads, webhooks, events);
 

--- a/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
+++ b/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
@@ -16,7 +16,6 @@ using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.Entities.AuditLogs;
 
-
 internal static class AuditLogParser
 {
     /// <summary>
@@ -101,7 +100,11 @@ internal static class AuditLogParser
         IOrderedEnumerable<AuditLogAction>? auditLogActions = auditLog.Entries.OrderByDescending(xa => xa.Id);
         foreach (AuditLogAction? auditLogAction in auditLogActions)
         {
-            if (cancellationToken.IsCancellationRequested) yield break;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                yield break;
+            }
+            
             DiscordAuditLogEntry? entry =
                 await ParseAuditLogEntryAsync(guild, auditLogAction, members, threads, webhooks, events);
 

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -472,7 +472,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
     }
 
     /// <summary>
-    /// Returns a list of messages before a certain message. Does one request per 100 messages
+    /// Returns a list of messages before a certain message. This will execute one API request per 100 messages.
     /// <param name="limit">The amount of messages to fetch.</param>
     /// <param name="before">Message to fetch before from.</param>
     /// <param name="cancellationToken">Cancels the enumeration before doing the next api request</param>
@@ -485,7 +485,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
         => this.GetMessagesInternalAsync(limit, before, cancellationToken: cancellationToken);
 
     /// <summary>
-    /// Returns a list of messages after a certain message. Does one request per 100 messages
+    /// Returns a list of messages after a certain message. This will execute one API request per 100 messages.
     /// <param name="limit">The amount of messages to fetch.</param>
     /// <param name="after">Message to fetch after from.</param>
     /// <param name="cancellationToken">Cancels the enumeration before doing the next api request</param>
@@ -498,7 +498,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
         => this.GetMessagesInternalAsync(limit, after: after, cancellationToken: cancellationToken);
 
     /// <summary>
-    /// Returns a list of messages around a certain message. Does one request per 100 messages
+    /// Returns a list of messages around a certain message. This will execute one API request per 100 messages.
     /// <param name="limit">The amount of messages to fetch.</param>
     /// <param name="around">Message to fetch around from.</param>
     /// <param name="cancellationToken">Cancels the enumeration before doing the next api request</param>
@@ -511,7 +511,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
         => this.GetMessagesInternalAsync(limit, around: around, cancellationToken: cancellationToken);
 
     /// <summary>
-    /// Returns a list of messages from the last message in the channel. Does one request per 100 messages
+    /// Returns a list of messages from the last message in the channel. This will execute one API request per 100 messages.
     /// <param name="limit">The amount of messages to fetch.</param>
     /// <param name="cancellationToken">Cancels the enumeration before doing the next api request</param>
     /// </summary>
@@ -561,7 +561,10 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
         int lastCount;
         do
         {
-            if (cancellationToken.IsCancellationRequested) yield break;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                yield break;
+            }
             
             int fetchSize = remaining > 100 ? 100 : remaining;
             IReadOnlyList<DiscordMessage> fetchedMessages = await this.Discord.ApiClient.GetChannelMessagesAsync(this.Id, fetchSize, isbefore ? last ?? before : null, !isbefore ? last ?? after : null, around);

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using DSharpPlus.Exceptions;
 using DSharpPlus.Net.Abstractions;
@@ -470,53 +472,65 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
     }
 
     /// <summary>
-    /// Returns a list of messages before a certain message.
+    /// Returns a list of messages before a certain message. Does one request per 100 messages
     /// <param name="limit">The amount of messages to fetch.</param>
     /// <param name="before">Message to fetch before from.</param>
+    /// <param name="cancellationToken">Cancels the enumeration before doing the next api request</param>
     /// </summary>
     /// <exception cref="UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.AccessChannels"/> permission.</exception>
     /// <exception cref="NotFoundException">Thrown when the channel does not exist.</exception>
     /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
     /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-    public IAsyncEnumerable<DiscordMessage> GetMessagesBeforeAsync(ulong before, int limit = 100)
-        => this.GetMessagesInternalAsync(limit, before, null, null);
+    public IAsyncEnumerable<DiscordMessage> GetMessagesBeforeAsync(ulong before, int limit = 100, CancellationToken cancellationToken = default)
+        => this.GetMessagesInternalAsync(limit, before, cancellationToken: cancellationToken);
 
     /// <summary>
-    /// Returns a list of messages after a certain message.
+    /// Returns a list of messages after a certain message. Does one request per 100 messages
     /// <param name="limit">The amount of messages to fetch.</param>
     /// <param name="after">Message to fetch after from.</param>
+    /// <param name="cancellationToken">Cancels the enumeration before doing the next api request</param>
     /// </summary>
     /// <exception cref="UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.AccessChannels"/> permission.</exception>
     /// <exception cref="NotFoundException">Thrown when the channel does not exist.</exception>
     /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
     /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-    public IAsyncEnumerable<DiscordMessage> GetMessagesAfterAsync(ulong after, int limit = 100)
-        => this.GetMessagesInternalAsync(limit, null, after, null);
+    public IAsyncEnumerable<DiscordMessage> GetMessagesAfterAsync(ulong after, int limit = 100, CancellationToken cancellationToken = default)
+        => this.GetMessagesInternalAsync(limit, after: after, cancellationToken: cancellationToken);
 
     /// <summary>
-    /// Returns a list of messages around a certain message.
+    /// Returns a list of messages around a certain message. Does one request per 100 messages
     /// <param name="limit">The amount of messages to fetch.</param>
     /// <param name="around">Message to fetch around from.</param>
+    /// <param name="cancellationToken">Cancels the enumeration before doing the next api request</param>
     /// </summary>
     /// <exception cref="UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.AccessChannels"/> permission.</exception>
     /// <exception cref="NotFoundException">Thrown when the channel does not exist.</exception>
     /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
     /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-    public IAsyncEnumerable<DiscordMessage> GetMessagesAroundAsync(ulong around, int limit = 100)
-        => this.GetMessagesInternalAsync(limit, null, null, around);
+    public IAsyncEnumerable<DiscordMessage> GetMessagesAroundAsync(ulong around, int limit = 100, CancellationToken cancellationToken = default)
+        => this.GetMessagesInternalAsync(limit, around: around, cancellationToken: cancellationToken);
 
     /// <summary>
-    /// Returns a list of messages from the last message in the channel.
+    /// Returns a list of messages from the last message in the channel. Does one request per 100 messages
     /// <param name="limit">The amount of messages to fetch.</param>
+    /// <param name="cancellationToken">Cancels the enumeration before doing the next api request</param>
     /// </summary>
     /// <exception cref="UnauthorizedException">Thrown when the client does not have the <see cref="Permissions.AccessChannels"/> permission.</exception>
     /// <exception cref="NotFoundException">Thrown when the channel does not exist.</exception>
     /// <exception cref="BadRequestException">Thrown when an invalid parameter was provided.</exception>
     /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-    public IAsyncEnumerable<DiscordMessage> GetMessagesAsync(int limit = 100) =>
-        this.GetMessagesInternalAsync(limit, null, null, null);
+    public IAsyncEnumerable<DiscordMessage> GetMessagesAsync(int limit = 100, CancellationToken cancellationToken = default) =>
+        this.GetMessagesInternalAsync(limit, cancellationToken: cancellationToken);
 
-    private async IAsyncEnumerable<DiscordMessage> GetMessagesInternalAsync(int limit = 100, ulong? before = null, ulong? after = null, ulong? around = null)
+    private async IAsyncEnumerable<DiscordMessage> GetMessagesInternalAsync
+    (
+        int limit = 100,
+        ulong? before = null,
+        ulong? after = null,
+        ulong? around = null,
+        [EnumeratorCancellation]
+        CancellationToken cancellationToken = default
+    )
     {
         if (!Utilities.IsTextableChannel(this))
         {
@@ -547,6 +561,8 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
         int lastCount;
         do
         {
+            if (cancellationToken.IsCancellationRequested) yield break;
+            
             int fetchSize = remaining > 100 ? 100 : remaining;
             IReadOnlyList<DiscordMessage> fetchedMessages = await this.Discord.ApiClient.GetChannelMessagesAsync(this.Id, fetchSize, isbefore ? last ?? before : null, !isbefore ? last ?? after : null, around);
 
@@ -680,7 +696,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
     }
     
     /// <summary>
-    /// Deletes multiple messages if they are less than 14 days old.
+    /// Deletes multiple messages if they are less than 14 days old. Does one api request per 100 
     /// </summary>
     /// <param name="messages">A collection of messages to delete.</param>
     /// <param name="reason">Reason for audit logs.</param>

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -1453,18 +1453,26 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     }
 
     /// <summary>
-    /// Retrieves a full list of members from Discord. This method will bypass cache. Does one api request per 1000 member
+    /// Retrieves a full list of members from Discord. This method will bypass cache. This will execute one API request per 1000 entities.
     /// </summary>
     /// <param name="cancellationToken">Cancels the enumeration before the next api request</param>
     /// <returns>A collection of all members in this guild.</returns>
     /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-    public async IAsyncEnumerable<DiscordMember> GetAllMembersAsync( [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    public async IAsyncEnumerable<DiscordMember> GetAllMembersAsync
+    ( 
+        [EnumeratorCancellation] 
+        CancellationToken cancellationToken = default
+    )
     {
         int recievedLastCall = 1000;
         ulong last = 0ul;
         while (recievedLastCall > 0)
         {
-            if (cancellationToken.IsCancellationRequested) yield break;
+            if (cancellationToken.IsCancellationRequested)
+            {
+                yield break;
+            }
+            
             IReadOnlyList<TransportMember> tms = await this.Discord.ApiClient.ListGuildMembersAsync(this.Id, 1000, last == 0 ? null : last);
             recievedLastCall = tms.Count;
 

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 using DSharpPlus.Entities.AuditLogs;
@@ -1451,24 +1453,26 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     }
 
     /// <summary>
-    /// Retrieves a full list of members from Discord. This method will bypass cache.
+    /// Retrieves a full list of members from Discord. This method will bypass cache. Does one api request per 1000 member
     /// </summary>
+    /// <param name="cancellationToken">Cancels the enumeration before the next api request</param>
     /// <returns>A collection of all members in this guild.</returns>
     /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-    public async IAsyncEnumerable<DiscordMember> GetAllMembersAsync()
+    public async IAsyncEnumerable<DiscordMember> GetAllMembersAsync( [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         int recievedLastCall = 1000;
         ulong last = 0ul;
         while (recievedLastCall > 0)
         {
-            IReadOnlyList<TransportMember> tms = await this.Discord.ApiClient.ListGuildMembersAsync(this.Id, 1000, last == 0 ? null : (ulong?)last);
+            if (cancellationToken.IsCancellationRequested) yield break;
+            IReadOnlyList<TransportMember> tms = await this.Discord.ApiClient.ListGuildMembersAsync(this.Id, 1000, last == 0 ? null : last);
             recievedLastCall = tms.Count;
 
             foreach (TransportMember transportMember in tms)
             {
                 DiscordUser user = new(transportMember.User) { Discord = this.Discord };
 
-                user = this.Discord.UpdateUserCache(user);
+                _ = this.Discord.UpdateUserCache(user);
 
                 DiscordMember member = new (transportMember) { Discord = this.Discord, _guild_id = this.Id };
                 yield return member;


### PR DESCRIPTION
# Summary
Adds "first party support" to cancel methods which do multiple api requests. The cancelation token support is prefered compared to a `break` in an `await foreach` because we can cancel after we returned all entities we already got