### PR TITLE
respect `ParameterAttribute`

### DIFF
--- a/DSharpPlus.Commands/ParameterAttribute.cs
+++ b/DSharpPlus.Commands/ParameterAttribute.cs
@@ -1,10 +1,8 @@
-using DSharpPlus.Commands;
+using System;
 
 namespace DSharpPlus.Commands;
 
-using System;
-
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Delegate)]
+[AttributeUsage(AttributeTargets.Parameter)]
 public sealed class ParameterAttribute : Attribute
 {
     /// <summary>

--- a/DSharpPlus.Commands/Trees/CommandParameterBuilder.cs
+++ b/DSharpPlus.Commands/Trees/CommandParameterBuilder.cs
@@ -116,8 +116,11 @@ public class CommandParameterBuilder
             commandParameterBuilder.WithDefaultValue(parameterInfo.DefaultValue);
         }
 
-        // Might be set by the `ArgumentAttribute`
-        if (string.IsNullOrWhiteSpace(commandParameterBuilder.Name) && !string.IsNullOrWhiteSpace(parameterInfo.Name))
+        if (parameterInfo.GetCustomAttribute<ParameterAttribute>() is { } attribute)
+        {
+            commandParameterBuilder.WithName(attribute.Name);
+        }
+        else if (!string.IsNullOrWhiteSpace(parameterInfo.Name))
         {
             commandParameterBuilder.WithName(parameterInfo.Name);
         }

--- a/DSharpPlus.Commands/Trees/CommandParameterBuilder.cs
+++ b/DSharpPlus.Commands/Trees/CommandParameterBuilder.cs
@@ -116,7 +116,7 @@ public class CommandParameterBuilder
             commandParameterBuilder.WithDefaultValue(parameterInfo.DefaultValue);
         }
 
-        if (parameterInfo.GetCustomAttribute<ParameterAttribute>() is { } attribute)
+        if (parameterInfo.GetCustomAttribute<ParameterAttribute>() is ParameterAttribute attribute)
         {
             commandParameterBuilder.WithName(attribute.Name);
         }


### PR DESCRIPTION
ParameterAttribute succeeds SlashCommands' OptionAttribute

tested with slash commands, afaik text commands don't use this anyway