### PR TITLE
[Commands] Fixes the SlashMinMaxLengthAttribute

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/ArgumentModifiers/SlashMinMaxLengthAttribute.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/ArgumentModifiers/SlashMinMaxLengthAttribute.cs
@@ -8,22 +8,37 @@ using System;
 [AttributeUsage(AttributeTargets.Parameter)]
 public sealed class SlashMinMaxLengthAttribute : Attribute
 {
+    private const int MinLengthMinimum = 0;
+    private const int MinLengthMaximum = 6000;
+    private const int MaxLengthMinimum = 1;
+    private const int MaxLengthMaximum = 6000;
+
     /// <summary>
     /// The minimum length that this parameter can accept.
     /// </summary>
-    public int? MinLength { get; init; }
+    public int MinLength { get; init; } = MinLengthMinimum;
 
     /// <summary>
     /// The maximum length that this parameter can accept.
     /// </summary>
-    public int? MaxLength { get; init; }
+    public int MaxLength { get; init; } = MaxLengthMaximum;
 
     /// <summary>
     /// Determines the minimum and maximum length that a parameter can accept.
     /// </summary>
     public SlashMinMaxLengthAttribute()
     {
-        if (this.MinLength is not null && this.MaxLength is not null && this.MinLength > this.MaxLength)
+        if (this.MinLength < MinLengthMinimum || this.MinLength > MinLengthMaximum)
+        {
+            throw new ArgumentException($"The minimum length cannot be less than {MinLengthMinimum} and greater than {MinLengthMaximum}.");
+        }
+
+        if (this.MaxLength < MaxLengthMinimum || this.MaxLength > MaxLengthMaximum)
+        {
+            throw new ArgumentException($"The maximum length cannot be less than {MaxLengthMinimum} and greater than {MaxLengthMaximum}.");
+        }
+
+        if (this.MinLength > this.MaxLength)
         {
             throw new ArgumentException("The minimum length cannot be greater than the maximum length.");
         }


### PR DESCRIPTION
Fixes the `SlashMinMaxLengthAttribute` by adding a default value to use `int` instead of the non supported `int?`

the const values come from the doc : https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure


