### PR TITLE
Implement SnowflakeObject SlashArgumentConverter

### DIFF
--- a/DSharpPlus.Commands/Converters/DiscordRoleConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordRoleConverter.cs
@@ -29,7 +29,7 @@ public partial class DiscordRoleConverter : ISlashArgumentConverter<DiscordRole>
         {
             // value can be a raw channel id or a channel mention. The regex will match both.
             Match match = _getRoleRegex().Match(context.Argument);
-            if (!match.Success || !ulong.TryParse(match.Captures[0].ValueSpan, NumberStyles.Number, CultureInfo.InvariantCulture, out roleId))
+            if (!match.Success || !ulong.TryParse(match.Groups[1].ValueSpan, NumberStyles.Number, CultureInfo.InvariantCulture, out roleId))
             {
                 // Attempt to find a role by name, case sensitive.
                 DiscordRole? namedRole = context.Guild.Roles.Values.FirstOrDefault(role => role.Name.Equals(context.Argument, StringComparison.Ordinal));

--- a/DSharpPlus.Commands/Converters/DiscordSnowflakeObjectConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordSnowflakeObjectConverter.cs
@@ -1,0 +1,44 @@
+namespace DSharpPlus.Commands.Converters;
+
+using DSharpPlus.Commands.Processors.SlashCommands;
+using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+public partial class DiscordSnowflakeObjectConverter : ISlashArgumentConverter<SnowflakeObject>
+{
+    public DiscordApplicationCommandOptionType ParameterType { get; init; } = DiscordApplicationCommandOptionType.Mentionable;
+    public bool RequiresText { get; init; } = true;
+    private readonly ILogger<DiscordSnowflakeObjectConverter> _logger;
+
+    public DiscordSnowflakeObjectConverter(ILogger<DiscordSnowflakeObjectConverter>? logger = null) => this._logger = logger ?? NullLogger<DiscordSnowflakeObjectConverter>.Instance;
+
+    public Task<Optional<SnowflakeObject>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs)
+    {
+        DiscordInteractionDataOption option = eventArgs.Interaction.Data.Options.Single(x =>
+                    x.Name.Equals(context.Parameter.Name, StringComparison.InvariantCultureIgnoreCase));
+
+        //Checks through resolved
+        if (eventArgs.Interaction.Data.Resolved.Roles != null && eventArgs.Interaction.Data.Resolved.Roles.TryGetValue((ulong)option.Value, out DiscordRole? role))
+        {
+            return Task.FromResult(Optional.FromValue<SnowflakeObject>(role));            
+        }
+        else if (eventArgs.Interaction.Data.Resolved.Members != null && eventArgs.Interaction.Data.Resolved.Members.TryGetValue((ulong)option.Value, out DiscordMember? member))
+        {
+            return Task.FromResult(Optional.FromValue<SnowflakeObject>(member));
+        }
+        else if (eventArgs.Interaction.Data.Resolved.Users != null && eventArgs.Interaction.Data.Resolved.Users.TryGetValue((ulong)option.Value, out DiscordUser? user))
+        {
+            return Task.FromResult(Optional.FromValue<SnowflakeObject>(user));
+        }
+        else
+        {
+            this._logger.LogError("Failed to resolve SnowflakeObject type."); 
+            return Task.FromResult(Optional.FromNoValue<SnowflakeObject>());
+        }
+    }
+}

--- a/DSharpPlus.Commands/Converters/DiscordSnowflakeObjectConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordSnowflakeObjectConverter.cs
@@ -13,18 +13,12 @@ public partial class DiscordSnowflakeObjectConverter : ISlashArgumentConverter<S
     public DiscordApplicationCommandOptionType ParameterType { get; init; } = DiscordApplicationCommandOptionType.Mentionable;
     public bool RequiresText { get; init; } = true;
 
-    private readonly ILogger<DiscordSnowflakeObjectConverter> _logger;
     private readonly DiscordMemberConverter discordMemberSlashArgumentConverter;
     private readonly DiscordUserConverter discordUserSlashArgumentConverter;
     private readonly DiscordRoleConverter discordRoleSlashArgumentConverter;
 
-    public DiscordSnowflakeObjectConverter(
-        ILogger<DiscordSnowflakeObjectConverter>? logger = null,
-        ILogger<DiscordMemberConverter>? discordMemberSlashArgumentConverter = null,
-        ILogger<DiscordUserConverter>? discordUserSlashArgumentConverter = null
-    )
+    public DiscordSnowflakeObjectConverter(ILogger<DiscordMemberConverter>? discordMemberSlashArgumentConverter = null, ILogger<DiscordUserConverter>? discordUserSlashArgumentConverter = null)
     {
-        this._logger = logger ?? NullLogger<DiscordSnowflakeObjectConverter>.Instance;
         this.discordMemberSlashArgumentConverter = new DiscordMemberConverter(discordMemberSlashArgumentConverter ?? NullLogger<DiscordMemberConverter>.Instance);
         this.discordUserSlashArgumentConverter = new DiscordUserConverter(discordUserSlashArgumentConverter ?? NullLogger<DiscordUserConverter>.Instance);
         this.discordRoleSlashArgumentConverter = new DiscordRoleConverter();
@@ -45,11 +39,8 @@ public partial class DiscordSnowflakeObjectConverter : ISlashArgumentConverter<S
         {
             return Optional.FromValue<SnowflakeObject>(user.Value);
         }
-        else
-        {
-            this._logger.LogError("Failed to resolve SnowflakeObject type.");
-            return Optional.FromNoValue<SnowflakeObject>();
-        }
+
+        return Optional.FromNoValue<SnowflakeObject>();
     }
 
     // Duplicated logic for overload resolving
@@ -68,10 +59,7 @@ public partial class DiscordSnowflakeObjectConverter : ISlashArgumentConverter<S
         {
             return Optional.FromValue<SnowflakeObject>(user.Value);
         }
-        else
-        {
-            this._logger.LogError("Failed to resolve SnowflakeObject type.");
-            return Optional.FromNoValue<SnowflakeObject>();
-        }
+
+        return Optional.FromNoValue<SnowflakeObject>();
     }
 }

--- a/DSharpPlus.Commands/Converters/DiscordSnowflakeObjectConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordSnowflakeObjectConverter.cs
@@ -21,7 +21,7 @@ public partial class DiscordSnowflakeObjectConverter : ISlashArgumentConverter<S
         this.discordMemberSlashArgumentConverter = discordMemberSlashArgumentConverter;
         this.discordRoleSlashArgumentConverter = discordRoleSlashArgumentConverter;
         this.discordUserSlashArgumentConverter = discordUserSlashArgumentConverter;
-        this._logger = this._logger = logger ?? NullLogger<DiscordSnowflakeObjectConverter>.Instance;
+        this._logger = logger ?? NullLogger<DiscordSnowflakeObjectConverter>.Instance;
     }
 
     public async Task<Optional<SnowflakeObject>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs)

--- a/DSharpPlus.Commands/Converters/DiscordSnowflakeObjectConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordSnowflakeObjectConverter.cs
@@ -1,22 +1,29 @@
 namespace DSharpPlus.Commands.Converters;
 
+using System.Threading.Tasks;
 using DSharpPlus.Commands.Processors.SlashCommands;
+using DSharpPlus.Commands.Processors.TextCommands;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System.Threading.Tasks;
 
-public partial class DiscordSnowflakeObjectConverter : ISlashArgumentConverter<SnowflakeObject>
+public partial class DiscordSnowflakeObjectConverter : ISlashArgumentConverter<SnowflakeObject>, ITextArgumentConverter<SnowflakeObject>
 {
     public DiscordApplicationCommandOptionType ParameterType { get; init; } = DiscordApplicationCommandOptionType.Mentionable;
     public bool RequiresText { get; init; } = true;
-    private readonly ILogger<DiscordSnowflakeObjectConverter> _logger;
-    private readonly ISlashArgumentConverter<DiscordMember> discordMemberSlashArgumentConverter;
-    private readonly ISlashArgumentConverter<DiscordRole> discordRoleSlashArgumentConverter;
-    private readonly ISlashArgumentConverter<DiscordUser> discordUserSlashArgumentConverter;
 
-    public DiscordSnowflakeObjectConverter(ISlashArgumentConverter<DiscordMember> discordMemberSlashArgumentConverter, ISlashArgumentConverter<DiscordRole> discordRoleSlashArgumentConverter, ISlashArgumentConverter<DiscordUser> discordUserSlashArgumentConverter, ILogger<DiscordSnowflakeObjectConverter>? logger = null)
+    private readonly DiscordMemberConverter discordMemberSlashArgumentConverter;
+    private readonly DiscordRoleConverter discordRoleSlashArgumentConverter;
+    private readonly DiscordUserConverter discordUserSlashArgumentConverter;
+    private readonly ILogger<DiscordSnowflakeObjectConverter> _logger;
+
+    public DiscordSnowflakeObjectConverter(
+        DiscordMemberConverter discordMemberSlashArgumentConverter,
+        DiscordRoleConverter discordRoleSlashArgumentConverter,
+        DiscordUserConverter discordUserSlashArgumentConverter,
+        ILogger<DiscordSnowflakeObjectConverter>? logger = null
+    )
     {
         this.discordMemberSlashArgumentConverter = discordMemberSlashArgumentConverter;
         this.discordRoleSlashArgumentConverter = discordRoleSlashArgumentConverter;
@@ -41,7 +48,30 @@ public partial class DiscordSnowflakeObjectConverter : ISlashArgumentConverter<S
         }
         else
         {
-            this._logger.LogError("Failed to resolve SnowflakeObject type."); 
+            this._logger.LogError("Failed to resolve SnowflakeObject type.");
+            return Optional.FromNoValue<SnowflakeObject>();
+        }
+    }
+
+    // Duplicated logic for overload resolving
+    public async Task<Optional<SnowflakeObject>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs)
+    {
+        //Checks through existing converters
+        if (await discordRoleSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordRole> role && role.HasValue)
+        {
+            return Optional.FromValue<SnowflakeObject>(role.Value);
+        }
+        else if (await discordMemberSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordMember> member && member.HasValue)
+        {
+            return Optional.FromValue<SnowflakeObject>(member.Value);
+        }
+        else if (await discordUserSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordUser> user && user.HasValue)
+        {
+            return Optional.FromValue<SnowflakeObject>(user.Value);
+        }
+        else
+        {
+            this._logger.LogError("Failed to resolve SnowflakeObject type.");
             return Optional.FromNoValue<SnowflakeObject>();
         }
     }

--- a/DSharpPlus.Commands/Converters/DiscordSnowflakeObjectConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordSnowflakeObjectConverter.cs
@@ -13,22 +13,21 @@ public partial class DiscordSnowflakeObjectConverter : ISlashArgumentConverter<S
     public DiscordApplicationCommandOptionType ParameterType { get; init; } = DiscordApplicationCommandOptionType.Mentionable;
     public bool RequiresText { get; init; } = true;
 
-    private readonly DiscordMemberConverter discordMemberSlashArgumentConverter;
-    private readonly DiscordRoleConverter discordRoleSlashArgumentConverter;
-    private readonly DiscordUserConverter discordUserSlashArgumentConverter;
     private readonly ILogger<DiscordSnowflakeObjectConverter> _logger;
+    private readonly DiscordMemberConverter discordMemberSlashArgumentConverter;
+    private readonly DiscordUserConverter discordUserSlashArgumentConverter;
+    private readonly DiscordRoleConverter discordRoleSlashArgumentConverter;
 
     public DiscordSnowflakeObjectConverter(
-        DiscordMemberConverter discordMemberSlashArgumentConverter,
-        DiscordRoleConverter discordRoleSlashArgumentConverter,
-        DiscordUserConverter discordUserSlashArgumentConverter,
-        ILogger<DiscordSnowflakeObjectConverter>? logger = null
+        ILogger<DiscordSnowflakeObjectConverter>? logger = null,
+        ILogger<DiscordMemberConverter>? discordMemberSlashArgumentConverter = null,
+        ILogger<DiscordUserConverter>? discordUserSlashArgumentConverter = null
     )
     {
-        this.discordMemberSlashArgumentConverter = discordMemberSlashArgumentConverter;
-        this.discordRoleSlashArgumentConverter = discordRoleSlashArgumentConverter;
-        this.discordUserSlashArgumentConverter = discordUserSlashArgumentConverter;
         this._logger = logger ?? NullLogger<DiscordSnowflakeObjectConverter>.Instance;
+        this.discordMemberSlashArgumentConverter = new DiscordMemberConverter(discordMemberSlashArgumentConverter ?? NullLogger<DiscordMemberConverter>.Instance);
+        this.discordUserSlashArgumentConverter = new DiscordUserConverter(discordUserSlashArgumentConverter ?? NullLogger<DiscordUserConverter>.Instance);
+        this.discordRoleSlashArgumentConverter = new DiscordRoleConverter();
     }
 
     public async Task<Optional<SnowflakeObject>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs)


### PR DESCRIPTION
# Summary
Implement the use of `SnowflakeObject` in Slash command arguments for the `DSP.Commands` lib

# Details
Created mostly out of necessity for an individual project, this takes a note from `DSP.SlashCommands` `SlashCommandsExtension`, and implements the converter in a similar fashion.

# Changes proposed
* With limitations on the number of SlashCommands able to be registered, making a new command to take either a Role or DiscordMember seems unnecessary and a waste of our limited number of commands. This will allow users to be able to cast the SnowflakeObject into either a DiscordUser, DiscordMember or DiscordRole and be able to either perform an action on a single user, or all users in a role, much like how it was historically done in DSP.SlashCommands.

# Notes
No testing has been performed, at all, what-so-ever. 
This is more of a "please make this work, I need it" kind of PR.