### PR TITLE
fix a crash when using autocomplete on enums

### DIFF
--- a/DSharpPlus.Commands/Trees/CommandParameterBuilder.cs
+++ b/DSharpPlus.Commands/Trees/CommandParameterBuilder.cs
@@ -39,7 +39,7 @@ public class CommandParameterBuilder
     public CommandParameterBuilder WithType(Type type)
     {
         this.Type = type;
-        if (type.IsEnum && !this.Attributes.Any(attribute => attribute is SlashChoiceProviderAttribute or SlashAutoCompleteProviderAttribute))
+        if (type.IsEnum && this.Attributes.All(attribute => attribute is not SlashChoiceProviderAttribute and not SlashAutoCompleteProviderAttribute))
         {
             this.Attributes.Add(new SlashChoiceProviderAttribute<EnumOptionProvider>());
         }

--- a/DSharpPlus.Commands/Trees/CommandParameterBuilder.cs
+++ b/DSharpPlus.Commands/Trees/CommandParameterBuilder.cs
@@ -39,7 +39,7 @@ public class CommandParameterBuilder
     public CommandParameterBuilder WithType(Type type)
     {
         this.Type = type;
-        if (type.IsEnum && !this.Attributes.Any(attribute => attribute is SlashChoiceProviderAttribute))
+        if (type.IsEnum && !this.Attributes.Any(attribute => attribute is SlashChoiceProviderAttribute or SlashAutoCompleteProviderAttribute))
         {
             this.Attributes.Add(new SlashChoiceProviderAttribute<EnumOptionProvider>());
         }


### PR DESCRIPTION
this doesn't necessarily represent how this feature should look in the end, there's still some design holes and pitfalls (mainly, users not being forced to select an autocompleted value), but in the interim we should probably not crash

this is also documented on @OoLunar s WIP documentation as possible: https://github.com/DSharpPlus/DSharpPlus/blob/oolunar/docs/commands/docs/articles/commands/processors/slash_commands/choice_provider_vs_autocomplete.md?plain=1#L39-L42