### PR TITLE
[Commands] Fixes wrong AutoCompleteArgument on the context

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -23,7 +23,6 @@ using DSharpPlus.EventArgs;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using System.Diagnostics;
 
 public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCreateEventArgs, ISlashArgumentConverter, InteractionConverterContext, SlashCommandContext>
 {

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -457,6 +457,7 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
             // Parse until we find the parameter that the user is currently typing
             while (converterContext.NextParameter())
             {
+                //TODO: Change this comparison to use StringComparison.Ordinal once the automatic conversion to snake_case is no longer applied.
                 DiscordInteractionDataOption? option = converterContext.Options.FirstOrDefault(x => x.Name.Equals(converterContext.Parameter.Name, StringComparison.OrdinalIgnoreCase));
                 if (option is null)
                 {

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -457,7 +457,7 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
             // Parse until we find the parameter that the user is currently typing
             while (converterContext.NextParameter())
             {
-                DiscordInteractionDataOption? option = converterContext.Options.FirstOrDefault(x => x.Name.Equals(converterContext.Parameter.Name));
+                DiscordInteractionDataOption? option = converterContext.Options.FirstOrDefault(x => x.Name.Equals(converterContext.Parameter.Name, StringComparison.OrdinalIgnoreCase));
                 if (option is not null && option.Focused)
                 {
                     autoCompleteParameter = converterContext.Parameter;

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -23,6 +23,7 @@ using DSharpPlus.EventArgs;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Diagnostics;
 
 public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCreateEventArgs, ISlashArgumentConverter, InteractionConverterContext, SlashCommandContext>
 {
@@ -480,7 +481,8 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
 
             if (autoCompleteParameter is null || autoCompleteOption is null)
             {
-                throw new InvalidOperationException("Cannot find the parameter that the user is currently typing.");
+                _logger.LogWarning("Cannot find the auto complete parameter that the user is currently typing - this should be reported to library developers.");
+                return null;
             }
         }
         catch (Exception error)

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -458,7 +458,12 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
             while (converterContext.NextParameter())
             {
                 DiscordInteractionDataOption? option = converterContext.Options.FirstOrDefault(x => x.Name.Equals(converterContext.Parameter.Name, StringComparison.OrdinalIgnoreCase));
-                if (option is not null && option.Focused)
+                if (option is null)
+                {
+                    continue;
+                }
+
+                if (option.Focused)
                 {
                     autoCompleteParameter = converterContext.Parameter;
                     autoCompleteOption = option;


### PR DESCRIPTION
If the user ignores one (or more) parameter of the command, the get `AutoCompleteArgument` will not be the correct one, this solves this issue.