### PR TITLE
Account for exceptions messages over char limit of discord messages in…

### DIFF
--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -340,11 +340,13 @@ public sealed class CommandsExtension : BaseExtension
                 messageBuilder.AddFile("StackTrace.txt", new MemoryStream(Encoding.UTF8.GetBytes(eventArgs.Exception.StackTrace)), AddFileOptions.CloseStream);
             }
         }
+        // If no stack trace, and the message is still too long, attatch a file with the message and use a simple message in the content.
         else if (stringBuilder.Length >= 2000)
         {
             messageBuilder.WithContent("Exception Message exceeds character limit, see attached file.");
             messageBuilder.AddFile("Message.txt", new MemoryStream(Encoding.UTF8.GetBytes(stringBuilder.ToString())), AddFileOptions.CloseStream);
         }
+        // Otherwise, if no stack trace and the Exception message will fit, send the message as content
         else
         {
             messageBuilder.WithContent(stringBuilder.ToString());


### PR DESCRIPTION
… DefaultCommandErrorHandlerAsync

# Summary
Fixes #1860 
Account for long exception messages.

# Details
Add some additional if/else to the DefaultCommandErrorHandlerAsync, adding the Exception Message to the attached file response if it's too big, with a generic message in the response content.
