### PR TITLE
Update CommandsExtension.cs

### DIFF
--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -424,7 +424,7 @@ public sealed class CommandsExtension : BaseExtension
         if (!string.IsNullOrWhiteSpace(eventArgs.Exception.StackTrace))
         {
             // If the stack trace can fit inside a codeblock
-            if (8 + eventArgs.Exception.StackTrace.Length + stringBuilder.Length >= 2000)
+            if (8 + eventArgs.Exception.StackTrace.Length + stringBuilder.Length <= 2000)
             {
                 stringBuilder.Append($"```\n{eventArgs.Exception.StackTrace}\n```");
                 messageBuilder.WithContent(stringBuilder.ToString());


### PR DESCRIPTION
crocodile's mouth facing the wrong way

# Summary
Invert if statement: Only add stacktrace to message content if it can fit in content.

# Notes
Currently it adds the stacktrace to the messages content only if it exceeds the allowed content length.