### PR TITLE
Hotfix for NRE when parsing UserApp created interactions

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -1232,15 +1232,15 @@ public sealed partial class DiscordClient : BaseDiscordClient
                 _privateChannels.TryAdd(channel.Id, dmChannel);
                 break;
             case DiscordThreadChannel threadChannel:
-                if (_guilds.ContainsKey(channel.GuildId!.Value))
+                if (_guilds.TryGetValue(channel.GuildId!.Value, out DiscordGuild? guild))
                 {
-                    _guilds[channel.GuildId!.Value]._threads.TryAdd(channel.Id, threadChannel);
+                    guild._threads.TryAdd(channel.Id, threadChannel);
                 }
                 break;
             default:
-                if (_guilds.ContainsKey(channel.GuildId!.Value))
+                if (_guilds.TryGetValue(channel.GuildId!.Value, out guild))
                 {
-                    _guilds[channel.GuildId!.Value]._channels.TryAdd(channel.Id, channel);
+                    guild._channels.TryAdd(channel.Id, channel);
                 }
                 break;
         }

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -1232,10 +1232,16 @@ public sealed partial class DiscordClient : BaseDiscordClient
                 _privateChannels.TryAdd(channel.Id, dmChannel);
                 break;
             case DiscordThreadChannel threadChannel:
-                _guilds[channel.GuildId!.Value]._threads.TryAdd(channel.Id, threadChannel);
+                if (_guilds.ContainsKey(channel.GuildId!.Value))
+                {
+                    _guilds[channel.GuildId!.Value]._threads.TryAdd(channel.Id, threadChannel);
+                }
                 break;
             default:
-                _guilds[channel.GuildId!.Value]._channels.TryAdd(channel.Id, channel);
+                if (_guilds.ContainsKey(channel.GuildId!.Value))
+                {
+                    _guilds[channel.GuildId!.Value]._channels.TryAdd(channel.Id, channel);
+                }
                 break;
         }
     }


### PR DESCRIPTION
# Summary
Last PR introduced a possible NRE when processing inteactions from user apps when the guild it was triggered in doesnt have the guild app installed. This PR only prevents the NRE, we currently think about creating skeleton entities for user apps where we only get partial data from discord