### PR TITLE
fixes a bug where an empty parameter list would not cause a command to execute with default values

### DIFF
--- a/DSharpPlus.Commands/Converters/ConverterContext.cs
+++ b/DSharpPlus.Commands/Converters/ConverterContext.cs
@@ -8,7 +8,7 @@ public abstract record ConverterContext : AbstractContext
     public int ParameterIndex { get; private set; } = -1;
     public CommandParameter Parameter => this.Command.Parameters[this.ParameterIndex];
 
-    public bool NextParameter()
+    public virtual bool NextParameter()
     {
         if (this.ParameterIndex + 1 >= this.Command.Parameters.Count)
         {

--- a/DSharpPlus.Commands/Processors/BaseCommandProcessor/BaseCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/BaseCommandProcessor/BaseCommandProcessor.cs
@@ -227,10 +227,22 @@ public abstract class BaseCommandProcessor<TEventArgs, TConverter, TConverterCon
             {
                 foreach (CommandParameter parameter in converterContext.Command.Parameters)
                 {
+                    if (!parameter.DefaultValue.HasValue)
+                    {
+                        await this.extension.commandErrored.InvokeAsync(converterContext.Extension, new CommandErroredEventArgs()
+                        {
+                            Context = CreateCommandContext(converterContext, eventArgs, parsedArguments),
+                            Exception = new ArgumentParseException(converterContext.Parameter, null, $"Argument Converter for type {converterContext.Parameter.Type.FullName} was unable to parse the argument."),
+                            CommandObject = null
+                        });
+
+                        return null;
+                    }
+
                     parsedArguments.Add
                     (
                         parameter,
-                        parameter.DefaultValue.HasValue ? parameter.DefaultValue.Value : null
+                        parameter.DefaultValue.Value
                     );
                 }
             }

--- a/DSharpPlus.Commands/Processors/BaseCommandProcessor/BaseCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/BaseCommandProcessor/BaseCommandProcessor.cs
@@ -232,7 +232,7 @@ public abstract class BaseCommandProcessor<TEventArgs, TConverter, TConverterCon
                         await this.extension.commandErrored.InvokeAsync(converterContext.Extension, new CommandErroredEventArgs()
                         {
                             Context = CreateCommandContext(converterContext, eventArgs, parsedArguments),
-                            Exception = new ArgumentParseException(converterContext.Parameter, null, $"Argument Converter for type {converterContext.Parameter.Type.FullName} was unable to parse the argument."),
+                            Exception = new ArgumentParseException(converterContext.Parameter, null, $"Not enough argument data to parse {converterContext.Parameter.Name}."),
                             CommandObject = null
                         });
 

--- a/DSharpPlus.Commands/Processors/BaseCommandProcessor/BaseCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/BaseCommandProcessor/BaseCommandProcessor.cs
@@ -223,6 +223,18 @@ public abstract class BaseCommandProcessor<TEventArgs, TConverter, TConverterCon
                 parsedArguments.Add(converterContext.Parameter, optional.RawValue);
             }
 
+            if (parsedArguments.Count == 0)
+            {
+                foreach (CommandParameter parameter in converterContext.Command.Parameters)
+                {
+                    parsedArguments.Add
+                    (
+                        parameter,
+                        parameter.DefaultValue.HasValue ? parameter.DefaultValue.Value : null
+                    );
+                }
+            }
+
             if (parsedArguments.Count != converterContext.Command.Parameters.Count)
             {
                 // Try to fill with default values

--- a/DSharpPlus.Commands/Processors/SlashCommands/InteractionConverterContext.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/InteractionConverterContext.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+
 using DSharpPlus.Commands.Converters;
 using DSharpPlus.Entities;
 
@@ -10,6 +11,10 @@ public record InteractionConverterContext : ConverterContext
     public required IReadOnlyList<DiscordInteractionDataOption> Options { get; init; }
     public override DiscordInteractionDataOption Argument => this.Options[this.ParameterIndex];
     public int ArgumentIndex { get; private set; } = -1;
+
+    /// <inheritdoc/>
+    public override bool NextParameter() 
+        => this.Interaction.Data.Options is not null && base.NextParameter();
 
     public override bool NextArgument()
     {

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
@@ -33,7 +33,6 @@ public sealed class DiscordInteractionDataOption
     [JsonProperty("value")]
     public string? RawValue { get; internal set; }
 
-#pragma warning disable IDE0046
     /// <summary>
     /// Gets the value of this interaction parameter.
     /// <para>This can be cast to a <see langword="long"/>, <see langword="bool"></see>, <see langword="string"></see>, <see langword="double"></see> or <see langword="ulong"/> depending on the <see cref="Type"/></para>
@@ -43,13 +42,9 @@ public sealed class DiscordInteractionDataOption
     {
         get
         {
-            if (this.RawValue is null)
-            {
-                return this.RawValue;
-            }
-
             return this.Type switch
             {
+                _ when this.RawValue is null => null,
                 DiscordApplicationCommandOptionType.Boolean => bool.Parse(this.RawValue),
                 DiscordApplicationCommandOptionType.Integer => long.Parse(this.RawValue),
                 DiscordApplicationCommandOptionType.String => this.RawValue,
@@ -63,7 +58,6 @@ public sealed class DiscordInteractionDataOption
             };
         }
     }
-#pragma warning restore IDE0046
 
     /// <summary>
     /// Gets the additional parameters if this parameter is a subcommand.

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionDataOption.cs
@@ -27,27 +27,43 @@ public sealed class DiscordInteractionDataOption
     [JsonProperty("focused")]
     public bool Focused { get; internal set; }
 
+    /// <summary>
+    /// Gets the raw value of this interaction parameter.
+    /// </summary>
     [JsonProperty("value")]
-    public string RawValue { get; internal set; }
+    public string? RawValue { get; internal set; }
 
+#pragma warning disable IDE0046
     /// <summary>
     /// Gets the value of this interaction parameter.
     /// <para>This can be cast to a <see langword="long"/>, <see langword="bool"></see>, <see langword="string"></see>, <see langword="double"></see> or <see langword="ulong"/> depending on the <see cref="Type"/></para>
     /// </summary>
     [JsonIgnore]
-    public object Value => this.Type switch
+    public object? Value
     {
-        DiscordApplicationCommandOptionType.Boolean => bool.Parse(this.RawValue),
-        DiscordApplicationCommandOptionType.Integer => long.Parse(this.RawValue),
-        DiscordApplicationCommandOptionType.String => this.RawValue,
-        DiscordApplicationCommandOptionType.Channel => ulong.Parse(this.RawValue),
-        DiscordApplicationCommandOptionType.User => ulong.Parse(this.RawValue),
-        DiscordApplicationCommandOptionType.Role => ulong.Parse(this.RawValue),
-        DiscordApplicationCommandOptionType.Mentionable => ulong.Parse(this.RawValue),
-        DiscordApplicationCommandOptionType.Number => double.Parse(this.RawValue, CultureInfo.InvariantCulture),
-        DiscordApplicationCommandOptionType.Attachment => ulong.Parse(this.RawValue, CultureInfo.InvariantCulture),
-        _ => this.RawValue,
-    };
+        get
+        {
+            if (this.RawValue is null)
+            {
+                return this.RawValue;
+            }
+
+            return this.Type switch
+            {
+                DiscordApplicationCommandOptionType.Boolean => bool.Parse(this.RawValue),
+                DiscordApplicationCommandOptionType.Integer => long.Parse(this.RawValue),
+                DiscordApplicationCommandOptionType.String => this.RawValue,
+                DiscordApplicationCommandOptionType.Channel => ulong.Parse(this.RawValue),
+                DiscordApplicationCommandOptionType.User => ulong.Parse(this.RawValue),
+                DiscordApplicationCommandOptionType.Role => ulong.Parse(this.RawValue),
+                DiscordApplicationCommandOptionType.Mentionable => ulong.Parse(this.RawValue),
+                DiscordApplicationCommandOptionType.Number => double.Parse(this.RawValue, CultureInfo.InvariantCulture),
+                DiscordApplicationCommandOptionType.Attachment => ulong.Parse(this.RawValue, CultureInfo.InvariantCulture),
+                _ => this.RawValue,
+            };
+        }
+    }
+#pragma warning restore IDE0046
 
     /// <summary>
     /// Gets the additional parameters if this parameter is a subcommand.


### PR DESCRIPTION
this, notably, does not address #1864/#1843, which hit when some but not all parameters are supplied