### PR TITLE
Add GatewayResumeUrl and use it when connecting to GW

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -22,6 +22,7 @@ public sealed partial class DiscordClient
     #region Private Fields
 
     private string sessionId;
+    private string? gatewayResumeUrl;
     private bool guildDownloadCompleted = false;
 
     #endregion
@@ -572,6 +573,7 @@ public sealed partial class DiscordClient
 
         this.GatewayVersion = ready.GatewayVersion;
         this.sessionId = ready.SessionId;
+        this.gatewayResumeUrl = ready.ResumeGatewayUrl;
         Dictionary<ulong, JObject> raw_guild_index = rawGuilds.ToDictionary(xt => (ulong)xt["id"], xt => (JObject)xt);
 
         this.privateChannels.Clear();

--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -116,10 +116,20 @@ public sealed partial class DiscordClient
         this.webSocketClient.MessageReceived += SocketOnMessage;
         this.webSocketClient.ExceptionThrown += SocketOnException;
 
-        QueryUriBuilder gwuri = new QueryUriBuilder(this.GatewayUri.ToString())
-            .AddParameter("v", "10")
-            .AddParameter("encoding", "json");
+        QueryUriBuilder gwuri;
 
+        if (this.gatewayResumeUrl is not null && !string.IsNullOrWhiteSpace(this.sessionId))
+        {
+            gwuri = new QueryUriBuilder(this.gatewayResumeUrl);
+        }
+        else
+        {
+            gwuri = new QueryUriBuilder(this.GatewayUri.ToString());
+        }
+        
+        gwuri.AddParameter("v", "10")
+             .AddParameter("encoding", "json");
+        
         if (this.Configuration.GatewayCompressionLevel == GatewayCompressionLevel.Stream)
         {
             gwuri.AddParameter("compress", "zlib-stream");

--- a/DSharpPlus/Net/Abstractions/ReadyPayload.cs
+++ b/DSharpPlus/Net/Abstractions/ReadyPayload.cs
@@ -40,6 +40,12 @@ internal class ReadyPayload
     public string SessionId { get; private set; }
 
     /// <summary>
+    /// Gets the url which should be used for resuming the session after disconnect/reconnect
+    /// </summary>
+    [JsonProperty("resume_gateway_url")]
+    public string ResumeGatewayUrl { get; private set; }
+
+    /// <summary>
     /// Gets debug data sent by Discord. This contains a list of servers to which the client is connected.
     /// </summary>
     [JsonProperty("_trace")]


### PR DESCRIPTION
# Summary
Adds field to the ReadyPayload and store it on the client. When connecting to the gateway we look if we have a sessionId and a resume url and use those when possible