### PR TITLE
[Commands] Improve slash command registered log message

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -249,13 +249,13 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
 
             if (!commandFound)
             {
-                SlashLogging.UnknownCommandName(this.logger, discordCommand.Name, null);
+                SlashLogging.unknownCommandName(this.logger, discordCommand.Name, null);
                 continue;
             }
         }
 
         this.Commands = commandsDictionary.ToFrozenDictionary();
-        SlashLogging.RegisteredCommands(this.logger, this.Commands.Count, null);
+        SlashLogging.registeredCommands(this.logger, this.Commands.Count, null);
     }
 
     public async Task<DiscordApplicationCommand> ToApplicationCommandAsync(Command command)

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -255,7 +255,7 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
         }
 
         this.Commands = commandsDictionary.ToFrozenDictionary();
-        SlashLogging.registeredCommands(this.logger, this.Commands.Count, null);
+        SlashLogging.registeredCommands(this.logger, this.Commands.Count, this.Commands.Values.SelectMany(command => command.Walk()).Count(), null);
     }
 
     public async Task<DiscordApplicationCommand> ToApplicationCommandAsync(Command command)

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashLogging.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashLogging.cs
@@ -6,6 +6,6 @@ namespace DSharpPlus.Commands.Processors.SlashCommands;
 internal static class SlashLogging
 {
     // Startup logs
-    public static readonly Action<ILogger, int, Exception?> RegisteredCommands = LoggerMessage.Define<int>(LogLevel.Information, new EventId(1, "Slash Commands Startup"), "Registered {CommandCount:N0} slash commands.");
-    public static readonly Action<ILogger, string, Exception?> UnknownCommandName = LoggerMessage.Define<string>(LogLevel.Trace, new EventId(1, "Slash Commands Runtime"), "Received Command '{CommandName}' but no matching local command was found. Was this command for a different process?");
+    internal static readonly Action<ILogger, int, Exception?> registeredCommands = LoggerMessage.Define<int>(LogLevel.Information, new EventId(1, "Slash Commands Startup"), "Registered {CommandCount:N0} slash commands.");
+    internal static readonly Action<ILogger, string, Exception?> unknownCommandName = LoggerMessage.Define<string>(LogLevel.Trace, new EventId(1, "Slash Commands Runtime"), "Received Command '{CommandName}' but no matching local command was found. Was this command for a different process?");
 }

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashLogging.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashLogging.cs
@@ -6,6 +6,6 @@ namespace DSharpPlus.Commands.Processors.SlashCommands;
 internal static class SlashLogging
 {
     // Startup logs
-    internal static readonly Action<ILogger, int, Exception?> registeredCommands = LoggerMessage.Define<int>(LogLevel.Information, new EventId(1, "Slash Commands Startup"), "Registered {CommandCount:N0} slash commands.");
+    internal static readonly Action<ILogger, int, int, Exception?> registeredCommands = LoggerMessage.Define<int, int>(LogLevel.Information, new EventId(1, "Slash Commands Startup"), "Registered {TopLevelCommandCount:N0} top-level slash commands, {TotalCommandCount:N0} total slash commands.");
     internal static readonly Action<ILogger, string, Exception?> unknownCommandName = LoggerMessage.Define<string>(LogLevel.Trace, new EventId(1, "Slash Commands Runtime"), "Received Command '{CommandName}' but no matching local command was found. Was this command for a different process?");
 }

--- a/DSharpPlus.Commands/Trees/Command.cs
+++ b/DSharpPlus.Commands/Trees/Command.cs
@@ -20,4 +20,19 @@ public record Command
     public string FullName => this.Parent is null ? this.Name : $"{this.Parent.FullName} {this.Name}";
 
     public Command(IEnumerable<CommandBuilder> subCommandBuilders) => this.Subcommands = subCommandBuilders.Select(x => x.WithParent(this).Build()).ToArray();
+
+    /// <summary>
+    /// Traverses this command tree, returning this command and all subcommands recursively.
+    /// </summary>
+    /// <returns>A list of all commands in this tree.</returns>
+    public IReadOnlyList<Command> Walk()
+    {
+        List<Command> commands = [this];
+        foreach (Command subcommand in this.Subcommands)
+        {
+            commands.AddRange(subcommand.Walk());
+        }
+
+        return commands;
+    }
 }


### PR DESCRIPTION
# Summary
This PR now shows the dev how many top level and how many total commands there are registered. Additionally a new `Command.Walk` method was introduced.

```
[2024-05-07T00:17:05.9530470-05:00] [INFO] DSharpPlus.Commands.Processors.BaseCommandProcessor:
Registered 34 top-level slash commands, 46 total slash commands.
```

# Notes
Tested.