### PR TITLE
[CNext] Check if command has atleast one parameter instead of has no parameter

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextUtilities.cs
@@ -355,7 +355,7 @@ public static partial class CommandsNextUtilities
 
         // check if appropriate return and arguments
         parameters = method.GetParameters();
-        if (parameters.Length != 0 || parameters[0].ParameterType != typeof(CommandContext) || method.ReturnType != typeof(Task))
+        if (parameters.Length < 1 || parameters[0].ParameterType != typeof(CommandContext) || method.ReturnType != typeof(Task))
         {
             return false;
         }


### PR DESCRIPTION
# Summary
#1870 changed a `!parameters.Any()` to `parameters.Length != 0` instead of `parameters.Length < 1`