### PR TITLE
support `Nullable<T> where T : Enum` as command parameters

### DIFF
--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -411,12 +411,24 @@ public sealed class CommandsExtension : BaseExtension
         // Error message
         stringBuilder.Append(eventArgs.Exception switch
         {
-            CommandNotFoundException commandNotFoundException => $"Command {Formatter.InlineCode(Formatter.Sanitize(commandNotFoundException.CommandName))} was not found.",
-            ArgumentParseException argumentParseException => $"Failed to parse argument {Formatter.InlineCode(Formatter.Sanitize(argumentParseException.Parameter.Name))}.",
-            ChecksFailedException checksFailedException when checksFailedException.Errors.Count == 1 => $"The following error occurred: {Formatter.InlineCode(Formatter.Sanitize(checksFailedException.Errors[0].ErrorMessage))}",
-            ChecksFailedException checksFailedException => $"The following context checks failed: {Formatter.InlineCode(Formatter.Sanitize(string.Join("\n\n", checksFailedException.Errors.Select(x => x.ErrorMessage))))}.",
-            DiscordException discordException when discordException.Response is not null && (int)discordException.Response.StatusCode >= 500 && (int)discordException.Response.StatusCode < 600 => $"Discord API error {discordException.Response.StatusCode} occurred: {discordException.JsonMessage ?? "No further information was provided."}",
-            DiscordException discordException when discordException.Response is not null => $"Discord API error {discordException.Response.StatusCode} occurred: {discordException.JsonMessage ?? discordException.Message}",
+            CommandNotFoundException commandNotFoundException 
+                => $"Command {Formatter.InlineCode(Formatter.Sanitize(commandNotFoundException.CommandName))} was not found.",
+            ArgumentParseException argumentParseException 
+                => $"Failed to parse argument {Formatter.InlineCode(Formatter.Sanitize(argumentParseException.Parameter.Name))}.",
+            ChecksFailedException checksFailedException when checksFailedException.Errors.Count == 1 
+                => $"The following error occurred: {Formatter.InlineCode(Formatter.Sanitize(checksFailedException.Errors[0].ErrorMessage))}",
+            ChecksFailedException checksFailedException 
+                => $"The following context checks failed: {Formatter.InlineCode(Formatter.Sanitize(string.Join("\n\n", checksFailedException.Errors.Select(x => x.ErrorMessage))))}.",
+            ParameterChecksFailedException checksFailedException when checksFailedException.Errors.Count == 1
+                => $"The following error occurred: {Formatter.InlineCode(Formatter.Sanitize(checksFailedException.Errors[0].ErrorMessage))}",
+            ParameterChecksFailedException checksFailedException
+                => $"The following context checks failed: {Formatter.InlineCode(Formatter.Sanitize(string.Join("\n\n", checksFailedException.Errors.Select(x => x.ErrorMessage))))}.",
+            DiscordException discordException when discordException.Response is not null 
+                && (int)discordException.Response.StatusCode >= 500 
+                && (int)discordException.Response.StatusCode < 600 
+                => $"Discord API error {discordException.Response.StatusCode} occurred: {discordException.JsonMessage ?? "No further information was provided."}",
+            DiscordException discordException when discordException.Response is not null 
+            => $"Discord API error {discordException.Response.StatusCode} occurred: {discordException.JsonMessage ?? discordException.Message}",
             _ => $"An unexpected error occurred: {eventArgs.Exception.Message}"
         });
 

--- a/DSharpPlus.Commands/Converters/EnumArgumentConverter.cs
+++ b/DSharpPlus.Commands/Converters/EnumArgumentConverter.cs
@@ -14,15 +14,26 @@ public class EnumConverter : ISlashArgumentConverter<Enum>, ITextArgumentConvert
     public string ReadableName => "Multiple Choice";
     public bool RequiresText => true;
 
-    public Task<Optional<Enum>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs) => Task.FromResult(Enum.TryParse(context.Parameter.Type, context.Argument, true, out object? result)
-        ? Optional.FromValue((Enum)result)
-        : Optional.FromNoValue<Enum>());
+    public Task<Optional<Enum>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs)
+    {
+        return Task.FromResult(Enum.TryParse(context.Parameter.Type, context.Argument, true, out object? result)
+            ? Optional.FromValue((Enum)result)
+            : Optional.FromNoValue<Enum>());
+    }
 
     public Task<Optional<Enum>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs)
     {
-        object value = Convert.ChangeType(context.Argument.Value, Enum.GetUnderlyingType(context.Parameter.Type), CultureInfo.InvariantCulture);
-        return Enum.IsDefined(context.Parameter.Type, value)
-            ? Task.FromResult(Optional.FromValue((Enum)Enum.ToObject(context.Parameter.Type, value)))
+        Type effectiveType = Nullable.GetUnderlyingType(context.Parameter.Type) ?? context.Parameter.Type;
+
+        object value = Convert.ChangeType
+        (
+            context.Argument.Value,
+            Enum.GetUnderlyingType(effectiveType),
+            CultureInfo.InvariantCulture
+        );
+
+        return Enum.IsDefined(effectiveType, value)
+            ? Task.FromResult(Optional.FromValue((Enum)Enum.ToObject(effectiveType, value)))
             : Task.FromResult(Optional.FromNoValue<Enum>());
     }
 }

--- a/DSharpPlus.Commands/Processors/BaseCommandProcessor/BaseCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/BaseCommandProcessor/BaseCommandProcessor.cs
@@ -289,16 +289,18 @@ public abstract class BaseCommandProcessor<TEventArgs, TConverter, TConverterCon
     {
         ArgumentNullException.ThrowIfNull(type, nameof(type));
 
-        if (type.IsEnum)
+        Type effectiveType = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (effectiveType.IsEnum)
         {
             return typeof(Enum);
         }
-        else if (type.IsArray)
+        else if (effectiveType.IsArray)
         {
-            return type.GetElementType()!;
+            return effectiveType.GetElementType()!;
         }
 
-        return Nullable.GetUnderlyingType(type) ?? type;
+        return effectiveType;
     }
 
     protected virtual async Task<IOptional> ExecuteConverterAsync<T>(TConverter converter, TConverterContext converterContext, TEventArgs eventArgs)

--- a/DSharpPlus.Commands/Trees/CommandParameterBuilder.EnumOptionProvider.cs
+++ b/DSharpPlus.Commands/Trees/CommandParameterBuilder.EnumOptionProvider.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+
+using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;
+
+namespace DSharpPlus.Commands.Trees;
+
+public partial class CommandParameterBuilder
+{
+    public class EnumOptionProvider : IChoiceProvider
+    {
+        public ValueTask<IReadOnlyDictionary<string, object>> ProvideAsync(CommandParameter parameter)
+        {
+            List<string> enumNames = [];
+            Type effectiveType = Nullable.GetUnderlyingType(parameter.Type) ?? parameter.Type;
+
+            foreach (FieldInfo fieldInfo in effectiveType.GetFields())
+            {
+                if (fieldInfo.IsSpecialName || !fieldInfo.IsStatic)
+                {
+                    continue;
+                }
+                else if (fieldInfo.GetCustomAttribute<ChoiceDisplayNameAttribute>() is ChoiceDisplayNameAttribute displayNameAttribute)
+                {
+                    enumNames.Add(displayNameAttribute.DisplayName);
+                }
+                else
+                {
+                    enumNames.Add(fieldInfo.Name);
+                }
+            }
+
+            Dictionary<string, object> choices = [];
+            Array enumValues = Enum.GetValuesAsUnderlyingType(effectiveType);
+            for (int i = 0; i < enumNames.Count; i++)
+            {
+                string? value = enumValues.GetValue(i)?.ToString() ?? throw new InvalidOperationException($"Failed to get the value of the enum {parameter.Type.Name} for element {enumNames[i]}");
+                choices.Add(enumNames[i], value.ToString());
+            }
+
+            return ValueTask.FromResult<IReadOnlyDictionary<string, object>>(choices);
+        }
+    }
+}


### PR DESCRIPTION
closes #1865

our NVT handling is very cursed and we might want to steer it into more obvious behavior (ie, not relying on `unbox.any` to convert T -> Nullable<T> if applicable)