### PR TITLE
Null Check before invoking external converters

### DIFF
--- a/DSharpPlus.Commands/Converters/DiscordSnowflakeObjectConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordSnowflakeObjectConverter.cs
@@ -28,15 +28,15 @@ public partial class DiscordSnowflakeObjectConverter : ISlashArgumentConverter<S
     public async Task<Optional<SnowflakeObject>> ConvertAsync(InteractionConverterContext context, InteractionCreateEventArgs eventArgs)
     {
         //Checks through existing converters
-        if (await this.discordRoleSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordRole> role && role.HasValue)
+        if (context.Interaction.Data.Resolved != null && context.Interaction.Data.Resolved.Roles != null && await this.discordRoleSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordRole> role && role.HasValue)
         {
             return Optional.FromValue<SnowflakeObject>(role.Value);
         }
-        else if (await this.discordMemberSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordMember> member && member.HasValue)
+        else if (context.Interaction.Data.Resolved != null && context.Interaction.Data.Resolved.Members != null && await this.discordMemberSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordMember> member && member.HasValue)
         {
             return Optional.FromValue<SnowflakeObject>(member.Value);
         }
-        else if (await this.discordUserSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordUser> user && user.HasValue)
+        else if (context.Interaction.Data.Resolved != null && context.Interaction.Data.Resolved.Users != null && await this.discordUserSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordUser> user && user.HasValue)
         {
             return Optional.FromValue<SnowflakeObject>(user.Value);
         }
@@ -48,15 +48,15 @@ public partial class DiscordSnowflakeObjectConverter : ISlashArgumentConverter<S
     public async Task<Optional<SnowflakeObject>> ConvertAsync(TextConverterContext context, MessageCreateEventArgs eventArgs)
     {
         //Checks through existing converters
-        if (await this.discordRoleSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordRole> role && role.HasValue)
+        if (context.Guild is not null && context.Guild.Roles is not null && await this.discordRoleSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordRole> role && role.HasValue)
         {
             return Optional.FromValue<SnowflakeObject>(role.Value);
         }
-        else if (await this.discordMemberSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordMember> member && member.HasValue)
+        else if (context.Guild is not null && context.Guild.Members is not null && await this.discordMemberSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordMember> member && member.HasValue)
         {
             return Optional.FromValue<SnowflakeObject>(member.Value);
         }
-        else if (await this.discordUserSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordUser> user && user.HasValue)
+        else if (context.Guild is not null && context.Guild.Members is not null && await this.discordUserSlashArgumentConverter.ConvertAsync(context, eventArgs) is Optional<DiscordUser> user && user.HasValue)
         {
             return Optional.FromValue<SnowflakeObject>(user.Value);
         }


### PR DESCRIPTION
# Summary
Fixes #1895 
Individual `ISlashArgumentConverter<>`'s make some assumptions, since I guess they were created for a single purpose and not to be invoked by an external `ISlashArgumentConverter<>`

# Details
Check for nulls before invoking additional `ISlashArgumentConverter<>`'s

# Changes proposed

# Notes
Any additional notes go here.