### PR TITLE
fix optional slash command parameters

### DIFF
--- a/DSharpPlus.Commands/Converters/ConverterContext.cs
+++ b/DSharpPlus.Commands/Converters/ConverterContext.cs
@@ -2,12 +2,29 @@ using DSharpPlus.Commands.Trees;
 
 namespace DSharpPlus.Commands.Converters;
 
+/// <summary>
+/// Represents context provided to argument converters.
+/// </summary>
 public abstract record ConverterContext : AbstractContext
 {
+    /// <summary>
+    /// The value of the current raw argument.
+    /// </summary>
     public virtual object? Argument { get; protected set; }
+
+    /// <summary>
+    /// The index of the current parameter.
+    /// </summary>
     public int ParameterIndex { get; private set; } = -1;
+
+    /// <summary>
+    /// The current parameter.
+    /// </summary>
     public CommandParameter Parameter => this.Command.Parameters[this.ParameterIndex];
 
+    /// <summary>
+    /// Advances to the next parameter, returning a value indicating whether there was another parameter.
+    /// </summary>
     public virtual bool NextParameter()
     {
         if (this.ParameterIndex + 1 >= this.Command.Parameters.Count)
@@ -19,7 +36,8 @@ public abstract record ConverterContext : AbstractContext
         return true;
     }
 
-    public abstract bool NextArgument();
-
+    /// <summary>
+    /// Short-hand for converting to a more specific converter context type.
+    /// </summary>
     public T As<T>() where T : ConverterContext => (T)this;
 }

--- a/DSharpPlus.Commands/Converters/ConverterDelegate`1.cs
+++ b/DSharpPlus.Commands/Converters/ConverterDelegate`1.cs
@@ -4,4 +4,4 @@ using DSharpPlus.Entities;
 
 namespace DSharpPlus.Commands.Converters;
 
-public delegate Task<IOptional> ConverterDelegate<T>(ConverterContext context, T eventArgs) where T : AsyncEventArgs;
+public delegate ValueTask<IOptional> ConverterDelegate<T>(ConverterContext context, T eventArgs) where T : AsyncEventArgs;

--- a/DSharpPlus.Commands/Invocation/ConverterUtil.cs
+++ b/DSharpPlus.Commands/Invocation/ConverterUtil.cs
@@ -1,0 +1,8 @@
+namespace DSharpPlus.Commands.Invocation;
+
+/// <summary>
+/// Provides utility methods for handling converters and their state management.
+/// </summary>
+internal static class ConverterUtil
+{
+}

--- a/DSharpPlus.Commands/Processors/BaseCommandProcessor/BaseCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/BaseCommandProcessor/BaseCommandProcessor.cs
@@ -310,7 +310,6 @@ public abstract class BaseCommandProcessor<TEventArgs, TConverter, TConverterCon
     (
         TConverterContext context,
         TConverter converter,
-        TEventArgs eventArgs,
-        Func<TConverter, TConverterContext, TEventArgs, ValueTask<IOptional>> execute
+        TEventArgs eventArgs
     );
 }

--- a/DSharpPlus.Commands/Processors/SlashCommands/InteractionConverterContext.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/InteractionConverterContext.cs
@@ -1,29 +1,33 @@
 using System.Collections.Generic;
+using System.Linq;
 
 using DSharpPlus.Commands.Converters;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.Commands.Processors.SlashCommands;
 
+/// <summary>
+/// Represents a context for interaction-based argument converters.
+/// </summary>
 public record InteractionConverterContext : ConverterContext
 {
+    /// <summary>
+    /// The underlying interaction.
+    /// </summary>
     public required DiscordInteraction Interaction { get; init; }
+
+    /// <summary>
+    /// The options passed to this command.
+    /// </summary>
     public required IReadOnlyList<DiscordInteractionDataOption> Options { get; init; }
-    public override DiscordInteractionDataOption Argument => this.Options[this.ParameterIndex];
-    public int ArgumentIndex { get; private set; } = -1;
+
+    /// <summary>
+    /// The current argument to convert.
+    /// </summary>
+    public override DiscordInteractionDataOption? Argument 
+        => this.Options.SingleOrDefault(x => x.Name == this.Parameter.Name);
 
     /// <inheritdoc/>
     public override bool NextParameter() 
         => this.Interaction.Data.Options is not null && base.NextParameter();
-
-    public override bool NextArgument()
-    {
-        if (this.ArgumentIndex + 1 >= this.Options.Count)
-        {
-            return false;
-        }
-
-        this.ArgumentIndex++;
-        return true;
-    }
 }

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 using DSharpPlus.Commands.ArgumentModifiers;
 using DSharpPlus.Commands.ContextChecks;
+using DSharpPlus.Commands.Converters;
 using DSharpPlus.Commands.EventArgs;
 using DSharpPlus.Commands.Exceptions;
 using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;
@@ -620,4 +621,14 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
 
         return stringBuilder.ToString();
     }
+
+    /// <inheritdoc/>
+    protected override ValueTask<IOptional> ExecuteConverterAsync<T>
+    (
+        InteractionConverterContext context,
+        ISlashArgumentConverter converter,
+        InteractionCreateEventArgs eventArgs,
+        Func<ISlashArgumentConverter, InteractionConverterContext, InteractionCreateEventArgs, ValueTask<IOptional>> execute
+    )
+        => execute(converter, context, eventArgs);
 }

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -626,8 +626,8 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
     /// <inheritdoc/>
     protected override async ValueTask<IOptional> ExecuteConverterAsync<T>
     (
-        InteractionConverterContext converterContext,
         ISlashArgumentConverter converter,
+        InteractionConverterContext converterContext,
         InteractionCreateEventArgs eventArgs
     )
     {

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -235,8 +235,8 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
     /// <inheritdoc/>
     protected override async ValueTask<IOptional> ExecuteConverterAsync<T>
     (
-        TextConverterContext converterContext,
         ITextArgumentConverter converter,
+        TextConverterContext converterContext,
         MessageCreateEventArgs eventArgs
     )
     {   

--- a/DSharpPlus.Commands/Processors/TextCommands/TextConverterContext.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextConverterContext.cs
@@ -11,7 +11,7 @@ public record TextConverterContext : ConverterContext
     public int CurrentArgumentIndex { get; private set; }
     public int NextArgumentIndex { get; private set; }
 
-    public override bool NextArgument()
+    public bool NextArgument()
     {
         if (this.NextArgumentIndex >= this.RawArguments.Length || this.NextArgumentIndex == -1)
         {


### PR DESCRIPTION
fixes #1843 
fixes #1864 

removes all order dependencies from converter execution.

converters will, regardless, require quite some work still, with regards to typing, performance, scope correctness and error reporting