### PR TITLE
Improved the remarks for the ThreadMemberUpdated event

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -672,8 +672,8 @@ public sealed partial class DiscordClient
     /// For this Event you need the <see cref="DiscordIntents.Guilds"/> intent specified in <seealso cref="DiscordConfiguration.Intents"/>
     /// </summary>
     /// <remarks>
-    /// This event is mostly documented for completeness, and it not fired every time
-    /// DM channels in which no prior messages were received or sent.
+    /// This event is primarily documented for completeness and is not fired every time
+    /// in DM channels where no prior messages have been received or sent.
     /// </remarks>
     public event AsyncEventHandler<DiscordClient, ThreadMemberUpdateEventArgs> ThreadMemberUpdated
     {

--- a/DSharpPlus/Clients/DiscordClient.Events.cs
+++ b/DSharpPlus/Clients/DiscordClient.Events.cs
@@ -672,8 +672,7 @@ public sealed partial class DiscordClient
     /// For this Event you need the <see cref="DiscordIntents.Guilds"/> intent specified in <seealso cref="DiscordConfiguration.Intents"/>
     /// </summary>
     /// <remarks>
-    /// This event is primarily documented for completeness and is not fired every time
-    /// in DM channels where no prior messages have been received or sent.
+    /// This event is primarily implemented for completeness and unlikely to be useful to bots.
     /// </remarks>
     public event AsyncEventHandler<DiscordClient, ThreadMemberUpdateEventArgs> ThreadMemberUpdated
     {


### PR DESCRIPTION
# Summary
Improved the remarks section in the documentation for the `ThreadMemberUpdated` event.

# Details
- Ensured the sentence is grammatically correct and easier to understand.

**Original Sentence:**
`This event is mostly documented for completeness, and it not fired every time DM channels in which no prior messages were received or sent.`

**Revised Sentence:**
`This event is primarily implemented for completeness and unlikely to be useful to bots.`

### Testing
- No code changes; documentation update only.
