### PR TITLE
Replace DiscordShardedClient with regular one in Commands documentation

### DIFF
--- a/docs/articles/commands/introduction.md
+++ b/docs/articles/commands/introduction.md
@@ -40,13 +40,13 @@ public async Task Main(string[] args)
     commandsExtension.AddCommands(typeof(Program).Assembly);
     TextCommandProcessor textCommandProcessor = new(new()
     {
-            // By default, the prefix will be "!"
-            // However the bot will *always* respond to a direct mention
-            // as long as the `DefaultPrefixResolver` is used
-            PrefixResolver = new DefaultPrefixResolver("?").ResolvePrefixAsync
+        // By default, the prefix will be "!"
+        // However the bot will *always* respond to a direct mention
+        // as long as the `DefaultPrefixResolver` is used
+        PrefixResolver = new DefaultPrefixResolver("?").ResolvePrefixAsync
     });
 
-        // Add text commands with a custom prefix (?ping)
+    // Add text commands with a custom prefix (?ping)
     await commandsExtension.AddProcessorsAsync(textCommandProcessor);
 }
 ```
@@ -92,14 +92,14 @@ CommandsExtension commandsExtensions = await discordClient.UseCommandsAsync(new 
 commandsExtension.AddCommands(typeof(Program).Assembly);
 TextCommandProcessor textCommandProcessor = new(new()
 {
-      // By default, the prefix will be "!"
-     // However the bot will *always* respond to a direct mention
-     // as long as the `DefaultPrefixResolver` is used
-     PrefixResolver = new DefaultPrefixResolver("?").ResolvePrefixAsync
+    // By default, the prefix will be "!"
+    // However the bot will *always* respond to a direct mention
+    // as long as the `DefaultPrefixResolver` is used
+    PrefixResolver = new DefaultPrefixResolver("?").ResolvePrefixAsync
 });
 
-        // Add text commands with a custom prefix (?ping)
-    await commandsExtension.AddProcessorsAsync(textCommandProcessor);
+// Add text commands with a custom prefix (?ping)
+await commandsExtension.AddProcessorsAsync(textCommandProcessor);
 
 ```
 

--- a/docs/articles/commands/introduction.md
+++ b/docs/articles/commands/introduction.md
@@ -74,7 +74,7 @@ serviceCollection.AddSingleton(_ =>
 });
 ```
 
-And when your program actually~~~~ starts, you'll want to register the command framework:
+And when your program actually starts, you'll want to register the command framework:
 
 ```cs
 DiscordClient discordClient = serviceProvider.GetRequiredService<DiscordClient>();

--- a/docs/articles/commands/introduction.md
+++ b/docs/articles/commands/introduction.md
@@ -28,7 +28,7 @@ public async Task Main(string[] args)
     });
 
     // Use the commands extension
-    CommandsExtension commandsExtension = await discordClient.UseCommandsAsync(new CommandsConfiguration()
+    CommandsExtension commandsExtension = discordClient.UseCommands(new CommandsConfiguration()
     {
         ServiceProvider = serviceProvider,
         DebugGuildId = Environment.GetEnvironmentVariable("DEBUG_GUILD_ID") ?? 0,
@@ -47,7 +47,7 @@ public async Task Main(string[] args)
     });
 
     // Add text commands with a custom prefix (?ping)
-    commandsExtension.AddProcessors(textCommandProcessor);
+    await commandsExtension.AddProcessorsAsync(textCommandProcessor);
 }
 ```
 
@@ -80,7 +80,7 @@ And when your program actually starts, you'll want to register the command frame
 DiscordClient discordClient = serviceProvider.GetRequiredService<DiscordClient>();
 
 // Register extensions outside of the service provider lambda since these involve asynchronous operations
-CommandsExtension commandsExtensions = await discordClient.UseCommandsAsync(new CommandsConfiguration()
+CommandsExtension commandsExtensions = discordClient.UseCommands(new CommandsConfiguration()
 {
     ServiceProvider = serviceProvider,
     DebugGuildId = Environment.GetEnvironmentVariable("DEBUG_GUILD_ID") ?? 0,
@@ -99,7 +99,7 @@ TextCommandProcessor textCommandProcessor = new(new()
 });
 
 // Add text commands with a custom prefix (?ping)
-commandsExtension.AddProcessors(textCommandProcessor);
+await commandsExtension.AddProcessorsAsync(textCommandProcessor);
 
 ```
 

--- a/docs/articles/commands/introduction.md
+++ b/docs/articles/commands/introduction.md
@@ -47,7 +47,7 @@ public async Task Main(string[] args)
     });
 
     // Add text commands with a custom prefix (?ping)
-    await commandsExtension.AddProcessorsAsync(textCommandProcessor);
+    commandsExtension.AddProcessors(textCommandProcessor);
 }
 ```
 
@@ -99,7 +99,7 @@ TextCommandProcessor textCommandProcessor = new(new()
 });
 
 // Add text commands with a custom prefix (?ping)
-await commandsExtension.AddProcessorsAsync(textCommandProcessor);
+commandsExtension.AddProcessors(textCommandProcessor);
 
 ```
 


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Replaces all mentions of DSC with regular DC. That includes changing all stuff for making commands work with sharding, as you can see in PR.


# Notes
An actually well-written InF PR? You're sleeping. And now i go summon some lovecraftian gods right in here:
Y'AI 'NG'NGAH, YOG-SOTHOTH H'EE-L'GEB F'AI THRODOG UAAAH.