### PR TITLE
Channeltype Groupe is also a DiscordDmChannel

### DIFF
--- a/DSharpPlus/Net/Serialization/DiscordForumChannelJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/DiscordForumChannelJsonConverter.cs
@@ -40,7 +40,7 @@ public class DiscordForumChannelJsonConverter : JsonConverter
 
             channel = chn;
         }
-        else if (channelType is DiscordChannelType.Private)
+        else if (channelType is DiscordChannelType.Private or DiscordChannelType.Group)
         {
             channel = new DiscordDmChannel();
             serializer.Populate(job.CreateReader(), channel);


### PR DESCRIPTION
# Summary
JsonConverter didnt parsed channels with type `group` (group dms) as a DiscordDMChannel

# Notes
Tested but waiting for reporting user to confirm