### PR TITLE
Remove all DocFX API reference links + touchups.

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.WebSocket.cs
+++ b/DSharpPlus/Clients/DiscordClient.WebSocket.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -523,12 +524,13 @@ public sealed partial class DiscordClient
     /// <param name="opCode">The opcode to send to the Discord gateway.</param>
     /// <param name="data">The data to deserialize.</param>
     /// <typeparam name="T">The type of data that the object belongs to.</typeparam>
+    /// <remarks>This method should not be used unless you know what you're doing. Instead, look towards the other explicitly implemented methods which come with client-side validation.</remarks>
     /// <returns>A task representing the payload being sent.</returns>
-    [Obsolete("This method should not be used unless you know what you're doing. Instead, look towards the other explicitly implemented methods which come with client-side validation.")]
+    [Experimental("DSP0004")]
     public Task SendPayloadAsync<T>(GatewayOpCode opCode, T data) => SendPayloadAsync(opCode, (object?)data);
 
     /// <inheritdoc cref="SendPayloadAsync{T}(GatewayOpCode, T)"/>
-    [Obsolete("This method should not be used unless you know what you're doing. Instead, look towards the other explicitly implemented methods which come with client-side validation.")]
+    [Experimental("DSP0004")]
     public Task SendPayloadAsync(GatewayOpCode opCode, object? data = null)
     {
         GatewayPayload payload = new()

--- a/docs/articles/advanced_topics/buttons.md
+++ b/docs/articles/advanced_topics/buttons.md
@@ -46,7 +46,7 @@ var myButton = new DiscordButtonComponent(
 ```
 
 This will create a blurple button with the text that reads "Very cool button!". When a user pushes it,
-`"my_very_cool_button"` will be sent back as the @DSharpPlus.EventArgs.ComponentInteractionCreateEventArgs.Id property
+`"my_very_cool_button"` will be sent back as the `ComponentInteractionCreateEventArgs.Id` property
 on the event. This is expanded on in the [how to respond to buttons][2].
 
 The label of a button is optional *if* an emoji is specified. The label can be up to 80 characters in length. The emoji
@@ -69,7 +69,7 @@ var builder = new DiscordMessageBuilder();
 builder.WithContent("This message has buttons! Pretty neat innit?");
 ```
 
-Well, there's a builder, but no buttons. What now? Simply make a new @DSharpPlus.Entities.DiscordButtonComponent object
+Well, there's a builder, but no buttons. What now? Simply make a new `DiscordButtonComponent` object
 and call AddComponents on the
 message builder.
 
@@ -100,7 +100,7 @@ var builder = new DiscordMessageBuilder()
     });
 ```
 
-As promised, not too complicated. Links however are @DSharpPlus.Entities.DiscordLinkButtonComponent, which takes a URL
+As promised, not too complicated. Links however are `DiscordLinkButtonComponent`, which takes a URL
 as its first parameter, and the label. Link buttons can also have an emoji, like regular buttons.
 
 Lets also add a second row of buttons, but disable them, so the user can't push them all willy-nilly.
@@ -117,7 +117,7 @@ builder.AddComponents(new DiscordComponent[]
 ```
 
 Practically identical, but now with `true` as an extra paremeter. This is the
-@DSharpPlus.Entities.DiscordButtonComponent.Disabled property.
+`DiscordButtonComponent.Disabled` property.
 
 Produces a message like such:
 
@@ -142,17 +142,16 @@ Pikachu enjoying a lolipop. Adorable.
 
 # Responding to button presses
 
-When any button is pressed, it will fire the @DSharpPlus.DiscordClient.ComponentInteractionCreated.
+When any button is pressed, it will fire the `ComponentInteractionCreated`
 
-In the event args, @DSharpPlus.EventArgs.ComponentInteractionCreateEventArgs.Id will be the id of the button you
-specified. There's also an @DSharpPlus.EventArgs.InteractionCreateEventArgs.Interaction property, which contains the
+In the event args, `ComponentInteractionCreateEventArgs.Id ` will be the id of the button you
+specified. There's also an `InteractionCreateEventArgs.Interaction` property, which contains the
 interaction the event created. It's important to respond to an interaction within 3 seconds, or it will time out.
-Responding after this period will throw a @DSharpPlus.Exceptions.NotFoundException.
+Responding after this period will throw a `NotFoundException`
 
-With buttons, there are two new response types: @DSharpPlus.InteractionResponseType.DeferredMessageUpdate and
-@DSharpPlus.InteractionResponseType.UpdateMessage.
+With buttons, there are two new response types: `InteractionResponseType.DeferredMessageUpdate` and `InteractionResponseType.UpdateMessage`.
 
-Using @DSharpPlus.InteractionResponseType.DeferredMessageUpdate lets you create followup messages via the
+Using `DSharpPlus.InteractionResponseType.DeferredMessageUpdate` lets you create followup messages via the
 [followup message builder][6]. The button will return to being in it's 'dormant' state, or it's 'unpushed' state, if you
 will.
 
@@ -167,8 +166,8 @@ client.ComponentInteractionCreated += async (s, e) =>
 ```
 
 If you would like to update the message when a button is pressed, however, you'd use
-@DSharpPlus.InteractionResponseType.UpdateMessage instead, and pass a
-@DSharpPlus.Entities.DiscordInteractionResponseBuilder with the new content you'd like.
+`InteractionResponseType.UpdateMessage` instead, and pass a
+`DiscordInteractionResponseBuilder` with the new content you'd like.
 
 ```cs
 client.ComponentInteractionCreated += async (s, e) =>
@@ -184,27 +183,27 @@ This will update the message, and remove all the buttons. Nice.
 
 # Interactivity
 
-Along with the typical @DSharpPlus.Interactivity.InteractivityExtension.WaitForMessageAsync* and
-@DSharpPlus.Interactivity.InteractivityExtension.WaitForReactionAsync* methods provided by interactivity, there are also
+Along with the typical `InteractivityExtension.WaitForMessageAsync` and
+`InteractivityExtension.WaitForReactionAsync` methods provided by interactivity, there are also
 button implementations as well.
 
 More information about how interactivity works can be found in [the interactivity article][7].
 
 Since buttons create interactions, there are also two additional properties in the configuration:
 
-- @DSharpPlus.Interactivity.InteractivityConfiguration.ResponseBehavior
-- @DSharpPlus.Interactivity.InteractivityConfiguration.ResponseMessage
+- `InteractivityConfiguration.ResponseBehavior`
+- `InteractivityConfiguration.ResponseMessage`
 
-@DSharpPlus.Interactivity.InteractivityConfiguration.ResponseBehavior is what interactivity will do when handling
-something that isn't a valid valid button, in the context of waiting for a specific button. It defaults to
-@DSharpPlus.Interactivity.Enums.InteractionResponseBehavior.Ignore, which will cause the interaction fail.
+`InteractivityConfiguration.ResponseBehavior` is what interactivity will do when handling
+something that isn't a valid button, in the context of waiting for a specific button. It defaults to
+`InteractionResponseBehavior.Ignore`, which will cause the interaction fail.
 
-Alternatively, setting it to @DSharpPlus.Interactivity.Enums.InteractionResponseBehavior.Ack will acknowledge the
+Alternatively, setting it to `InteractionResponseBehavior.Ack` will acknowledge the
 button, and continue waiting.
 
 Respond will reply with an ephemeral message with the aforementioned response message.
 
-@DSharpPlus.Interactivity.InteractivityConfiguration.ResponseBehavior only applies to the overload accepting a string id
+`InteractivityConfiguration.ResponseBehavior` only applies to the overload accepting a string id
 of the button to wait for.
 
 <!-- LINKS -->

--- a/docs/articles/advanced_topics/buttons.md
+++ b/docs/articles/advanced_topics/buttons.md
@@ -152,7 +152,7 @@ Responding after this period will throw a `NotFoundException`
 With buttons, there are two new response types: `InteractionResponseType.DeferredMessageUpdate` and `InteractionResponseType.UpdateMessage`.
 
 Using `DSharpPlus.InteractionResponseType.DeferredMessageUpdate` lets you create followup messages via the
-[followup message builder][6]. The button will return to being in it's 'dormant' state, or it's 'unpushed' state, if you
+followup message builder. The button will return to being in it's 'dormant' state, or it's 'unpushed' state, if you
 will.
 
 You have 15 minutes from that point to make followup messages. Responding to that interaction looks like this:

--- a/docs/articles/advanced_topics/metrics_profiling.md
+++ b/docs/articles/advanced_topics/metrics_profiling.md
@@ -15,8 +15,8 @@ their outcomes, and we intend to add more insights - feel free to let us know vi
 ## Rest Metrics
 
 Metrics on REST requests can be obtained through `GetRequestMetrics` methods on the respective client.
-This is supported on the webhook client, @DSharpPlus.DiscordRestClient and @DSharpPlus.DiscordClient. To
-obtain metrics from a @DSharpPlus.DiscordShardedClient , fetch metrics from the first shard.
+This is supported on the webhook client, `DiscordRestClient` and `DiscordClient`. To
+obtain metrics from a `DiscordShardedClient` , fetch metrics from the first shard.
 
 You may optionally specify to reset the tracking metrics, for example when polling regularly to calculate
 statistics:

--- a/docs/articles/advanced_topics/selects.md
+++ b/docs/articles/advanced_topics/selects.md
@@ -7,7 +7,7 @@ title: Select Menus
 **They're here!** What's here? Select menus (aka dropdowns) of course.
 
 Dropdowns are another [message component][0] added to the Discord API. Additionally, just like buttons, dropdowns are
-supported in all builders that take @DSharpPlus.Entities.DiscordComponent. However, dropdowns occupy an entire action
+supported in all builders that take `DiscordComponent`. However, dropdowns occupy an entire action
 row, so you can only have up to 5! Furthermore, buttons cannot occupy the same row as a dropdown.
 
 In this article, we will go over what dropdowns are, how to use them, and the limitations of dropdowns.
@@ -30,7 +30,7 @@ Dropdowns consist of several parts, and share some in common with buttons. They 
 So lets go over these one by one, starting with the id. The id of a dropdown should of course be unique, just like
 buttons, and Discord will send this id back in the [interaction object][1].
 
-Placeholder is also relatively relatively simple! It's hopefully self-explanatory, too. Placeholder text is the text the
+Placeholder is also relatively simple! It's hopefully self-explanatory, too. Placeholder text is the text the
 user will see when no options are selected.
 
 If you do not wish to have placeholder text, simply pass `null` as that parameter in the constructor for the dropdown.
@@ -58,14 +58,14 @@ to **25** options, but must have at least 1. These consist of several parts:
 Label is the label of the option. This is always required, and can be up to **100** characters long.
 
 Value is like the custom id of the dropdown; for the most part it should be unique. This will be accessible on the
-@DSharpPlus.Entities.DiscordInteractionData.Values property the interaction, and will contain all the selected options.
+`DiscordInteractionData.Values` property the interaction, and will contain all the selected options.
 
 Individual values unfortunately cannot be disabled.
 
 Description is text that is placed under the label on each option, and can also be up to 100 characters. This text is
 also plain-text, and does not support markdown.
 
-Default determines whether or not the option will be the default option (which overrides placeholder). If you set
+Default determines whether the option will be the default option (which overrides placeholder). If you set
 multiple to default (and allow multiple to be selected), the user will see the options as pre-selected.
 
 Emoji is the same as a button. You can pass an emoji id, a unicode emote or a DiscordEmoji object, which will
@@ -116,8 +116,8 @@ var dropdown = new DiscordSelectComponent("dropdown", null, options, false, 1, 2
 ```
 
 Okay, so we have a dropdown...now what? Simply pass it to any builder that constructs a response, be it a
-@DSharpPlus.Entities.DiscordMessageBuilder, @DSharpPlus.Entities.DiscordInteractionResponseBuilder, or
-@DSharpPlus.Entities.DiscordWebhookBuilder.
+`DiscordMessageBuilder`, `DiscordInteractionResponseBuilder`, or
+`DiscordWebhookBuilder`.
 
 It'll look something like this, using the code above:
 
@@ -147,11 +147,11 @@ two options.
 "**Oh no, I'm getting 'This interaction failed' when selecting! What do I do?**"
 
 Dropdowns are like buttons; when a user interacts with them, you need to respond to that interaction.
-@DSharpPlus.DiscordClient.ComponentInteractionCreated is fired from the client, just like buttons.
+`DiscordClient.ComponentInteractionCreated` is fired from the client, just like buttons.
 
 This applies to interactivity, too! Simply swap
-@DSharpPlus.Interactivity.Extensions.MessageExtensions.WaitForButtonAsync* for
-@DSharpPlus.Interactivity.Extensions.MessageExtensions.WaitForSelectAsync*, and pass a dropdown. How to go about
+`WaitForButtonAsync` for
+`WaitForSelectAsync`, and pass a dropdown. How to go about
 component-based interactivity is described [in the buttons article][4].
 
 And that's it! Go forth and create amazing things.

--- a/docs/articles/audio/lavalink/configuration.md
+++ b/docs/articles/audio/lavalink/configuration.md
@@ -2,6 +2,10 @@
 uid: articles.audio.lavalink.configuration
 title: Lavalink Configuration
 ---
+---
+uid: articles.audio.lavalink.configuration
+title: Lavalink Configuration
+---
 
 >[!WARNING]
 > `DSharpPlus.Lavalink` has been deprecated, and this article may contain outdated information. Both the extension and this article will be removed

--- a/docs/articles/audio/lavalink/music_commands.md
+++ b/docs/articles/audio/lavalink/music_commands.md
@@ -9,7 +9,7 @@ title: Lavalink Music Commands
 
 # Adding Music Commands
 
-This article assumes that you know how to use CommandsNext. If you do not, you should learn [here][0]
+This article assumes that you know how to use CommandsNext. If you do not, you should check out intro articles for Commands.
 before continuing with this guide.
 
 ## Prerequisites
@@ -356,13 +356,10 @@ public async Task Pause(CommandContext ctx)
 }
 ```
 
-Of course, there are other commands Lavalink has to offer. Check out [the docs][1] to view the commands you can use
+Of course, there are other commands Lavalink has to offer. Check out the docs to view the commands you can use
 while playing tracks.
 
-There are also open source examples such as Emzi0767's [Companion Cube Bot][2] and [Turret Bot][3].
+There are also open source examples such as Emzi0767's [Turret Bot][0].
 
 <!-- LINKS -->
-[0]:  xref:articles.commands_next.intro
-[1]:  xref:DSharpPlus.Lavalink.LavalinkGuildConnection
-[2]:  https://github.com/Emzi0767/Discord-Companion-Cube-Bot
-[3]:  https://github.com/Emzi0767/Discord-Music-Turret-Bot
+[0]:  https://github.com/Emzi0767/Discord-Music-Turret-Bot

--- a/docs/articles/audio/lavalink/music_commands.md
+++ b/docs/articles/audio/lavalink/music_commands.md
@@ -60,7 +60,7 @@ public async Task Leave(CommandContext ctx, DiscordChannel channel)
 
 In order to connect to a voice channel, we'll need to do a few things.
 
-1. Get our node connection. You can either use linq or @DSharpPlus.Lavalink.LavalinkExtension.GetIdealNodeConnection*
+1. Get our node connection. You can either use LINQ or `LavalinkExtension.GetIdealNodeConnection`
 2. Check if the channel is a voice channel, and tell the user if not.
 3. Connect the node to the channel.
 
@@ -72,7 +72,7 @@ And for the leave command:
 4. Check if the connection exists, and tell the user if not.
 5. Disconnect from the channel.
 
-@DSharpPlus.Lavalink.LavalinkExtension.GetIdealNodeConnection* will return the least affected node through load
+`LavalinkExtension.GetIdealNodeConnection` will return the least affected node through load
 balancing, which is useful for larger bots. It can also filter nodes based on an optional voice region to use the
 closest nodes available. Since we only have one connection we can use linq's `.First()` method on the extensions
 connected nodes to get what we need.
@@ -195,14 +195,14 @@ if (conn == null)
 }
 ```
 
-Next, we will get the track details by calling @DSharpPlus.Lavalink.LavalinkGuildConnection.GetTracksAsync*. There is a
+Next, we will get the track details by calling `LavalinkGuildConnection.GetTracksAsync`. There is a
 variety of overloads for this:
 
-1. @DSharpPlus.Lavalink.LavalinkGuildConnection.GetTracksAsync(System.String,DSharpPlus.Lavalink.LavalinkSearchType)
+1. `GuildConnection.GetTracksAsync`
    will search various services for the specified query:
-   - @DSharpPlus.Lavalink.LavalinkSearchType.Youtube will search YouTube
-   - @DSharpPlus.Lavalink.LavalinkSearchType.SoundCloud will search SoundCloud
-2. @DSharpPlus.Lavalink.LavalinkGuildConnection.GetTracksAsync(System.Uri) will use the direct url to obtain the track. This is
+   - `LavalinkSearchType.Youtube` will search YouTube
+   - `LavalinkSearchType.SoundCloud` will search SoundCloud
+2. `LavalinkGuildConnection.GetTracksAsync(Uri)` will use the direct url to obtain the track. This is
    mainly used for the other media sources.
 
 For this guide we will be searching YouTube. Let's pass in our search string and store the result in a variable:
@@ -213,7 +213,7 @@ For this guide we will be searching YouTube. Let's pass in our search string and
 var loadResult = await node.Rest.GetTracksAsync(search);
 ```
 
-The load result will contain an enum called @DSharpPlus.Lavalink.LavalinkLoadResult.LoadResultType, which will inform us
+The load result will contain an enum called `LavalinkLoadResult.LoadResultType`, which will inform us
 if Lavalink was able to retrieve the track data. We can use this as a check:
 
 ```csharp
@@ -229,7 +229,7 @@ if (loadResult.LoadResultType == LavalinkLoadResultType.LoadFailed
 ```
 
 Lavalink will return the track data from your search in a collection called
-@DSharpPlus.Lavalink.LavalinkLoadResult.Tracks, similar to using the search bar in YouTube or SoundCloud directly. The
+`LavalinkLoadResult.Tracks`, similar to using the search bar in YouTube or SoundCloud directly. The
 first track is typically the most accurate one, so that is what we will use:
 
 ```csharp
@@ -308,7 +308,7 @@ public async Task Pause(CommandContext ctx)
 ```
 
 For this command we will also want to check the player state to determine if we should send a pause command. We can do
-so by checking @DSharpPlus.Lavalink.Entities.LavalinkPlayerState.CurrentTrack:
+so by checking `LavalinkPlayerState.CurrentTrack`:
 
 ```csharp
 if (conn.CurrentState.CurrentTrack == null)

--- a/docs/articles/audio/voicenext/receive.md
+++ b/docs/articles/audio/voicenext/receive.md
@@ -9,7 +9,7 @@ title: Receiving
 
 Receiving incoming audio is disabled by default to save on bandwidth, as most users will never make use of incoming
 data. This can be changed by providing a configuration object to
-@DSharpPlus.VoiceNext.DiscordClientExtensions.UseVoiceNext*.
+`DiscordClientExtensions.UseVoiceNext`.
 
 ```cs
 var discord = new DiscordClient();
@@ -31,8 +31,8 @@ VoiceNextConnection connection = await channel.ConnectAsync();
 
 ### Write Event Handler
 
-We'll be able to receive incoming audio from the @DSharpPlus.VoiceNext.VoiceNextConnection.VoiceReceived event fired by
-@DSharpPlus.VoiceNext.VoiceNextConnection.
+We'll be able to receive incoming audio from the `VoiceNextConnection.VoiceReceived` event fired by
+`VoiceNext.VoiceNextConnection`.
 
 ```cs
 connection.VoiceReceived += ReceiveHandler;
@@ -44,7 +44,7 @@ The event arguments will contain a PCM audio packet for you to make use of. You 
 format, concatenate them all together, feed them into an external program, or process the packets any way that'll suit
 your needs.
 
-When a user is speaking, @DSharpPlus.VoiceNext.VoiceNextConnection.VoiceReceived should fire once every twenty
+When a user is speaking, `VoiceNextConnection.VoiceReceived should` fire once every twenty
 milliseconds and its packet will contain around twenty milliseconds worth of audio; this can vary due to differences in
 client settings. To help keep track of the torrent of packets for each user, you can use user IDs in combination the
 synchronization value (SSRC) sent by Discord to determine the source of each packet.

--- a/docs/articles/audio/voicenext/transmit.md
+++ b/docs/articles/audio/voicenext/transmit.md
@@ -11,8 +11,8 @@ Install the `DSharpPlus.VoiceNext` package from NuGet.
 
 ![NuGet Package Manager][0]
 
-Then use the @DSharpPlus.VoiceNext.DiscordClientExtensions.UseVoiceNext* extension method on your instance of
-@DSharpPlus.DiscordClient.
+Then use the `DiscordClientExtensions.UseVoiceNext` extension method on your instance of
+`DiscordClient`.
 
 ```cs
 var discord = new DiscordClient();
@@ -21,8 +21,8 @@ discord.UseVoiceNext();
 
 ### Connect
 
-Joining a voice channel is *very* easy; simply use the @DSharpPlus.VoiceNext.DiscordClientExtensions.ConnectAsync*
-extension method on @DSharpPlus.Entities.DiscordChannel.
+Joining a voice channel is *very* easy; simply use the `ConnectAsync`
+extension method on `DiscordChannel`.
 
 ```cs
 DiscordChannel channel;

--- a/docs/articles/basics/first_bot.md
+++ b/docs/articles/basics/first_bot.md
@@ -96,11 +96,11 @@ Then apply the recommended solution.
 
 We'll now create a new `DiscordClient` instance in our brand new asynchronous method.
 
-Create a new variable in `Main` and assign it a new @DSharpPlus.DiscordClient instance, then pass an instance of
-@DSharpPlus.DiscordConfiguration to its constructor. Create an object initializer for @DSharpPlus.DiscordConfiguration
-and populate the @DSharpPlus.DiscordConfiguration.Token property with your bot token then set the
-@DSharpPlus.DiscordConfiguration.TokenType property to @DSharpPlus.TokenType.Bot. Next add the
-@DSharpPlus.DiscordClient.Intents property and populate it with @DSharpPlus.DiscordIntents.AllUnprivileged.
+Create a new variable in `Main` and assign it a new `DSharpPlus.DiscordClient` instance, then pass an instance of
+`DSharpPlus.DiscordConfiguration` to its constructor. Create an object initializer for `DiscordConfiguration`
+and populate the `DiscordConfiguration.Token` property with your bot token then set the
+`DiscordConfiguration.TokenType` property to `TokenType.Bot`. Next add the
+`DiscordClient.Intents` property and populate it with `DiscordIntents.AllUnprivileged`.
 These Intents are required for certain events to be fired. Please visit this [article][14] for more information.
 
 ```cs
@@ -119,7 +119,7 @@ var discord = new DiscordClient(new DiscordConfiguration()
 > Instead you should store your token in an external medium, such as a configuration file or environment variable, and
 > read that into your program to be used with DSharpPlus.
 
-Follow that up with @DSharpPlus.DiscordClient.ConnectAsync* to connect and login to Discord, and `await Task.Delay(-1);`
+Follow that up with `DiscordClient.ConnectAsync` to connect and login to Discord, and `await Task.Delay(-1);`
 at the end of the method to prevent the console window from closing prematurely.
 
 ```cs
@@ -159,7 +159,7 @@ var discord = new DiscordClient(new DiscordConfiguration()
 
 Now you can start to listen to messages.
 
-Hook the @DSharpPlus.DiscordClient.MessageCreated event fired by @DSharpPlus.DiscordClient with a [lambda][18]. Mark it
+Hook the `DiscordClient.MessageCreated` event fired by `DiscordClient` with a [lambda][18]. Mark it
 as `async` and give it two parameters: `s` and `e`.
 
 ```cs
@@ -170,8 +170,8 @@ discord.MessageCreated += async (s, e) =>
 ```
 
 Then, add an `if` statement into the body of your event lambda that will check if
-@DSharpPlus.Entities.DiscordMessage.Content starts with your desired trigger word and respond with a message using
-@DSharpPlus.Entities.DiscordMessage.RespondAsync* if it does. For this example, we'll have the bot to respond with
+`DiscordMessage.Content` starts with your desired trigger word and respond with a message using
+`DiscordMessage.RespondAsync` if it does. For this example, we'll have the bot to respond with
 *pong!*for each message that starts with*ping*.
 
 ```cs

--- a/docs/articles/beyond_basics/intents.md
+++ b/docs/articles/beyond_basics/intents.md
@@ -7,7 +7,7 @@ title: Intents
 
 Intents were added to Discord to help the service not have to push so many events to the bots that were not using them.
 If you are going to be needing to subscribe to any type of event, they are going to have to be defined **BOTH** within
-the [Discord Application under the Bot Page][0] on Discords Site and also within the @DSharpPlus.DiscordConfiguration.
+the [Discord Application under the Bot Page][0] on Discords Site and also within the `DiscordConfiguration`.
 
 ### Discord Application
 
@@ -25,10 +25,10 @@ run into issues when retrieving entities from the library's cache.
 
 ### Discord Configuration
 
-Within your @DSharpPlus.DiscordConfiguration you will have to specify all the intents you will need. Here is a list of
+Within your `DSharpPlus.DiscordConfiguration` you will have to specify all the intents you will need. Here is a list of
 all the [Intents][3] DSharpPlus Supports. By default, the configuration will use
-@DSharpPlus.DiscordIntents.AllUnprivileged as the default value. Like above however, we recommend having all intents
-enabled at first, so you should specify @DSharpPlus.DiscordIntents.All in your configuration which will include the
+`DiscordIntents.AllUnprivileged` as the default value. Like above however, we recommend having all intents
+enabled at first, so you should specify `DiscordIntents.All` in your configuration which will include the
 privleged intents you enabled in your application:
 
 ```csharp
@@ -39,7 +39,7 @@ var config = new DiscordConfiguration()
 ```
 
 When you become more advanced, you can try experimenting with turning off intents you do not need in order to save
-resources. In your @DSharpPlus.DiscordConfiguration you can specify one or many.
+resources. In your `DSharpPlus.DiscordConfiguration` you can specify one or many.
 
 Here is an example of just specifying one:
 
@@ -68,7 +68,7 @@ var config = new DiscordConfiguration()
 };
 ```
 
-Please Note, if you specify a privileged intent within your @DSharpPlus.DiscordConfiguration that you have not signed up
+Please Note, if you specify a privileged intent within your `DiscordConfiguration` that you have not signed up
 for on the Discord Application page, an error will be thrown on the connection.
 
 <!-- LINKS -->

--- a/docs/articles/beyond_basics/intents.md
+++ b/docs/articles/beyond_basics/intents.md
@@ -25,8 +25,7 @@ run into issues when retrieving entities from the library's cache.
 
 ### Discord Configuration
 
-Within your `DSharpPlus.DiscordConfiguration` you will have to specify all the intents you will need. Here is a list of
-all the [Intents][3] DSharpPlus Supports. By default, the configuration will use
+Within your `DSharpPlus.DiscordConfiguration` you will have to specify all the intents you will need. By default, the configuration will use
 `DiscordIntents.AllUnprivileged` as the default value. Like above however, we recommend having all intents
 enabled at first, so you should specify `DiscordIntents.All` in your configuration which will include the
 privleged intents you enabled in your application:
@@ -75,4 +74,3 @@ for on the Discord Application page, an error will be thrown on the connection.
 [0]: https://discord.com/developers/applications
 [1]: ../../images/Intents.png
 [2]: https://support.discord.com/hc/en-us/articles/360040720412-Bot-Verification-and-Data-Whitelisting
-[3]: xref:DSharpPlus.DiscordIntents

--- a/docs/articles/beyond_basics/logging/default.md
+++ b/docs/articles/beyond_basics/logging/default.md
@@ -13,7 +13,7 @@ This is a basic implementation that only sends log messages to the console.
 
 #### Minimum Logging Level
 
-You're able to adjust the verbosity of log messages via @DSharpPlus.DiscordConfiguration.
+You're able to adjust the verbosity of log messages via `DiscordConfiguration`.
 
 ```cs
 new DiscordConfiguration()
@@ -28,7 +28,7 @@ The example above will display level log messages that are higher than or equal 
 
 #### Timestamp Format
 
-You're also able to change the format of the log timestamp; this is also set through @DSharpPlus.DiscordConfiguration.
+You're also able to change the format of the log timestamp; this is also set through `DiscordConfiguration`.
 
 ```cs
 new DiscordConfiguration()

--- a/docs/articles/beyond_basics/logging/third_party.md
+++ b/docs/articles/beyond_basics/logging/third_party.md
@@ -33,8 +33,8 @@ Next, create a new variable and assign it a new `LoggerFactory` instance which c
 var logFactory = new LoggerFactory().AddSerilog();
 ```
 
-Then assign that variable to the @DSharpPlus.DiscordConfiguration.LoggerFactory property of your of
-@DSharpPlus.DiscordConfiguration.
+Then assign that variable to the `DiscordConfiguration.LoggerFactory` property of your of
+`DiscordConfiguration`.
 
 ```cs
 new DiscordConfiguration()

--- a/docs/articles/beyond_basics/messagebuilder.md
+++ b/docs/articles/beyond_basics/messagebuilder.md
@@ -6,12 +6,12 @@ title: Message Builder
 ## Background
 
 Before the message builder was put into place, we had one large method for sending messages along with 3 additional
-methods for sending files. This was becoming a major code smell and it was hard to maintain and add more parameters onto
+methods for sending files. This was becoming a major code smell, and it was hard to maintain and add more parameters onto
 it. Now we support just sending a simple message, an embed, a simple message with an embed, or a message builder.
 
 ## Using the Message Builder
 
-The API Documentation for the message builder can be found at @DSharpPlus.Entities.DiscordMessageBuilder but here we'll
+The API Documentation for the message builder can be found at `DiscordMessageBuilder` but here we'll
 go over some of the concepts of using the message builder:
 
 ### Adding a File

--- a/docs/articles/beyond_basics/sharding.md
+++ b/docs/articles/beyond_basics/sharding.md
@@ -5,7 +5,7 @@ title: Sharding
 
 # Sharding
 
-As your bot joins more guilds, your poor @DSharpPlus.DiscordClient will be hit with an increasing number of events.
+As your bot joins more guilds, your poor `DiscordClient` will be hit with an increasing number of events.
 Thankfully, Discord allows you to establish multiple connections to split the event workload; this is called *sharding*
 and each individual connection is referred to as a *shard*. Each shard handles a separate set of servers and will *only*
 receive events from those servers. However, all direct messages will be handled by your first shard.
@@ -14,7 +14,7 @@ Sharding is recommended once you reach 1,000 servers, and is a *requirement* whe
 
 ## Automated Sharding
 
-DSharpPlus provides a built-in sharding solution: @DSharpPlus.DiscordShardedClient. This client will *automatically*
+DSharpPlus provides a built-in sharding solution: `DiscordShardedClient`. This client will *automatically*
 spawn shards for you and manage their events. Each DSharpPlus extension (e.g. CommandsNext, Interactivity) also supplies
 an extension method to register themselves automatically on each shard.
 
@@ -33,9 +33,9 @@ await discord.UseCommandsNextAsync(new CommandsNextConfiguration()
 
 ## Manual Sharding
 
-For most looking to shard, the built-in @DSharpPlus.DiscordShardedClient will work well enough. However, those looking
+For most looking to shard, the built-in `DiscordShardedClient` will work well enough. However, those looking
 for more control over the sharding process may want to handle it manually.
 
-This would involve creating new @DSharpPlus.DiscordClient instances, assigning each one an appropriate shard ID number,
+This would involve creating new `DiscordClient` instances, assigning each one an appropriate shard ID number,
 and handling the events from each instance. Considering the potential complexity imposed by this process, you should
 only do this if you have a valid reason to do so and *know what you are doing*.

--- a/docs/articles/commands_next/argument_converters.md
+++ b/docs/articles/commands_next/argument_converters.md
@@ -11,10 +11,10 @@ title: Argument Converter
 Writing your own argument converter will enable you to convert custom types and replace the functionality of existing
 converters. Like many things in DSharpPlus, doing this is straightforward and simple.
 
-First, create a new class which implements @DSharpPlus.CommandsNext.Converters.IArgumentConverter`1 and its method
-@DSharpPlus.CommandsNext.Converters.IArgumentConverter`1.ConvertAsync(System.String,DSharpPlus.CommandsNext.CommandContext).
+First, create a new class which implements `IArgumentConverter` and its method
+`IArgumentConverter.ConvertAsync`.
 Our example will be a boolean converter, so we'll also pass `bool` as the type parameter for
-@DSharpPlus.CommandsNext.Converters.IArgumentConverter`1.
+`IArgumentConverter`.
 
 ```cs
 public class CustomArgumentConverter : IArgumentConverter<bool>

--- a/docs/articles/commands_next/command_attributes.md
+++ b/docs/articles/commands_next/command_attributes.md
@@ -66,7 +66,7 @@ public class RequireYearAttribute : CheckBaseAttribute
 }
 ```
 
-You can provide feedback to the user using the @DSharpPlus.CommandsNext.CommandsNextExtension.CommandErrored event.
+You can provide feedback to the user using the `CommandsNextExtension.CommandErrored` event.
 
 ```cs
 private async Task Main(string[] args)

--- a/docs/articles/commands_next/command_attributes.md
+++ b/docs/articles/commands_next/command_attributes.md
@@ -11,29 +11,29 @@ title: Command Attributes
 CommandsNext has a variety of built-in attributes to enhance your commands and provide some access control.
 The majority of these attributes can be applied to your command methods and command groups.
 
-- @DSharpPlus.CommandsNext.Attributes.AliasesAttribute
-- @DSharpPlus.CommandsNext.Attributes.CooldownAttribute
-- @DSharpPlus.CommandsNext.Attributes.DescriptionAttribute
-- @DSharpPlus.CommandsNext.Attributes.CategoryAttribute
-- @DSharpPlus.CommandsNext.Attributes.DontInjectAttribute
-- @DSharpPlus.CommandsNext.Attributes.HiddenAttribute
-- @DSharpPlus.CommandsNext.Attributes.ModuleLifespanAttribute
-- @DSharpPlus.CommandsNext.Attributes.PriorityAttribute
-- @DSharpPlus.CommandsNext.Attributes.RemainingTextAttribute
-- @DSharpPlus.CommandsNext.Attributes.RequireBotPermissionsAttribute
-- @DSharpPlus.CommandsNext.Attributes.RequireDirectMessageAttribute
-- @DSharpPlus.CommandsNext.Attributes.RequireGuildAttribute
-- @DSharpPlus.CommandsNext.Attributes.RequireNsfwAttribute
-- @DSharpPlus.CommandsNext.Attributes.RequireOwnerAttribute
-- @DSharpPlus.CommandsNext.Attributes.RequirePermissionsAttribute
-- @DSharpPlus.CommandsNext.Attributes.RequirePrefixesAttribute
-- @DSharpPlus.CommandsNext.Attributes.RequireRolesAttribute
-- @DSharpPlus.CommandsNext.Attributes.RequireUserPermissionsAttribute
+- `AliasesAttribute`
+- `CooldownAttribute`
+- `DescriptionAttribute`
+- `CategoryAttribute`
+- `DontInjectAttribute`
+- `HiddenAttribute`
+- `ModuleLifespanAttribute`
+- `PriorityAttribute`
+- `RemainingTextAttribute`
+- `RequireBotPermissionsAttribute`
+- `RequireDirectMessageAttribute`
+- `RequireGuildAttribute`
+- `RequireNsfwAttribute`
+- `RequireOwnerAttribute`
+- `RequirePermissionsAttribute`
+- `RequirePrefixesAttribute`
+- `RequireRolesAttribute`
+- `RequireUserPermissionsAttribute`
 
 ## Custom Attributes
 
 If the above attributes don't meet your needs, CommandsNext also gives you the option of writing your own!
-Simply create a new class which inherits from @DSharpPlus.CommandsNext.Attributes.CheckBaseAttribute and implement the
+Simply create a new class which inherits from `CheckBaseAttribute` and implement the
 required method.
 
 Our example below will only allow a command to be ran during a specified year.

--- a/docs/articles/commands_next/command_handler.md
+++ b/docs/articles/commands_next/command_handler.md
@@ -15,7 +15,7 @@ title: Custom Command Handler
 ### Disable Default Handler
 
 To begin, we'll need to disable the default command handler provided by CommandsNext. This is done by setting the
-@DSharpPlus.CommandsNext.CommandsNextConfiguration.UseDefaultCommandHandler configuration property to `false`.
+`UseDefaultCommandHandler` configuration property to `false`.
 
 ```cs
 var discord = new DiscordClient();
@@ -27,8 +27,8 @@ var commands = discord.UseCommandsNext(new CommandsNextConfiguration()
 
 ### Create Event Handler
 
-We'll then write a new handler for the @DSharpPlus.DiscordClient.MessageCreated event fired from
-@DSharpPlus.DiscordClient.
+We'll then write a new handler for the `MessageCreated` event fired from
+`DiscordClient`.
 
 ```cs
 discord.MessageCreated += CommandHandler;
@@ -62,7 +62,7 @@ var prefix = msg.Content.Substring(0, cmdStart);
 var cmdString = msg.Content.Substring(cmdStart);
 ```
 
-Then provide the command string to @DSharpPlus.CommandsNext.CommandsNextExtension.FindCommand*.
+Then provide the command string to `FindCommand`.
 
 ```cs
 var command = cnext.FindCommand(cmdString, out var args);
@@ -74,7 +74,7 @@ Create a command context using our message and prefix, along with the command an
 var ctx = cnext.CreateContext(msg, prefix, command, args);
 ```
 
-And pass the context to @DSharpPlus.CommandsNext.CommandsNextExtension.ExecuteCommandAsync* to execute the command.
+And pass the context to `ExecuteCommandAsync` to execute the command.
 
 ```cs
 _ = Task.Run(async () => await cnext.ExecuteCommandAsync(ctx));

--- a/docs/articles/commands_next/dependency_injection.md
+++ b/docs/articles/commands_next/dependency_injection.md
@@ -21,7 +21,7 @@ We'll go through a simple example of this process to help you understand better.
 ### Create a Service Provider
 
 To begin, we'll need to create a service provider; this will act as the container for the services you need for your
-commands. Create a new variable just before you register CommandsNext with your @DSharpPlus.DiscordClient and assign it
+commands. Create a new variable just before you register CommandsNext with your `DiscordClient` and assign it
 a new instance of `ServiceCollection`.
 
 ```cs
@@ -88,7 +88,7 @@ module constructor and CommandsNext will take care of the rest. Ain't that neat?
 
 By default, all command modules have a singleton lifespan; this means each command module is instantiated once for the
 lifetime of the CommandsNext instance. However, if the reuse of a module instance is undesired, you also have the option
-to change the lifespan of a module to *transient* using the @DSharpPlus.CommandsNext.Attributes.ModuleLifespanAttribute.
+to change the lifespan of a module to *transient* using the `ModuleLifespanAttribute`.
 
 ```cs
 [ModuleLifespan(ModuleLifespan.Transient)]

--- a/docs/articles/commands_next/help_formatter.md
+++ b/docs/articles/commands_next/help_formatter.md
@@ -12,7 +12,7 @@ The built-in help command provided by CommandsNext is generated with a *help for
 a command and its subcommands then returns a formatted help message. If you're not happy with the default help
 formatter, you're able to write your own and customize the output to your liking.
 
-Simply inherit from @DSharpPlus.CommandsNext.Converters.BaseHelpFormatter and provide an implementation for each of the
+Simply inherit from `BaseHelpFormatter` and provide an implementation for each of the
 required methods.
 
 ```cs
@@ -60,8 +60,8 @@ public class CustomHelpFormatter : BaseHelpFormatter
 ```
 
 Alternatively, if you're only wanting to make a few small tweaks to the default help, you can write a simple help
-formatter which inherits from @DSharpPlus.CommandsNext.Converters.DefaultHelpFormatter and modify the inherited
-@DSharpPlus.CommandsNext.Converters.DefaultHelpFormatter.EmbedBuilder property.
+formatter which inherits from `DefaultHelpFormatter` and modify the inherited
+`DefaultHelpFormatter.EmbedBuilder` property.
 
 ```cs
 public class CustomHelpFormatter : DefaultHelpFormatter

--- a/docs/articles/commands_next/intro.md
+++ b/docs/articles/commands_next/intro.md
@@ -43,7 +43,7 @@ public class MyFirstModule : BaseCommandModule
 ### Create a Command Method
 
 Within our new module, create a method named `GreetCommand` marked as `async` with a `Task` return type. The first
-parameter of your method *must* be of type @DSharpPlus.CommandsNext.CommandContext, as required by CommandsNext.
+parameter of your method *must* be of type `CommandsNext.CommandContext`, as required by CommandsNext.
 
 ```cs
 public async Task GreetCommand(CommandContext ctx)
@@ -52,13 +52,13 @@ public async Task GreetCommand(CommandContext ctx)
 }
 ```
 
-In the body of our new method, we'll use @DSharpPlus.CommandsNext.CommandContext.RespondAsync* to send a simple message.
+In the body of our new method, we'll use `CommandContext.RespondAsync` to send a simple message.
 
 ```cs
 await ctx.RespondAsync("Greetings! Thank you for executing me!");
 ```
 
-Finally, mark your command method with the @DSharpPlus.CommandsNext.Attributes.CommandAttribute so CommandsNext will
+Finally, mark your command method with the `CommandAttribute` so CommandsNext will
 know to treat our method as a command method. This attribute takes a single parameter: the name of the command.
 
 We'll name our command *greet* to match the name of the method.
@@ -105,9 +105,9 @@ discord.MessageCreated += async (s, e) =>               // REMOVE
 await discord.ConnectAsync();
 ```
 
-Next, call the @DSharpPlus.CommandsNext.ExtensionMethods.UseCommandsNext* extension method on your
-@DSharpPlus.DiscordClient instance and pass it a new @DSharpPlus.CommandsNext.CommandsNextConfiguration instance. Assign
-the resulting @DSharpPlus.CommandsNext.CommandsNextExtension instance to a new variable named*commands*. This important
+Next, call the `ExtensionMethods.UseCommandsNext`* extension method on your
+`DiscordClient` instance and pass it a new `CommandsNextConfiguration` instance. Assign
+the resulting `CommandsNext.CommandsNextExtension` instance to a new variable named *commands*. This important
 step will enable CommandsNext for your Discord client.
 
 ```cs
@@ -115,8 +115,8 @@ var discord = new DiscordClient();
 var commands = discord.UseCommandsNext(new CommandsNextConfiguration());
 ```
 
-Create an object initializer for @DSharpPlus.CommandsNext.CommandsNextConfiguration and assign the
-@DSharpPlus.CommandsNext.CommandsNextConfiguration.StringPrefixes property a new `string` array containing your desired
+Create an object initializer for `CommandsNextConfiguration` and assign the
+`CommandsNextConfiguration.StringPrefixes` property a new `string` array containing your desired
 prefixes. Our example below will only define a single prefix: `!`.
 
 ```cs
@@ -126,8 +126,8 @@ new CommandsNextConfiguration()
 }
 ```
 
-Now we'll register our command module. Call the @DSharpPlus.CommandsNext.CommandsNextExtension.RegisterCommands* method
-on our @DSharpPlus.CommandsNext.CommandsNextExtension instance and provide it with your command module.
+Now we'll register our command module. Call the `CommandsNextExtension.RegisterCommands` method
+on our `CommandsNext.CommandsNextExtension` instance and provide it with your command module.
 
 ```cs
 var discord = new DiscordClient();
@@ -220,7 +220,7 @@ argument, allowing your command to be executed.
 !greet "Luke Smith"
 ```
 
-If you would prefer not to use quotes, you can use the @DSharpPlus.CommandsNext.Attributes.RemainingTextAttribute
+If you would prefer not to use quotes, you can use the `RemainingTextAttribute`
 attribute on your parameter. This attribute will instruct CommandsNext to parse all remaining arguments into that
 parameter.
 
@@ -294,14 +294,14 @@ CommandsNext converted the two arguments from `string` into `int` and passed the
 removing the need to manually parse and convert the arguments yourself.
 
 We'll do one more to drive the point home. Head back to our old `GreetCommand` method, remove our `name` parameter, and
-replace it with a new parameter of type @DSharpPlus.Entities.DiscordMember named `member`.
+replace it with a new parameter of type `DiscordMember` named `member`.
 
 ```cs
 public async Task GreetCommand(CommandContext ctx, DiscordMember member)
 ```
 
-Then modify the response to mention the provided member with the @DSharpPlus.Entities.DiscordUser.Mention property on
-@DSharpPlus.Entities.DiscordMember.
+Then modify the response to mention the provided member with the `DiscordUser.Mention` property on
+`DiscordMember`.
 
 ```cs
 public async Task GreetCommand(CommandContext ctx, DiscordMember member)
@@ -318,7 +318,7 @@ Go ahead and give that a test run.
 
 ![Its wings are too small to get its fat little body off the ground.][13]
 
-The argument converter for @DSharpPlus.Entities.DiscordMember is able to parse mentions, usernames, nicknames, and user
+The argument converter for `DiscordMember` is able to parse mentions, usernames, nicknames, and user
 IDs then look for a matching member within the guild the command was executed from. Ain't that neat?
 
 ## Command Overloads

--- a/docs/articles/interactivity.md
+++ b/docs/articles/interactivity.md
@@ -15,8 +15,8 @@ Make sure to install the `DSharpPlus.Interactivity` package from NuGet before co
 ## Enabling Interactivity
 
 Interactivity can be registered using the
-@DSharpPlus.Interactivity.Extensions.ClientExtensions.UseInteractivity(DSharpPlus.DiscordClient,DSharpPlus.Interactivity.InteractivityConfiguration)
-extension method. Optionally, you can also provide an instance of @DSharpPlus.Interactivity.InteractivityConfiguration
+`UseInteractivity`
+extension method. Optionally, you can also provide an instance of `InteractivityConfiguration`
 to modify default behaviors.
 
 ```cs
@@ -33,25 +33,25 @@ discord.UseInteractivity(new InteractivityConfiguration()
 
 There are two ways available to use interactivity:
 
-* Extension methods available for @DSharpPlus.Entities.DiscordChannel and @DSharpPlus.Entities.DiscordMessage.
-* [Instance methods][1] available from @DSharpPlus.Interactivity.InteractivityExtension.
+* Extension methods available for `DiscordChannel` and `DiscordMessage`
+* Instance methods available from `InteractivityExtension`
 
 We'll have a quick look at a few common interactivity methods along with an example of use for each.
 
 The first (and arguably most useful) extension method is
-@DSharpPlus.Interactivity.InteractivityExtension.SendPaginatedMessageAsync* for @DSharpPlus.Entities.DiscordChannel
+`SendPaginatedMessageAsync` for `DiscordChannel`
 
 This method displays a collection of *'pages'* which are selected one-at-a-time by the user through reaction buttons.
 Each button click will move the page view in one direction or the other until the timeout is reached.
 
 You'll need to create a collection of pages before you can invoke this method. This can be done easily using the
-@DSharpPlus.Interactivity.InteractivityExtension.GeneratePagesInEmbed* and
-@DSharpPlus.Interactivity.InteractivityExtension.GeneratePagesInContent* instance methods from
-@DSharpPlus.Interactivity.InteractivityExtension.
-Alternatively, for pre-generated content, you can create and add individual instances of @DSharpPlus.Interactivity.Page
+`GeneratePagesInEmbed`and
+`GeneratePagesInContent` instance methods from
+`InteractivityExtension`
+Alternatively, for pre-generated content, you can create and add individual instances of `DSharpPlus.Interactivity.Page`
 to a collection.
 
-This example will use the @DSharpPlus.Interactivity.InteractivityExtension.GeneratePagesInEmbed* method to generate the
+This example will use the `GeneratePagesInEmbed` method to generate the
 pages.
 
 ```cs
@@ -68,8 +68,8 @@ public async Task PaginationCommand(CommandContext ctx)
 
 ![Pagination Pages][2]
 
-Next we'll look at the @DSharpPlus.Interactivity.Extensions.MessageExtensions.WaitForReactionAsync* extension method for
-@DSharpPlus.Entities.DiscordMessage. This method waits for a reaction from a specific user and returns the emoji that
+Next we'll look at the `WaitForReactionAsync` extension method for
+`DiscordMessage`. This method waits for a reaction from a specific user and returns the emoji that
 was used.
 
 An overload of this method also enables you to wait for a *specific* reaction, as shown in the example below.
@@ -88,8 +88,8 @@ public async Task ReactionCommand(CommandContext ctx, DiscordMember member)
 
 ![Thank You!][3]
 
-Another reaction extension method for @DSharpPlus.Entities.DiscordMessage is
-@DSharpPlus.Interactivity.InteractivityExtension.CollectReactionsAsync* As the name implies, this method collects all
+Another reaction extension method for `DiscordMessage` is
+`CollectReactionsAsync`. As the name implies, this method collects all
 reactions on a message until the timeout is reached.
 
 ```cs
@@ -110,8 +110,8 @@ public async Task CollectionCommand(CommandContext ctx)
 
 ![Reaction Count][4]
 
-The final one we'll take a look at is the @DSharpPlus.Interactivity.Extensions.ChannelExtensions.GetNextMessageAsync*
-extension method for @DSharpPlus.Entities.DiscordMessage.
+The final one we'll take a look at is the `GetNextMessageAsync`
+extension method for `DiscordMessage`.
 
 This method will return the next message sent from the author of the original message. Our example here will use its
 alternate overload which accepts an additional predicate.

--- a/docs/articles/migration/2x_to_3x.md
+++ b/docs/articles/migration/2x_to_3x.md
@@ -10,17 +10,17 @@ Major breaking changes:
 * Most classes were organized into namespaces.
 * Several classes and methods were renamed to maintain consistency with the rest of the library.
 * All events were renamed to be in the past tense.
-* @DSharpPlus.Entities.DiscordEmbed instances are no longer constructed directly.
-  * Instead, they are built using a @DSharpPlus.Entities.DiscordEmbedBuilder.
-* All colors are now passed as instances of @DSharpPlus.Entities.DiscordColor.
+* `DiscordEmbed` instances are no longer constructed directly.
+  * Instead, they are built using a `DiscordEmbedBuilder`.
+* All colors are now passed as instances of `DiscordColor`
 * Command modules are now based on an abstract class rather than an interface.
 * A brand-new ratelimit handler has been implemented.
 
 ## Fixing namespace issues
 
-Entities such as @DSharpPlus.Entities.DiscordUser, @DSharpPlus.Entities.DiscordChannel, and similar are in the
-@DSharpPlus.Entities namespace, exceptions in @DSharpPlus.Exceptions, event arguments in @DSharpPlus.EventArgs, and
-network components in @DSharpPlus.Net.
+Entities such as `DSharpPlus.Entities.DiscordUser`, `DSharpPlus.Entities.DiscordChannel`, and similar are in the
+`DSharpPlus.Entities` namespace, exceptions in `DSharpPlus.Exceptions`, event arguments in `DSharpPlus.EventArgs`, and
+network components in `DSharpPlus.Net`.
 
 Be sure to add these namespaces to your `using` directives as needed.
 
@@ -48,8 +48,8 @@ Embeds can no longer be constructed or modified directly. Instead, you have to u
 this can be achieved using Find/Replace and doing `new DiscordEmbed` -> `new DiscordEmbedBuilder`.
 
 On top of that, to add fields to an embed, you no longer create a new list for fields and assign it to
-@DSharpPlus.Entities.DiscordEmbedBuilder.Fields, but instead you use the
-@DSharpPlus.Entities.DiscordEmbedBuilder.AddField* method on the builder.
+`DiscordEmbedBuilder.Fields`, but instead you use the
+`DiscordEmbedBuilder.AddField` method on the builder.
 
 To modify an existing embed, pass said embed to builder's constructor. The builder will use it as a prototype.
 
@@ -70,7 +70,7 @@ is facilitated via `DiscordGuild.GetDefaultChannel()`.
 ## Module changes
 
 The `IModule` interface was removed, and replaced with `BaseModule` class. The most notable change is that your module
-should no longer define the field which holds your instance of @DSharpPlus.DiscordClient, as that's on the base class
+should no longer define the field which holds your instance of `DiscordClient`, as that's on the base class
 itself. On top of that, you need to change modifiers of `.Setup()` from `public` to `protected internal override`.
 
 ## New ratelimit handler

--- a/docs/articles/migration/3x_to_4x.md
+++ b/docs/articles/migration/3x_to_4x.md
@@ -8,7 +8,7 @@ title: Migration 3.x - 4.x
 ### Proxy Support
 
 The client now supports proxies for both WebSocket and HTTP traffic. To proxy your traffic, create a new instance of
-`System.Net.WebProxy` and assign it to @DSharpPlus.DiscordConfiguration.Proxy property.
+`System.Net.WebProxy` and assign it to `DiscordConfiguration.Proxy` property.
 
 ### Module Rename
 
@@ -22,7 +22,7 @@ The client now supports proxies for both WebSocket and HTTP traffic. To proxy yo
 ### Intents
 
 Due to a change by Discord on their V8 endpoint which DSharpPlus targets, in order to recieve events, intents will have
-to be enabled in both the @DSharpPlus.DiscordConfiguration and the Discord Application Portal. We have an [article][0]
+to be enabled in both the `DiscordConfiguration` and the Discord Application Portal. We have an [article][0]
 that covers all that has to be done to set this up.
 
 ### Event Handlers
@@ -68,16 +68,16 @@ for sending and modifing messages:
 * `DiscordMessage.ModifyAsync(DSharpPlus.Entities.Optional<string>, DSharpPlus.Entities.Optional<DSharpPlus.Entities.DiscordEmbed>)`
 * `DiscordMessage.ModifyAsync(DSharpPlus.Entities.DiscordMessageBuilder)`
 
-Using the @DSharpPlus.Entities.DiscordMessageBuilder can be found [here][2].
+Using the `DiscordMessageBuilder` can be found [here][2].
 
 ### Logging Changes
 
-Logging was overhauled and now some of the Properties on @DSharpPlus.DiscordConfiguration along with some of the events
-on @DSharpPlus.DiscordClient are Gone/Modified/Added. Below is a listing of what changed:
+Logging was overhauled and now some of the Properties on `DiscordConfiguration` along with some of the events
+on `DiscordClient `are Gone/Modified/Added. Below is a listing of what changed:
 
-* @DSharpPlus.DiscordConfiguration.LoggerFactory - this is where you can specify your own logging factory to help
+* `DiscordConfiguration.LoggerFactory` - this is where you can specify your own logging factory to help
   augment the output of the log messages, redirect the output to other locations, etc.
-* @DSharpPlus.DiscordConfiguration.MinimumLogLevel - this replaces LogLevel
+* `DiscordConfiguration.MinimumLogLevel` - this replaces LogLevel
 * **DebugLogger** - this has been removed.
 * **UseInternalLogHandler** - this has been removed.
 * **DebugLogMessageEventArgs** - this event has been removed.
@@ -92,7 +92,7 @@ We have also created an [article][3] on how to setup the new logger.
   override set on channels. Furthermore, the overwrite building is now more intuitive.
 * **Indefinite reconnecting** - the client can now be configured to attempt reconnecting indefinitely.
 * **Channel.Users** - you can now query users in voice and text channels by using
-  @DSharpPlus.Entities.DiscordChannel.Users property.
+  `DiscordChannel.Users` property.
 * **SendFileAsync argument reordering** - arguments for these methods were reordered to prevent overload confusion.
 * **New Discord features** - support for animated emoji and slow mode.
 
@@ -103,16 +103,16 @@ different.
 
 ### Multiprefix support
 
-Prefixes are now configured via @DSharpPlus.CommandsNext.CommandsNextConfiguration.StringPrefixes instead of old
+Prefixes are now configured via `CommandsNextConfiguration.StringPrefixes` instead of old
 `StringPrefix` property. Prefixes passed in this array will all function at the same time. At the same time,
-@DSharpPlus.CommandsNext.CommandContext class has been augmented with @DSharpPlus.CommandsNext.CommandContext.Prefix
+`CommandContext` class has been augmented with `CommandContext.Prefix`
 property, which allows for checking which prefix was used to trigger the command. Furthermore, the new
-@DSharpPlus.CommandsNext.Attributes.RequirePrefixesAttribute can be used as a check to require a specific prefix to be
+`RequirePrefixesAttribute` can be used as a check to require a specific prefix to be
 used with a command.
 
 ### Command hiding inheritance
 
-Much like checks, the @DSharpPlus.CommandsNext.Attributes.HiddenAttribute is now inherited in modules which are not
+Much like checks, the `DSharpPlus.CommandsNext.Attributes.HiddenAttribute` is now inherited in modules which are not
 command groups.
 
 ### Support for `Nullable<T>` and `System.Uri` conversion
@@ -139,14 +139,14 @@ which have the same argument types and order.
 Checks are pooled between all overloads, which means that specifying the same check on every overload will make it run
 several times; if you apply a check to a single overload, it will apply to all of them.
 
-Group command is also done by marking a command with @DSharpPlus.CommandsNext.Attributes.GroupCommandAttribute instead
+Group command is also done by marking a command with `GroupCommandAttribute` instead
 of regular `CommandAttribute`. They can also be overloaded.
 
 ### Common module base
 
-All command modules are now required to inherit from @DSharpPlus.CommandsNext.BaseCommandModule. This also enables the
-modules to use @DSharpPlus.CommandsNext.BaseCommandModule.BeforeExecutionAsync(DSharpPlus.CommandsNext.CommandContext)
-and @DSharpPlus.CommandsNext.BaseCommandModule.AfterExecutionAsync(DSharpPlus.CommandsNext.CommandContext).
+All command modules are now required to inherit from `DSharpPlus.CommandsNext.BaseCommandModule`. This also enables the
+modules to use `DSharpPlus.CommandsNext.BaseCommandModule.BeforeExecutionAsync(DSharpPlus.CommandsNext.CommandContext)`
+and `DSharpPlus.CommandsNext.BaseCommandModule.AfterExecutionAsync(DSharpPlus.CommandsNext.CommandContext)`.
 
 ### Module lifespans
 
@@ -168,7 +168,7 @@ If you need to implement a custom help formatter, see [Custom Help Formatter][6]
 
 ### Custom command handlers
 
-You can now disabe the built-in command handler, and create your own. For more information, see
+You can now disable the built-in command handler, and create your own. For more information, see
 [Custom Command Handlers][7].
 
 ### Minor changes

--- a/docs/articles/migration/dsharp.md
+++ b/docs/articles/migration/dsharp.md
@@ -15,7 +15,7 @@ discord.SendLoginRequest();
 discord.Connect();
 ```
 
-The constructor of the @DSharpPlus.DiscordClient now requires a @DSharpPlus.DiscordConfiguration object instead of a
+The constructor of the `DiscordClient` now requires a `DiscordConfiguration` object instead of a
 simple string token and boolean.
 
 ```cs
@@ -44,7 +44,6 @@ discord.MessageReceived += async (sender, arg) =>
 };
 ```
 
-We have a small article covering DSharpPlus events [here][1].
 
 #### New events
 
@@ -97,4 +96,3 @@ PrivateMessageDeleted  | MessageDeleted.
 
 <!-- LINKS -->
 [0]:  https://docs.microsoft.com/en-us/dotnet/standard/asynchronous-programming-patterns/task-based-asynchronous-pattern-tap
-[1]:  xref:articles.beyond_basics.events

--- a/docs/articles/migration/slashcommands_to_commands.md
+++ b/docs/articles/migration/slashcommands_to_commands.md
@@ -10,7 +10,7 @@ This section will focus on migrating existing code - there is a rough sketch of 
 > [!NOTE]
 > This setup will register commands to both slash and text commands. If you want to use only slash commands, either disable the text command processor or mark your commands with `[AllowedProcessors(typeof(SlashCommandProcessor))]`.
 
-Before migrating to the shiny new command farmework, you should make sure to update to the latest available build of the library - migrating both at once will be considerably more challenging. Then, we'll need to do some setup.
+Before migrating to the shiny new command framework, you should make sure to update to the latest available build of the library - migrating both at once will be considerably more challenging. Then, we'll need to do some setup.
 
 Remove the SlashCommands reference and install the package. Then, set up a [service collection](https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection) containing all services your commands need, as well as a logger. Then, call `BuildServiceProvider()` to obtain a service provider.
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -12,8 +12,8 @@
         }
       ],
       "dest": "api",
+      "outputFormat": "apiPage",
       "filter": "filter_config.yml",
-      "memberLayout": "separatePages"
     } 
 
   ],


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
- Change outputFormat for API articles to ApiPage for better looking API documentation. Has a side effect of breaking all links to API documentation, but:
- Remove all API links, because they suck and can break even if you don't touch them. Had that with my first DocFX PR on this repository.
- Remove link to Emzi's Companion Cube Bot because it contains no source code now. 
- Minor grammar changes in one file.


# Notes
I require exorcism now.
Have a lyrics that i stolen and edited from one song:
🎵 
If it’s the last thing I do then it’s worth it
I see a new world and I must unearth it
(and ~~Odin~~ DocFX must pay!)
My destiny is calling
And i stare into my fate
🎵