### PR TITLE
Add additional slash command validation

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -28,7 +28,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DSharpPlus.Commands.Processors.SlashCommands;
 
-public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCreateEventArgs, ISlashArgumentConverter, InteractionConverterContext, SlashCommandContext>
+public sealed partial class SlashCommandProcessor : BaseCommandProcessor<InteractionCreateEventArgs, ISlashArgumentConverter, InteractionConverterContext, SlashCommandContext>
 {
     // Required for GuildDownloadCompleted event
     public const DiscordIntents RequiredIntents = DiscordIntents.Guilds;
@@ -38,6 +38,12 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
 
     private static readonly List<DiscordApplicationCommand> applicationCommands = [];
     private static IReadOnlyDictionary<ulong, Command> applicationCommandsMapping;
+
+    [GeneratedRegex(@"^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$")]
+    private partial Regex NameLocalizationRegex();
+
+    [GeneratedRegex("^.{1,100}$")]
+    private partial Regex DescrtiptionLocalizationRegex();
 
     private bool configured;
 
@@ -813,7 +819,7 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
                 );
             }
 
-            if (!SlashCommandRegexHelper.NameLocalizationRegex().IsMatch(nameLocalization.Key))
+            if (!NameLocalizationRegex().IsMatch(nameLocalization.Key))
             {
                 throw new InvalidOperationException
                 (
@@ -834,7 +840,7 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
                 );
             }
 
-            if (!SlashCommandRegexHelper.DescriptionLocalizationRegex().IsMatch(descriptionLocalization.Key))
+            if (!DescrtiptionLocalizationRegex().IsMatch(descriptionLocalization.Key))
             {
                 throw new InvalidOperationException
                 (
@@ -844,7 +850,7 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
             }
         }
 
-        if (!SlashCommandRegexHelper.NameLocalizationRegex().IsMatch(command.Name))
+        if (!NameLocalizationRegex().IsMatch(command.Name))
         {
             throw new InvalidOperationException
             (
@@ -852,7 +858,7 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
             );
         }
 
-        if (!string.IsNullOrWhiteSpace(command.Description) && !SlashCommandRegexHelper.DescriptionLocalizationRegex().IsMatch(command.Description))
+        if (!string.IsNullOrWhiteSpace(command.Description) && !DescrtiptionLocalizationRegex().IsMatch(command.Description))
         {
             throw new InvalidOperationException
             (
@@ -860,13 +866,4 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
             );
         }
     }
-}
-
-internal static partial class SlashCommandRegexHelper
-{
-    [GeneratedRegex(@"^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$")]
-    public static partial Regex NameLocalizationRegex();
-
-    [GeneratedRegex(@"^.{1,100}$")]
-    public static partial Regex DescriptionLocalizationRegex();
 }

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -39,9 +39,6 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
     private static readonly List<DiscordApplicationCommand> applicationCommands = [];
     private static IReadOnlyDictionary<ulong, Command> applicationCommandsMapping;
 
-    private readonly Regex nameLocalizationRegex = new(@"^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$");
-    private readonly Regex descrtiptionLocalizationRegex = new("^.{1,100}$");
-
     private bool configured;
 
     public override async ValueTask ConfigureAsync(CommandsExtension extension)
@@ -816,7 +813,7 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
                 );
             }
 
-            if (!nameLocalizationRegex.IsMatch(nameLocalization.Key))
+            if (!SlashCommandRegexHelper.NameLocalizationRegex().IsMatch(nameLocalization.Key))
             {
                 throw new InvalidOperationException
                 (
@@ -837,7 +834,7 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
                 );
             }
 
-            if (!descrtiptionLocalizationRegex.IsMatch(descriptionLocalization.Key))
+            if (!SlashCommandRegexHelper.DescriptionLocalizationRegex().IsMatch(descriptionLocalization.Key))
             {
                 throw new InvalidOperationException
                 (
@@ -847,7 +844,7 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
             }
         }
 
-        if (!nameLocalizationRegex.IsMatch(command.Name))
+        if (!SlashCommandRegexHelper.NameLocalizationRegex().IsMatch(command.Name))
         {
             throw new InvalidOperationException
             (
@@ -855,7 +852,7 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
             );
         }
 
-        if (!string.IsNullOrWhiteSpace(command.Description) && !descrtiptionLocalizationRegex.IsMatch(command.Description))
+        if (!string.IsNullOrWhiteSpace(command.Description) && !SlashCommandRegexHelper.DescriptionLocalizationRegex().IsMatch(command.Description))
         {
             throw new InvalidOperationException
             (
@@ -863,4 +860,13 @@ public sealed class SlashCommandProcessor : BaseCommandProcessor<InteractionCrea
             );
         }
     }
+}
+
+internal static partial class SlashCommandRegexHelper
+{
+    [GeneratedRegex(@"^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$")]
+    public static partial Regex NameLocalizationRegex();
+
+    [GeneratedRegex(@"^.{1,100}$")]
+    public static partial Regex DescriptionLocalizationRegex();
 }


### PR DESCRIPTION
This adds additional slash command validation, namely validating names/descriptions according to [Discord's regex](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-naming)

This also validates that commands do not nest more than 3 layers deep, which currently causes a generic exception to be thrown because registration fails at the REST request.

Closes #1924