### PR TITLE
Add GuildId to synthetic threadchannel in Auditlogparser

### DIFF
--- a/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
+++ b/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
@@ -653,7 +653,7 @@ internal static class AuditLogParser
                 threads.TryGetValue(auditLogAction.TargetId!.Value,
                     out DiscordThreadChannel? channel)
                     ? channel
-                    : new DiscordThreadChannel() { Id = auditLogAction.TargetId.Value, Discord = guild.Discord },
+                    : new DiscordThreadChannel() { Id = auditLogAction.TargetId.Value, Discord = guild.Discord, GuildId = guild.Id}
         };
 
         foreach (AuditLogActionChange change in auditLogAction.Changes)

--- a/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
+++ b/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
@@ -653,7 +653,7 @@ internal static class AuditLogParser
                 threads.TryGetValue(auditLogAction.TargetId!.Value,
                     out DiscordThreadChannel? channel)
                     ? channel
-                    : new DiscordThreadChannel() { Id = auditLogAction.TargetId.Value, Discord = guild.Discord, GuildId = guild.Id}
+                    : new DiscordThreadChannel() { Id = auditLogAction.TargetId.Value, Discord = guild.Discord, GuildId = guild.Id }
         };
 
         foreach (AuditLogActionChange change in auditLogAction.Changes)


### PR DESCRIPTION
# Summary
In one place we forgot to add the guild id to a synthetic thread channel