### PR TITLE
fix #1917

### DIFF
--- a/DSharpPlus.Commands/ContextChecks/RequirePermissionsCheck.cs
+++ b/DSharpPlus.Commands/ContextChecks/RequirePermissionsCheck.cs
@@ -1,5 +1,9 @@
 #pragma warning disable IDE0046
+
 using System.Threading.Tasks;
+
+using DSharpPlus.Commands.Processors.SlashCommands;
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.Commands.ContextChecks;
 
@@ -7,6 +11,16 @@ internal sealed class RequirePermissionsCheck : IContextCheck<RequirePermissions
 {
     public ValueTask<string?> ExecuteCheckAsync(RequirePermissionsAttribute attribute, CommandContext context)
     {
+        if (context is SlashCommandContext slashContext)
+        {
+            if (!slashContext.Interaction.AppPermissions.HasPermission(attribute.BotPermissions))
+            {
+                return ValueTask.FromResult<string?>("The bot did not have the needed permissions to execute this command.");
+            }
+
+            return ValueTask.FromResult<string?>(null);
+        }
+
         if (context.Guild is null)
         {
             return ValueTask.FromResult<string?>(RequireGuildCheck.ErrorMessage);


### PR DESCRIPTION
closes #1917 

note: this check is still problematic for users seeking to build their own permission systems. that issue is best addressed in the scope of #1820 allowing users to shim/override the check logic with their own permission system.