### PR TITLE
Fix `InvalidOperationException` due to Interactivity not switching to the new event system.

### DIFF
--- a/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
@@ -19,7 +19,7 @@ namespace DSharpPlus.Interactivity.EventHandling;
 internal class EventWaiter<T> : IDisposable where T : AsyncEventArgs
 {
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "events")]
-    private static extern ref readonly ConcurrentDictionary<Type, AsyncEvent> GetEventsField(DiscordClient client);
+    private static extern ConcurrentDictionary<Type, AsyncEvent> GetEventsField(DiscordClient client);
 
     private DiscordClient client;
     private AsyncEvent<DiscordClient, T> @event;

--- a/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
@@ -19,7 +19,7 @@ namespace DSharpPlus.Interactivity.EventHandling;
 internal class EventWaiter<T> : IDisposable where T : AsyncEventArgs
 {
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "events")]
-    private static extern ref ConcurrentDictionary<Type, AsyncEvent> GetEventsField(DiscordClient client);
+    private static extern ref readonly ConcurrentDictionary<Type, AsyncEvent> GetEventsField(DiscordClient client);
 
     private DiscordClient client;
     private AsyncEvent<DiscordClient, T> @event;

--- a/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/EventWaiter.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using ConcurrentCollections;
 using DSharpPlus.AsyncEvents;
@@ -18,9 +18,6 @@ namespace DSharpPlus.Interactivity.EventHandling;
 /// <typeparam name="T"></typeparam>
 internal class EventWaiter<T> : IDisposable where T : AsyncEventArgs
 {
-    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "events")]
-    private static extern ConcurrentDictionary<Type, AsyncEvent> GetEventsField(DiscordClient client);
-
     private DiscordClient client;
     private AsyncEvent<DiscordClient, T> @event;
     private AsyncEventHandler<DiscordClient, T> handler;
@@ -35,14 +32,14 @@ internal class EventWaiter<T> : IDisposable where T : AsyncEventArgs
     public EventWaiter(DiscordClient client)
     {
         this.client = client;
-        if (GetEventsField(client) is not ConcurrentDictionary<Type, AsyncEvent> events)
+        if (InteractivityExtension.GetEventsField(client) is not ConcurrentDictionary<Type, AsyncEvent> events)
         {
-            throw new NotImplementedException("Could not get the events from the events field in DiscordClient. This is a bug, please report it.");
+            throw new UnreachableException("Could not get the events from the events field in DiscordClient. This is a bug, please report it.");
         }
 
         if (!events.TryGetValue(typeof(T), out AsyncEvent? @event))
         {
-            throw new InvalidOperationException($"The event {typeof(T).Name} is not registered in the DiscordClient. This is a bug, please report it.");
+            throw new UnreachableException($"The event {typeof(T).Name} is not registered in the DiscordClient. This is a bug, please report it.");
         }
 
         this.matchrequests = [];

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using DSharpPlus.AsyncEvents;
@@ -17,6 +19,9 @@ namespace DSharpPlus.Interactivity;
 /// </summary>
 public class InteractivityExtension : BaseExtension
 {
+    // This is declared here because apparently the UnsafeAccessorAttribute cannot be used within generic types.
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "events")]
+    internal static extern ref readonly ConcurrentDictionary<Type, AsyncEvent> GetEventsField(DiscordClient client);
 
 #pragma warning disable IDE1006 // Naming Styles
     internal InteractivityConfiguration Config { get; }

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -1049,7 +1049,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
                 GuildId = guild.Id,
                 Discord = this
             };
-        
+
         UpdateChannelCache(channel);
 
         message.Channel = channel;


### PR DESCRIPTION
# Summary
Currently `EventWaiter` will throw when attempting to search for the private `AsyncEvent` event fields that were previously on `DiscordClient`. Now it searches for the `events` dictionary through `UnsafeAccessor`. Since reflection is no longer used within the constructor, this has the added benefit of not being slow anymore.

# Notes
Untested.