### PR TITLE
fix(gateway): Disable zlib compression by default

### DIFF
--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -84,7 +84,7 @@ public sealed class DiscordConfiguration
     /// <summary>
     /// <para>Sets the level of compression for WebSocket traffic.</para>
     /// <para>Disabling this option will increase the amount of traffic sent via WebSocket. Setting <see cref="GatewayCompressionLevel.Payload"/> will enable compression for READY and GUILD_CREATE payloads. Setting <see cref="Stream"/> will enable compression for the entire WebSocket stream, drastically reducing amount of traffic.</para>
-    /// <para>Defaults to <see cref="None"/>.</para>
+    /// <para>Defaults to <see cref="GatewayCompressionLevel.None"/>.</para>
     /// </summary>
     /// <remarks>This value used to <see cref="GatewayCompressionLevel.Stream"/>, however due to a bug with rapid reconnections, this has been disabled by default.</remarks>
     // Here be dragons, ye who use compression.

--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -86,7 +86,7 @@ public sealed class DiscordConfiguration
     /// <para>Disabling this option will increase the amount of traffic sent via WebSocket. Setting <see cref="GatewayCompressionLevel.Payload"/> will enable compression for READY and GUILD_CREATE payloads. Setting <see cref="Stream"/> will enable compression for the entire WebSocket stream, drastically reducing amount of traffic.</para>
     /// <para>Defaults to <see cref="GatewayCompressionLevel.None"/>.</para>
     /// </summary>
-    /// <remarks>This value used to <see cref="GatewayCompressionLevel.Stream"/>, however due to a bug with rapid reconnections, this has been disabled by default.</remarks>
+    /// <remarks>This property's default has been changed from <see cref="GatewayCompressionLevel.Stream"/> due to a bug in the client wherein rapid reconnections causes payloads to be decompressed into a mangled string.</remarks>
     // Here be dragons, ye who use compression.
     public GatewayCompressionLevel GatewayCompressionLevel { internal get; set; } = GatewayCompressionLevel.None;
 

--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -86,7 +86,7 @@ public sealed class DiscordConfiguration
     /// <para>Disabling this option will increase the amount of traffic sent via WebSocket. Setting <see cref="GatewayCompressionLevel.Payload"/> will enable compression for READY and GUILD_CREATE payloads. Setting <see cref="Stream"/> will enable compression for the entire WebSocket stream, drastically reducing amount of traffic.</para>
     /// <para>Defaults to <see cref="Stream"/>.</para>
     /// </summary>
-    public GatewayCompressionLevel GatewayCompressionLevel { internal get; set; } = GatewayCompressionLevel.Stream;
+    public GatewayCompressionLevel GatewayCompressionLevel { internal get; set; } = GatewayCompressionLevel.None;
 
     /// <summary>
     /// Specifies the probing interval in ms to use when first making requests to the API. This should be slightly higher than your average ping to the discord rest api.

--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -84,8 +84,10 @@ public sealed class DiscordConfiguration
     /// <summary>
     /// <para>Sets the level of compression for WebSocket traffic.</para>
     /// <para>Disabling this option will increase the amount of traffic sent via WebSocket. Setting <see cref="GatewayCompressionLevel.Payload"/> will enable compression for READY and GUILD_CREATE payloads. Setting <see cref="Stream"/> will enable compression for the entire WebSocket stream, drastically reducing amount of traffic.</para>
-    /// <para>Defaults to <see cref="Stream"/>.</para>
+    /// <para>Defaults to <see cref="None"/>.</para>
     /// </summary>
+    /// <remarks>This value used to <see cref="GatewayCompressionLevel.Stream"/>, however due to a bug with rapid reconnections, this has been disabled by default.</remarks>
+    // Here be dragons, ye who use compression.
     public GatewayCompressionLevel GatewayCompressionLevel { internal get; set; } = GatewayCompressionLevel.None;
 
     /// <summary>


### PR DESCRIPTION
Fixes a potential issue wherein our decompressor dies because of rapid reconnections, causing mangled payloads. That issue still needs to be fixed, but this is a stopgap to help see if this is Discord's fault.
