### PR TITLE
Run Actions for obsolete modules

### DIFF
--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -8,7 +8,7 @@ on:
       - "DSharpPlus*/**"
       - "tools/**"
       - "*.sln"
-      - 'obsolete/DSharpPlus*/**'
+      - "obsolete/DSharpPlus*/**"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -8,6 +8,7 @@ on:
       - "DSharpPlus*/**"
       - "tools/**"
       - "*.sln"
+      - 'obsolete/DSharpPlus*/**'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Needed for #1973 to be built

# Summary
The Actions workflow is rude and ignores changes to obsolete modules, so we need it to not do that.

Not tested because the difficulty of doing that for Actions is too high. But it should be fine, right?