### PR TITLE
Filter subcommands in the ToApplicationCommand method 

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -835,7 +835,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
             {
                 // If there is a SlashCommandTypesAttribute, check if it contains SlashCommandTypes.ApplicationCommand
                 // If there isn't, default to SlashCommands
-                if (command.Attributes.OfType<SlashCommandTypesAttribute>().FirstOrDefault() is SlashCommandTypesAttribute slashCommandTypesAttribute &&
+                if (subCommand.Attributes.OfType<SlashCommandTypesAttribute>().FirstOrDefault() is SlashCommandTypesAttribute slashCommandTypesAttribute &&
                     !slashCommandTypesAttribute.ApplicationCommandTypes.Contains(DiscordApplicationCommandType.SlashCommand))
                 {
                     continue;

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -819,12 +819,28 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
         return CreateCommandContext(converterContext, eventArgs, parsedArguments);
     }
 
+    /// <summary>
+    /// Only use this for commands of type <see cref="DiscordApplicationCommandType.SlashCommand "/>.
+    /// It will NOT validate every subcommands which are considered to be a SlashCommand 
+    /// </summary>
+    /// <param name="command"></param>
+    /// <param name="nameLocalizations"></param>
+    /// <param name="descriptionLocalizations"></param>
+    /// <exception cref="InvalidOperationException"></exception>
     private void ValidateSlashCommand(Command command, IReadOnlyDictionary<string, string> nameLocalizations, IReadOnlyDictionary<string, string> descriptionLocalizations)
     {
         if (command.Subcommands.Count > 0)
         {
             foreach (Command subCommand in command.Subcommands)
             {
+                // If there is a SlashCommandTypesAttribute, check if it contains SlashCommandTypes.ApplicationCommand
+                // If there isn't, default to SlashCommands
+                if (command.Attributes.OfType<SlashCommandTypesAttribute>().FirstOrDefault() is SlashCommandTypesAttribute slashCommandTypesAttribute &&
+                    !slashCommandTypesAttribute.ApplicationCommandTypes.Contains(DiscordApplicationCommandType.SlashCommand))
+                {
+                    continue;
+                }
+                
                 ValidateSlashCommand(subCommand, nameLocalizations, descriptionLocalizations);
             }
         }

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -332,7 +332,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
             {
                 // If there is a SlashCommandTypesAttribute, check if it contains SlashCommandTypes.ApplicationCommand
                 // If there isn't, default to SlashCommands
-                if (command.Attributes.OfType<SlashCommandTypesAttribute>().FirstOrDefault() is SlashCommandTypesAttribute slashCommandTypesAttribute &&
+                if (subCommand.Attributes.OfType<SlashCommandTypesAttribute>().FirstOrDefault() is SlashCommandTypesAttribute slashCommandTypesAttribute &&
                     !slashCommandTypesAttribute.ApplicationCommandTypes.Contains(DiscordApplicationCommandType.SlashCommand))
                 {
                     continue;

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -299,6 +299,13 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
     }
 
 
+    /// <summary>
+    /// Only use this for commands of type <see cref="DiscordApplicationCommandType.SlashCommand "/>.
+    /// It will cut out every subcommands which are considered to be not a SlashCommand 
+    /// </summary>
+    /// <param name="command"></param>
+    /// <returns></returns>
+    /// <exception cref="InvalidOperationException"></exception>
     public async Task<DiscordApplicationCommand> ToApplicationCommandAsync(Command command)
     {
         if (this.extension is null)
@@ -323,6 +330,14 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
         {
             foreach (Command subCommand in command.Subcommands)
             {
+                // If there is a SlashCommandTypesAttribute, check if it contains SlashCommandTypes.ApplicationCommand
+                // If there isn't, default to SlashCommands
+                if (command.Attributes.OfType<SlashCommandTypesAttribute>().FirstOrDefault() is SlashCommandTypesAttribute slashCommandTypesAttribute &&
+                    !slashCommandTypesAttribute.ApplicationCommandTypes.Contains(DiscordApplicationCommandType.SlashCommand))
+                {
+                    continue;
+                }
+                
                 options.Add(await ToApplicationParameterAsync(subCommand));
             }
         }


### PR DESCRIPTION
# Summary
When converting to applcation commands we also have to filter the subcommands acording to their `SlashCommandTypes`.

# Notes
Currently untested, waiting on user feedback.