### PR TITLE
Changed ConfigureEvents to ConfigureEventHandlers in the preamble docs

### DIFF
--- a/docs/articles/basics/first_bot.md
+++ b/docs/articles/basics/first_bot.md
@@ -153,7 +153,7 @@ Now you can start to listen to messages.
 Register an event handler as follows:
 
 ```cs
-builder.ConfigureEvents
+builder.ConfigureEventHandlers
 (
     b => b.HandleMessageCreated(async s, e) => {})
 );
@@ -165,7 +165,7 @@ Then, add an `if` statement into the body of your event lambda that will check i
 *pong!*for each message that starts with*ping*.
 
 ```cs
-builder.ConfigureEvents
+builder.ConfigureEventHandlers
 (
     b => b.HandleMessageCreated(async s, e) => 
     {
@@ -194,7 +194,7 @@ namespace MyFirstBot
         {
             DiscordClientBuilder builder = DiscordClientBuilder.CreateDefault("My First Token", DiscordIntents.AllUnprivileged | DiscordIntents.MessageContents);
 
-            builder.ConfigureEvents
+            builder.ConfigureEventHandlers
             (
                 b => b.HandleMessageCreated(async (s, e) => 
                 {


### PR DESCRIPTION
In the documentation from Preamble I changed `ConfigureEvents` to `ConfigureEventHandlers` as `ConfigureEvents` does not exist.