### PR TITLE
Add configurable string comparison to TextCommandProcessor...

### DIFF
--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandConfiguration.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandConfiguration.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using DSharpPlus.Commands.Processors.TextCommands.Parsing;
 
 namespace DSharpPlus.Commands.Processors.TextCommands;
@@ -13,4 +15,6 @@ public record TextCommandConfiguration
     /// Whether to suppress the missing message content intent warning.
     /// </summary>
     public bool SuppressMissingMessageContentIntentWarning { get; set; }
+    
+    public IEqualityComparer<string> CommandNameComparer { get; init; } = StringComparer.OrdinalIgnoreCase;
 }

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -96,7 +96,7 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
             foreach (Command officialCommand in this.commands.Values)
             {
                 TextAliasAttribute? aliasAttribute = officialCommand.Attributes.OfType<TextAliasAttribute>().FirstOrDefault();
-                if (aliasAttribute is not null && aliasAttribute.Aliases.Any(alias => alias.Equals(commandText[..index], StringComparison.OrdinalIgnoreCase)))
+                if (aliasAttribute is not null && aliasAttribute.Aliases.Any(alias => this.Configuration.CommandNameComparer.Equals(alias, commandText[..index])))
                 {
                     command = officialCommand;
                     break;
@@ -156,7 +156,7 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
             Command? foundCommand = command.Subcommands.FirstOrDefault(command => command.Name.Equals(commandText[index..nextIndex], StringComparison.OrdinalIgnoreCase));
             if (foundCommand is null)
             {
-                foundCommand = command.Subcommands.FirstOrDefault(command => command.Attributes.OfType<TextAliasAttribute>().FirstOrDefault()?.Aliases.Any(alias => alias.Equals(commandText[index..nextIndex], StringComparison.OrdinalIgnoreCase)) ?? false);
+                foundCommand = command.Subcommands.FirstOrDefault(command => command.Attributes.OfType<TextAliasAttribute>().FirstOrDefault()?.Aliases.Any(alias => this.Configuration.CommandNameComparer.Equals(alias, commandText[..index])) ?? false);
                 if (foundCommand is null)
                 {
                     break;

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -38,7 +38,7 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
             textCommands.Add(command.Name, command);
         }
  
-        this.commands = textCommands.ToFrozenDictionary();
+        this.commands = textCommands.ToFrozenDictionary(this.Configuration.CommandNameComparer);
         
         if (this.configured)
         {

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -156,7 +156,7 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
             Command? foundCommand = command.Subcommands.FirstOrDefault(command => command.Name.Equals(commandText[index..nextIndex], StringComparison.OrdinalIgnoreCase));
             if (foundCommand is null)
             {
-                foundCommand = command.Subcommands.FirstOrDefault(command => command.Attributes.OfType<TextAliasAttribute>().FirstOrDefault()?.Aliases.Any(alias => this.Configuration.CommandNameComparer.Equals(alias, commandText[..index])) ?? false);
+                foundCommand = command.Subcommands.FirstOrDefault(command => command.Attributes.OfType<TextAliasAttribute>().FirstOrDefault()?.Aliases.Any(alias => this.Configuration.CommandNameComparer.Equals(alias, commandText[index..nextIndex])) ?? false);
                 if (foundCommand is null)
                 {
                     break;


### PR DESCRIPTION
for matching command names

# Summary
Adds a `IEqualityComparer<string> CommandNameComparer` to the text command configuration and use it in the processors dictionary 