### PR TITLE
support reconnecting on fatal gateway errors

### DIFF
--- a/DSharpPlus/Clients/DiscordClientBuilder.cs
+++ b/DSharpPlus/Clients/DiscordClientBuilder.cs
@@ -202,6 +202,17 @@ public sealed class DiscordClientBuilder
     }
 
     /// <summary>
+    /// Instructs DSharpPlus to try reconnecting when encountering a fatal gateway error. By default, DSharpPlus will
+    /// leave the decision on fatal gateway errors to the user.
+    /// </summary>
+    /// <returns>The current instance for chaining.</returns>
+    public DiscordClientBuilder SetReconnectOnFatalGatewayErrors()
+    {
+        this.serviceCollection.AddOrReplace<IGatewayController, ReconnectingGatewayController>(ServiceLifetime.Singleton);
+        return this;
+    }
+
+    /// <summary>
     /// Builds a new client from the present builder.
     /// </summary>
     public DiscordClient Build()

--- a/DSharpPlus/Net/Gateway/DefaultGatewayController.cs
+++ b/DSharpPlus/Net/Gateway/DefaultGatewayController.cs
@@ -9,5 +9,4 @@ namespace DSharpPlus.Clients;
 internal class DefaultGatewayController : IGatewayController
 {
     public ValueTask ZombiedAsync(IGatewayClient client) => ValueTask.CompletedTask;
-    public Task HeartbeatedAsync(IGatewayClient client) => Task.CompletedTask;
 }

--- a/DSharpPlus/Net/Gateway/DefaultGatewayController.cs
+++ b/DSharpPlus/Net/Gateway/DefaultGatewayController.cs
@@ -8,5 +8,9 @@ namespace DSharpPlus.Clients;
 // with anything we could provide.
 internal class DefaultGatewayController : IGatewayController
 {
+    /// <inheritdoc/>
+    public Task HeartbeatedAsync(IGatewayClient client) => Task.CompletedTask;
+
+    /// <inheritdoc/>
     public ValueTask ZombiedAsync(IGatewayClient client) => ValueTask.CompletedTask;
 }

--- a/DSharpPlus/Net/Gateway/GatewayClient.cs
+++ b/DSharpPlus/Net/Gateway/GatewayClient.cs
@@ -6,8 +6,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-
-using DSharpPlus.Clients;
 using DSharpPlus.Entities;
 using DSharpPlus.Net.Abstractions;
 using DSharpPlus.Net.Serialization;

--- a/DSharpPlus/Net/Gateway/IGatewayController.cs
+++ b/DSharpPlus/Net/Gateway/IGatewayController.cs
@@ -1,8 +1,6 @@
 using System.Threading.Tasks;
 
-using DSharpPlus.Net.Gateway;
-
-namespace DSharpPlus.Clients;
+namespace DSharpPlus.Net.Gateway;
 
 /// <summary>
 /// Provides a low-level interface for controlling individual gateway clients and their connections.

--- a/DSharpPlus/Net/Gateway/ReconnectingGatewayController.cs
+++ b/DSharpPlus/Net/Gateway/ReconnectingGatewayController.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace DSharpPlus.Net.Gateway;
+
+/// <summary>
+/// A gateway controller implementation that automatically attempts to reconnect.
+/// </summary>
+public sealed class ReconnectingGatewayController : IGatewayController
+{
+    /// <inheritdoc/>
+    public Task HeartbeatedAsync(IGatewayClient client) => Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public async ValueTask ZombiedAsync(IGatewayClient client) => await client.ReconnectAsync();
+}


### PR DESCRIPTION
just for convenience, but since this brings some compatibility-with-user-code concerns not enabled by default (namely, making your own IGatewayController would come with a bit of a pitfall in that this implementation would be ignored, unless you decorate it)