### PR TITLE
add expirations to the message cache

### DIFF
--- a/DSharpPlus/DiscordConfiguration.cs
+++ b/DSharpPlus/DiscordConfiguration.cs
@@ -30,6 +30,17 @@ public sealed class DiscordConfiguration
     public bool AlwaysCacheMembers { internal get; set; } = true;
 
     /// <summary>
+    /// Sets the default absolute expiration time for cached messages.
+    /// </summary>
+    public TimeSpan AbsoluteMessageCacheExpiration { internal get; set; } = TimeSpan.FromDays(1);
+
+    /// <summary>
+    /// Sets the default sliding expiration time for cached messages. This is refreshed every time the message is
+    /// accessed.
+    /// </summary>
+    public TimeSpan SlidingMessageCacheExpiration { internal get; set; } = TimeSpan.FromMinutes(30);
+    
+    /// <summary>
     /// <para>Sets the factory method used to create instances of UDP clients.</para>
     /// <para>Use <see cref="DspUdpClient.CreateNew"/> and equivalents on other implementations to switch out client implementations.</para>
     /// <para>Defaults to <see cref="DspUdpClient.CreateNew"/>.</para>

--- a/DSharpPlus/MessageCache.cs
+++ b/DSharpPlus/MessageCache.cs
@@ -9,31 +9,21 @@ public class MessageCache : IMessageCacheProvider
     private readonly IMemoryCache cache;
     private readonly MemoryCacheEntryOptions entryOptions;
 
-    public MessageCache(IMemoryCache cache)
+    public MessageCache(IMemoryCache cache, IOptions<DiscordConfiguration> config)
     {
         this.cache = cache;
 
         this.entryOptions = new MemoryCacheEntryOptions()
         {
             Size = 1,
-        };
-    }
-
-    internal MessageCache(int capacity)
-    {
-        this.cache = new MemoryCache(Options.Create(new MemoryCacheOptions
-        {
-            SizeLimit = capacity
-        }));
-
-        this.entryOptions = new MemoryCacheEntryOptions()
-        {
-            Size = 1,
+            SlidingExpiration = config.Value.SlidingMessageCacheExpiration,
+            AbsoluteExpirationRelativeToNow = config.Value.AbsoluteMessageCacheExpiration
         };
     }
 
     /// <inheritdoc/>
-    public void Add(DiscordMessage message) => this.cache.Set(message.Id, message, this.entryOptions);
+    public void Add(DiscordMessage message) 
+        => this.cache.Set(message.Id, message, this.entryOptions);
 
     /// <inheritdoc/>
     public void Remove(ulong messageId) => this.cache.Remove(messageId);


### PR DESCRIPTION
originally, we set a fixed size limit on the message cache. that caused a problem once the cache was full: it didn't evict old entries, it rejected new entries, so cache would forever be stale.
then, we stopped setting a size limit. cache wouldn't forever be stale, but it would grow unbounded.

now we have expirations the user can override