### PR TITLE
Fix inconsistent variable name

### DIFF
--- a/docs/articles/basics/first_bot.md
+++ b/docs/articles/basics/first_bot.md
@@ -122,7 +122,7 @@ at the end of the method to prevent the console window from closing prematurely.
 ```cs
 DiscordClient client = builder.Build();
 
-await discord.ConnectAsync();
+await client.ConnectAsync();
 await Task.Delay(-1);
 ```
 


### PR DESCRIPTION
# Summary
Fixes a very severe instance of the compiler error [CS0103](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0103) which would occur trying to run the code in the code block. This however also makes it easier for a script kiddie to copy and paste the code, and then ask basic coding questions in the discord.

# Changes proposed
`U+64 U+69 U+73 U+63 U+6F U+72 U+64` -> `U+63 U+6C U+69 U+65 U+6E U+74`

# Notes
This will get me the devs role, right?