### PR TITLE
Make dynamic prefixes easier to implement

### DIFF
--- a/DSharpPlus.Commands/Processors/TextCommands/Parsing/DefaultPrefixResolver.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/Parsing/DefaultPrefixResolver.cs
@@ -7,13 +7,13 @@ namespace DSharpPlus.Commands.Processors.TextCommands.Parsing;
 
 public delegate ValueTask<int> ResolvePrefixDelegateAsync(CommandsExtension extension, DiscordMessage message);
 
-public sealed class DefaultPrefixResolver
+public sealed class DefaultPrefixResolver : IPrefixResolver
 {
     /// <summary>
     /// Prefixes which will trigger command execution
     /// </summary>
     public string[] Prefixes { get; init; }
-    
+
     /// <summary>
     /// Setting if a mention will trigger command execution
     /// </summary>

--- a/DSharpPlus.Commands/Processors/TextCommands/Parsing/IPrefixResolver.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/Parsing/IPrefixResolver.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.Commands.Processors.TextCommands.Parsing;
+
+/// <summary>
+/// Represents a resolver for command prefixes.
+/// </summary>
+public interface IPrefixResolver
+{
+    /// <summary>
+    /// Resolves the prefix for the command.
+    /// </summary>
+    /// <param name="extension">The commands extension.</param>
+    /// <param name="message">The message to resolve the prefix for.</param>
+    /// <returns>An integer representing the length of the prefix.</returns>
+    public ValueTask<int> ResolvePrefixAsync(CommandsExtension extension, DiscordMessage message);
+}

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandConfiguration.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandConfiguration.cs
@@ -6,6 +6,10 @@ namespace DSharpPlus.Commands.Processors.TextCommands;
 
 public record TextCommandConfiguration
 {
+    /// <summary>
+    /// The function to use to resolve prefixes for commands.
+    /// </summary>
+    /// <remarks>For dynamic prefix resolving, <see cref="IPrefixResolver"/> registered to the <see cref="DiscordClient"/>'s <see cref="IServiceProvider"/> should be preferred.</remarks>
     public ResolvePrefixDelegateAsync PrefixResolver { get; init; } = new DefaultPrefixResolver(true,"!").ResolvePrefixAsync;
     public TextArgumentSplicer TextArgumentSplicer { get; init; } = DefaultTextArgumentSplicer.Splice;
     public char[] QuoteCharacters { get; init; } = ['"', '\'', '«', '»', '‘', '“', '„', '‟'];
@@ -15,6 +19,6 @@ public record TextCommandConfiguration
     /// Whether to suppress the missing message content intent warning.
     /// </summary>
     public bool SuppressMissingMessageContentIntentWarning { get; set; }
-    
+
     public IEqualityComparer<string> CommandNameComparer { get; init; } = StringComparer.OrdinalIgnoreCase;
 }

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using DSharpPlus.Commands.EventArgs;
 using DSharpPlus.Commands.Exceptions;
+using DSharpPlus.Commands.Processors.TextCommands.Parsing;
 using DSharpPlus.Commands.Trees;
 using DSharpPlus.Commands.Trees.Metadata;
 using DSharpPlus.Entities;
@@ -37,9 +38,9 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
         {
             textCommands.Add(command.Name, command);
         }
- 
+
         this.commands = textCommands.ToFrozenDictionary(this.Configuration.CommandNameComparer);
-        
+
         if (this.configured)
         {
             return;
@@ -70,7 +71,10 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
             return;
         }
 
-        int prefixLength = await this.Configuration.PrefixResolver(this.extension, eventArgs.Message);
+        AsyncServiceScope scope = this.extension.ServiceProvider.CreateAsyncScope();
+        ResolvePrefixDelegateAsync resolvePrefix = scope.ServiceProvider.GetService<IPrefixResolver>() is {} pr ? pr.ResolvePrefixAsync : this.Configuration.PrefixResolver;
+
+        int prefixLength = await resolvePrefix(this.extension, eventArgs.Message);
         if (prefixLength < 0)
         {
             return;
@@ -89,7 +93,6 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
             }
         }
 
-        AsyncServiceScope scope = this.extension.ServiceProvider.CreateAsyncScope();
         if (!this.commands.TryGetValue(commandText[..index], out Command? command))
         {
             // Search for any aliases
@@ -241,7 +244,7 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
         TextConverterContext converterContext,
         MessageCreatedEventArgs eventArgs
     )
-    {   
+    {
         if (converter is not ITextArgumentConverter<T> typedConverter)
         {
             throw new InvalidOperationException("The provided converter was of the wrong type.");
@@ -259,7 +262,7 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
         }
 
         List<T> values = [];
-        
+
         do
         {
             Optional<T> optional = await typedConverter.ConvertAsync(converterContext, eventArgs);
@@ -278,7 +281,7 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
     /// <inheritdoc/>
     public override async ValueTask<TextCommandContext?> ParseArgumentsAsync
     (
-        TextConverterContext converterContext, 
+        TextConverterContext converterContext,
         MessageCreatedEventArgs eventArgs
     )
     {


### PR DESCRIPTION
Adds an IPrefixResolver interface that users can implement to resolve prefixes with the added benefit of having DI.

To those interested, you can do it like this:
```cs
DiscordClientBuilder.CreateDefault("token", DiscordIntents.AllUnprivileged).ConfigureServices(s => s.AddScoped<IPrefixResolver, MyCustomPrefixResolver>());
```

Boom. Text commands will now invoke your prefix resolver in favor of the default prefix resolver delegate.
