### PR TITLE
fix: Register app commands once 

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -67,7 +67,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
         {
             this.configured = true;
             extension.Client.InteractionCreated += ExecuteInteractionAsync;
-            extension.Client.GuildDownloadCompleted += async (client, eventArgs) => await RegisterSlashCommandsAsync(extension);
+            extension.Client.SessionCreated += async (client, eventArgs) => await RegisterSlashCommandsAsync(extension);
         }
     }
 
@@ -195,9 +195,13 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
         }
     }
 
-    [MemberNotNull(nameof(applicationCommands))]
     public async Task RegisterSlashCommandsAsync(CommandsExtension extension)
     {
+        if (!this.configured)
+        {
+            return;
+        }
+
         IReadOnlyList<Command> processorSpecificCommands = extension.GetCommandsForProcessor(this);
         List<DiscordApplicationCommand> globalApplicationCommands = [];
         Dictionary<ulong, List<DiscordApplicationCommand>> guildsApplicationCommands = [];
@@ -302,7 +306,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
 
     /// <summary>
     /// Only use this for commands of type <see cref="DiscordApplicationCommandType.SlashCommand "/>.
-    /// It will cut out every subcommands which are considered to be not a SlashCommand 
+    /// It will cut out every subcommands which are considered to be not a SlashCommand
     /// </summary>
     /// <param name="command"></param>
     /// <returns></returns>
@@ -338,7 +342,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
                 {
                     continue;
                 }
-                
+
                 options.Add(await ToApplicationParameterAsync(subCommand));
             }
         }
@@ -822,7 +826,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
 
     /// <summary>
     /// Only use this for commands of type <see cref="DiscordApplicationCommandType.SlashCommand "/>.
-    /// It will NOT validate every subcommands which are considered to be a SlashCommand 
+    /// It will NOT validate every subcommands which are considered to be a SlashCommand
     /// </summary>
     /// <param name="command"></param>
     /// <param name="nameLocalizations"></param>
@@ -841,7 +845,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
                 {
                     continue;
                 }
-                
+
                 ValidateSlashCommand(subCommand, nameLocalizations, descriptionLocalizations);
             }
         }


### PR DESCRIPTION
Registers slash commands on session created, and checks that it hasn't been configured already. Should fix an issue with A) Large bots that receive lots of interactions at startup and B) Re-registering commands on resume 