### PR TITLE
Add nullability on MessageBefore in MessageUpdatedEventArgs.cs

### DIFF
--- a/DSharpPlus/EventArgs/Message/MessageUpdatedEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/MessageUpdatedEventArgs.cs
@@ -16,7 +16,7 @@ public class MessageUpdatedEventArgs : DiscordEventArgs
     /// <summary>
     /// Gets the message before it got updated. This property will be null if the message was not cached.
     /// </summary>
-    public DiscordMessage MessageBefore { get; internal set; }
+    public DiscordMessage? MessageBefore { get; internal set; }
 
     /// <summary>
     /// Gets the channel this message belongs to.


### PR DESCRIPTION
Change `DiscordMessage` to `DiscordMessage?`, as it can be null. 