### PR TITLE
fix: Fix sharding killing the dispatcher

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -37,8 +37,15 @@ public sealed partial class DiscordClient
         while (!this.eventReader.Completion.IsCompleted)
         {
             GatewayPayload payload = await this.eventReader.ReadAsync();
-            try { await HandleDispatchAsync(payload); }
-            catch (Exception ex) { this.Logger.LogCritical(ex, "Dispatch threw an exception: "); }
+
+            try
+            {
+                await HandleDispatchAsync(payload);
+            }
+            catch (Exception ex)
+            {
+                this.Logger.LogError(ex, "Dispatch threw an exception: ");
+            }
         }
     }
 

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -37,7 +37,8 @@ public sealed partial class DiscordClient
         while (!this.eventReader.Completion.IsCompleted)
         {
             GatewayPayload payload = await this.eventReader.ReadAsync();
-            await HandleDispatchAsync(payload);
+            try { await HandleDispatchAsync(payload); }
+            catch (Exception ex) { this.Logger.LogCritical(ex, "Dispatch threw an exception: "); }
         }
     }
 
@@ -614,8 +615,6 @@ public sealed partial class DiscordClient
 
             this.privateChannels[channel.Id] = channel;
         }
-
-        this.guilds.Clear();
 
         IEnumerable<DiscordGuild> guilds = rawGuilds.ToDiscordObject<IEnumerable<DiscordGuild>>();
         foreach (DiscordGuild guild in guilds)


### PR DESCRIPTION
The miraculous issue wherein slash commands stopped working on sharding was due to the ready event clearing guilds, which caused a whole host of issues downstream: Namely, updating cache throwing an exception because InternalGetCachedGuild would return null when unexpected.

Furthermore, I've wrapped the dispatch call in a try/catch with logging so that users may be slightly more informed when something goes awry. This may cause some commands to fail, but it's better than the entire bot falling silent. 