### PR TITLE
Increase default HTTP Timeouts

### DIFF
--- a/DSharpPlus/Net/Rest/RestClientOptions.cs
+++ b/DSharpPlus/Net/Rest/RestClientOptions.cs
@@ -9,9 +9,9 @@ public sealed class RestClientOptions
 {
     /// <summary>
     /// Sets the timeout for HTTP operations. Set this to <see cref="System.Threading.Timeout.InfiniteTimeSpan"/> 
-    /// to never time out. Defaults to 10 seconds.
+    /// to never time out. Defaults to 100 seconds.
     /// </summary>
-    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(10);
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
 
     /// <summary>
     /// Specifies the maximum amount of retries to attempt when ratelimited. Retries will still try to respect the ratelimit.


### PR DESCRIPTION
# Summary
Increase default Timeout to the previous 100 seconds.

# Details
I recently upgraded from nightly 02271 to the latest nightly (Pre-Builder to Post-Builder)
One issue I immediately noticed is that multiple times a day I would get an HttpTimeout of 10 seconds error. Previously I believe it was the default was 100 seconds provided by dotnet HttpClient which I've only hit an error with once a month.

This is likely because we do upload sizable files/attachments often. Along with that, seeing an issue like #1986 encountering the same problem, I have a feeling this might become a common issue.

# Notes
I have worked around this for my project with this:
```csharp
.ConfigureRestClient(restConfigure =>
{
    restConfigure.Timeout = TimeSpan.FromSeconds(100);
})
```
