### PR TITLE
Use ByteArrayContent instead of StreamContent for MultipartRestRequest

### DIFF
--- a/DSharpPlus/Net/Rest/MultipartRestRequest.cs
+++ b/DSharpPlus/Net/Rest/MultipartRestRequest.cs
@@ -113,7 +113,7 @@ internal readonly record struct MultipartRestRequest : IRestRequest
                 }
                 catch
                 {
-                    writer = new ArrayPoolBufferWriter<byte>();
+                    writer = new ArrayPoolBufferWriter<byte>(4096);
                 }
 
                 current.Stream.Seek(0, SeekOrigin.Begin);

--- a/DSharpPlus/Net/Rest/MultipartRestRequest.cs
+++ b/DSharpPlus/Net/Rest/MultipartRestRequest.cs
@@ -116,8 +116,6 @@ internal readonly record struct MultipartRestRequest : IRestRequest
                     writer = new ArrayPoolBufferWriter<byte>(4096);
                 }
 
-                current.Stream.Seek(0, SeekOrigin.Begin);
-
                 int writtenBytes;
                 while ((writtenBytes = current.Stream.Read(writer.GetSpan())) > 0)
                 {

--- a/DSharpPlus/Net/Rest/MultipartRestRequest.cs
+++ b/DSharpPlus/Net/Rest/MultipartRestRequest.cs
@@ -118,12 +118,16 @@ internal readonly record struct MultipartRestRequest : IRestRequest
 
                 current.Stream.Seek(0, SeekOrigin.Begin);
 
-                while (current.Stream.Read(writer.GetSpan()) > 0)
+                int writtenBytes;
+                while ((writtenBytes = current.Stream.Read(writer.GetSpan())) > 0)
                 {
+                    writer.Advance(writtenBytes);
                 }
 
                 ByteArrayContent file = new(writer.WrittenSpan.ToArray());
 
+                writer.Dispose();
+                
                 if (current.ContentType is not null)
                 {
                     file.Headers.ContentType = MediaTypeHeaderValue.Parse(current.ContentType);

--- a/DSharpPlus/Net/Rest/MultipartRestRequest.cs
+++ b/DSharpPlus/Net/Rest/MultipartRestRequest.cs
@@ -109,9 +109,9 @@ internal readonly record struct MultipartRestRequest : IRestRequest
 
                 try
                 {
-                    writer = new ArrayPoolBufferWriter<byte>((int)current.Stream.Length);
+                    writer = new ArrayPoolBufferWriter<byte>(checked((int)current.Stream.Length));
                 }
-                catch
+                catch (NotSupportedException)
                 {
                     writer = new ArrayPoolBufferWriter<byte>(4096);
                 }


### PR DESCRIPTION
# Summary
Fixes an problem with retries when uploading a file and using an unrewindable stream. Also this aproach increases performance