### PR TITLE
Reduce usage of `Lazy` for ReadOnly mirror of a collection

### DIFF
--- a/DSharpPlus.CommandsNext/CommandsNextExtension.cs
+++ b/DSharpPlus.CommandsNext/CommandsNextExtension.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -46,7 +45,6 @@ public class CommandsNextExtension : BaseExtension
     {
         this.Config = new CommandsNextConfiguration(cfg);
         this.TopLevelCommands = [];
-        this.registeredCommandsLazy = new Lazy<IReadOnlyDictionary<string, Command>>(() => new ReadOnlyDictionary<string, Command>(this.TopLevelCommands));
         this.HelpFormatter = new HelpFormatterFactory();
         this.HelpFormatter.SetFormatterType<DefaultHelpFormatter>();
 
@@ -431,10 +429,9 @@ public class CommandsNextExtension : BaseExtension
     /// Gets a dictionary of registered top-level commands.
     /// </summary>
     public IReadOnlyDictionary<string, Command> RegisteredCommands
-        => this.registeredCommandsLazy.Value;
+        => this.TopLevelCommands;
 
     private Dictionary<string, Command> TopLevelCommands { get; set; }
-    private readonly Lazy<IReadOnlyDictionary<string, Command>> registeredCommandsLazy;
 
     /// <summary>
     /// Registers all commands from a given assembly. The command classes need to be public to be considered for registration.

--- a/DSharpPlus/Clients/BaseDiscordClient.cs
+++ b/DSharpPlus/Clients/BaseDiscordClient.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -62,13 +60,12 @@ public abstract class BaseDiscordClient : IDisposable
     /// Gets the list of available voice regions. Note that this property will not contain VIP voice regions.
     /// </summary>
     public IReadOnlyDictionary<string, DiscordVoiceRegion> VoiceRegions
-        => this.voice_regions_lazy.Value;
+        => this.InternalVoiceRegions;
 
     /// <summary>
     /// Gets the list of available voice regions. This property is meant as a way to modify <see cref="VoiceRegions"/>.
     /// </summary>
     protected internal ConcurrentDictionary<string, DiscordVoiceRegion> InternalVoiceRegions { get; set; }
-    internal Lazy<IReadOnlyDictionary<string, DiscordVoiceRegion>> voice_regions_lazy;
 
     /// <summary>
     /// Initializes this Discord API client.
@@ -77,8 +74,7 @@ public abstract class BaseDiscordClient : IDisposable
     {
         this.UserCache = new ConcurrentDictionary<ulong, DiscordUser>();
         this.InternalVoiceRegions = new ConcurrentDictionary<string, DiscordVoiceRegion>();
-        this.voice_regions_lazy = new Lazy<IReadOnlyDictionary<string, DiscordVoiceRegion>>(() => new ReadOnlyDictionary<string, DiscordVoiceRegion>(this.InternalVoiceRegions));
-
+        
         Assembly a = typeof(DiscordClient).GetTypeInfo().Assembly;
 
         AssemblyInformationalVersionAttribute? iv = a.GetCustomAttribute<AssemblyInformationalVersionAttribute>();

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -89,10 +88,9 @@ public sealed partial class DiscordClient : BaseDiscordClient
     /// Gets the collection of presences held by this client.
     /// </summary>
     public IReadOnlyDictionary<ulong, DiscordPresence> Presences
-        => this.presencesLazy.Value;
+        => this.presences;
 
     internal Dictionary<ulong, DiscordPresence> presences = [];
-    private Lazy<IReadOnlyDictionary<ulong, DiscordPresence>> presencesLazy;
 
     [ActivatorUtilitiesConstructor]
     public DiscordClient
@@ -147,8 +145,6 @@ public sealed partial class DiscordClient : BaseDiscordClient
                 asyncEvent.Register(d);
             }
         }
-
-        this.presencesLazy = new Lazy<IReadOnlyDictionary<ulong, DiscordPresence>>(() => new ReadOnlyDictionary<ulong, DiscordPresence>(this.presences));
     }
 
     internal void InternalSetup(IClientErrorHandler error)
@@ -230,8 +226,6 @@ public sealed partial class DiscordClient : BaseDiscordClient
         this.events[typeof(ThreadMembersUpdatedEventArgs)] = new AsyncEvent<DiscordClient, ThreadMembersUpdatedEventArgs>(error);
 
         this.guilds.Clear();
-
-        this.presencesLazy = new Lazy<IReadOnlyDictionary<ulong, DiscordPresence>>(() => new ReadOnlyDictionary<ulong, DiscordPresence>(this.presences));
     }
 
     #region Client Extension Methods

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -90,13 +89,10 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
     /// </summary>
     [JsonIgnore]
     public IReadOnlyList<DiscordOverwrite> PermissionOverwrites
-        => this.permissionOverwritesLazy.Value;
+        => this.permissionOverwrites;
 
     [JsonProperty("permission_overwrites", NullValueHandling = NullValueHandling.Ignore)]
     internal List<DiscordOverwrite> permissionOverwrites = [];
-
-    [JsonIgnore]
-    private readonly Lazy<IReadOnlyList<DiscordOverwrite>> permissionOverwritesLazy;
 
     /// <summary>
     /// Gets the channel's topic. This is applicable to text channels only.
@@ -198,7 +194,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
     [JsonProperty("permissions")]
     public DiscordPermissions? UserPermissions { get; internal set; }
 
-    internal DiscordChannel() => this.permissionOverwritesLazy = new Lazy<IReadOnlyList<DiscordOverwrite>>(() => new ReadOnlyCollection<DiscordOverwrite>(this.permissionOverwrites));
+    internal DiscordChannel() { }
 
     #region Methods
 

--- a/DSharpPlus/Entities/Emoji/DiscordEmoji.cs
+++ b/DSharpPlus/Entities/Emoji/DiscordEmoji.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using Newtonsoft.Json;
@@ -22,11 +21,10 @@ public partial class DiscordEmoji : SnowflakeObject, IEquatable<DiscordEmoji>
     /// Gets IDs the roles this emoji is enabled for.
     /// </summary>
     [JsonIgnore]
-    public IReadOnlyList<ulong> Roles => this.rolesLazy.Value;
+    public IReadOnlyList<ulong> Roles => this.roles;
 
     [JsonProperty("roles", NullValueHandling = NullValueHandling.Ignore)]
     internal List<ulong> roles;
-    private readonly Lazy<IReadOnlyList<ulong>> rolesLazy;
 
     /// <summary>
     /// Gets the user who uploaded this emoji.
@@ -70,7 +68,7 @@ public partial class DiscordEmoji : SnowflakeObject, IEquatable<DiscordEmoji>
     [JsonProperty("available", NullValueHandling = NullValueHandling.Ignore)]
     public bool IsAvailable { get; internal set; }
 
-    internal DiscordEmoji() => this.rolesLazy = new Lazy<IReadOnlyList<ulong>>(() => new ReadOnlyCollection<ulong>(this.roles));
+    internal DiscordEmoji() { }
 
     /// <summary>
     /// Gets emoji's name in non-Unicode format (eg. :thinking: instead of the Unicode representation of the emoji).

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -16,7 +15,7 @@ namespace DSharpPlus.Entities;
 /// </summary>
 public class DiscordMember : DiscordUser, IEquatable<DiscordMember>
 {
-    internal DiscordMember() => this.role_ids_lazy = new Lazy<IReadOnlyList<ulong>>(() => new ReadOnlyCollection<ulong>(this.role_ids));
+    internal DiscordMember() { }
 
     internal DiscordMember(DiscordUser user)
     {
@@ -25,7 +24,6 @@ public class DiscordMember : DiscordUser, IEquatable<DiscordMember>
         this.Id = user.Id;
 
         this.role_ids = [];
-        this.role_ids_lazy = new Lazy<IReadOnlyList<ulong>>(() => new ReadOnlyCollection<ulong>(this.role_ids));
     }
 
     internal DiscordMember(TransportMember member)
@@ -39,7 +37,6 @@ public class DiscordMember : DiscordUser, IEquatable<DiscordMember>
         this.IsPending = member.IsPending;
         this.avatarHash = member.AvatarHash;
         this.role_ids = member.Roles ?? [];
-        this.role_ids_lazy = new Lazy<IReadOnlyList<ulong>>(() => new ReadOnlyCollection<ulong>(this.role_ids));
         this.CommunicationDisabledUntil = member.CommunicationDisabledUntil;
     }
 
@@ -80,12 +77,10 @@ public class DiscordMember : DiscordUser, IEquatable<DiscordMember>
     /// List of role IDs
     /// </summary>
     [JsonIgnore]
-    internal IReadOnlyList<ulong> RoleIds => this.role_ids_lazy.Value;
+    internal IReadOnlyList<ulong> RoleIds => this.role_ids;
 
     [JsonProperty("roles", NullValueHandling = NullValueHandling.Ignore)]
     internal List<ulong> role_ids;
-    [JsonIgnore]
-    private readonly Lazy<IReadOnlyList<ulong>> role_ids_lazy;
 
     /// <summary>
     /// Gets the list of roles associated with this member.


### PR DESCRIPTION
# Summary
Lazy doesn't seem like a proper solution for the ReadOnly, and it may be a culprit for some high memory usage.

# Details
- ~~TBD (will fill out with actual changes in memory usage later)~~

# Changes proposed
I propose just returning the collection as an `IReadOnly`, while this doesn't stop the user from casting it back, I feel just returning it as IReadOnly should be enough.