### PR TITLE
Improve dispatch performance

### DIFF
--- a/DSharpPlus/Extensions/ServiceCollectionExtensions.InternalSetup.cs
+++ b/DSharpPlus/Extensions/ServiceCollectionExtensions.InternalSetup.cs
@@ -45,7 +45,7 @@ public static partial class ServiceCollectionExtensions
 
         // gateway setup
         serviceCollection.Configure<GatewayClientOptions>(c => c.Intents = intents)
-            .AddKeyedSingleton("DSharpPlus.Gateway.EventChannel", Channel.CreateUnbounded<GatewayPayload>())
+            .AddKeyedSingleton("DSharpPlus.Gateway.EventChannel", Channel.CreateUnbounded<GatewayPayload>(new UnboundedChannelOptions { SingleReader = true }))
             .AddTransient<ITransportService, TransportService>()
             .AddTransient<IGatewayClient, GatewayClient>()
             .AddTransient<PayloadDecompressor>()
@@ -85,7 +85,7 @@ public static partial class ServiceCollectionExtensions
 
         // gateway setup
         serviceCollection.Configure<GatewayClientOptions>(c => c.Intents = intents)
-            .AddKeyedSingleton("DSharpPlus.Gateway.EventChannel", Channel.CreateUnbounded<GatewayPayload>())
+            .AddKeyedSingleton("DSharpPlus.Gateway.EventChannel", Channel.CreateUnbounded<GatewayPayload>(new UnboundedChannelOptions { SingleReader = true }))
             .AddTransient<ITransportService, TransportService>()
             .AddTransient<IGatewayClient, GatewayClient>()
             .AddTransient<PayloadDecompressor>()


### PR DESCRIPTION
This is small PR that improves the performance of dispatch by 50% in microbenchmarks - the actual performance gain in the dispatcher with async overhead is..arguable, but this should, in theory, also help alleviate some issues with backpressure, since the actual read is faster.

Benchmark numbers for the micro-optimizers (looking at you, Aki):

```fix
| Method                         | Mean     | Error    | StdDev   |
|------------------------------- |---------:|---------:|---------:|
| ReadDefaultChannel             | 293.5 ns | 16.07 ns | 43.73 ns |
| ReadSingleReaderChannel        | 154.3 ns | 20.40 ns | 56.52 ns |
| ReadSingleWriterChannel        | 266.4 ns | 17.49 ns | 50.19 ns |
| ReadSingleReaderWriterChannel  | 208.9 ns | 17.96 ns | 50.94 ns |
| WriteDefaultChannel            | 367.0 ns | 30.95 ns | 89.30 ns |
| WriteSingleReaderChannel       | 428.0 ns | 32.68 ns | 94.82 ns |
| WriteSingleWriterChannel       | 381.5 ns | 24.53 ns | 71.16 ns |
| WriteSingleReaderWriterChannel | 365.6 ns | 15.99 ns | 46.91 ns |
```

Technically speaking, writing is now marginally slower (60ns, or 15%), but this is amortized by the ~50% improvement in reading, which should allow critical events (interactions) to be fired faster, in theory.

