### PR TITLE
Improve performance of fetching a cached channel by avoiding a full iteration

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -534,7 +534,8 @@ public sealed partial class DiscordClient
                     mbr = rawMbr.ToDiscordObject<TransportMember>();
                 }
 
-                await OnTypingStartEventAsync((ulong)dat["user_id"], cid, InternalGetCachedChannel(cid), (ulong?)dat["guild_id"], Utilities.GetDateTimeOffset((long)dat["timestamp"]), mbr);
+                ulong? guildId = (ulong?)dat["guild_id"];
+                await OnTypingStartEventAsync((ulong)dat["user_id"], cid, InternalGetCachedChannel(cid, guildId)!, guildId, Utilities.GetDateTimeOffset((long)dat["timestamp"]), mbr);
                 break;
 
             case "webhooks_update":
@@ -744,8 +745,8 @@ public sealed partial class DiscordClient
 
         DiscordGuild? gld = channel.Guild;
 
-        DiscordChannel? channel_new = InternalGetCachedChannel(channel.Id);
-        DiscordChannel channel_old = null;
+        DiscordChannel? channel_new = InternalGetCachedChannel(channel.Id, channel.GuildId);
+        DiscordChannel channel_old = null!;
 
         if (channel_new != null)
         {
@@ -840,7 +841,7 @@ public sealed partial class DiscordClient
     internal async Task OnChannelPinsUpdateAsync(ulong? guildId, ulong channelId, DateTimeOffset? lastPinTimestamp)
     {
         DiscordGuild guild = InternalGetCachedGuild(guildId);
-        DiscordChannel? channel = InternalGetCachedChannel(channelId) ?? InternalGetCachedThread(channelId);
+        DiscordChannel? channel = InternalGetCachedChannel(channelId, guildId) ?? InternalGetCachedThread(channelId);
 
         if (channel == null)
         {
@@ -1632,7 +1633,7 @@ public sealed partial class DiscordClient
     internal async Task OnInviteCreateEventAsync(ulong channelId, ulong guildId, DiscordInvite invite)
     {
         DiscordGuild guild = InternalGetCachedGuild(guildId);
-        DiscordChannel channel = InternalGetCachedChannel(channelId);
+        DiscordChannel channel = InternalGetCachedChannel(channelId, guildId);
 
         invite.Discord = this;
 
@@ -1653,7 +1654,7 @@ public sealed partial class DiscordClient
     internal async Task OnInviteDeleteEventAsync(ulong channelId, ulong guildId, JToken dat)
     {
         DiscordGuild guild = InternalGetCachedGuild(guildId);
-        DiscordChannel channel = InternalGetCachedChannel(channelId);
+        DiscordChannel channel = InternalGetCachedChannel(channelId, guildId);
 
         if (!guild.invites.TryRemove(dat["code"].ToString(), out DiscordInvite? invite))
         {
@@ -1777,7 +1778,7 @@ public sealed partial class DiscordClient
     internal async Task OnMessageDeleteEventAsync(ulong messageId, ulong channelId, ulong? guildId)
     {
         DiscordGuild guild = InternalGetCachedGuild(guildId);
-        DiscordChannel? channel = InternalGetCachedChannel(channelId) ?? InternalGetCachedThread(channelId);
+        DiscordChannel? channel = InternalGetCachedChannel(channelId, guildId) ?? InternalGetCachedThread(channelId);
 
         if (channel == null)
         {
@@ -1834,7 +1835,7 @@ public sealed partial class DiscordClient
 
     internal async Task OnMessageBulkDeleteEventAsync(ulong[] messageIds, ulong channelId, ulong? guildId)
     {
-        DiscordChannel? channel = InternalGetCachedChannel(channelId) ?? InternalGetCachedThread(channelId);
+        DiscordChannel? channel = InternalGetCachedChannel(channelId, guildId) ?? InternalGetCachedThread(channelId);
 
         List<DiscordMessage> msgs = new(messageIds.Length);
         foreach (ulong messageId in messageIds)
@@ -1874,7 +1875,7 @@ public sealed partial class DiscordClient
 
     internal async Task OnMessageReactionAddAsync(ulong userId, ulong messageId, ulong channelId, ulong? guildId, TransportMember mbr, DiscordEmoji emoji)
     {
-        DiscordChannel? channel = InternalGetCachedChannel(channelId) ?? InternalGetCachedThread(channelId);
+        DiscordChannel? channel = InternalGetCachedChannel(channelId, guildId) ?? InternalGetCachedThread(channelId);
         DiscordGuild? guild = InternalGetCachedGuild(guildId);
 
         emoji.Discord = this;
@@ -1939,7 +1940,7 @@ public sealed partial class DiscordClient
 
     internal async Task OnMessageReactionRemoveAsync(ulong userId, ulong messageId, ulong channelId, ulong? guildId, DiscordEmoji emoji)
     {
-        DiscordChannel? channel = InternalGetCachedChannel(channelId) ?? InternalGetCachedThread(channelId);
+        DiscordChannel? channel = InternalGetCachedChannel(channelId, guildId) ?? InternalGetCachedThread(channelId);
 
         emoji.Discord = this;
 
@@ -2039,7 +2040,7 @@ public sealed partial class DiscordClient
     internal async Task OnMessageReactionRemoveEmojiAsync(ulong messageId, ulong channelId, ulong guildId, JToken dat)
     {
         DiscordGuild guild = InternalGetCachedGuild(guildId);
-        DiscordChannel? channel = InternalGetCachedChannel(channelId) ?? InternalGetCachedThread(channelId);
+        DiscordChannel? channel = InternalGetCachedChannel(channelId, guildId) ?? InternalGetCachedThread(channelId);
 
         if (channel == null)
         {

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -1006,6 +1006,21 @@ public sealed partial class DiscordClient : BaseDiscordClient
         return null;
     }
 
+    internal DiscordChannel? InternalGetCachedChannel(ulong channelId, ulong? guildId)
+    {
+        if (guildId is not { } nonNullGuildID)
+        {
+            return this.privateChannels.GetValueOrDefault(channelId);
+        }
+
+        if (this.guilds.TryGetValue(nonNullGuildID, out DiscordGuild? guild))
+        {
+            return guild.Channels.GetValueOrDefault(channelId);
+        }
+
+        return null;
+    }
+
     internal DiscordGuild InternalGetCachedGuild(ulong? guildId)
     {
         if (this.guilds != null && guildId.HasValue)
@@ -1033,7 +1048,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
             message.Author = UpdateUser(usr, guild?.Id, guild, member);
         }
 
-        DiscordChannel? channel = InternalGetCachedChannel(message.ChannelId) ?? InternalGetCachedThread(message.ChannelId);
+        DiscordChannel? channel = InternalGetCachedChannel(message.ChannelId, message.guildId) ?? InternalGetCachedThread(message.ChannelId);
 
         if (channel != null)
         {

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -67,7 +67,13 @@ public class DiscordMessage : SnowflakeObject, IEquatable<DiscordMessage>
     [JsonIgnore]
     public DiscordChannel? Channel
     {
-        get => (this.Discord as DiscordClient)?.InternalGetCachedChannel(this.ChannelId) ?? (this.Discord as DiscordClient)?.InternalGetCachedThread(this.ChannelId) ?? this.channel;
+        get
+        {
+            DiscordClient? client = this.Discord as DiscordClient;
+
+            return client?.InternalGetCachedChannel(this.ChannelId, this.guildId) ??
+                   client?.InternalGetCachedThread(this.ChannelId) ?? this.channel;
+        }
         internal set => this.channel = value;
     }
 
@@ -326,7 +332,7 @@ public class DiscordMessage : SnowflakeObject, IEquatable<DiscordMessage>
                 };
         }
 
-        DiscordChannel channel = client.InternalGetCachedChannel(channelId!.Value);
+        DiscordChannel? channel = client.InternalGetCachedChannel(channelId!.Value, this.guildId);
 
         if (channel is null)
         {

--- a/DSharpPlus/Entities/Channel/Message/Poll/DiscordPollVoteUpdate.cs
+++ b/DSharpPlus/Entities/Channel/Message/Poll/DiscordPollVoteUpdate.cs
@@ -24,7 +24,7 @@ public class DiscordPollVoteUpdate
     public DiscordUser User => this.client.GetCachedOrEmptyUserInternal(this.UserId);
 
     [JsonIgnore]
-    public DiscordChannel Channel => this.client.InternalGetCachedChannel(this.ChannelId);
+    public DiscordChannel Channel => this.client.InternalGetCachedChannel(this.ChannelId, this.GuildId);
 
     /// <summary>
     /// Gets the message that the poll is attached to.
@@ -34,7 +34,7 @@ public class DiscordPollVoteUpdate
     /// being enabled in the client. If no cache provider is enabled, this property will always return <see langword="null"/>.
     /// </remarks>
     // Should this pull from cache as an auto-property? Perhaps having a hard-set message pulled from cache further up
-    // instead. 
+    // instead.
     [JsonIgnore]
     public DiscordMessage? Message
         => this.client.MessageCache?.TryGet(this.MessageId, out DiscordMessage? msg) ?? false ? msg : null;

--- a/DSharpPlus/Entities/Channel/Stage/DiscordStageInstance.cs
+++ b/DSharpPlus/Entities/Channel/Stage/DiscordStageInstance.cs
@@ -28,7 +28,7 @@ public sealed class DiscordStageInstance : SnowflakeObject
     /// </summary>
     [JsonIgnore]
     public DiscordChannel Channel
-        => (this.Discord as DiscordClient)?.InternalGetCachedChannel(this.ChannelId) ?? null;
+        => (this.Discord as DiscordClient)?.InternalGetCachedChannel(this.ChannelId, this.GuildId) ?? null;
 
     /// <summary>
     /// Gets the id of the channel this stage instance is in.

--- a/DSharpPlus/Entities/Voice/DiscordVoiceState.cs
+++ b/DSharpPlus/Entities/Voice/DiscordVoiceState.cs
@@ -35,7 +35,7 @@ public class DiscordVoiceState
     /// Gets the channel this user is connected to.
     /// </summary>
     [JsonIgnore]
-    public DiscordChannel? Channel => (this.ChannelId.HasValue && this.ChannelId.Value != 0) ? this.Discord.InternalGetCachedChannel(this.ChannelId.Value) : null;
+    public DiscordChannel? Channel => this.ChannelId is {} cid and not 0 ? this.Discord.InternalGetCachedChannel(cid, this.GuildId) : null;
 
     /// <summary>
     /// Gets ID of the user to which this voice state belongs.


### PR DESCRIPTION
This PR adds an overload to InternalGetCachedChannel which takes a guild ID, which  skips iterating ALL guilds to find a channel. There are some instances where the guild ID is not available, and thus iteration must prevail, but in 90% of the API calls this is present, and thus can benefit.

The sample data (and thus, PR title) is derived from testing with about 4000 dictionary keys

```fix
| Method               | Mean          | Error       | StdDev      |
|--------------------- |--------------:|------------:|------------:|
| WorstCaseIterate     | 19,867.684 ns | 326.9402 ns | 273.0099 ns |
| BestCaseIterate      |      7.253 ns |   0.1474 ns |   0.2251 ns |
| WorstCaseTryGetValue |      3.941 ns |   0.0711 ns |   0.0631 ns |
| BestCaseTryGetValue  |      6.927 ns |   0.0987 ns |   0.0825 ns |
```

It is also worth noting that "Worst" and "Best" for TGV are actually backward - Worst case is 1 call (guild not present) and "best" case is when the guild and channel are present. 

---

Reviewer's note: if you ever dispute that this is faster than the code it replaces, you should get your performance senses checked, but since there's a fair bit more to it than the benchmarks here, see the discussion on discord: https://canary.discord.com/channels/379378609942560770/379386901725052928/1265540956816412734