### PR TITLE
Allow for the creation of fake `MessageCreateEventArgs`

### DIFF
--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -36,7 +36,7 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
 
     /// <inheritdoc />
     public override IReadOnlyList<Command> Commands => this.commands.Values;
-    private FrozenDictionary<string, Command> commands = new Dictionary<string, Command>().ToFrozenDictionary();
+    private FrozenDictionary<string, Command> commands = FrozenDictionary<string, Command>.Empty;
 
     /// <inheritdoc />
     public override async ValueTask ConfigureAsync(CommandsExtension extension)
@@ -174,9 +174,9 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
         await this.extension.CommandExecutor.ExecuteAsync(commandContext);
     }
 
-    /// <inheritdoc cref="TextExtensions.CreateFakeMessageEventArgs(CommandContext, DiscordMessage, string)" />
-    public static MessageCreatedEventArgs CreateFakeMessageEventArgs(CommandContext context, DiscordMessage message, string content)
-        => TextExtensions.CreateFakeMessageEventArgs(context, message, content);
+    /// <inheritdoc cref="TextExtensions.CreateFakeMessageEventArgsAsync(CommandContext, DiscordMessage, string)" />
+    public static async ValueTask<MessageCreatedEventArgs> CreateFakeMessageEventArgsAsync(CommandContext context, DiscordMessage message, string content)
+        => await TextExtensions.CreateFakeMessageEventArgsAsync(context, message, content);
 
     /// <inheritdoc/>
     public override TextCommandContext CreateCommandContext

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -70,7 +70,7 @@ public sealed class TextCommandProcessor(TextCommandConfiguration? configuration
     }
 
     /// <summary>
-    /// Parses, resolves, and executes a text command.
+    /// Resolves, parses, and executes a text command.
     /// </summary>
     /// <param name="client">The client that received the message.</param>
     /// <param name="eventArgs">The event arguments containing the message.</param>

--- a/DSharpPlus.Commands/Processors/TextCommands/TextExtensions.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextExtensions.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
+using DSharpPlus.Exceptions;
+
+namespace DSharpPlus.Commands.Processors.TextCommands;
+
+internal static partial class TextExtensions
+{
+    [GeneratedRegex(@"<@&(\d+)>", RegexOptions.Compiled)] private static partial Regex _roleMentionRegex();
+    [GeneratedRegex(@"<@!?(\d+)>", RegexOptions.Compiled)] private static partial Regex _userMentionRegex();
+    [GeneratedRegex(@"<#(\d+)>", RegexOptions.Compiled)] private static partial Regex _channelMentionRegex();
+
+    [UnsafeAccessor(UnsafeAccessorKind.Constructor)] private static extern MessageCreatedEventArgs _messageCreateEventArgsConstructor();
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Message")] private static extern void _messageCreateEventArgsMessageSetter(MessageCreatedEventArgs messageCreateEventArgs, DiscordMessage message);
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_MentionedUsers")] private static extern void _messageCreateEventArgsMentionedUsersSetter(MessageCreatedEventArgs messageCreateEventArgs, IReadOnlyList<DiscordUser> mentionedUsers);
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_MentionedRoles")] private static extern void _messageCreateEventArgsMentionedRolesSetter(MessageCreatedEventArgs messageCreateEventArgs, IReadOnlyList<DiscordRole> mentionedRoles);
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_MentionedChannels")] private static extern void _messageCreateEventArgsMentionedChannelsSetter(MessageCreatedEventArgs messageCreateEventArgs, IReadOnlyList<DiscordChannel> mentionedChannels);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Constructor)] private static extern DiscordMessage _messageConstructor();
+    [UnsafeAccessor(UnsafeAccessorKind.Constructor)] private static extern DiscordMessage _messageConstructor(DiscordMessage message);
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Content")] private static extern void _messageContentSetter(DiscordMessage message, string content);
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_ChannelId")] private static extern void _messageChannelIdSetter(DiscordMessage message, ulong channelId);
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Author")] private static extern void _messageAuthorSetter(DiscordMessage message, DiscordUser author);
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "mentionedUsers")] private static extern ref List<DiscordUser> _messageMentionedUsersSetter(DiscordMessage message);
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "mentionedRoles")] private static extern ref List<DiscordRole> _messageMentionedRolesSetter(DiscordMessage message);
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "mentionedChannels")] private static extern ref List<DiscordChannel> _messageMentionedChannelsSetter(DiscordMessage message);
+
+    /// <summary>
+    /// Creates a shallow copy of a Discord message.
+    /// </summary>
+    /// <param name="message">The message to copy.</param>
+    /// <returns>A shallow copy of the message.</returns>
+    public static DiscordMessage Copy(this DiscordMessage message) => _messageConstructor(message);
+
+    /// <summary>
+    /// Creates a fake message created event args object with the specified content.
+    /// </summary>
+    /// <param name="context">The command context to use for the message.</param>
+    /// <param name="message">The message to use as a base for the new message.</param>
+    /// <param name="content">The content of the new message.</param>
+    /// <returns>The created message created event args object.</returns>
+    public static MessageCreatedEventArgs CreateFakeMessageEventArgs(CommandContext context, DiscordMessage message, string content)
+    {
+        ArgumentNullException.ThrowIfNull(context, nameof(context));
+        ArgumentNullException.ThrowIfNull(message, nameof(message));
+        ArgumentException.ThrowIfNullOrWhiteSpace(content, nameof(content));
+
+        // Create a copy of the message to modify to prevent modifying the original message.
+        // By modifying the original message, we could potentially cause issues with the message cache.
+        DiscordMessage messageCopy = message.Copy();
+
+        // Modify the copied message to contain the contents that the user wants.
+        messageCopy.ModifyMessageProperties(content, context.Client, context.User, context.Channel, context.Guild);
+
+        // Create the message created event args.
+        MessageCreatedEventArgs messageCreateEventArgs = _messageCreateEventArgsConstructor();
+        _messageCreateEventArgsMessageSetter(messageCreateEventArgs, message);
+        _messageCreateEventArgsMentionedUsersSetter(messageCreateEventArgs, message.MentionedUsers);
+        _messageCreateEventArgsMentionedRolesSetter(messageCreateEventArgs, message.MentionedRoles);
+        _messageCreateEventArgsMentionedChannelsSetter(messageCreateEventArgs, message.MentionedChannels);
+
+        // Return the message created event args, which can be used for argument conversion or command execution.
+        return messageCreateEventArgs;
+    }
+
+    /// <summary>
+    /// Modifies the internal properties of a message, changing the content, author, channel, and mentions.
+    /// </summary>
+    /// <param name="message">The message to modify.</param>
+    /// <param name="content">The new content of the message.</param>
+    /// <param name="client">The client to use for fetching users and channels.</param>
+    /// <param name="user">The new author of the message.</param>
+    /// <param name="channel">The new channel of the message.</param>
+    /// <param name="guild">The guild to use for fetching roles.</param>
+    public static void ModifyMessageProperties(this DiscordMessage message, string content, DiscordClient client, DiscordUser user, DiscordChannel channel, DiscordGuild? guild = null)
+    {
+        List<DiscordRole> roleMentions = [];
+        List<DiscordUser> userMentions = [];
+        List<DiscordChannel> channelMentions = [];
+        if (guild is not null)
+        {
+            MatchCollection roleMatches = _roleMentionRegex().Matches(content);
+            foreach (Match match in roleMatches.Cast<Match>())
+            {
+                if (ulong.TryParse(match.Groups[1].Value, out ulong roleId) && guild.GetRole(roleId) is DiscordRole role)
+                {
+                    roleMentions.Add(role);
+                }
+            }
+
+            MatchCollection userMatches = _userMentionRegex().Matches(content);
+            foreach (Match match in userMatches.Cast<Match>())
+            {
+                if (ulong.TryParse(match.Groups[1].Value, out ulong userId))
+                {
+                    userMentions.Add(client.GetUserAsync(userId).GetAwaiter().GetResult());
+                }
+            }
+        }
+
+        MatchCollection channelMatches = _channelMentionRegex().Matches(content);
+        foreach (Match match in channelMatches.Cast<Match>())
+        {
+            if (ulong.TryParse(match.Groups[1].Value, out ulong channelId))
+            {
+                DiscordChannel? mentionedChannel;
+                try
+                {
+                    mentionedChannel = client.GetChannelAsync(channelId).GetAwaiter().GetResult();
+                }
+                catch (DiscordException)
+                {
+                    continue;
+                }
+
+                channelMentions.Add(mentionedChannel);
+            }
+        }
+
+        _messageContentSetter(message, content);
+        _messageChannelIdSetter(message, channel.Id);
+        _messageAuthorSetter(message, user);
+        _messageMentionedUsersSetter(message) = userMentions;
+        _messageMentionedRolesSetter(message) = roleMentions;
+        _messageMentionedChannelsSetter(message) = channelMentions;
+    }
+}

--- a/DSharpPlus.Commands/Processors/TextCommands/TextExtensions.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextExtensions.cs
@@ -11,33 +11,66 @@ namespace DSharpPlus.Commands.Processors.TextCommands;
 
 internal static partial class TextExtensions
 {
-    [GeneratedRegex(@"<@&(\d+)>", RegexOptions.Compiled)] private static partial Regex _roleMentionRegex();
-    [GeneratedRegex(@"<@!?(\d+)>", RegexOptions.Compiled)] private static partial Regex _userMentionRegex();
-    [GeneratedRegex(@"<#(\d+)>", RegexOptions.Compiled)] private static partial Regex _channelMentionRegex();
+    [GeneratedRegex(@"<@&(\d+)>", RegexOptions.Compiled)]
+    private static partial Regex roleMentionRegex();
 
-    [UnsafeAccessor(UnsafeAccessorKind.Constructor)] private static extern MessageCreatedEventArgs _messageCreateEventArgsConstructor();
-    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Message")] private static extern void _messageCreateEventArgsMessageSetter(MessageCreatedEventArgs messageCreateEventArgs, DiscordMessage message);
-    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_MentionedUsers")] private static extern void _messageCreateEventArgsMentionedUsersSetter(MessageCreatedEventArgs messageCreateEventArgs, IReadOnlyList<DiscordUser> mentionedUsers);
-    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_MentionedRoles")] private static extern void _messageCreateEventArgsMentionedRolesSetter(MessageCreatedEventArgs messageCreateEventArgs, IReadOnlyList<DiscordRole> mentionedRoles);
-    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_MentionedChannels")] private static extern void _messageCreateEventArgsMentionedChannelsSetter(MessageCreatedEventArgs messageCreateEventArgs, IReadOnlyList<DiscordChannel> mentionedChannels);
+    [GeneratedRegex(@"<@!?(\d+)>", RegexOptions.Compiled)]
+    private static partial Regex userMentionRegex();
 
-    [UnsafeAccessor(UnsafeAccessorKind.Constructor)] private static extern DiscordMessage _messageConstructor();
-    [UnsafeAccessor(UnsafeAccessorKind.Constructor)] private static extern DiscordMessage _messageConstructor(DiscordMessage message);
-    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Content")] private static extern void _messageContentSetter(DiscordMessage message, string content);
-    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Channel")] private static extern void _messageChannelSetter(DiscordMessage message, DiscordChannel channel);
-    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_ChannelId")] private static extern void _messageChannelIdSetter(DiscordMessage message, ulong channelId);
-    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_guildId")] private static extern void _messageGuildIdSetter(DiscordMessage message, ulong? guildId);
-    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Author")] private static extern void _messageAuthorSetter(DiscordMessage message, DiscordUser author);
-    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "mentionedUsers")] private static extern ref List<DiscordUser> _messageMentionedUsersSetter(DiscordMessage message);
-    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "mentionedRoles")] private static extern ref List<DiscordRole> _messageMentionedRolesSetter(DiscordMessage message);
-    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "mentionedChannels")] private static extern ref List<DiscordChannel> _messageMentionedChannelsSetter(DiscordMessage message);
+    [GeneratedRegex(@"<#(\d+)>", RegexOptions.Compiled)]
+    private static partial Regex channelMentionRegex();
+
+    [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
+    private static extern MessageCreatedEventArgs messageCreateEventArgsConstructor();
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Message")]
+    private static extern void messageCreateEventArgsMessageSetter(MessageCreatedEventArgs messageCreateEventArgs, DiscordMessage message);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_MentionedUsers")]
+    private static extern void messageCreateEventArgsMentionedUsersSetter(MessageCreatedEventArgs messageCreateEventArgs, IReadOnlyList<DiscordUser> mentionedUsers);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_MentionedRoles")]
+    private static extern void messageCreateEventArgsMentionedRolesSetter(MessageCreatedEventArgs messageCreateEventArgs, IReadOnlyList<DiscordRole> mentionedRoles);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_MentionedChannels")]
+    private static extern void messageCreateEventArgsMentionedChannelsSetter(MessageCreatedEventArgs messageCreateEventArgs, IReadOnlyList<DiscordChannel> mentionedChannels);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
+    private static extern DiscordMessage messageConstructor();
+
+    [UnsafeAccessor(UnsafeAccessorKind.Constructor)]
+    private static extern DiscordMessage messageConstructor(DiscordMessage message);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Content")]
+    private static extern void messageContentSetter(DiscordMessage message, string content);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Channel")]
+    private static extern void messageChannelSetter(DiscordMessage message, DiscordChannel channel);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_ChannelId")]
+    private static extern void messageChannelIdSetter(DiscordMessage message, ulong channelId);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_guildId")]
+    private static extern void messageGuildIdSetter(DiscordMessage message, ulong? guildId);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Author")]
+    private static extern void messageAuthorSetter(DiscordMessage message, DiscordUser author);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "mentionedUsers")]
+    private static extern ref List<DiscordUser> messageMentionedUsersSetter(DiscordMessage message);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "mentionedRoles")]
+    private static extern ref List<DiscordRole> messageMentionedRolesSetter(DiscordMessage message);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "mentionedChannels")]
+    private static extern ref List<DiscordChannel> messageMentionedChannelsSetter(DiscordMessage message);
 
     /// <summary>
     /// Creates a shallow copy of a Discord message.
     /// </summary>
     /// <param name="message">The message to copy.</param>
     /// <returns>A shallow copy of the message.</returns>
-    public static DiscordMessage Copy(this DiscordMessage message) => _messageConstructor(message);
+    public static DiscordMessage Copy(this DiscordMessage message) => messageConstructor(message);
 
     /// <summary>
     /// Creates a fake message created event args object with the specified content.
@@ -60,11 +93,11 @@ internal static partial class TextExtensions
         messageCopy.ModifyMessageProperties(content, context.Client, context.User, context.Channel, context.Guild);
 
         // Create the message created event args.
-        MessageCreatedEventArgs messageCreateEventArgs = _messageCreateEventArgsConstructor();
-        _messageCreateEventArgsMessageSetter(messageCreateEventArgs, messageCopy);
-        _messageCreateEventArgsMentionedUsersSetter(messageCreateEventArgs, message.MentionedUsers);
-        _messageCreateEventArgsMentionedRolesSetter(messageCreateEventArgs, message.MentionedRoles);
-        _messageCreateEventArgsMentionedChannelsSetter(messageCreateEventArgs, message.MentionedChannels);
+        MessageCreatedEventArgs messageCreateEventArgs = messageCreateEventArgsConstructor();
+        messageCreateEventArgsMessageSetter(messageCreateEventArgs, messageCopy);
+        messageCreateEventArgsMentionedUsersSetter(messageCreateEventArgs, messageCopy.MentionedUsers);
+        messageCreateEventArgsMentionedRolesSetter(messageCreateEventArgs, messageCopy.MentionedRoles);
+        messageCreateEventArgsMentionedChannelsSetter(messageCreateEventArgs, messageCopy.MentionedChannels);
 
         // Return the message created event args, which can be used for argument conversion or command execution.
         return messageCreateEventArgs;
@@ -79,14 +112,20 @@ internal static partial class TextExtensions
     /// <param name="user">The new author of the message.</param>
     /// <param name="channel">The new channel of the message.</param>
     /// <param name="guild">The guild to use for fetching roles.</param>
-    public static void ModifyMessageProperties(this DiscordMessage message, string content, DiscordClient client, DiscordUser user, DiscordChannel channel, DiscordGuild? guild = null)
+    public static void ModifyMessageProperties(
+        this DiscordMessage message,
+        string content,
+        DiscordClient client,
+        DiscordUser user,
+        DiscordChannel channel,
+        DiscordGuild? guild = null)
     {
         List<DiscordRole> roleMentions = [];
         List<DiscordUser> userMentions = [];
         List<DiscordChannel> channelMentions = [];
         if (guild is not null)
         {
-            MatchCollection roleMatches = _roleMentionRegex().Matches(content);
+            MatchCollection roleMatches = roleMentionRegex().Matches(content);
             foreach (Match match in roleMatches.Cast<Match>())
             {
                 if (ulong.TryParse(match.Groups[1].Value, out ulong roleId) && guild.GetRole(roleId) is DiscordRole role)
@@ -95,7 +134,7 @@ internal static partial class TextExtensions
                 }
             }
 
-            MatchCollection userMatches = _userMentionRegex().Matches(content);
+            MatchCollection userMatches = userMentionRegex().Matches(content);
             foreach (Match match in userMatches.Cast<Match>())
             {
                 if (ulong.TryParse(match.Groups[1].Value, out ulong userId))
@@ -105,7 +144,7 @@ internal static partial class TextExtensions
             }
         }
 
-        MatchCollection channelMatches = _channelMentionRegex().Matches(content);
+        MatchCollection channelMatches = channelMentionRegex().Matches(content);
         foreach (Match match in channelMatches.Cast<Match>())
         {
             if (ulong.TryParse(match.Groups[1].Value, out ulong channelId))
@@ -124,13 +163,13 @@ internal static partial class TextExtensions
             }
         }
 
-        _messageContentSetter(message, content);
-        _messageChannelSetter(message, channel);
-        _messageChannelIdSetter(message, channel.Id);
-        _messageGuildIdSetter(message, channel.GuildId);
-        _messageAuthorSetter(message, user);
-        _messageMentionedUsersSetter(message) = userMentions;
-        _messageMentionedRolesSetter(message) = roleMentions;
-        _messageMentionedChannelsSetter(message) = channelMentions;
+        messageContentSetter(message, content);
+        messageChannelSetter(message, channel);
+        messageChannelIdSetter(message, channel.Id);
+        messageGuildIdSetter(message, channel.GuildId);
+        messageAuthorSetter(message, user);
+        messageMentionedUsersSetter(message) = userMentions;
+        messageMentionedRolesSetter(message) = roleMentions;
+        messageMentionedChannelsSetter(message) = channelMentions;
     }
 }

--- a/DSharpPlus.Commands/Processors/TextCommands/TextExtensions.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextExtensions.cs
@@ -24,7 +24,9 @@ internal static partial class TextExtensions
     [UnsafeAccessor(UnsafeAccessorKind.Constructor)] private static extern DiscordMessage _messageConstructor();
     [UnsafeAccessor(UnsafeAccessorKind.Constructor)] private static extern DiscordMessage _messageConstructor(DiscordMessage message);
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Content")] private static extern void _messageContentSetter(DiscordMessage message, string content);
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Channel")] private static extern void _messageChannelSetter(DiscordMessage message, DiscordChannel channel);
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_ChannelId")] private static extern void _messageChannelIdSetter(DiscordMessage message, ulong channelId);
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_guildId")] private static extern void _messageGuildIdSetter(DiscordMessage message, ulong? guildId);
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Author")] private static extern void _messageAuthorSetter(DiscordMessage message, DiscordUser author);
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "mentionedUsers")] private static extern ref List<DiscordUser> _messageMentionedUsersSetter(DiscordMessage message);
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "mentionedRoles")] private static extern ref List<DiscordRole> _messageMentionedRolesSetter(DiscordMessage message);
@@ -59,7 +61,7 @@ internal static partial class TextExtensions
 
         // Create the message created event args.
         MessageCreatedEventArgs messageCreateEventArgs = _messageCreateEventArgsConstructor();
-        _messageCreateEventArgsMessageSetter(messageCreateEventArgs, message);
+        _messageCreateEventArgsMessageSetter(messageCreateEventArgs, messageCopy);
         _messageCreateEventArgsMentionedUsersSetter(messageCreateEventArgs, message.MentionedUsers);
         _messageCreateEventArgsMentionedRolesSetter(messageCreateEventArgs, message.MentionedRoles);
         _messageCreateEventArgsMentionedChannelsSetter(messageCreateEventArgs, message.MentionedChannels);
@@ -123,7 +125,9 @@ internal static partial class TextExtensions
         }
 
         _messageContentSetter(message, content);
+        _messageChannelSetter(message, channel);
         _messageChannelIdSetter(message, channel.Id);
+        _messageGuildIdSetter(message, channel.GuildId ?? 0);
         _messageAuthorSetter(message, user);
         _messageMentionedUsersSetter(message) = userMentions;
         _messageMentionedRolesSetter(message) = roleMentions;

--- a/DSharpPlus.Commands/Processors/TextCommands/TextExtensions.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextExtensions.cs
@@ -127,7 +127,7 @@ internal static partial class TextExtensions
         _messageContentSetter(message, content);
         _messageChannelSetter(message, channel);
         _messageChannelIdSetter(message, channel.Id);
-        _messageGuildIdSetter(message, channel.GuildId ?? 0);
+        _messageGuildIdSetter(message, channel.GuildId);
         _messageAuthorSetter(message, user);
         _messageMentionedUsersSetter(message) = userMentions;
         _messageMentionedRolesSetter(message) = roleMentions;

--- a/DSharpPlus.Commands/Processors/TextCommands/TextExtensions.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextExtensions.cs
@@ -113,13 +113,15 @@ internal static partial class TextExtensions
     /// <param name="user">The new author of the message.</param>
     /// <param name="channel">The new channel of the message.</param>
     /// <param name="guild">The guild to use for fetching roles.</param>
-    public static async ValueTask ModifyMessagePropertiesAsync(
+    public static async ValueTask ModifyMessagePropertiesAsync
+    (
         this DiscordMessage message,
         string content,
         DiscordClient client,
         DiscordUser user,
         DiscordChannel channel,
-        DiscordGuild? guild = null)
+        DiscordGuild? guild = null
+    )
     {
         List<DiscordRole> roleMentions = [];
         List<DiscordUser> userMentions = [];

--- a/DSharpPlus.Commands/Processors/TextCommands/TextExtensions.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 using DSharpPlus.Exceptions;
@@ -79,7 +80,7 @@ internal static partial class TextExtensions
     /// <param name="message">The message to use as a base for the new message.</param>
     /// <param name="content">The content of the new message.</param>
     /// <returns>The created message created event args object.</returns>
-    public static MessageCreatedEventArgs CreateFakeMessageEventArgs(CommandContext context, DiscordMessage message, string content)
+    public static async ValueTask<MessageCreatedEventArgs> CreateFakeMessageEventArgsAsync(CommandContext context, DiscordMessage message, string content)
     {
         ArgumentNullException.ThrowIfNull(context, nameof(context));
         ArgumentNullException.ThrowIfNull(message, nameof(message));
@@ -90,7 +91,7 @@ internal static partial class TextExtensions
         DiscordMessage messageCopy = message.Copy();
 
         // Modify the copied message to contain the contents that the user wants.
-        messageCopy.ModifyMessageProperties(content, context.Client, context.User, context.Channel, context.Guild);
+        await messageCopy.ModifyMessagePropertiesAsync(content, context.Client, context.User, context.Channel, context.Guild);
 
         // Create the message created event args.
         MessageCreatedEventArgs messageCreateEventArgs = messageCreateEventArgsConstructor();
@@ -112,7 +113,7 @@ internal static partial class TextExtensions
     /// <param name="user">The new author of the message.</param>
     /// <param name="channel">The new channel of the message.</param>
     /// <param name="guild">The guild to use for fetching roles.</param>
-    public static void ModifyMessageProperties(
+    public static async ValueTask ModifyMessagePropertiesAsync(
         this DiscordMessage message,
         string content,
         DiscordClient client,
@@ -139,7 +140,7 @@ internal static partial class TextExtensions
             {
                 if (ulong.TryParse(match.Groups[1].Value, out ulong userId))
                 {
-                    userMentions.Add(client.GetUserAsync(userId).GetAwaiter().GetResult());
+                    userMentions.Add(await client.GetUserAsync(userId));
                 }
             }
         }
@@ -152,7 +153,7 @@ internal static partial class TextExtensions
                 DiscordChannel? mentionedChannel;
                 try
                 {
-                    mentionedChannel = client.GetChannelAsync(channelId).GetAwaiter().GetResult();
+                    mentionedChannel = await client.GetChannelAsync(channelId);
                 }
                 catch (DiscordException)
                 {

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -58,6 +58,7 @@ public class DiscordMessage : SnowflakeObject, IEquatable<DiscordMessage>
         this.Timestamp = other.Timestamp;
         this.WebhookId = other.WebhookId;
         this.ApplicationId = other.ApplicationId;
+        this.Components = other.Components;
     }
 
     /// <summary>


### PR DESCRIPTION
# Summary
In order to use any functionality of `TextCommandProcessor` you must have a `MessageCreateEventArgs` available. Currently, users cannot create any entities or event args. If the dev wants to run a command as another user or parse event arguments, they must create event args through reflection. This PR does that for them.

# Notes
Tested.