### PR TITLE
Remove (leftover?) assert

### DIFF
--- a/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
@@ -66,8 +66,6 @@ public class DiscordInteraction : SnowflakeObject
                 return cachedChannel;
             }
 
-            Trace.Assert(this.GuildId is null, "GuildId is not null, but channel is not cached.");
-
             return new DiscordDmChannel
             {
                 Id = this.ChannelId,


### PR DESCRIPTION
Remove the assert introduced in https://github.com/DSharpPlus/DSharpPlus/pull/2036
This is being tripped up in a user-app context where Guild would not exist in the guild cache.