### PR TITLE
Fix commands not registering on startup

### DIFF
--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -87,10 +87,10 @@ public sealed class CommandsExtension : BaseExtension
     /// <summary>
     /// Executed everytime a command is finished executing.
     /// </summary>
-    public event AsyncEventHandler<CommandsExtension, CommandExecutedEventArgs> CommandExecuted 
-    { 
-        add => this.commandExecuted.Register(value); 
-        remove => this.commandExecuted.Unregister(value); 
+    public event AsyncEventHandler<CommandsExtension, CommandExecutedEventArgs> CommandExecuted
+    {
+        add => this.commandExecuted.Register(value);
+        remove => this.commandExecuted.Unregister(value);
     }
 
     internal AsyncEvent<CommandsExtension, CommandExecutedEventArgs> commandExecuted;
@@ -98,10 +98,10 @@ public sealed class CommandsExtension : BaseExtension
     /// <summary>
     /// Executed everytime a command has errored.
     /// </summary>
-    public event AsyncEventHandler<CommandsExtension, CommandErroredEventArgs> CommandErrored 
-    { 
-        add => this.commandErrored.Register(value); 
-        remove => this.commandErrored.Unregister(value); 
+    public event AsyncEventHandler<CommandsExtension, CommandErroredEventArgs> CommandErrored
+    {
+        add => this.commandErrored.Register(value);
+        remove => this.commandErrored.Unregister(value);
     }
 
     internal AsyncEvent<CommandsExtension, CommandErroredEventArgs> commandErrored;
@@ -215,15 +215,15 @@ public sealed class CommandsExtension : BaseExtension
     /// <returns>Returns a list of valid commands. This list can be empty if no commands are valid for this processor type</returns>
     public IReadOnlyList<Command> GetCommandsForProcessor(ICommandProcessor processor)
     {
-        // Those processors use a different attribute to filter and filter themself 
+        // Those processors use a different attribute to filter and filter themself
         if (processor is MessageCommandProcessor or UserCommandProcessor)
         {
             return this.Commands.Values.ToList();
         }
-        
+
         Type contextType = processor.ContextType;
         Type processorType = processor.GetType();
-        
+
         List<Command> commands = new(this.Commands.Values.Count());
 
         foreach (Command command in this.Commands.Values)
@@ -254,7 +254,7 @@ public sealed class CommandsExtension : BaseExtension
                 return null;
             }
         }
-        
+
         List<Command> subCommands = new(command.Subcommands.Count);
         foreach (Command subcommand in command.Subcommands)
         {
@@ -279,8 +279,7 @@ public sealed class CommandsExtension : BaseExtension
     {
         foreach (ICommandProcessor processor in processors)
         {
-            this.processors.Add(processor.GetType(), processor);
-            await processor.ConfigureAsync(this);
+            await AddProcessorAsync(processor);
         }
     }
 
@@ -435,7 +434,7 @@ public sealed class CommandsExtension : BaseExtension
     public async Task RefreshAsync()
     {
         BuildCommands();
-        
+
         if (this.RegisterDefaultCommandProcessors)
         {
             this.processors.TryAdd(typeof(TextCommandProcessor), new TextCommandProcessor());
@@ -498,23 +497,23 @@ public sealed class CommandsExtension : BaseExtension
         // Error message
         stringBuilder.Append(eventArgs.Exception switch
         {
-            CommandNotFoundException commandNotFoundException 
+            CommandNotFoundException commandNotFoundException
                 => $"Command {Formatter.InlineCode(Formatter.Sanitize(commandNotFoundException.CommandName))} was not found.",
-            ArgumentParseException argumentParseException 
+            ArgumentParseException argumentParseException
                 => $"Failed to parse argument {Formatter.InlineCode(Formatter.Sanitize(argumentParseException.Parameter.Name))}.",
-            ChecksFailedException checksFailedException when checksFailedException.Errors.Count == 1 
+            ChecksFailedException checksFailedException when checksFailedException.Errors.Count == 1
                 => $"The following error occurred: {Formatter.InlineCode(Formatter.Sanitize(checksFailedException.Errors[0].ErrorMessage))}",
-            ChecksFailedException checksFailedException 
+            ChecksFailedException checksFailedException
                 => $"The following context checks failed: {Formatter.InlineCode(Formatter.Sanitize(string.Join("\n\n", checksFailedException.Errors.Select(x => x.ErrorMessage))))}.",
             ParameterChecksFailedException checksFailedException when checksFailedException.Errors.Count == 1
                 => $"The following error occurred: {Formatter.InlineCode(Formatter.Sanitize(checksFailedException.Errors[0].ErrorMessage))}",
             ParameterChecksFailedException checksFailedException
                 => $"The following context checks failed: {Formatter.InlineCode(Formatter.Sanitize(string.Join("\n\n", checksFailedException.Errors.Select(x => x.ErrorMessage))))}.",
-            DiscordException discordException when discordException.Response is not null 
-                && (int)discordException.Response.StatusCode >= 500 
-                && (int)discordException.Response.StatusCode < 600 
+            DiscordException discordException when discordException.Response is not null
+                && (int)discordException.Response.StatusCode >= 500
+                && (int)discordException.Response.StatusCode < 600
                 => $"Discord API error {discordException.Response.StatusCode} occurred: {discordException.JsonMessage ?? "No further information was provided."}",
-            DiscordException discordException when discordException.Response is not null 
+            DiscordException discordException when discordException.Response is not null
             => $"Discord API error {discordException.Response.StatusCode} occurred: {discordException.JsonMessage ?? discordException.Message}",
             _ => $"An unexpected error occurred: {eventArgs.Exception.Message}"
         });

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandConfiguration.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandConfiguration.cs
@@ -1,0 +1,17 @@
+namespace DSharpPlus.Commands.Processors.SlashCommands;
+
+/// <summary>
+/// The configuration for the <see cref="SlashCommandProcessor"/>.
+/// </summary>
+public sealed class SlashCommandConfiguration
+{
+    /// <summary>
+    /// Whether to register <see cref="CommandsExtension.Commands"/> in their
+    /// application command form and map them back to their original commands.
+    /// </summary>
+    /// <remarks>
+    /// Set this to <see langword="false"/> if you want to manually register
+    /// commands or obtain your application commands from a different source.
+    /// </remarks>
+    public bool RegisterCommands { get; init; } = true;
+}

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -50,7 +50,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
     private static partial Regex NameLocalizationRegex();
 
     [GeneratedRegex("^.{1,100}$")]
-    private static partial Regex DescrtiptionLocalizationRegex();
+    private static partial Regex DescriptionLocalizationRegex();
 
     private bool configured;
     private bool registered;
@@ -939,7 +939,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
                 );
             }
 
-            if (!DescrtiptionLocalizationRegex().IsMatch(descriptionLocalization.Key))
+            if (!DescriptionLocalizationRegex().IsMatch(descriptionLocalization.Key))
             {
                 throw new InvalidOperationException
                 (
@@ -957,7 +957,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
             );
         }
 
-        if (!string.IsNullOrWhiteSpace(command.Description) && !DescrtiptionLocalizationRegex().IsMatch(command.Description))
+        if (!string.IsNullOrWhiteSpace(command.Description) && !DescriptionLocalizationRegex().IsMatch(command.Description))
         {
             throw new InvalidOperationException
             (

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -49,9 +49,6 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
     [GeneratedRegex(@"^[-_\p{L}\p{N}\p{IsDevanagari}\p{IsThai}]{1,32}$")]
     private static partial Regex NameLocalizationRegex();
 
-    [GeneratedRegex("^.{1,100}$")]
-    private static partial Regex DescriptionLocalizationRegex();
-
     private bool configured;
     private bool registered;
 
@@ -939,13 +936,20 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
                 );
             }
 
-            if (!DescriptionLocalizationRegex().IsMatch(descriptionLocalization.Key))
+            if (descriptionLocalization.Key.Length is < 1 or > 100)
             {
                 throw new InvalidOperationException
                 (
-                    $"Slash command failed validation: {command.Name} description localization key contains invalid characters.\n" +
-                    $"(Description localization key ({descriptionLocalization.Key}) contains invalid characters)"
+                    $"Slash command failed validation: {command.Name} description localization key is longer than 100 characters.\n" +
+                    $"(Description localization key ({descriptionLocalization.Key}) is {descriptionLocalization.Key.Length - 100} characters too long)"
                 );
+
+                // Come back to this when we have actual validation that does more than a length check
+                //throw new InvalidOperationException
+                //(
+                //    $"Slash command failed validation: {command.Name} description localization key contains invalid characters.\n" +
+                //    $"(Description localization key ({descriptionLocalization.Key}) contains invalid characters)"
+                //);
             }
         }
 
@@ -957,12 +961,18 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
             );
         }
 
-        if (!string.IsNullOrWhiteSpace(command.Description) && !DescriptionLocalizationRegex().IsMatch(command.Description))
+        if (command.Description?.Length is < 1 or > 100)
         {
             throw new InvalidOperationException
             (
-                $"Slash command failed validation: {command.Name} description contains invalid characters."
+                $"Slash command failed validation: {command.Name} description is longer than 100 characters."
             );
+
+            // Come back to this when we have actual validation that does more than a length check
+            //throw new InvalidOperationException
+            //(
+            //    $"Slash command failed validation: {command.Name} description contains invalid characters."
+            //);
         }
     }
 }

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -69,8 +69,11 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
             extension.Client.InteractionCreated += ExecuteInteractionAsync;
         }
 
-        // ConfigureAsync is called everytime DiscordClient.SessionCreated is invoked
-        await RegisterSlashCommandsAsync(extension);
+        if (!this.registered)
+        {
+            // ConfigureAsync is called everytime DiscordClient.SessionCreated is invoked
+            await RegisterSlashCommandsAsync(extension);
+        }
     }
 
     public async Task ExecuteInteractionAsync(DiscordClient client, InteractionCreatedEventArgs eventArgs)

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -67,8 +67,10 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
         {
             this.configured = true;
             extension.Client.InteractionCreated += ExecuteInteractionAsync;
-            extension.Client.SessionCreated += async (client, eventArgs) => await RegisterSlashCommandsAsync(extension);
         }
+
+        // ConfigureAsync is called everytime DiscordClient.SessionCreated is invoked
+        await RegisterSlashCommandsAsync(extension);
     }
 
     public async Task ExecuteInteractionAsync(DiscordClient client, InteractionCreatedEventArgs eventArgs)

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -36,7 +36,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
     public IReadOnlyDictionary<ulong, Command> ApplicationCommandMapping => applicationCommandMapping;
 
     /// <inheritdoc/>
-    public override IReadOnlyList<Command> Commands => [.. this.ApplicationCommandMapping.Values];
+    public override IReadOnlyList<Command> Commands => applicationCommandMapping.Values;
 
     /// <summary>
     /// The configuration values being used for this processor.

--- a/DSharpPlus.Tests/Commands/CommandFiltering/Tests.cs
+++ b/DSharpPlus.Tests/Commands/CommandFiltering/Tests.cs
@@ -17,25 +17,29 @@ public class Tests
 {
     private static CommandsExtension extension = null!;
     private static TextCommandProcessor textCommandProcessor = new();
-    private static SlashCommandProcessor slashCommandProcessor = new();
+    private static SlashCommandProcessor slashCommandProcessor = new(new()
+    {
+        RegisterCommands = false
+    });
+
     private static UserCommandProcessor userCommandProcessor = new();
     private static MessageCommandProcessor messageCommandProcessor = new();
-    
+
     [OneTimeSetUp]
     public static async Task CreateExtensionAsync()
     {
         DiscordClient client = DiscordClientBuilder.CreateDefault("faketoken", DiscordIntents.None).Build();
-        
+
         extension = client.UseCommands(new CommandsConfiguration()
         {
             RegisterDefaultCommandProcessors = false
         });
-        
+
         await extension.AddProcessorAsync(textCommandProcessor);
         await extension.AddProcessorAsync(slashCommandProcessor);
         await extension.AddProcessorAsync(userCommandProcessor);
         await extension.AddProcessorAsync(messageCommandProcessor);
-        
+
         extension.AddCommands([typeof(TestMultiLevelSubCommandsFiltered.RootCommand), typeof(TestMultiLevelSubCommandsFiltered.ContextMenues), typeof(TestMultiLevelSubCommandsFiltered.ContextMenuesInGroup)]);
         extension.BuildCommands();
         await userCommandProcessor.ConfigureAsync(extension);
@@ -46,10 +50,10 @@ public class Tests
     public static void TestSubGroupTextProcessor()
     {
         IReadOnlyList<Command> commands = extension.GetCommandsForProcessor(textCommandProcessor);
-        
+
         Command? root = commands.FirstOrDefault(x => x.Name == "root");
         Assert.That(root, Is.Not.Null);
-        
+
         Assert.That(root.Subcommands, Has.Count.EqualTo(2));
         Assert.That(root.Subcommands[0].Name, Is.EqualTo("subgroup"));
         Assert.That(root.Subcommands[1].Name, Is.EqualTo("subgroup-text-only"));
@@ -58,22 +62,22 @@ public class Tests
         Assert.That(generalGroup.Subcommands, Has.Count.EqualTo(2));
         Assert.That(generalGroup.Subcommands[0].Name, Is.EqualTo("command-text-only-attribute"));
         Assert.That(generalGroup.Subcommands[1].Name, Is.EqualTo("command-text-only-parameter"));
-        
+
         Command textGroup = root.Subcommands[1];
         Assert.That(textGroup.Subcommands, Has.Count.EqualTo(2));
         Assert.That(textGroup.Subcommands[0].Name, Is.EqualTo("text-only-group"));
         Assert.That(textGroup.Subcommands[1].Name, Is.EqualTo("text-only-group2"));
     }
-    
+
     [Test]
     public static void TestSubGroupSlashProcessor()
     {
         IReadOnlyList<Command> commands = extension.GetCommandsForProcessor(slashCommandProcessor);
-        
+
         //toplevel command "root"
         Command? root = commands.FirstOrDefault(x => x.Name == "root");
         Assert.That(root, Is.Not.Null);
-        
+
         Assert.That(root.Subcommands, Has.Count.EqualTo(2));
         Assert.That(root.Subcommands[0].Name, Is.EqualTo("subgroup"));
         Assert.That(root.Subcommands[1].Name, Is.EqualTo("subgroup-slash-only"));
@@ -84,7 +88,7 @@ public class Tests
         Assert.That(generalGroup.Subcommands, Has.Count.EqualTo(2));
         Assert.That(generalGroup.Subcommands[0].Name, Is.EqualTo("command-slash-only-attribute"));
         Assert.That(generalGroup.Subcommands[1].Name, Is.EqualTo("command-slash-only-parameter"));
-        
+
         Assert.That(slashGroup.Subcommands, Has.Count.EqualTo(2));
         Assert.That(slashGroup.Subcommands[0].Name, Is.EqualTo("slash-only-group"));
         Assert.That(slashGroup.Subcommands[1].Name, Is.EqualTo("slash-only-group2"));
@@ -94,17 +98,17 @@ public class Tests
     public static void TestUserContextMenu()
     {
         IReadOnlyList<Command> userContextCommands = userCommandProcessor.Commands;
-        
+
         Command? contextOnlyCommand = userContextCommands.FirstOrDefault(x => x.Name == "UserContextOnly");
         Assert.That(contextOnlyCommand, Is.Not.Null);
-        
+
         Command? bothCommand = userContextCommands.FirstOrDefault(x => x.Name == "SlashUserContext");
         Assert.That(bothCommand, Is.Not.Null);
-        
+
         IReadOnlyList<Command> slashCommands = extension.GetCommandsForProcessor(slashCommandProcessor);
         Assert.That(slashCommands.FirstOrDefault(x => x.Name == "SlashUserContext"), Is.Not.Null);
     }
-    
+
     [Test]
     public static void TestMessageContextMenu()
     {
@@ -112,43 +116,43 @@ public class Tests
 
         Command? contextOnlyCommand = messageContextCommands.FirstOrDefault(x => x.Name == "MessageContextOnly");
         Assert.That(contextOnlyCommand, Is.Not.Null);
-        
+
         Command? bothCommand = messageContextCommands.FirstOrDefault(x => x.Name == "SlashMessageContext");
         Assert.That(bothCommand, Is.Not.Null);
-        
+
         IReadOnlyList<Command> slashCommands = extension.GetCommandsForProcessor(slashCommandProcessor);
         Assert.That(slashCommands.FirstOrDefault(x => x.Name == "SlashMessageContext"), Is.Not.Null);
     }
-    
+
     [Test]
     public static void TestUserContextMenuInGroup()
     {
         IReadOnlyList<Command> userContextCommands = userCommandProcessor.Commands;
-        
+
         Command? contextOnlyCommand = userContextCommands.FirstOrDefault(x => x.FullName == "group UserContextOnly");
         Assert.That(contextOnlyCommand, Is.Not.Null);
-        
+
         Command? bothCommand = userContextCommands.FirstOrDefault(x => x.FullName == "group SlashUserContext");
         Assert.That(bothCommand, Is.Not.Null);
-        
+
         IReadOnlyList<Command> slashCommands = extension.GetCommandsForProcessor(slashCommandProcessor);
         Command? group = slashCommands.FirstOrDefault(x => x.Name == "group");
         Assert.That(group, Is.Not.Null);
         Assert.That(group.Subcommands.Any(x => x.Name == "SlashUserContext"));
-        
+
     }
-    
+
     [Test]
     public static void TestMessageContextMenuInGroup()
     {
         IReadOnlyList<Command> messageContextCommands = messageCommandProcessor.Commands;
-        
+
         Command? contextOnlyCommand = messageContextCommands.FirstOrDefault(x => x.FullName == "group MessageContextOnly");
         Assert.That(contextOnlyCommand, Is.Not.Null);
-        
+
         Command? bothCommand = messageContextCommands.FirstOrDefault(x => x.FullName == "group SlashMessageContext");
         Assert.That(bothCommand, Is.Not.Null);
-        
+
         IReadOnlyList<Command> slashCommands = extension.GetCommandsForProcessor(slashCommandProcessor);
         Command? group = slashCommands.FirstOrDefault(x => x.Name == "group");
         Assert.That(group, Is.Not.Null);

--- a/DSharpPlus.Tests/DSharpPlus.Tests.csproj
+++ b/DSharpPlus.Tests/DSharpPlus.Tests.csproj
@@ -1,18 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="NUnit" />
-        <PackageReference Include="NUnit.Analyzers" />
-        <PackageReference Include="NUnit3TestAdapter" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="$(ProjectRoot)\DSharpPlus\DSharpPlus.csproj" />
-        <ProjectReference Include="$(ProjectRoot)\DSharpPlus.Commands\DSharpPlus.Commands.csproj" />
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit.Analyzers" />
+    <PackageReference Include="NUnit3TestAdapter" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(ProjectRoot)\DSharpPlus\DSharpPlus.csproj" />
+    <ProjectReference Include="$(ProjectRoot)\DSharpPlus.Commands\DSharpPlus.Commands.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
# Summary
Previously commands were registered on startup via `GuildDownloadCompleted`. https://github.com/DSharpPlus/DSharpPlus/pull/2019 changed this to be every `SessionCreated`. However `ICommandProcessor.ConfigureAsync` is invoked everytime `SessionCreated` is invoked. This meant that when `SessionCreated` the first time, the event handler to register application commands was then added to `SessionCreated`, meaning the client had to reconnect in order to register application commands.

Now the client only needs to connect once instead of twice to register application commands.

# Notes
Tested.