### PR TITLE
New DisableCommandNotFoundException for the text processor

### DIFF
--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandConfiguration.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandConfiguration.cs
@@ -10,10 +10,15 @@ public record TextCommandConfiguration
     /// The function to use to resolve prefixes for commands.
     /// </summary>
     /// <remarks>For dynamic prefix resolving, <see cref="IPrefixResolver"/> registered to the <see cref="DiscordClient"/>'s <see cref="IServiceProvider"/> should be preferred.</remarks>
-    public ResolvePrefixDelegateAsync PrefixResolver { get; init; } = new DefaultPrefixResolver(true,"!").ResolvePrefixAsync;
+    public ResolvePrefixDelegateAsync PrefixResolver { get; init; } = new DefaultPrefixResolver(true, "!").ResolvePrefixAsync;
     public TextArgumentSplicer TextArgumentSplicer { get; init; } = DefaultTextArgumentSplicer.Splice;
     public char[] QuoteCharacters { get; init; } = ['"', '\'', '«', '»', '‘', '“', '„', '‟'];
     public bool IgnoreBots { get; init; } = true;
+
+    /// <summary>
+    /// Disables the exception thrown when a command is not found.
+    /// </summary>
+    public bool DisableCommandNotFoundException { get; init; }
 
     /// <summary>
     /// Whether to suppress the missing message content intent warning.

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandConfiguration.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandConfiguration.cs
@@ -18,7 +18,7 @@ public record TextCommandConfiguration
     /// <summary>
     /// Disables the exception thrown when a command is not found.
     /// </summary>
-    public bool DisableCommandNotFoundException { get; init; }
+    public bool EnableCommandNotFoundException { get; init; }
 
     /// <summary>
     /// Whether to suppress the missing message content intent warning.

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -124,7 +124,7 @@ public sealed class TextCommandProcessor : BaseCommandProcessor<MessageCreatedEv
         if (command is null ||
             (command.GuildIds.Count > 0 && !command.GuildIds.Contains(eventArgs.Guild?.Id ?? 0)))
         {
-            if (configuration!.EnableCommandNotFoundException)
+            if (this.Configuration!.EnableCommandNotFoundException)
             {
                 await this.extension.commandErrored.InvokeAsync(this.extension, new CommandErroredEventArgs()
                 {
@@ -191,7 +191,7 @@ public sealed class TextCommandProcessor : BaseCommandProcessor<MessageCreatedEv
             Command? defaultGroupCommand = command.Subcommands.FirstOrDefault(subcommand => subcommand.Attributes.OfType<DefaultGroupCommandAttribute>().Any());
             if (defaultGroupCommand is null)
             {
-                if (configuration!.EnableCommandNotFoundException)
+                if (this.Configuration!.EnableCommandNotFoundException)
                 {
                     await this.extension.commandErrored.InvokeAsync(this.extension, new CommandErroredEventArgs()
                     {

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -124,7 +124,7 @@ public sealed class TextCommandProcessor : BaseCommandProcessor<MessageCreatedEv
         if (command is null ||
             (command.GuildIds.Count > 0 && !command.GuildIds.Contains(eventArgs.Guild?.Id ?? 0)))
         {
-            if (!configuration!.DisableCommandNotFoundException)
+            if (configuration!.EnableCommandNotFoundException)
             {
                 await this.extension.commandErrored.InvokeAsync(this.extension, new CommandErroredEventArgs()
                 {
@@ -191,7 +191,7 @@ public sealed class TextCommandProcessor : BaseCommandProcessor<MessageCreatedEv
             Command? defaultGroupCommand = command.Subcommands.FirstOrDefault(subcommand => subcommand.Attributes.OfType<DefaultGroupCommandAttribute>().Any());
             if (defaultGroupCommand is null)
             {
-                if (!configuration!.DisableCommandNotFoundException)
+                if (configuration!.EnableCommandNotFoundException)
                 {
                     await this.extension.commandErrored.InvokeAsync(this.extension, new CommandErroredEventArgs()
                     {


### PR DESCRIPTION
# Summary
A few people have reported that the command not found error message isn't enjoyable to have by default. With slash commands, this error is a bit difficult to produce and very likely won't happen in production scenarios. For text commands, this error is very common. The new configuration option should be a much more convenient way to ignore the exception rather than disabling the default error handler and providing your own.

# Notes
Untested.