### PR TITLE
Update DiscordPermissions.All

### DIFF
--- a/DSharpPlus/Entities/Application/DiscordApplication.cs
+++ b/DSharpPlus/Entities/Application/DiscordApplication.cs
@@ -92,9 +92,7 @@ public sealed class DiscordApplication : DiscordMessageApplication, IEquatable<D
     /// <summary>
     /// Default scopes and permissions for each supported installation context.
     /// </summary>
-    public IReadOnlyDictionary<DiscordApplicationIntegrationType, DiscordApplicationIntegrationTypeConfiguration>?
-        IntegrationTypeConfigurations
-    { get; internal set; }
+    public IReadOnlyDictionary<DiscordApplicationIntegrationType, DiscordApplicationIntegrationTypeConfiguration>? IntegrationTypeConfigurations { get; internal set; }
 
     /// <summary>
     /// Guild associated with the app. For example, a developer support server.

--- a/DSharpPlus/Entities/Application/DiscordApplication.cs
+++ b/DSharpPlus/Entities/Application/DiscordApplication.cs
@@ -78,14 +78,14 @@ public sealed class DiscordApplication : DiscordMessageApplication, IEquatable<D
     /// Gets the team which owns this application.
     /// </summary>
     public DiscordTeam? Team { get; internal set; }
-    
+
     /// <summary>
     /// Public key used to verify http interactions
     /// </summary>
     public string VerifyKey { get; internal set; }
-    
+
     /// <summary>
-    /// Partial user object for the bot user associated with the app. 
+    /// Partial user object for the bot user associated with the app.
     /// </summary>
     public DiscordUser? Bot { get; internal set; }
 
@@ -93,43 +93,44 @@ public sealed class DiscordApplication : DiscordMessageApplication, IEquatable<D
     /// Default scopes and permissions for each supported installation context.
     /// </summary>
     public IReadOnlyDictionary<DiscordApplicationIntegrationType, DiscordApplicationIntegrationTypeConfiguration>?
-        IntegrationTypeConfigurations { get; internal set; }
-    
+        IntegrationTypeConfigurations
+    { get; internal set; }
+
     /// <summary>
     /// Guild associated with the app. For example, a developer support server.
     /// </summary>
     public ulong? GuildId { get; internal set; }
-    
+
     /// <summary>
     /// Partial object of the associated guild
     /// </summary>
     public DiscordGuild? Guild { get; internal set; }
-    
+
     /// <summary>
     /// If this app is a game sold on Discord, this field will be the id of the "Game SKU" that is created, if exists
     /// </summary>
     public ulong? PrimarySkuId { get; internal set; }
-    
+
     /// <summary>
     /// If this app is a game sold on Discord, this field will be the URL slug that links to the store page
     /// </summary>
     public string? Slug { get; internal set; }
-    
+
     /// <summary>
     /// Approximate count of guilds the app has been added to
     /// </summary>
     public int? ApproximateGuildCount { get; internal set; }
-    
+
     /// <summary>
     /// Array of redirect URIs for the app
     /// </summary>
     public string[] RedirectUris { get; internal set; }
-    
+
     /// <summary>
     /// Interactions endpoint URL for the app
     /// </summary>
     public string? InteractionsEndpointUrl { get; internal set; }
-    
+
     /// <summary>
     /// Interactions endpoint URL for the app
     /// </summary>
@@ -139,18 +140,18 @@ public sealed class DiscordApplication : DiscordMessageApplication, IEquatable<D
     /// List of tags describing the content and functionality of the app. Max of 5 tags.
     /// </summary>
     public string[]? Tags { get; internal set; }
-    
+
     /// <summary>
     /// Settings for the app's default in-app authorization link, if enabled
     /// </summary>
     public DiscordApplicationOAuth2InstallParams? InstallParams { get; internal set; }
-    
-    
+
+
     /// <summary>
     /// Default custom authorization URL for the app, if enabled
     /// </summary>
     public string? CustomInstallUrl { get; internal set; }
-    
+
     private IReadOnlyList<DiscordApplicationAsset>? Assets { get; set; }
 
     internal DiscordApplication() { }
@@ -172,9 +173,9 @@ public sealed class DiscordApplication : DiscordMessageApplication, IEquatable<D
         this.CoverImageHash = transportApplication.CoverImageHash;
         this.VerifyKey = transportApplication.VerifyKey;
 
-        this.Bot = transportApplication.Bot is null 
-            ? null 
-            : new DiscordUser(transportApplication.Bot) 
+        this.Bot = transportApplication.Bot is null
+            ? null
+            : new DiscordUser(transportApplication.Bot)
             {
                 Discord = this.Discord
             };
@@ -185,7 +186,7 @@ public sealed class DiscordApplication : DiscordMessageApplication, IEquatable<D
         {
             this.Guild.Discord = this.Discord;
         }
-        
+
         this.PrimarySkuId = transportApplication.PrimarySkuId;
         this.Slug = transportApplication.Slug;
         this.ApproximateGuildCount = transportApplication.ApproximateGuildCount;
@@ -196,7 +197,7 @@ public sealed class DiscordApplication : DiscordMessageApplication, IEquatable<D
         this.InstallParams = transportApplication.InstallParams;
         this.IntegrationTypeConfigurations = transportApplication.IntegrationTypeConfigurations;
         this.CustomInstallUrl = transportApplication.CustomInstallUrl;
-        
+
 
         // do team and owners
         // tbh fuck doing this properly
@@ -292,7 +293,7 @@ public sealed class DiscordApplication : DiscordMessageApplication, IEquatable<D
 
     public string GenerateBotOAuth(DiscordPermissions permissions = DiscordPermissions.None)
     {
-        permissions &= PermissionMethods.FULL_PERMS;
+        permissions &= DiscordPermissions.All;
         // hey look, it's not all annoying and blue :P
         return new QueryUriBuilder("https://discord.com/oauth2/authorize")
             .AddParameter("client_id", this.Id.ToString(CultureInfo.InvariantCulture))
@@ -314,7 +315,7 @@ public sealed class DiscordApplication : DiscordMessageApplication, IEquatable<D
     public string GenerateOAuthUri(string? redirectUri = null, DiscordPermissions? permissions = null,
         params DiscordOAuthScope[] scopes)
     {
-        permissions &= PermissionMethods.FULL_PERMS;
+        permissions &= DiscordPermissions.All;
 
         StringBuilder scopeBuilder = new();
 

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -999,7 +999,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
 
         if (this.Guild.OwnerId == mbr.Id)
         {
-            return PermissionMethods.FULL_PERMS;
+            return DiscordPermissions.All;
         }
 
         DiscordPermissions perms;
@@ -1017,7 +1017,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
         // Administrator grants all permissions and cannot be overridden
         if ((perms & DiscordPermissions.Administrator) == DiscordPermissions.Administrator)
         {
-            return PermissionMethods.FULL_PERMS;
+            return DiscordPermissions.All;
         }
 
         // channel overrides for roles that member is in
@@ -1087,7 +1087,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
         // Administrator grants all permissions and cannot be overridden
         if ((perms & DiscordPermissions.Administrator) == DiscordPermissions.Administrator)
         {
-            return PermissionMethods.FULL_PERMS;
+            return DiscordPermissions.All;
         }
 
         // channel overrides for the @everyone role

--- a/DSharpPlus/Entities/DiscordPermissions.cs
+++ b/DSharpPlus/Entities/DiscordPermissions.cs
@@ -357,7 +357,7 @@ public enum DiscordPermissions : long
     /// Indicates all permissions are granted
     /// </summary>
     [PermissionString("All permissions")]
-    // TODO: When Discord adds a new permission, update this to use the permission with the largest value
+    // TODO: When Discord adds a new permission, update this and prepend the new permission.
     All = UseExternalApps | SendPolls | SendVoiceMessages | UseExternalSounds | CreateEvents | CreateGuildExpressions | UseSoundboard | ViewCreatorMonetizationAnalytics | ModerateMembers | StartEmbeddedActivities | SendMessagesInThreads | UseExternalStickers | CreatePrivateThreads | CreatePublicThreads | ManageThreads | ManageEvents | RequestToSpeak | UseApplicationCommands | ManageEmojis | ManageWebhooks | ManageRoles | ManageNicknames | ChangeNickname | UseVoiceDetection | MoveMembers | DeafenMembers | MuteMembers | Speak | UseVoice | UseExternalEmojis | MentionEveryone | ReadMessageHistory | AttachFiles | EmbedLinks | ManageMessages | SendTtsMessages | SendMessages | AccessChannels | Stream | PrioritySpeaker | ViewAuditLog | AddReactions | ManageGuild | ManageChannels | Administrator | BanMembers | KickMembers | CreateInstantInvite,
 }
 

--- a/DSharpPlus/Entities/DiscordPermissions.cs
+++ b/DSharpPlus/Entities/DiscordPermissions.cs
@@ -4,8 +4,6 @@ namespace DSharpPlus.Entities;
 
 public static class PermissionMethods
 {
-    internal static DiscordPermissions FULL_PERMS { get; } = (DiscordPermissions)0x0006_7FFF_FFFF_FFFF;
-    
     /// <summary>
     /// Calculates whether this permission set contains the given permission.
     /// </summary>
@@ -64,12 +62,6 @@ public enum DiscordPermissions : long
     /// </summary>
     [PermissionString("No permissions")]
     None = 0x0000000000000000,
-
-    /// <summary>
-    /// Indicates all permissions are granted
-    /// </summary>
-    [PermissionString("All permissions")]
-    All = 703687441776639,
 
     /// <summary>
     /// Allows creation of instant channel invites.
@@ -352,7 +344,7 @@ public enum DiscordPermissions : long
     /// </summary>
     [PermissionString("Send Polls")]
     SendPolls = 0x0002000000000000,
-    
+
     /// <summary>
     /// Allows user-installed apps to send public responses.
     /// When disabled, users will still be allowed to use their apps but the responses will be ephemeral.
@@ -360,6 +352,13 @@ public enum DiscordPermissions : long
     /// </summary>
     [PermissionString("Use External Apps")]
     UseExternalApps = 0x0004000000000000,
+
+    /// <summary>
+    /// Indicates all permissions are granted
+    /// </summary>
+    [PermissionString("All permissions")]
+    // TODO: When Discord adds a new permission, update this to use the permission with the largest value
+    All = UseExternalApps | SendPolls | SendVoiceMessages | UseExternalSounds | CreateEvents | CreateGuildExpressions | UseSoundboard | ViewCreatorMonetizationAnalytics | ModerateMembers | StartEmbeddedActivities | SendMessagesInThreads | UseExternalStickers | CreatePrivateThreads | CreatePublicThreads | ManageThreads | ManageEvents | RequestToSpeak | UseApplicationCommands | ManageEmojis | ManageWebhooks | ManageRoles | ManageNicknames | ChangeNickname | UseVoiceDetection | MoveMembers | DeafenMembers | MuteMembers | Speak | UseVoice | UseExternalEmojis | MentionEveryone | ReadMessageHistory | AttachFiles | EmbedLinks | ManageMessages | SendTtsMessages | SendMessages | AccessChannels | Stream | PrioritySpeaker | ViewAuditLog | AddReactions | ManageGuild | ManageChannels | Administrator | BanMembers | KickMembers | CreateInstantInvite,
 }
 
 /// <summary>

--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -604,7 +604,7 @@ public class DiscordMember : DiscordUser, IEquatable<DiscordMember>
     {
         if (this.Guild.OwnerId == this.Id)
         {
-            return PermissionMethods.FULL_PERMS;
+            return DiscordPermissions.All;
         }
 
         DiscordPermissions perms;
@@ -617,6 +617,6 @@ public class DiscordMember : DiscordUser, IEquatable<DiscordMember>
         perms |= this.Roles.Aggregate(DiscordPermissions.None, (c, role) => c | role.Permissions);
 
         // Administrator grants all permissions and cannot be overridden
-        return (perms & DiscordPermissions.Administrator) == DiscordPermissions.Administrator ? PermissionMethods.FULL_PERMS : perms;
+        return (perms & DiscordPermissions.Administrator) == DiscordPermissions.Administrator ? DiscordPermissions.All : perms;
     }
 }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -2660,8 +2660,8 @@ public sealed class DiscordApiClient
         RestChannelPermissionEditPayload pld = new()
         {
             Type = type,
-            Allow = allow & PermissionMethods.FULL_PERMS,
-            Deny = deny & PermissionMethods.FULL_PERMS
+            Allow = allow & DiscordPermissions.All,
+            Deny = deny & DiscordPermissions.All
         };
 
         Dictionary<string, string> headers = [];
@@ -3878,7 +3878,7 @@ public sealed class DiscordApiClient
         RestGuildRolePayload pld = new()
         {
             Name = name,
-            Permissions = permissions & PermissionMethods.FULL_PERMS,
+            Permissions = permissions & DiscordPermissions.All,
             Color = color,
             Hoist = hoist,
             Mentionable = mentionable,
@@ -3964,7 +3964,7 @@ public sealed class DiscordApiClient
         RestGuildRolePayload pld = new()
         {
             Name = name,
-            Permissions = permissions & PermissionMethods.FULL_PERMS,
+            Permissions = permissions & DiscordPermissions.All,
             Color = color,
             Hoist = hoist,
             Mentionable = mentionable,

--- a/DSharpPlus/Utilities.cs
+++ b/DSharpPlus/Utilities.cs
@@ -259,7 +259,7 @@ public static partial class Utilities
             return PermissionStrings[perm];
         }
 
-        perm &= PermissionMethods.FULL_PERMS;
+        perm &= DiscordPermissions.All;
 
         IEnumerable<string> strs = PermissionStrings
             .Where(xkvp => xkvp.Key != DiscordPermissions.None && (perm & xkvp.Key) == xkvp.Key)


### PR DESCRIPTION
# Summary
Updates `DiscordPermissions.All` to use a bitwise combination of all existing members in reversed order, hopefully allowing the next contributor to notice the pattern and to prepend the new member. Also removed `PermissionMethods.FULL_PERMS` since it seemed out of date and seems like it was intended to do the same thing as `DiscordPermissions.All`?