### PR TITLE
Configure contextmenu processors before slashcommand processor

### DIFF
--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -438,8 +438,25 @@ public sealed class CommandsExtension : BaseExtension
             this.processors.TryAdd(typeof(UserCommandProcessor), new UserCommandProcessor());
         }
 
+
+        if (this.processors.TryGetValue(typeof(UserCommandProcessor), out ICommandProcessor userProcessor))
+        {
+            await userProcessor.ConfigureAsync(this);
+        }
+        
+        if (this.processors.TryGetValue(typeof(MessageCommandProcessor), out ICommandProcessor messageProcessor))
+        {
+            await messageProcessor.ConfigureAsync(this);
+        }
+        
         foreach (ICommandProcessor processor in this.processors.Values)
         {
+            Type type = processor.GetType();
+            if (type == typeof(UserCommandProcessor) || type == typeof(MessageCommandProcessor))
+            {
+                continue;
+            }
+            
             await processor.ConfigureAsync(this);
         }
     }

--- a/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandProcessor.cs
@@ -43,7 +43,6 @@ public sealed class MessageCommandProcessor : ICommandProcessor<InteractionCreat
 
         this.extension = extension;
         this.slashCommandProcessor = this.extension.GetProcessor<SlashCommandProcessor>() ?? new SlashCommandProcessor();
-        await this.slashCommandProcessor.ConfigureAsync(this.extension);
 
         ILogger<MessageCommandProcessor> logger = this.extension.ServiceProvider.GetService<ILogger<MessageCommandProcessor>>() ?? NullLogger<MessageCommandProcessor>.Instance;
         List<DiscordApplicationCommand> applicationCommands = [];

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -406,8 +406,9 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
 
         if (!descriptionLocalizations.TryGetValue("en-US", out string? description))
         {
-            description = command.Description;
         }
+        
+        description = command.Description;
 
         if (string.IsNullOrWhiteSpace(description))
         {
@@ -416,7 +417,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
 
         // Create the top level application command.
         return new(
-            name: ToSnakeCase(nameLocalizations.TryGetValue("en-US", out string? name) ? name : command.Name),
+            name: ToSnakeCase(command.Name),
             description: description,
             options: options,
             type: DiscordApplicationCommandType.SlashCommand,
@@ -536,17 +537,10 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
             using AsyncServiceScope scope = this.extension.ServiceProvider.CreateAsyncScope();
             choices = await choiceAttribute.GrabChoicesAsync(scope.ServiceProvider, parameter);
         }
-
-        if (!nameLocalizations.TryGetValue("en-US", out string? name))
-        {
-            name = i.HasValue ? $"{parameter.Name}_{i}" : parameter.Name;
-        }
-
-        if (!descriptionLocalizations.TryGetValue("en-US", out string? description))
-        {
-            description = parameter.Description;
-        }
-
+        
+        string name = i.HasValue ? $"{parameter.Name}_{i}" : parameter.Name;
+        string description = parameter.Description;
+        
         if (string.IsNullOrWhiteSpace(description))
         {
             description = "No description provided.";

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs
@@ -406,9 +406,8 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
 
         if (!descriptionLocalizations.TryGetValue("en-US", out string? description))
         {
+            description = command.Description;
         }
-        
-        description = command.Description;
 
         if (string.IsNullOrWhiteSpace(description))
         {
@@ -417,7 +416,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
 
         // Create the top level application command.
         return new(
-            name: ToSnakeCase(command.Name),
+            name: ToSnakeCase(nameLocalizations.TryGetValue("en-US", out string? name) ? name : command.Name),
             description: description,
             options: options,
             type: DiscordApplicationCommandType.SlashCommand,
@@ -537,10 +536,17 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<Interac
             using AsyncServiceScope scope = this.extension.ServiceProvider.CreateAsyncScope();
             choices = await choiceAttribute.GrabChoicesAsync(scope.ServiceProvider, parameter);
         }
-        
-        string name = i.HasValue ? $"{parameter.Name}_{i}" : parameter.Name;
-        string description = parameter.Description;
-        
+
+        if (!nameLocalizations.TryGetValue("en-US", out string? name))
+        {
+            name = i.HasValue ? $"{parameter.Name}_{i}" : parameter.Name;
+        }
+
+        if (!descriptionLocalizations.TryGetValue("en-US", out string? description))
+        {
+            description = parameter.Description;
+        }
+
         if (string.IsNullOrWhiteSpace(description))
         {
             description = "No description provided.";

--- a/DSharpPlus.Commands/Processors/UserCommands/UserCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/UserCommands/UserCommandProcessor.cs
@@ -43,7 +43,6 @@ public sealed class UserCommandProcessor : ICommandProcessor<InteractionCreatedE
 
         this.extension = extension;
         this.slashCommandProcessor = this.extension.GetProcessor<SlashCommandProcessor>() ?? new SlashCommandProcessor();
-        await this.slashCommandProcessor.ConfigureAsync(this.extension);
 
         ILogger<UserCommandProcessor> logger = this.extension.ServiceProvider.GetService<ILogger<UserCommandProcessor>>() ?? NullLogger<UserCommandProcessor>.Instance;
         List<DiscordApplicationCommand> applicationCommands = [];


### PR DESCRIPTION
# Summary
Context menus were not registered because the slashcommand processor was configured before the other processors.

# Note
This is a bandaid fix. #2057
Also: Tested.