### PR TITLE
expose total and connected shard counts on IShardOrchestrator

### DIFF
--- a/DSharpPlus/Clients/IShardOrchestrator.cs
+++ b/DSharpPlus/Clients/IShardOrchestrator.cs
@@ -37,11 +37,6 @@ public interface IShardOrchestrator
     public ValueTask BroadcastOutboundEventAsync(byte[] payload);
 
     /// <summary>
-    /// Indicates whether all shards are connected.
-    /// </summary>
-    public bool AllShardsConnected { get; }
-
-    /// <summary>
     /// Indicates whether the bot's connection to the given guild is functional.
     /// </summary>
     public bool IsConnected(ulong guildId);
@@ -50,4 +45,19 @@ public interface IShardOrchestrator
     /// Gets the connection latency to a specific guild, otherwise known as ping.
     /// </summary>
     public TimeSpan GetConnectionLatency(ulong guildId);
+
+    /// <summary>
+    /// Indicates whether all shards are connected.
+    /// </summary>
+    public bool AllShardsConnected { get; }
+
+    /// <summary>
+    /// Gets the total amount of shards connected to this bot.
+    /// </summary>
+    public int TotalShardCount { get; }
+
+    /// <summary>
+    /// Gets the amount of shards handled by this orchestrator.
+    /// </summary>
+    public int ConnectedShardCount { get; }
 }

--- a/DSharpPlus/Clients/MultiShardOrchestrator.cs
+++ b/DSharpPlus/Clients/MultiShardOrchestrator.cs
@@ -31,6 +31,24 @@ public sealed class MultiShardOrchestrator : IShardOrchestrator
     /// <inheritdoc/>
     public bool AllShardsConnected => this.shards?.All(shard => shard.IsConnected) == true;
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <remarks>
+    /// This value may be inaccurate before startup. It is guaranteed to be correct by the time the first SessionCreated event
+    /// is fired.
+    /// </remarks>
+    public int TotalShardCount => (int)this.totalShards;
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <remarks>
+    /// This value may be inaccurate before startup. It is guaranteed to be correct by the time the first SessionCreated event
+    /// is fired.
+    /// </remarks>
+    public int ConnectedShardCount => (int)this.shardCount;
+
     public MultiShardOrchestrator
     (
         IServiceProvider serviceProvider, 

--- a/DSharpPlus/Clients/SingleShardOrchestrator.cs
+++ b/DSharpPlus/Clients/SingleShardOrchestrator.cs
@@ -36,6 +36,12 @@ public sealed class SingleShardOrchestrator : IShardOrchestrator
     public bool AllShardsConnected => this.gatewayClient.IsConnected;
 
     /// <inheritdoc/>
+    public int TotalShardCount => 1;
+
+    /// <inheritdoc/>
+    public int ConnectedShardCount => 1;
+
+    /// <inheritdoc/>
     public async ValueTask BroadcastOutboundEventAsync(byte[] payload)
     {
         if (!this.AllShardsConnected)


### PR DESCRIPTION
as it says on the tin.

for MultiShardOrchestrator the values may be incorrect before we check back with Discord whether the value is correct, which is presently guaranteed by SessionCreated firing