### PR TITLE
add a few more control events

### DIFF
--- a/DSharpPlus.Commands/RefreshEventHandler.cs
+++ b/DSharpPlus.Commands/RefreshEventHandler.cs
@@ -4,13 +4,13 @@ using DSharpPlus.EventArgs;
 
 namespace DSharpPlus.Commands;
 
-internal sealed class RefreshEventHandler : IEventHandler<SessionCreatedEventArgs>
+internal sealed class RefreshEventHandler : IEventHandler<ClientStartedEventArgs>
 {
     private readonly CommandsExtension extension;
 
     public RefreshEventHandler(CommandsExtension extension)
         => this.extension = extension;
 
-    public async Task HandleEventAsync(DiscordClient sender, SessionCreatedEventArgs eventArgs)
+    public async Task HandleEventAsync(DiscordClient sender, ClientStartedEventArgs eventArgs)
         => await this.extension.RefreshAsync();
 }

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 
 using DSharpPlus.Clients;
 using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
 using DSharpPlus.Exceptions;
 using DSharpPlus.Net;
 using DSharpPlus.Net.Abstractions;
@@ -23,7 +24,7 @@ using DSharpPlus.Net.WebSocket;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
+
 using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus;
@@ -165,6 +166,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
 
         this.Logger.LogInformation(LoggerEvents.Startup, "DSharpPlus; version {Version}", this.VersionString);
 
+        await this.dispatcher.DispatchAsync(this, new ClientStartedEventArgs());
         _ = ReceiveGatewayEventsAsync();
         await this.orchestrator.StartAsync(activity, status, idlesince);
     }
@@ -204,7 +206,10 @@ public sealed partial class DiscordClient : BaseDiscordClient
     /// </summary>
     /// <returns></returns>
     public async Task DisconnectAsync()
-        => await this.orchestrator.StopAsync();
+    {
+        await this.orchestrator.StopAsync();
+        await this.dispatcher.DispatchAsync(this, new ClientStoppedEventArgs());
+    }
 
     #endregion
 

--- a/DSharpPlus/EventArgs/ClientStartedEventArgs.cs
+++ b/DSharpPlus/EventArgs/ClientStartedEventArgs.cs
@@ -1,0 +1,6 @@
+namespace DSharpPlus.EventArgs;
+
+/// <summary>
+/// Represents an event invoked when the client starts.
+/// </summary>
+public sealed class ClientStartedEventArgs : DiscordEventArgs;

--- a/DSharpPlus/EventArgs/ClientStoppedEventArgs.cs
+++ b/DSharpPlus/EventArgs/ClientStoppedEventArgs.cs
@@ -1,0 +1,6 @@
+namespace DSharpPlus.EventArgs;
+
+/// <summary>
+/// Represents an event fired when the client stops.
+/// </summary>
+public sealed class ClientStoppedEventArgs : DiscordEventArgs;

--- a/DSharpPlus/EventArgs/SessionCreatedEventArgs.cs
+++ b/DSharpPlus/EventArgs/SessionCreatedEventArgs.cs
@@ -6,4 +6,9 @@ namespace DSharpPlus.EventArgs;
 public sealed class SessionCreatedEventArgs : DiscordEventArgs
 {
     internal SessionCreatedEventArgs() : base() { }
+
+    /// <summary>
+    /// The ID of the shard this event occurred on.
+    /// </summary>
+    public int ShardId { get; internal set; }
 }

--- a/DSharpPlus/EventArgs/SessionResumedEventArgs.cs
+++ b/DSharpPlus/EventArgs/SessionResumedEventArgs.cs
@@ -6,4 +6,9 @@ namespace DSharpPlus.EventArgs;
 public sealed class SessionResumedEventArgs : DiscordEventArgs
 {
     internal SessionResumedEventArgs() : base() { }
+
+    /// <summary>
+    /// The ID of the shard this event occurred on.
+    /// </summary>
+    public int ShardId { get; internal set; }
 }

--- a/DSharpPlus/Net/Abstractions/Gateway/GatewayPayload.cs
+++ b/DSharpPlus/Net/Abstractions/Gateway/GatewayPayload.cs
@@ -5,7 +5,7 @@ namespace DSharpPlus.Net.Abstractions;
 /// <summary>
 /// Represents a websocket payload exchanged between Discord and the client.
 /// </summary>
-public sealed class GatewayPayload
+public class GatewayPayload
 {
     /// <summary>
     /// Gets or sets the OP code of the payload.

--- a/DSharpPlus/Net/Abstractions/Gateway/ShardIdContainingGatewayPayload.cs
+++ b/DSharpPlus/Net/Abstractions/Gateway/ShardIdContainingGatewayPayload.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Net.Abstractions;
+
+/// <summary>
+/// Internal implementation detail to communicate shard IDs between IGatewayClient and dispatch.
+/// </summary>
+internal sealed class ShardIdContainingGatewayPayload : GatewayPayload
+{
+    /// <summary>
+    /// Gets the shard ID that invoked this event.
+    /// </summary>
+    [JsonIgnore]
+    public int ShardId { get; internal set; }
+}

--- a/DSharpPlus/Net/Gateway/DefaultGatewayController.cs
+++ b/DSharpPlus/Net/Gateway/DefaultGatewayController.cs
@@ -12,5 +12,14 @@ internal class DefaultGatewayController : IGatewayController
     public Task HeartbeatedAsync(IGatewayClient client) => Task.CompletedTask;
 
     /// <inheritdoc/>
-    public ValueTask ZombiedAsync(IGatewayClient client) => ValueTask.CompletedTask;
+    public Task ReconnectFailedAsync(IGatewayClient client) => Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public Task ReconnectRequestedAsync(IGatewayClient client) => Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public Task SessionInvalidatedAsync(IGatewayClient client) => Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public Task ZombiedAsync(IGatewayClient client) => Task.CompletedTask;
 }

--- a/DSharpPlus/Net/Gateway/GatewayClient.cs
+++ b/DSharpPlus/Net/Gateway/GatewayClient.cs
@@ -54,6 +54,9 @@ public sealed class GatewayClient : IGatewayClient
     /// <inheritdoc/>
     public TimeSpan Ping { get; private set; }
 
+    /// <inheritdoc/>
+    public int ShardId => this.shardInfo?.ShardId ?? 0;
+
     public GatewayClient
     (
         [FromKeyedServices("DSharpPlus.Gateway.EventChannel")]
@@ -251,7 +254,7 @@ public sealed class GatewayClient : IGatewayClient
 
             if (this.pendingHeartbeats > 5)
             {
-                await this.controller.ZombiedAsync(this);
+                _ = this.controller.ZombiedAsync(this);
             }
         } while (await timer.WaitForNextTickAsync(ct));
     }
@@ -317,6 +320,7 @@ public sealed class GatewayClient : IGatewayClient
                         if (!success)
                         {
                             this.logger.LogError("The session was invalidated and resuming/reconnecting failed.");
+                            _ = this.controller.SessionInvalidatedAsync(this);
                         }
 
                         break;
@@ -324,10 +328,12 @@ public sealed class GatewayClient : IGatewayClient
                     case GatewayOpCode.Reconnect:
 
                         this.logger.LogTrace("Received RECONNECT");
+                        _ = this.controller.ReconnectRequestedAsync(this);
 
                         if (!(this.options.AutoReconnect && await TryReconnectAsync()))
                         {
                             this.logger.LogError("A reconnection attempt requested by Discord failed.");
+                            _ = this.controller.ReconnectFailedAsync(this);
                         }
 
                         continue;

--- a/DSharpPlus/Net/Gateway/GatewayClient.cs
+++ b/DSharpPlus/Net/Gateway/GatewayClient.cs
@@ -296,9 +296,31 @@ public sealed class GatewayClient : IGatewayClient
                         this.resumeUrl = readyPayload.ResumeGatewayUrl;
                         this.sessionId = readyPayload.SessionId;
 
+                        payload = new ShardIdContainingGatewayPayload
+                        {
+                            Data = payload.Data,
+                            EventName = payload.EventName,
+                            OpCode = payload.OpCode,
+                            Sequence = payload.Sequence,
+                            ShardId = this.ShardId
+                        };
+
                         this.IsConnected = true;
 
                         this.logger.LogTrace("Received READY, the gateway is now operational.");
+
+                        break;
+
+                    case GatewayOpCode.Resume:
+
+                        payload = new ShardIdContainingGatewayPayload
+                        {
+                            Data = payload.Data,
+                            EventName = payload.EventName,
+                            OpCode = payload.OpCode,
+                            Sequence = payload.Sequence,
+                            ShardId = this.ShardId
+                        };
 
                         break;
 

--- a/DSharpPlus/Net/Gateway/IGatewayClient.cs
+++ b/DSharpPlus/Net/Gateway/IGatewayClient.cs
@@ -52,4 +52,9 @@ public interface IGatewayClient
     /// Indicates the latency between this client and Discord.
     /// </summary>
     public TimeSpan Ping { get; }
+
+    /// <summary>
+    /// Gets the shard ID of this client. Defaults to zero if not sharding.
+    /// </summary>
+    public int ShardId { get; }
 }

--- a/DSharpPlus/Net/Gateway/IGatewayController.cs
+++ b/DSharpPlus/Net/Gateway/IGatewayController.cs
@@ -11,11 +11,29 @@ public interface IGatewayController
     /// Called when the gateway connection zombies.
     /// </summary>
     /// <param name="client">The gateway client whose connection zombied.</param>
-    public ValueTask ZombiedAsync(IGatewayClient client);
+    public Task ZombiedAsync(IGatewayClient client);
 
     /// <summary>
     /// Called when the gateway heartbeated correctly and got an ACK from Discord
     /// </summary>
     /// <param name="client">The gateway client who recieved the heartbeat ACK.</param>
     public Task HeartbeatedAsync(IGatewayClient client);
+
+    /// <summary>
+    /// Called when Discord requests a reconnect. This does not imply that DSharpPlus' reconnection attempt failed.
+    /// </summary>
+    /// <param name="client">The gateway client reconnection was requested from.</param>
+    public Task ReconnectRequestedAsync(IGatewayClient client);
+
+    /// <summary>
+    /// Called when a reconnecting attempt definitively failed and DSharpPlus can no longer reconnect on its own.
+    /// </summary>
+    /// <param name="client">The gateway client reconnection was requested from.</param>
+    public Task ReconnectFailedAsync(IGatewayClient client);
+
+    /// <summary>
+    /// Called when a session was invalidated and DSharpPlus failed to resume or reconnect.
+    /// </summary>
+    /// <param name="client">The gateway client reconnection was requested from.</param>
+    public Task SessionInvalidatedAsync(IGatewayClient client);
 }

--- a/DSharpPlus/Net/Gateway/ReconnectingGatewayController.cs
+++ b/DSharpPlus/Net/Gateway/ReconnectingGatewayController.cs
@@ -11,5 +11,14 @@ public sealed class ReconnectingGatewayController : IGatewayController
     public Task HeartbeatedAsync(IGatewayClient client) => Task.CompletedTask;
 
     /// <inheritdoc/>
-    public async ValueTask ZombiedAsync(IGatewayClient client) => await client.ReconnectAsync();
+    public Task ReconnectFailedAsync(IGatewayClient client) => Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public Task ReconnectRequestedAsync(IGatewayClient client) => Task.CompletedTask;
+
+    /// <inheritdoc/>
+    public async Task SessionInvalidatedAsync(IGatewayClient client) => await client.ReconnectAsync();
+
+    /// <inheritdoc/>
+    public async Task ZombiedAsync(IGatewayClient client) => await client.ReconnectAsync();
 }


### PR DESCRIPTION
more specifically, GatewayClient will now inform users about requested reconnects and whether reconnecting succeeded, and we now have ClientStarted and ClientStopped events that are fired exactly once per lifetime

also, SessionCreated and SessionResumed now expose the shard ID (which makes some sense to have there)

closes #2027