### PR TITLE
expose the guild IDs in SessionCreated

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -702,7 +702,8 @@ public sealed partial class DiscordClient
             this,
             new()
             {
-                ShardId = shardId
+                ShardId = shardId,
+                GuildIds = [.. guilds.Select(guild => guild.Id)]
             }
         );
 

--- a/DSharpPlus/EventArgs/SessionCreatedEventArgs.cs
+++ b/DSharpPlus/EventArgs/SessionCreatedEventArgs.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace DSharpPlus.EventArgs;
 
 /// <summary>
@@ -11,4 +13,11 @@ public sealed class SessionCreatedEventArgs : DiscordEventArgs
     /// The ID of the shard this event occurred on.
     /// </summary>
     public int ShardId { get; internal set; }
+
+    /// <summary>
+    /// Gets the IDs of guilds connected to the shard that created this session. Note that DiscordGuild objects may
+    /// not yet be available by the time this event is fired, and if you require access to any objects, you should wait
+    /// for GuildDownloadCompleted.
+    /// </summary>
+    public IReadOnlyList<ulong> GuildIds { get; internal set; }
 }


### PR DESCRIPTION
the event is significantly less useful without knowing what guilds it affects, especially in multi-process sharding contexts but also in regular in-process sharding