### PR TITLE
fix channel cache issues caused by #2036

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -961,9 +961,9 @@ public sealed partial class DiscordClient : BaseDiscordClient
 
     internal DiscordChannel? InternalGetCachedChannel(ulong channelId, ulong? guildId)
     {
-        if (guildId is not { } nonNullGuildID)
+        if (guildId is not ulong nonNullGuildID)
         {
-            return this.privateChannels.GetValueOrDefault(channelId);
+            return this.privateChannels.GetValueOrDefault(channelId) ?? InternalGetCachedChannel(channelId);
         }
 
         if (this.guilds.TryGetValue(nonNullGuildID, out DiscordGuild? guild))

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -971,7 +971,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
             return guild.Channels.GetValueOrDefault(channelId);
         }
 
-        return null;
+        return InternalGetCachedChannel(channelId);
     }
 
     internal DiscordGuild InternalGetCachedGuild(ulong? guildId)

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -5992,7 +5992,9 @@ public sealed class DiscordApiClient
         RestResponse res = await this.rest.ExecuteRequestAsync(request);
         DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
 
+        ret.Channel = (this.discord as DiscordClient).InternalGetCachedChannel(ret.ChannelId);
         ret.Discord = this.discord!;
+
         return ret;
     }
 


### PR DESCRIPTION
adds a fallback to perform the slower but clearly less error-prone search if the fast search didn't yield any results

closes #2076 
closes #2060 