### PR TITLE
feat(core)!: CreateInteractionResponse now returns a message 🎉

### DIFF
--- a/DSharpPlus.Commands/CommandContext.cs
+++ b/DSharpPlus.Commands/CommandContext.cs
@@ -22,10 +22,10 @@ public abstract record CommandContext : AbstractContext
     protected Dictionary<ulong, DiscordMessage> followupMessages = [];
 
     /// <inheritdoc cref="RespondAsync(string, DiscordEmbed)"/>
-    public virtual ValueTask RespondAsync(string content) => RespondAsync(new DiscordMessageBuilder().WithContent(content));
+    public virtual ValueTask<DiscordMessage> RespondAsync(string content) => RespondAsync(new DiscordMessageBuilder().WithContent(content));
 
     /// <inheritdoc cref="RespondAsync(string, DiscordEmbed)"/>
-    public virtual ValueTask RespondAsync(DiscordEmbed embed) => RespondAsync(new DiscordMessageBuilder().AddEmbed(embed));
+    public virtual ValueTask<DiscordMessage> RespondAsync(DiscordEmbed embed) => RespondAsync(new DiscordMessageBuilder().AddEmbed(embed));
 
     /// <summary>
     /// Creates a response to this interaction.
@@ -33,11 +33,11 @@ public abstract record CommandContext : AbstractContext
     /// </summary>
     /// <param name="content">Content to send in the response.</param>
     /// <param name="embed">Embed to send in the response.</param>
-    public virtual ValueTask RespondAsync(string content, DiscordEmbed embed) => RespondAsync(new DiscordMessageBuilder().WithContent(content).AddEmbed(embed));
+    public virtual ValueTask<DiscordMessage> RespondAsync(string content, DiscordEmbed embed) => RespondAsync(new DiscordMessageBuilder().WithContent(content).AddEmbed(embed));
 
     /// <inheritdoc cref="RespondAsync(string, DiscordEmbed)"/>
     /// <param name="builder">The message builder.</param>
-    public abstract ValueTask RespondAsync(IDiscordMessageBuilder builder);
+    public abstract ValueTask<DiscordMessage> RespondAsync(IDiscordMessageBuilder builder);
 
     /// <inheritdoc cref="EditResponseAsync(string, DiscordEmbed)"/>
     public virtual ValueTask<DiscordMessage> EditResponseAsync(string content) => EditResponseAsync(new DiscordMessageBuilder().WithContent(content));

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandContext.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandContext.cs
@@ -11,7 +11,7 @@ public sealed record TextCommandContext : CommandContext
     public bool Delayed { get; private set; }
 
     /// <inheritdoc />
-    public override async ValueTask RespondAsync(IDiscordMessageBuilder builder)
+    public override async ValueTask<DiscordMessage> RespondAsync(IDiscordMessageBuilder builder)
     {
         DiscordMessageBuilder messageBuilder = new(builder);
 
@@ -27,7 +27,7 @@ public sealed record TextCommandContext : CommandContext
             messageBuilder.WithAllowedMentions(Mentions.None);
         }
 
-        this.Response = await this.Channel.SendMessageAsync(messageBuilder);
+        return this.Response = await this.Channel.SendMessageAsync(messageBuilder);
     }
 
     /// <inheritdoc />

--- a/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteraction.cs
@@ -168,7 +168,7 @@ public class DiscordInteraction : SnowflakeObject
     /// </summary>
     /// <param name="type">The type of the response.</param>
     /// <param name="builder">The data, if any, to send.</param>
-    public virtual async Task CreateResponseAsync(DiscordInteractionResponseType type, DiscordInteractionResponseBuilder builder = null)
+    public virtual async Task<DiscordMessage> CreateResponseAsync(DiscordInteractionResponseType type, DiscordInteractionResponseBuilder builder = null)
     {
         if (this.ResponseState is not DiscordInteractionResponseState.Unacknowledged)
         {
@@ -179,7 +179,7 @@ public class DiscordInteraction : SnowflakeObject
             ? DiscordInteractionResponseState.Deferred
             : DiscordInteractionResponseState.Replied;
 
-        await this.Discord.ApiClient.CreateInteractionResponseAsync(this.Id, this.Token, type, builder);
+        return await this.Discord.ApiClient.CreateInteractionResponseAsync(this.Id, this.Token, type, builder);
     }
 
     /// <summary>

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -5884,7 +5884,7 @@ public sealed class DiscordApiClient
         await this.rest.ExecuteRequestAsync(request);
     }
 
-    internal async ValueTask CreateInteractionResponseAsync
+    internal async ValueTask<DiscordMessage> CreateInteractionResponseAsync
     (
         ulong interactionId,
         string interactionToken,
@@ -5934,7 +5934,7 @@ public sealed class DiscordApiClient
         }
 
         string route = $"{Endpoints.INTERACTIONS}/{interactionId}/:interaction_token/{Endpoints.CALLBACK}";
-        string url = $"{Endpoints.INTERACTIONS}/{interactionId}/{interactionToken}/{Endpoints.CALLBACK}";
+        string url = $"{Endpoints.INTERACTIONS}/{interactionId}/{interactionToken}/{Endpoints.CALLBACK}?with_response=true";
 
         if (builder is not null && builder.Files.Count != 0)
         {
@@ -5950,7 +5950,14 @@ public sealed class DiscordApiClient
 
             try
             {
-                await this.rest.ExecuteRequestAsync(request);
+                RestResponse ret = await this.rest.ExecuteRequestAsync(request);
+
+                DiscordMessage res = JsonConvert.DeserializeObject<DiscordMessage>(ret.Response!)!;
+
+                res.Channel = (this.discord as DiscordClient)!.InternalGetCachedChannel(res.ChannelId);
+                res.Discord = this.discord!;
+
+                return res;
             }
             finally
             {
@@ -5968,7 +5975,14 @@ public sealed class DiscordApiClient
                 IsExemptFromGlobalLimit = true
             };
 
-            await this.rest.ExecuteRequestAsync(request);
+            RestResponse res = await this.rest.ExecuteRequestAsync(request);
+
+            DiscordMessage ret = JsonConvert.DeserializeObject<DiscordMessage>(res.Response!)!;
+
+            ret.Channel = (this.discord as DiscordClient)!.InternalGetCachedChannel(ret.ChannelId);
+            ret.Discord = this.discord!;
+
+            return ret;
         }
     }
 


### PR DESCRIPTION
BREAKING-CHANGE: APIs that involve directly creating an interaction response have had their signatures changed from `[Value]Task` to `[Value]Task<DiscordMessage>` - this is a small, but technically-breaking change for consumers who both have explicitly-typed variables, and do not immediately `await` the result of creating a response.

This also affects DSharpPlus.Commands, as the APIs for creating responses have been unified - now both slash and text commands can return a message, allowing this to be changed at the base class.

(Unfortunately, this also means that HTTP Interactions must make an additional API call to retrieve the original message)

Anyway, thanks advaith. Very epic.