### PR TITLE
Add support for fetching localized command data via query parameters

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -564,9 +564,10 @@ public sealed partial class DiscordClient : BaseDiscordClient
     /// <summary>
     /// Gets all the global application commands for this application.
     /// </summary>
+    /// <param name="withLocalizations">Whether to include localizations in the response.</param>
     /// <returns>A list of global application commands.</returns>
-    public async Task<IReadOnlyList<DiscordApplicationCommand>> GetGlobalApplicationCommandsAsync() =>
-        await this.ApiClient.GetGlobalApplicationCommandsAsync(this.CurrentApplication.Id);
+    public async Task<IReadOnlyList<DiscordApplicationCommand>> GetGlobalApplicationCommandsAsync(bool withLocalizations = false) =>
+        await this.ApiClient.GetGlobalApplicationCommandsAsync(this.CurrentApplication.Id, withLocalizations);
 
     /// <summary>
     /// Overwrites the existing global application commands. New commands are automatically created and missing commands are automatically deleted.
@@ -596,10 +597,11 @@ public sealed partial class DiscordClient : BaseDiscordClient
     /// Gets a global application command by its name.
     /// </summary>
     /// <param name="commandName">The name of the command to get.</param>
+    /// <param name="withLocalizations">Whether to include localizations in the response.</param>
     /// <returns>The command with the name.</returns>
-    public async Task<DiscordApplicationCommand> GetGlobalApplicationCommandAsync(string commandName)
+    public async Task<DiscordApplicationCommand> GetGlobalApplicationCommandAsync(string commandName, bool withLocalizations = false)
     {
-        foreach (DiscordApplicationCommand command in await this.ApiClient.GetGlobalApplicationCommandsAsync(this.CurrentApplication.Id))
+        foreach (DiscordApplicationCommand command in await this.ApiClient.GetGlobalApplicationCommandsAsync(this.CurrentApplication.Id, withLocalizations))
         {
             if (command.Name == commandName)
             {
@@ -635,9 +637,10 @@ public sealed partial class DiscordClient : BaseDiscordClient
     /// Gets all the application commands for a guild.
     /// </summary>
     /// <param name="guildId">The ID of the guild to get application commands for.</param>
+    /// <param name="withLocalizations">Whether to include localizations in the response.</param>
     /// <returns>A list of application commands in the guild.</returns>
-    public async Task<IReadOnlyList<DiscordApplicationCommand>> GetGuildApplicationCommandsAsync(ulong guildId) =>
-        await this.ApiClient.GetGuildApplicationCommandsAsync(this.CurrentApplication.Id, guildId);
+    public async Task<IReadOnlyList<DiscordApplicationCommand>> GetGuildApplicationCommandsAsync(ulong guildId, bool withLocalizations = false) =>
+        await this.ApiClient.GetGuildApplicationCommandsAsync(this.CurrentApplication.Id, guildId, withLocalizations);
 
     /// <summary>
     /// Overwrites the existing application commands in a guild. New commands are automatically created and missing commands are automatically deleted.

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -2307,9 +2307,10 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     /// <summary>
     /// Gets all the application commands in this guild.
     /// </summary>
+    /// <param name="withLocalizations">Whether to include localizations in the response.</param>
     /// <returns>A list of application commands in this guild.</returns>
-    public async Task<IReadOnlyList<DiscordApplicationCommand>> GetApplicationCommandsAsync() =>
-        await this.Discord.ApiClient.GetGuildApplicationCommandsAsync(this.Discord.CurrentApplication.Id, this.Id);
+    public async Task<IReadOnlyList<DiscordApplicationCommand>> GetApplicationCommandsAsync(bool withLocalizations = false) =>
+        await this.Discord.ApiClient.GetGuildApplicationCommandsAsync(this.Discord.CurrentApplication.Id, this.Id, withLocalizations);
 
     /// <summary>
     /// Overwrites the existing application commands in this guild. New commands are automatically created and missing commands are automatically delete
@@ -2352,10 +2353,11 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     /// Gets a application command in this guild by its name.
     /// </summary>
     /// <param name="commandName">The name of the command to get.</param>
+    /// <param name="withLocalizations">Whether to include localizations in the response.</param>
     /// <returns>The command with the name. This is null when the command is not found</returns>
-    public async Task<DiscordApplicationCommand?> GetApplicationCommandAsync(string commandName)
+    public async Task<DiscordApplicationCommand?> GetApplicationCommandAsync(string commandName, bool withLocalizations = false)
     {
-        foreach (DiscordApplicationCommand command in await this.Discord.ApiClient.GetGlobalApplicationCommandsAsync(this.Discord.CurrentApplication.Id))
+        foreach (DiscordApplicationCommand command in await this.Discord.ApiClient.GetGlobalApplicationCommandsAsync(this.Discord.CurrentApplication.Id, withLocalizations))
         {
             if (command.Name == commandName)
             {

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
@@ -72,11 +72,17 @@ public sealed class DiscordApplicationCommand : SnowflakeObject, IEquatable<Disc
     [JsonProperty("version")]
     public ulong Version { get; internal set; }
 
+    /// <summary>
+    /// Gets the localization dictionary for the <see cref="Name"/> field.
+    /// </summary>
     [JsonProperty("name_localizations")]
-    public IReadOnlyDictionary<string, string> NameLocalizations { get; internal set; }
+    public IReadOnlyDictionary<string, string>? NameLocalizations { get; internal set; }
 
+    /// <summary>
+    /// Gets the localization dictionary for the <see cref="Description"/> field.
+    /// </summary>
     [JsonProperty("description_localizations")]
-    public IReadOnlyDictionary<string, string> DescriptionLocalizations { get; internal set; }
+    public IReadOnlyDictionary<string, string>? DescriptionLocalizations { get; internal set; }
 
     /// <summary>
     /// Contexts in which this command can be invoked.

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -5470,21 +5470,27 @@ public sealed class DiscordApiClient
     #region Application Commands
     internal async ValueTask<IReadOnlyList<DiscordApplicationCommand>> GetGlobalApplicationCommandsAsync
     (
-        ulong applicationId
+        ulong applicationId,
+        bool withLocalizations = false
     )
     {
         string route = $"{Endpoints.APPLICATIONS}/:application_id/{Endpoints.COMMANDS}";
-        string url = $"{Endpoints.APPLICATIONS}/{applicationId}/{Endpoints.COMMANDS}";
+        QueryUriBuilder builder = new($"{Endpoints.APPLICATIONS}/{applicationId}/{Endpoints.COMMANDS}");
+
+        if (withLocalizations)
+        {
+            builder.AddParameter("with_localizations", "true");
+        }
 
         RestRequest request = new()
         {
             Route = route,
-            Url = url,
+            Url = builder.Build(),
             Method = HttpMethod.Get
         };
 
         RestResponse res = await this.rest.ExecuteRequestAsync(request);
-
+        
         IEnumerable<DiscordApplicationCommand> ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response!)!;
         foreach (DiscordApplicationCommand app in ret)
         {
@@ -5680,16 +5686,22 @@ public sealed class DiscordApiClient
     internal async ValueTask<IReadOnlyList<DiscordApplicationCommand>> GetGuildApplicationCommandsAsync
     (
         ulong applicationId,
-        ulong guildId
+        ulong guildId,
+        bool withLocalizations = false
     )
     {
         string route = $"{Endpoints.APPLICATIONS}/:application_id/{Endpoints.GUILDS}/:guild_id/{Endpoints.COMMANDS}";
-        string url = $"{Endpoints.APPLICATIONS}/{applicationId}/{Endpoints.GUILDS}/{guildId}/{Endpoints.COMMANDS}";
+        QueryUriBuilder builder = new($"{Endpoints.APPLICATIONS}/{applicationId}/{Endpoints.GUILDS}/{guildId}/{Endpoints.COMMANDS}");
+
+        if (withLocalizations)
+        {
+            builder.AddParameter("with_localizations", "true");
+        }
 
         RestRequest request = new()
         {
             Route = route,
-            Url = url,
+            Url = builder.Build(),
             Method = HttpMethod.Get
         };
 

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -5490,7 +5490,7 @@ public sealed class DiscordApiClient
         };
 
         RestResponse res = await this.rest.ExecuteRequestAsync(request);
-        
+
         IEnumerable<DiscordApplicationCommand> ret = JsonConvert.DeserializeObject<IEnumerable<DiscordApplicationCommand>>(res.Response!)!;
         foreach (DiscordApplicationCommand app in ret)
         {


### PR DESCRIPTION
This PR add support for the optional query parameter `with_localizations`, allowing the retrieval of localization data when fetching all commands at once from the following endpoints:
- [Get Global Application Commands](https://discord.com/developers/docs/interactions/application-commands#get-global-application-commands)
- [Get Guild Application Commands](https://discord.com/developers/docs/interactions/application-commands#get-guild-application-commands)