### PR TITLE
Expose properties on edit entity models

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -35,10 +35,10 @@ public class DiscordRestClient : BaseDiscordClient
     public DiscordRestClient(RestClientOptions options, string token, TokenType tokenType, ILogger? logger = null) : base()
     {
         string headerTokenType = tokenType == TokenType.Bot ? "Bot" : "Bearer";
-        
+
         HttpClient httpClient = new();
         httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Authorization", $"{headerTokenType} {token}");
-        
+
         this.ApiClient = new(new
         (
             httpClient,
@@ -343,7 +343,7 @@ public class DiscordRestClient : BaseDiscordClient
 
         return await this.ApiClient.ModifyGuildAsync(guildId, mdl.Name, mdl.Region.IfPresent(x => x.Id), mdl.VerificationLevel, mdl.DefaultMessageNotifications,
             mdl.MfaLevel, mdl.ExplicitContentFilter, mdl.AfkChannel.IfPresent(x => x?.Id), mdl.AfkTimeout, iconb64, mdl.Owner.IfPresent(x => x.Id),
-            splashb64, mdl.SystemChannel.IfPresent(x => x?.Id), bannerb64, mdl.Description, mdl.DiscoverySplash, mdl.Features, mdl.PreferredLocale,
+            splashb64, mdl.SystemChannel.IfPresent(x => x?.Id), bannerb64, mdl.Description, mdl.DiscoverySplash, mdl.Features.Value, mdl.PreferredLocale,
             mdl.PublicUpdatesChannel.IfPresent(e => e?.Id), mdl.RulesChannel.IfPresent(e => e?.Id), mdl.SystemChannelFlags, mdl.AuditLogReason);
     }
 
@@ -574,7 +574,7 @@ public class DiscordRestClient : BaseDiscordClient
     {
         MembershipScreeningEditModel mdl = new();
         action(mdl);
-        return await this.ApiClient.ModifyGuildMembershipScreeningFormAsync(guildId, mdl.Enabled, mdl.Fields, mdl.Description);
+        return await this.ApiClient.ModifyGuildMembershipScreeningFormAsync(guildId, mdl.Enabled, mdl.Fields.Value, mdl.Description);
     }
 
     /// <summary>
@@ -1535,7 +1535,7 @@ public class DiscordRestClient : BaseDiscordClient
     {
         WelcomeScreenEditModel mdl = new();
         action(mdl);
-        return await this.ApiClient.ModifyGuildWelcomeScreenAsync(guildId, mdl.Enabled, mdl.WelcomeChannels, mdl.Description, reason);
+        return await this.ApiClient.ModifyGuildWelcomeScreenAsync(guildId, mdl.Enabled, mdl.WelcomeChannels.Value, mdl.Description, reason);
     }
 
     /// <summary>
@@ -1886,7 +1886,7 @@ public class DiscordRestClient : BaseDiscordClient
         ApplicationCommandEditModel mdl = new();
         action(mdl);
         ulong applicationId = this.CurrentApplication?.Id ?? (await GetCurrentApplicationAsync()).Id;
-        return await this.ApiClient.EditGlobalApplicationCommandAsync(applicationId, commandId, mdl.Name, mdl.Description, mdl.Options, mdl.DefaultPermission, mdl.NSFW, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
+        return await this.ApiClient.EditGlobalApplicationCommandAsync(applicationId, commandId, mdl.Name, mdl.Description, mdl.Options.Value, mdl.DefaultPermission, mdl.NSFW, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
     }
 
     /// <summary>
@@ -1943,7 +1943,7 @@ public class DiscordRestClient : BaseDiscordClient
         ApplicationCommandEditModel mdl = new();
         action(mdl);
         ulong applicationId = this.CurrentApplication?.Id ?? (await GetCurrentApplicationAsync()).Id;
-        return await this.ApiClient.EditGuildApplicationCommandAsync(applicationId, guildId, commandId, mdl.Name, mdl.Description, mdl.Options, mdl.DefaultPermission, mdl.NSFW, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
+        return await this.ApiClient.EditGuildApplicationCommandAsync(applicationId, guildId, commandId, mdl.Name, mdl.Description, mdl.Options.Value, mdl.DefaultPermission, mdl.NSFW, default, default, mdl.AllowDMUsage, mdl.DefaultMemberPermissions);
     }
 
     /// <summary>

--- a/DSharpPlus/Entities/AutoModeration/DiscordAutoModerationRule.cs
+++ b/DSharpPlus/Entities/AutoModeration/DiscordAutoModerationRule.cs
@@ -108,10 +108,10 @@ public class DiscordAutoModerationRule : SnowflakeObject
             model.Name,
             model.EventType,
             model.TriggerMetadata,
-            model.Actions,
+            model.Actions.Value,
             model.Enable,
-            model.ExemptRoles,
-            model.ExemptChannels,
+            model.ExemptRoles.Value,
+            model.ExemptChannels.Value,
             model.AuditLogReason
         );
     }

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -121,15 +121,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     /// </summary>
     /// <param name="skipCache">If set to true this method will skip all caches and always perform a rest api call</param>
     /// <returns>Returns null if the guild has no AFK channel</returns>
-    public async Task<DiscordChannel?> GetAfkChannelAsync(bool skipCache = false)
-    {
-        if (this.AfkChannelId is null)
-        {
-            return null;
-        }
-
-        return await GetChannelAsync(this.AfkChannelId.Value);
-    }
+    public async Task<DiscordChannel?> GetAfkChannelAsync(bool skipCache = false) => this.AfkChannelId is null ? null : await GetChannelAsync(this.AfkChannelId.Value, skipCache);
 
     /// <summary>
     /// Gets the guild's AFK timeout.
@@ -172,15 +164,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     /// </summary>
     /// <param name="skipCache">If set to true this method will skip all caches and always perform a rest api call</param>
     /// <returns>Returns null if the guild has no configured system channel.</returns>
-    public async Task<DiscordChannel?> GetSystemChannelAsync(bool skipCache = false)
-    {
-        if (this.SystemChannelId is null)
-        {
-            return null;
-        }
-
-        return await GetChannelAsync(this.SystemChannelId.Value);
-    }
+    public async Task<DiscordChannel?> GetSystemChannelAsync(bool skipCache = false) => this.SystemChannelId is null ? null : await GetChannelAsync(this.SystemChannelId.Value, skipCache);
 
     /// <summary>
     /// Gets the settings for this guild's system channel.
@@ -199,15 +183,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     /// </summary>
     /// <param name="skipCache">If set to true this method will skip all caches and always perform a rest api call</param>
     ///<returns>Returns null if the guild has no configured safety alerts channel.</returns>
-    public async Task<DiscordChannel?> GetSafetyAlertsChannelAsync(bool skipCache = false)
-    {
-        if (this.SafetyAlertsChannelId is null)
-        {
-            return null;
-        }
-
-        return await GetChannelAsync(this.SafetyAlertsChannelId.Value);
-    }
+    public async Task<DiscordChannel?> GetSafetyAlertsChannelAsync(bool skipCache = false) => this.SafetyAlertsChannelId is null ? null : await GetChannelAsync(this.SafetyAlertsChannelId.Value, skipCache);
 
     /// <summary>
     /// Gets whether this guild's widget is enabled.
@@ -226,15 +202,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     /// </summary>
     /// <param name="skipCache">If set to true this method will skip all caches and always perform a rest api call</param>
     /// <returns>Returns null if the guild has no widget channel configured.</returns>
-    public async Task<DiscordChannel?> GetWidgetChannelAsync(bool skipCache = false)
-    {
-        if (this.WidgetChannelId is null)
-        {
-            return null;
-        }
-
-        return await GetChannelAsync(this.WidgetChannelId.Value);
-    }
+    public async Task<DiscordChannel?> GetWidgetChannelAsync(bool skipCache = false) => this.WidgetChannelId is null ? null : await GetChannelAsync(this.WidgetChannelId.Value, skipCache);
 
     /// <summary>
     /// Id of the rules channel of this guild. Null if the guild has no configured rules channel.
@@ -248,15 +216,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     /// </summary>
     /// <param name="skipCache">If set to true this method will skip all caches and always perform a rest api call</param>
     /// <returns>Returns null if the guild has no rules channel configured</returns>
-    public async Task<DiscordChannel?> GetRulesChannelAsync(bool skipCache = false)
-    {
-        if (this.RulesChannelId is null)
-        {
-            return null;
-        }
-
-        return await GetChannelAsync(this.RulesChannelId.Value);
-    }
+    public async Task<DiscordChannel?> GetRulesChannelAsync(bool skipCache = false) => this.RulesChannelId is null ? null : await GetChannelAsync(this.RulesChannelId.Value, skipCache);
 
     /// <summary>
     /// Id of the channel where admins and moderators receive messages from Discord
@@ -270,15 +230,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     /// </summary>
     /// <param name="skipCache">If set to true this method will skip all caches and always perform a rest api call</param>
     /// <returns>Returns null if the guild has no public updates channel configured</returns>
-    public async Task<DiscordChannel?> GetPublicUpdatesChannelAsync(bool skipCache = false)
-    {
-        if (this.PublicUpdatesChannelId is null)
-        {
-            return null;
-        }
-
-        return await GetChannelAsync(this.PublicUpdatesChannelId.Value);
-    }
+    public async Task<DiscordChannel?> GetPublicUpdatesChannelAsync(bool skipCache = false) => this.PublicUpdatesChannelId is null ? null : await GetChannelAsync(this.PublicUpdatesChannelId.Value, skipCache);
 
     /// <summary>
     /// Gets the application ID of this guild if it is bot created.
@@ -972,7 +924,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     )
         => await this.Discord.ApiClient.AddGuildMemberAsync(this.Id, userId, accessToken, muted, deaf, nickname, roles);
 
-        /// <summary>
+    /// <summary>
     /// Adds a new member to this guild
     /// </summary>
     /// <param name="user">User to add</param>
@@ -1093,7 +1045,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
             mdl.VerificationLevel, mdl.DefaultMessageNotifications, mdl.MfaLevel, mdl.ExplicitContentFilter,
             mdl.AfkChannel.IfPresent(e => e?.Id), mdl.AfkTimeout, iconb64, mdl.Owner.IfPresent(e => e.Id), splashb64,
             mdl.SystemChannel.IfPresent(e => e?.Id), bannerb64,
-            mdl.Description, mdl.DiscoverySplash, mdl.Features, mdl.PreferredLocale,
+            mdl.Description, mdl.DiscoverySplash, mdl.Features.Value, mdl.PreferredLocale,
             mdl.PublicUpdatesChannel.IfPresent(e => e?.Id), mdl.RulesChannel.IfPresent(e => e?.Id),
             mdl.SystemChannelFlags, mdl.AuditLogReason);
     }
@@ -1898,13 +1850,9 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
         if (skipCache)
         {
             channel = await this.Discord.ApiClient.GetChannelAsync(id);
-
-            if (channel.GuildId is null || (channel.GuildId is not null && channel.GuildId.Value != this.Id))
-            {
-                throw new InvalidOperationException("The channel exists but does not belong to this guild.");
-            }
-
-            return channel;
+            return channel.GuildId is null || (channel.GuildId is not null && channel.GuildId.Value != this.Id)
+                ? throw new InvalidOperationException("The channel exists but does not belong to this guild.")
+                : channel;
         }
 
         if (this.channels is not null && this.channels.TryGetValue(id, out channel))
@@ -1918,13 +1866,9 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
         }
 
         channel = await this.Discord.ApiClient.GetChannelAsync(id);
-
-        if (channel.GuildId is null || (channel.GuildId is not null && channel.GuildId.Value != this.Id))
-        {
-            throw new InvalidOperationException("The channel exists but does not belong to this guild.");
-        }
-
-        return channel;
+        return channel.GuildId is null || (channel.GuildId is not null && channel.GuildId.Value != this.Id)
+            ? throw new InvalidOperationException("The channel exists but does not belong to this guild.")
+            : channel;
     }
 
     /// <summary>
@@ -2212,7 +2156,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     {
         MembershipScreeningEditModel editModel = new();
         action(editModel);
-        return await this.Discord.ApiClient.ModifyGuildMembershipScreeningFormAsync(this.Id, editModel.Enabled, editModel.Fields, editModel.Description);
+        return await this.Discord.ApiClient.ModifyGuildMembershipScreeningFormAsync(this.Id, editModel.Enabled, editModel.Fields.Value, editModel.Description);
     }
 
     /// <summary>
@@ -2338,7 +2282,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     {
         ApplicationCommandEditModel editModel = new();
         action(editModel);
-        return await this.Discord.ApiClient.EditGuildApplicationCommandAsync(this.Discord.CurrentApplication.Id, this.Id, commandId, editModel.Name, editModel.Description, editModel.Options, editModel.DefaultPermission, editModel.NSFW, default, default, editModel.AllowDMUsage, editModel.DefaultMemberPermissions);
+        return await this.Discord.ApiClient.EditGuildApplicationCommandAsync(this.Discord.CurrentApplication.Id, this.Id, commandId, editModel.Name, editModel.Description, editModel.Options.Value, editModel.DefaultPermission, editModel.NSFW, default, default, editModel.AllowDMUsage, editModel.DefaultMemberPermissions);
     }
 
     /// <summary>
@@ -2388,7 +2332,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     {
         WelcomeScreenEditModel editModel = new();
         action(editModel);
-        return await this.Discord.ApiClient.ModifyGuildWelcomeScreenAsync(this.Id, editModel.Enabled, editModel.WelcomeChannels, editModel.Description, reason);
+        return await this.Discord.ApiClient.ModifyGuildWelcomeScreenAsync(this.Id, editModel.Enabled, editModel.WelcomeChannels.Value, editModel.Description, reason);
     }
 
     /// <summary>
@@ -2499,10 +2443,10 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
             model.Name,
             model.EventType,
             model.TriggerMetadata,
-            model.Actions,
+            model.Actions.Value,
             model.Enable,
-            model.ExemptRoles,
-            model.ExemptChannels,
+            model.ExemptRoles.Value,
+            model.ExemptChannels.Value,
             model.AuditLogReason
         );
     }

--- a/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
@@ -342,7 +342,7 @@ internal class RestGuildMembershipScreeningFormModifyPayload
     public Optional<bool> Enabled { get; set; }
 
     [JsonProperty("form_fields", NullValueHandling = NullValueHandling.Ignore)]
-    public Optional<DiscordGuildMembershipScreeningField[]> Fields { get; set; }
+    public Optional<IReadOnlyList<DiscordGuildMembershipScreeningField>> Fields { get; set; }
 
     [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
     public Optional<string> Description { get; set; }

--- a/DSharpPlus/Net/Models/ApplicationCommandEditModel.cs
+++ b/DSharpPlus/Net/Models/ApplicationCommandEditModel.cs
@@ -4,6 +4,12 @@ using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models;
 
+/// <summary>
+/// Specifies the parameters for modifying an application command.
+/// </summary>
+/// <remarks>
+/// If an <see cref="Optional{T}"/> parameter is not specified, it's state will be left unchanged.
+/// </remarks>
 public class ApplicationCommandEditModel
 {
     /// <summary>
@@ -11,7 +17,7 @@ public class ApplicationCommandEditModel
     /// </summary>
     public Optional<string> Name
     {
-        internal get => this.name;
+        get => this.name;
         set
         {
             if (value.Value.Length > 32)
@@ -30,7 +36,7 @@ public class ApplicationCommandEditModel
     /// </summary>
     public Optional<string> Description
     {
-        internal get => this.description;
+        get => this.description;
         set
         {
             if (value.Value.Length > 100)
@@ -47,25 +53,25 @@ public class ApplicationCommandEditModel
     /// <summary>
     /// Sets the command's new options.
     /// </summary>
-    public Optional<IReadOnlyList<DiscordApplicationCommandOption>> Options { internal get; set; }
+    public Optional<List<DiscordApplicationCommandOption>> Options { get; set; }
 
     /// <summary>
     /// Sets whether the command is enabled by default when the application is added to a guild.
     /// </summary>
-    public Optional<bool?> DefaultPermission { internal get; set; }
+    public Optional<bool?> DefaultPermission { get; set; }
 
     /// <summary>
     /// Sets whether the command can be invoked in DMs.
     /// </summary>
-    public Optional<bool> AllowDMUsage { internal get; set; }
+    public Optional<bool> AllowDMUsage { get; set; }
 
     /// <summary>
     /// Sets the requisite permissions for the command.
     /// </summary>
-    public Optional<DiscordPermissions?> DefaultMemberPermissions { internal get; set; }
+    public Optional<DiscordPermissions?> DefaultMemberPermissions { get; set; }
 
     /// <summary>
     /// Sets whether this command is age restricted.
     /// </summary>
-    public Optional<bool?> NSFW { internal get; set; }
+    public Optional<bool?> NSFW { get; set; }
 }

--- a/DSharpPlus/Net/Models/AutoModerationRuleEditModel.cs
+++ b/DSharpPlus/Net/Models/AutoModerationRuleEditModel.cs
@@ -3,40 +3,46 @@ using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models;
 
+/// <summary>
+/// Specifies the parameters for modifying an auto moderation rule.
+/// </summary>
+/// <remarks>
+/// If an <see cref="Optional{T}"/> parameter is not specified, it's state will be left unchanged.
+/// </remarks>
 public class AutoModerationRuleEditModel : BaseEditModel
 {
     /// <summary>
     /// The new rule name.
     /// </summary>
-    public Optional<string> Name { internal get; set; }
+    public Optional<string> Name { get; set; }
 
     /// <summary>
     /// The new rule event type.
     /// </summary>
-    public Optional<DiscordRuleEventType> EventType { internal get; set; }
+    public Optional<DiscordRuleEventType> EventType { get; set; }
 
     /// <summary>
     /// The new rule trigger metadata.
     /// </summary>
-    public Optional<DiscordRuleTriggerMetadata> TriggerMetadata { internal get; set; }
+    public Optional<DiscordRuleTriggerMetadata> TriggerMetadata { get; set; }
 
     /// <summary>
     /// The new rule actions.
     /// </summary>
-    public Optional<IReadOnlyList<DiscordAutoModerationAction>> Actions { internal get; set; }
+    public Optional<List<DiscordAutoModerationAction>> Actions { get; set; }
 
     /// <summary>
     /// The new rule status.
     /// </summary>
-    public Optional<bool> Enable { internal get; set; }
+    public Optional<bool> Enable { get; set; }
 
     /// <summary>
     /// The new rule exempt roles.
     /// </summary>
-    public Optional<IReadOnlyList<DiscordRole>> ExemptRoles { internal get; set; }
+    public Optional<List<DiscordRole>> ExemptRoles { get; set; }
 
     /// <summary>
     /// The new rule exempt channels.
     /// </summary>
-    public Optional<IReadOnlyList<DiscordChannel>> ExemptChannels { internal get; set; }
+    public Optional<List<DiscordChannel>> ExemptChannels { get; set; }
 }

--- a/DSharpPlus/Net/Models/BaseEditModel.cs
+++ b/DSharpPlus/Net/Models/BaseEditModel.cs
@@ -1,10 +1,12 @@
 namespace DSharpPlus.Net.Models;
 
-
+/// <summary>
+/// The base model for editing objects.
+/// </summary>
 public class BaseEditModel
 {
     /// <summary>
     /// Reason given in audit logs
     /// </summary>
-    public string AuditLogReason { internal get; set; }
+    public string AuditLogReason { get; set; }
 }

--- a/DSharpPlus/Net/Models/ChannelEditModel.cs
+++ b/DSharpPlus/Net/Models/ChannelEditModel.cs
@@ -3,108 +3,114 @@ using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models;
 
+/// <summary>
+/// Specifies the parameters for modifying a channel.
+/// </summary>
+/// <remarks>
+/// If an <see cref="Optional{T}"/> parameter is not specified, it's state will be left unchanged.
+/// </remarks>
 public class ChannelEditModel : BaseEditModel
 {
     /// <summary>
     /// Sets the channel's new name.
     /// </summary>
-    public string Name { internal get; set; }
+    public string Name { get; set; }
 
     /// <summary>
     /// Sets the channel's new position.
     /// </summary>
-    public int? Position { internal get; set; }
+    public int? Position { get; set; }
 
     /// <summary>
     /// Sets the channel's new topic.
     /// </summary>
-    public Optional<string> Topic { internal get; set; }
+    public Optional<string> Topic { get; set; }
 
     /// <summary>
     /// Sets whether the channel is to be marked as NSFW.
     /// </summary>
-    public bool? Nsfw { internal get; set; }
+    public bool? Nsfw { get; set; }
 
     /// <summary>
-    /// <para>Sets the parent of this channel.</para>
-    /// <para>This should be channel with <see cref="DiscordChannel.Type"/> set to <see cref="DiscordChannelType.Category"/>.</para>
+    /// Sets the parent of this channel.
+    /// This should be channel with <see cref="DiscordChannel.Type"/> set to <see cref="DiscordChannelType.Category"/>.
     /// </summary>
-    public Optional<DiscordChannel> Parent { internal get; set; }
+    public Optional<DiscordChannel> Parent { get; set; }
 
     /// <summary>
     /// Sets the voice channel's new bitrate.
     /// </summary>
-    public int? Bitrate { internal get; set; }
+    public int? Bitrate { get; set; }
 
     /// <summary>
-    /// <para>Sets the voice channel's new user limit.</para>
-    /// <para>Setting this to 0 will disable the user limit.</para>
+    /// Sets the voice channel's new user limit.
+    /// Setting this to 0 will disable the user limit.
     /// </summary>
-    public int? Userlimit { internal get; set; }
+    public int? Userlimit { get; set; }
 
     /// <summary>
-    /// <para>Sets the channel's new slow mode timeout.</para>
-    /// <para>Setting this to null or 0 will disable slow mode.</para>
+    /// Sets the channel's new slow mode timeout.
+    /// Setting this to null or 0 will disable slow mode.
     /// </summary>
-    public Optional<int?> PerUserRateLimit { internal get; set; }
+    public Optional<int?> PerUserRateLimit { get; set; }
 
     /// <summary>
-    /// <para>Sets the voice channel's region override.</para>
-    /// <para>Setting this to null will set it to automatic.</para>
+    /// Sets the voice channel's region override.
+    /// Setting this to null will set it to automatic.
     /// </summary>
-    public Optional<DiscordVoiceRegion> RtcRegion { internal get; set; }
+    public Optional<DiscordVoiceRegion> RtcRegion { get; set; }
 
     /// <summary>
-    /// <para>Sets the voice channel's video quality.</para>
+    /// Sets the voice channel's video quality.
     /// </summary>
-    public DiscordVideoQualityMode? QualityMode { internal get; set; }
+    public DiscordVideoQualityMode? QualityMode { get; set; }
 
     /// <summary>
-    /// <para>Sets the channel's type.</para>
-    /// <para>This can only be used to convert between text and news channels.</para>
+    /// Sets the channel's type.
+    /// This can only be used to convert between text and news channels.
     /// </summary>
-    public Optional<DiscordChannelType> Type { internal get; set; }
+    public Optional<DiscordChannelType> Type { get; set; }
 
     /// <summary>
-    /// <para>Sets the channel's permission overwrites.</para>
+    /// Sets the channel's permission overwrites.
     /// </summary>
-    public IEnumerable<DiscordOverwriteBuilder> PermissionOverwrites { internal get; set; }
+    public List<DiscordOverwriteBuilder> PermissionOverwrites { get; set; }
 
     /// <summary>
-    /// <para>Sets the channel's auto-archive duration.</para>
+    /// Sets the channel's auto-archive duration.
     /// </summary>
-    public Optional<DiscordAutoArchiveDuration?> DefaultAutoArchiveDuration { internal get; set; }
+    public Optional<DiscordAutoArchiveDuration?> DefaultAutoArchiveDuration { get; set; }
 
     /// <summary>
-    /// <para>Sets the channel's flags (forum channels and posts only).</para>
+    /// Sets the channel's flags (forum channels and posts only).
     /// </summary>
-    public Optional<DiscordChannelFlags> Flags { internal get; set; }
+    public Optional<DiscordChannelFlags> Flags { get; set; }
 
     /// <summary>
-    /// <para>Sets the channel's available tags.</para>
+    /// Sets the channel's available tags.
     /// </summary>
-    public IEnumerable<DiscordForumTagBuilder> AvailableTags { internal get; set; }
+    public List<DiscordForumTagBuilder> AvailableTags { get; set; }
 
     /// <summary>
-    /// <para>Sets the channel's default reaction, if any.</para>
+    /// Sets the channel's default reaction, if any.
     /// </summary>
-    public Optional<DefaultReaction?> DefaultReaction { internal get; set; }
+    public Optional<DefaultReaction?> DefaultReaction { get; set; }
 
     /// <summary>
-    /// <para>Sets the default slowmode of newly created threads, but does not retroactively update.</para>
+    /// Sets the default slowmode of newly created threads, but does not retroactively update.
     /// </summary>
     /// <remarks>https://discord.com/developers/docs/resources/channel#modify-channel-json-params-guild-channel</remarks>
-    public Optional<int> DefaultThreadRateLimit { internal get; set; }
+    public Optional<int> DefaultThreadRateLimit { get; set; }
 
     /// <summary>
     /// Sets the default sort order of posts in this channel.
     /// </summary>
-    public Optional<DiscordDefaultSortOrder?> DefaultSortOrder { internal get; set; }
+    public Optional<DiscordDefaultSortOrder?> DefaultSortOrder { get; set; }
 
     /// <summary>
     /// Sets the default layout of posts in this channel.
     /// </summary>
-    public Optional<DiscordDefaultForumLayout> DefaultForumLayout { internal get; set; }
+    public Optional<DiscordDefaultForumLayout> DefaultForumLayout { get; set; }
 
     internal ChannelEditModel() { }
 }

--- a/DSharpPlus/Net/Models/GuildEditModel.cs
+++ b/DSharpPlus/Net/Models/GuildEditModel.cs
@@ -4,82 +4,88 @@ using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models;
 
+/// <summary>
+/// Specifies the parameters for modifying a guild.
+/// </summary>
+/// <remarks>
+/// If an <see cref="Optional{T}"/> parameter is not specified, it's state will be left unchanged.
+/// </remarks>
 public class GuildEditModel : BaseEditModel
 {
     /// <summary>
     /// The new guild name.
     /// </summary>
-    public Optional<string> Name { internal get; set; }
+    public Optional<string> Name { get; set; }
 
     /// <summary>
     /// The new guild voice region.
     /// </summary>
-    public Optional<DiscordVoiceRegion> Region { internal get; set; }
+    public Optional<DiscordVoiceRegion> Region { get; set; }
 
     /// <summary>
     /// The new guild icon.
     /// </summary>
-    public Optional<Stream> Icon { internal get; set; }
+    public Optional<Stream> Icon { get; set; }
 
     /// <summary>
     /// The new guild verification level.
     /// </summary>
-    public Optional<DiscordVerificationLevel> VerificationLevel { internal get; set; }
+    public Optional<DiscordVerificationLevel> VerificationLevel { get; set; }
 
     /// <summary>
     /// The new guild default message notification level.
     /// </summary>
-    public Optional<DiscordDefaultMessageNotifications> DefaultMessageNotifications { internal get; set; }
+    public Optional<DiscordDefaultMessageNotifications> DefaultMessageNotifications { get; set; }
 
     /// <summary>
     /// The new guild MFA level.
     /// </summary>
-    public Optional<DiscordMfaLevel> MfaLevel { internal get; set; }
+    public Optional<DiscordMfaLevel> MfaLevel { get; set; }
 
     /// <summary>
     /// The new guild explicit content filter level.
     /// </summary>
-    public Optional<DiscordExplicitContentFilter> ExplicitContentFilter { internal get; set; }
+    public Optional<DiscordExplicitContentFilter> ExplicitContentFilter { get; set; }
 
     /// <summary>
     /// The new AFK voice channel.
     /// </summary>
-    public Optional<DiscordChannel> AfkChannel { internal get; set; }
+    public Optional<DiscordChannel> AfkChannel { get; set; }
 
     /// <summary>
     /// The new AFK timeout time in seconds.
     /// </summary>
-    public Optional<int> AfkTimeout { internal get; set; }
+    public Optional<int> AfkTimeout { get; set; }
 
     /// <summary>
     /// The new guild owner.
     /// </summary>
-    public Optional<DiscordMember> Owner { internal get; set; }
+    public Optional<DiscordMember> Owner { get; set; }
 
     /// <summary>
     /// The new guild splash.
     /// </summary>
-    public Optional<Stream> Splash { internal get; set; }
+    public Optional<Stream> Splash { get; set; }
 
     /// <summary>
     /// The new guild system channel.
     /// </summary>
-    public Optional<DiscordChannel> SystemChannel { internal get; set; }
+    public Optional<DiscordChannel> SystemChannel { get; set; }
 
     /// <summary>
     /// The new guild rules channel.
     /// </summary>
-    public Optional<DiscordChannel> RulesChannel { internal get; set; }
+    public Optional<DiscordChannel> RulesChannel { get; set; }
 
     /// <summary>
     /// The new guild public updates channel.
     /// </summary>
-    public Optional<DiscordChannel> PublicUpdatesChannel { internal get; set; }
+    public Optional<DiscordChannel> PublicUpdatesChannel { get; set; }
 
     /// <summary>
     /// The new guild preferred locale.
     /// </summary>
-    public Optional<string> PreferredLocale { internal get; set; }
+    public Optional<string> PreferredLocale { get; set; }
 
     /// <summary>
     /// The new description of the guild
@@ -94,7 +100,7 @@ public class GuildEditModel : BaseEditModel
     /// <summary>
     /// A list of <see href="https://discord.com/developers/docs/resources/guild#guild-object-guild-features">guild features</see>
     /// </summary>
-    public Optional<IEnumerable<string>> Features { get; set; }
+    public Optional<List<string>> Features { get; set; }
 
     /// <summary>
     /// The new banner of the guild
@@ -106,8 +112,5 @@ public class GuildEditModel : BaseEditModel
     /// </summary>
     public Optional<DiscordSystemChannelFlags> SystemChannelFlags { get; set; }
 
-    internal GuildEditModel()
-    {
-
-    }
+    internal GuildEditModel() { }
 }

--- a/DSharpPlus/Net/Models/MemberEditModel.cs
+++ b/DSharpPlus/Net/Models/MemberEditModel.cs
@@ -4,36 +4,43 @@ using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models;
 
+/// <summary>
+/// Specifies the parameters for modifying a member.
+/// </summary>
+/// <remarks>
+/// If an <see cref="Optional{T}"/> parameter is not specified, it's state will be left unchanged.
+/// </remarks>
 public class MemberEditModel : BaseEditModel
 {
     /// <summary>
     /// New nickname
     /// </summary>
-    public Optional<string> Nickname { internal get; set; }
+    public Optional<string> Nickname { get; set; }
+
     /// <summary>
     /// New roles
     /// </summary>
-    public Optional<List<DiscordRole>> Roles { internal get; set; }
+    public Optional<List<DiscordRole>> Roles { get; set; }
+
     /// <summary>
     /// Whether this user should be muted in voice channels
     /// </summary>
-    public Optional<bool> Muted { internal get; set; }
+    public Optional<bool> Muted { get; set; }
+
     /// <summary>
     /// Whether this user should be deafened
     /// </summary>
-    public Optional<bool> Deafened { internal get; set; }
+    public Optional<bool> Deafened { get; set; }
+
     /// <summary>
     /// Voice channel to move this user to, set to null to kick
     /// </summary>
-    public Optional<DiscordChannel> VoiceChannel { internal get; set; }
+    public Optional<DiscordChannel> VoiceChannel { get; set; }
 
     /// <summary>
     /// Whether this member should have communication restricted
     /// </summary>
-    public Optional<DateTimeOffset?> CommunicationDisabledUntil { internal get; set; }
+    public Optional<DateTimeOffset?> CommunicationDisabledUntil { get; set; }
 
-    internal MemberEditModel()
-    {
-
-    }
+    internal MemberEditModel() { }
 }

--- a/DSharpPlus/Net/Models/MembershipScreeningEditModel.cs
+++ b/DSharpPlus/Net/Models/MembershipScreeningEditModel.cs
@@ -1,23 +1,30 @@
+using System.Collections.Generic;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models;
 
+/// <summary>
+/// Specifies the parameters for modifying a guild's membership screening.
+/// </summary>
+/// <remarks>
+/// If an <see cref="Optional{T}"/> parameter is not specified, it's state will be left unchanged.
+/// </remarks>
 public class MembershipScreeningEditModel : BaseEditModel
 {
     /// <summary>
     /// Sets whether membership screening should be enabled for this guild
     /// </summary>
-    public Optional<bool> Enabled { internal get; set; }
+    public Optional<bool> Enabled { get; set; }
 
     /// <summary>
     /// Sets the server description shown in the membership screening form
     /// </summary>
-    public Optional<string> Description { internal get; set; }
+    public Optional<string> Description { get; set; }
 
     /// <summary>
     /// Sets the fields in this membership screening form
     /// </summary>
-    public Optional<DiscordGuildMembershipScreeningField[]> Fields { internal get; set; }
+    public Optional<List<DiscordGuildMembershipScreeningField>> Fields { get; set; }
 
     internal MembershipScreeningEditModel() { }
 }

--- a/DSharpPlus/Net/Models/RoleEditModel.cs
+++ b/DSharpPlus/Net/Models/RoleEditModel.cs
@@ -3,45 +3,48 @@ using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models;
 
+/// <summary>
+/// Specifies the parameters for modifying a role.
+/// </summary>
+/// <remarks>
+/// If an <see cref="Optional{T}"/> parameter is not specified, it's state will be left unchanged.
+/// </remarks>
 public class RoleEditModel : BaseEditModel
 {
     /// <summary>
     /// New role name
     /// </summary>
-    public string Name { internal get; set; }
+    public string Name { get; set; }
+
     /// <summary>
     /// New role permissions
     /// </summary>
-    public DiscordPermissions? Permissions { internal get; set; }
+    public DiscordPermissions? Permissions { get; set; }
+
     /// <summary>
     /// New role color
     /// </summary>
-    public DiscordColor? Color { internal get; set; }
+    public DiscordColor? Color { get; set; }
+
     /// <summary>
     /// Whether new role should be hoisted
     /// </summary>
-    public bool? Hoist { internal get; set; } //tbh what is hoist
+    public bool? Hoist { get; set; } //tbh what is hoist
+
     /// <summary>
     /// Whether new role should be mentionable
     /// </summary>
-    public bool? Mentionable { internal get; set; }
+    public bool? Mentionable { get; set; }
 
     /// <summary>
     /// The emoji to set for role role icon; must be unicode.
     /// </summary>
-    public DiscordEmoji Emoji { internal get; set; }
+    public DiscordEmoji Emoji { get; set; }
 
     /// <summary>
     /// The stream to use for uploading a new role icon.
     /// </summary>
-    public Stream Icon { internal get; set; }
+    public Stream Icon { get; set; }
 
-    internal RoleEditModel()
-    {
-        this.Name = null;
-        this.Permissions = null;
-        this.Color = null;
-        this.Hoist = null;
-        this.Mentionable = null;
-    }
+    internal RoleEditModel() { }
 }

--- a/DSharpPlus/Net/Models/ScheduledGuildEventEditModel.cs
+++ b/DSharpPlus/Net/Models/ScheduledGuildEventEditModel.cs
@@ -4,6 +4,12 @@ using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models;
 
+/// <summary>
+/// Specifies the parameters for modifying a scheduled guild event.
+/// </summary>
+/// <remarks>
+/// If an <see cref="Optional{T}"/> parameter is not specified, it's state will be left unchanged.
+/// </remarks>
 public class ScheduledGuildEventEditModel : BaseEditModel
 {
     /// <summary>

--- a/DSharpPlus/Net/Models/StageInstanceEditModel.cs
+++ b/DSharpPlus/Net/Models/StageInstanceEditModel.cs
@@ -2,15 +2,21 @@ using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models;
 
+/// <summary>
+/// Specifies the parameters for modifying a stage instance.
+/// </summary>
+/// <remarks>
+/// If an <see cref="Optional{T}"/> parameter is not specified, it's state will be left unchanged.
+/// </remarks>
 public class StageInstanceEditModel : BaseEditModel
 {
     /// <summary>
     /// The new stage instance topic.
     /// </summary>
-    public Optional<string> Topic { internal get; set; }
+    public Optional<string> Topic { get; set; }
 
     /// <summary>
     /// The new stage instance privacy level.
     /// </summary>
-    public Optional<DiscordStagePrivacyLevel> PrivacyLevel { internal get; set; }
+    public Optional<DiscordStagePrivacyLevel> PrivacyLevel { get; set; }
 }

--- a/DSharpPlus/Net/Models/StickerEditModel.cs
+++ b/DSharpPlus/Net/Models/StickerEditModel.cs
@@ -2,11 +2,26 @@ using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models;
 
+/// <summary>
+/// Specifies the parameters for modifying a sticker.
+/// </summary>
+/// <remarks>
+/// If an <see cref="Optional{T}"/> parameter is not specified, it's state will be left unchanged.
+/// </remarks>
 public class StickerEditModel : BaseEditModel
 {
-    public Optional<string> Name { internal get; set; }
+    /// <summary>
+    /// The new sticker name.
+    /// </summary>
+    public Optional<string> Name { get; set; }
 
-    public Optional<string> Description { internal get; set; }
+    /// <summary>
+    /// The new sticker description.
+    /// </summary>
+    public Optional<string> Description { get; set; }
 
-    public Optional<string> Tags { internal get; set; }
+    /// <summary>
+    /// The new sticker tags, delimited by commas.
+    /// </summary>
+    public Optional<string> Tags { get; set; }
 }

--- a/DSharpPlus/Net/Models/ThreadChannelEditModel.cs
+++ b/DSharpPlus/Net/Models/ThreadChannelEditModel.cs
@@ -3,37 +3,43 @@ using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models;
 
+/// <summary>
+/// Specifies the parameters for modifying a thread channel.
+/// </summary>
+/// <remarks>
+/// If an <see cref="Optional{T}"/> parameter is not specified, it's state will be left unchanged.
+/// </remarks>
 public class ThreadChannelEditModel : ChannelEditModel
 {
     /// <summary>
     /// Sets if the thread is archived
     /// </summary>
-    public bool? IsArchived { internal get; set; }
+    public bool? IsArchived { get; set; }
 
     /// <summary>
     /// Sets AutoArchiveDuration of the thread
     /// </summary>
-    public DiscordAutoArchiveDuration? AutoArchiveDuration { internal get; set; }
+    public DiscordAutoArchiveDuration? AutoArchiveDuration { get; set; }
 
     /// <summary>
     /// Sets if anyone can unarchive a thread
     /// </summary>
-    public bool? Locked { internal get; set; }
+    public bool? Locked { get; set; }
 
     /// <summary>
     /// Sets the applied tags for the thread
     /// </summary>
-    public IEnumerable<ulong> AppliedTags { internal get; set; }
+    public List<ulong> AppliedTags { get; set; }
 
     /// <summary>
     /// Sets the flags for the channel (Either PINNED or REQUIRE_TAG)
     /// </summary>
-    public new DiscordChannelFlags? Flags { internal get; set; }
+    public new DiscordChannelFlags? Flags { get; set; }
 
     /// <summary>
     /// Sets whether non-moderators can add other non-moderators to a thread. Only available on private threads
     /// </summary>
-    public bool? IsInvitable { internal get; set; }
+    public bool? IsInvitable { get; set; }
 
     internal ThreadChannelEditModel() { }
 }

--- a/DSharpPlus/Net/Models/WelcomeScreenEditModel.cs
+++ b/DSharpPlus/Net/Models/WelcomeScreenEditModel.cs
@@ -3,20 +3,26 @@ using DSharpPlus.Entities;
 
 namespace DSharpPlus.Net.Models;
 
+/// <summary>
+/// Specifies the parameters for modifying a guild's welcome screen.
+/// </summary>
+/// <remarks>
+/// If an <see cref="Optional{T}"/> parameter is not specified, it's state will be left unchanged.
+/// </remarks>
 public class WelcomeScreenEditModel
 {
     /// <summary>
     /// Sets whether the welcome screen should be enabled.
     /// </summary>
-    public Optional<bool> Enabled { internal get; set; }
+    public Optional<bool> Enabled { get; set; }
 
     /// <summary>
     /// Sets the welcome channels.
     /// </summary>
-    public Optional<IEnumerable<DiscordGuildWelcomeScreenChannel>> WelcomeChannels { internal get; set; }
+    public Optional<List<DiscordGuildWelcomeScreenChannel>> WelcomeChannels { get; set; }
 
     /// <summary>
     /// Sets the serer description shown.
     /// </summary>
-    public Optional<string> Description { internal get; set; }
+    public Optional<string> Description { get; set; }
 }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -1121,7 +1121,7 @@ public sealed class DiscordApiClient
     (
         ulong guildId,
         Optional<bool> enabled = default,
-        Optional<DiscordGuildMembershipScreeningField[]> fields = default,
+        Optional<IReadOnlyList<DiscordGuildMembershipScreeningField>> fields = default,
         Optional<string> description = default
     )
     {


### PR DESCRIPTION
# Summary
- Fix `skipCache`.
- Fixes IDE warnings on modified files.
- Make accessors public.
- Add documentation to the edit models.
- Consistently use `List<T>` instead of `IEnumerable<T>` or `T[]` within the edit models.

# Notes
Unable to test these changes due to external factors.