### PR TITLE
trace logging runtime toggles

### DIFF
--- a/DSharpPlus/Logging/AnonymizationUtilities.cs
+++ b/DSharpPlus/Logging/AnonymizationUtilities.cs
@@ -1,0 +1,38 @@
+using System.Text.RegularExpressions;
+
+namespace DSharpPlus.Logging;
+
+internal static partial class AnonymizationUtilities
+{
+    [GeneratedRegex("\\\"token\\\":\\\"[a-zA-Z0-9\\-\\. ]+\\\"")]
+    private static partial Regex GetJsonEncodedTokenRegex();
+
+    [GeneratedRegex("\\/webhooks\\/[0-9]+\\/[a-zA-Z0-9\\-\\. ]+\\/")]
+    private static partial Regex GetWebhookPathRegex();
+
+    public static string AnonymizeTokens(string input)
+    {
+        string intermediate = GetJsonEncodedTokenRegex().Replace(input, "\"token\":\"<redacted>\"");
+        intermediate = GetWebhookPathRegex().Replace(intermediate, "/webhooks/<id>/<token>");
+        return intermediate;
+    }
+
+    // --------------------------------------------------------------------------------------------------
+
+    [GeneratedRegex("\\\"[0-9]{17,22}\\\"")]
+    private static partial Regex GetSnowflakeRegex();
+
+    [GeneratedRegex("\\\"content\\\":\\\"[^\"]+\\\"")]
+    private static partial Regex GetMessageContentRegex();
+
+    [GeneratedRegex("\\\"username\\\":\\\"[a-zA-Z0-9\\.\\-_]{3,32}\\\"")]
+    private static partial Regex GetUsernameRegex();
+
+    public static string AnonymizeContents(string input)
+    {
+        string intermediate = GetSnowflakeRegex().Replace(input, "\"<redacted ID>\"");
+        intermediate = GetMessageContentRegex().Replace(intermediate, "\"content\":\"<redacted>\"");
+        intermediate = GetUsernameRegex().Replace(intermediate, "\"username\":\"<redacted>\"");
+        return intermediate;
+    }
+}

--- a/DSharpPlus/Logging/AnonymizationUtilities.cs
+++ b/DSharpPlus/Logging/AnonymizationUtilities.cs
@@ -30,7 +30,7 @@ internal static partial class AnonymizationUtilities
 
     public static string AnonymizeContents(string input)
     {
-        string intermediate = GetSnowflakeRegex().Replace(input, "\"<redacted ID>\"");
+        string intermediate = GetSnowflakeRegex().Replace(input, "\"<redacted>\"");
         intermediate = GetMessageContentRegex().Replace(intermediate, "\"content\":\"<redacted>\"");
         intermediate = GetUsernameRegex().Replace(intermediate, "\"username\":\"<redacted>\"");
         return intermediate;

--- a/DSharpPlus/Logging/AnonymizationUtilities.cs
+++ b/DSharpPlus/Logging/AnonymizationUtilities.cs
@@ -4,10 +4,10 @@ namespace DSharpPlus.Logging;
 
 internal static partial class AnonymizationUtilities
 {
-    [GeneratedRegex("\\\"token\\\":\\\"[a-zA-Z0-9\\-\\. ]+\\\"")]
+    [GeneratedRegex(@"""token"":""[a-zA-Z0-9\-\. ]+""")]
     private static partial Regex GetJsonEncodedTokenRegex();
 
-    [GeneratedRegex("\\/webhooks\\/[0-9]+\\/[a-zA-Z0-9\\-\\. ]+\\/")]
+    [GeneratedRegex(@"\/webhooks\/[0-9]+\/[a-zA-Z0-9\-\. ]+\/")]
     private static partial Regex GetWebhookPathRegex();
 
     public static string AnonymizeTokens(string input)
@@ -19,13 +19,13 @@ internal static partial class AnonymizationUtilities
 
     // --------------------------------------------------------------------------------------------------
 
-    [GeneratedRegex("\\\"[0-9]{17,22}\\\"")]
+    [GeneratedRegex(@"""[0-9]{17,22}""")]
     private static partial Regex GetSnowflakeRegex();
 
-    [GeneratedRegex("\\\"content\\\":\\\"[^\"]+\\\"")]
+    [GeneratedRegex(@"""content"":""[^""]+""")]
     private static partial Regex GetMessageContentRegex();
 
-    [GeneratedRegex("\\\"username\\\":\\\"[a-zA-Z0-9\\.\\-_]{3,32}\\\"")]
+    [GeneratedRegex(@"""username"":""[a-zA-Z0-9\.\-_]{3,32}""")]
     private static partial Regex GetUsernameRegex();
 
     public static string AnonymizeContents(string input)

--- a/DSharpPlus/Logging/RuntimeFeatures.cs
+++ b/DSharpPlus/Logging/RuntimeFeatures.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace DSharpPlus.Logging;
+
+/// <summary>
+/// Contains runtime feature switches for trace logging.
+/// </summary>
+public static class RuntimeFeatures
+{
+    /// <summary>
+    /// Specifies whether bot and webhook tokens are being anonymized. Defaults to true.
+    /// </summary>
+    public static bool AnonymizeTokens 
+        => !AppContext.TryGetSwitch("DSharpPlus.Trace.AnonymizeTokens", out bool value) || value;
+
+    /// <summary>
+    /// Specifies whether snowflake IDs and message contents are being anonymized. Defaults to false.
+    /// </summary>
+    /// <remarks>
+    /// Note that enabling this switch may significantly reduce the quality of debugging data.
+    /// </remarks>
+    public static bool AnonymizeContents
+        => AppContext.TryGetSwitch("DSharpPlus.Trace.AnonymizeContents", out bool value) && value;
+
+    /// <summary>
+    /// Specifies whether rest requests should be logged. Defaults to true.
+    /// </summary>
+    public static bool EnableRestRequestLogging
+        => !AppContext.TryGetSwitch("DSharpPlus.Trace.EnableRestRequestLogging", out bool value) || value;
+
+    /// <summary>
+    /// Specifies whether inbound gateway payloads should be logged. Defaults to true.
+    /// </summary>
+    public static bool EnableInboundGatewayLogging
+        => !AppContext.TryGetSwitch("DSharpPlus.Trace.EnableInboundGatewayLogging", out bool value) || value;
+
+    /// <summary>
+    /// Specifies whether outbound gateway payloads should be logged. Defaults to true.
+    /// </summary>
+    public static bool EnableOutboundGatewayLogging
+        => !AppContext.TryGetSwitch("DSharpPlus.Trace.EnableOutboundGatewayLogging", out bool value) || value;
+}

--- a/DSharpPlus/Net/Gateway/TransportService.cs
+++ b/DSharpPlus/Net/Gateway/TransportService.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using CommunityToolkit.HighPerformance.Buffers;
+
 using DSharpPlus.Logging;
 using DSharpPlus.Net.WebSocket;
 

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using DSharpPlus.Exceptions;
+using DSharpPlus.Logging;
 using DSharpPlus.Metrics;
 
 using Microsoft.Extensions.Logging;
@@ -145,7 +146,22 @@ public sealed partial class RestClient : IDisposable
             string content = await response.Content.ReadAsStringAsync();
 
             // consider logging headers too
-            this.logger.LogTrace(LoggerEvents.RestRx, "Request {TraceId}: {Content}", traceId, content);
+            if (this.logger.IsEnabled(LogLevel.Trace) && RuntimeFeatures.EnableRestRequestLogging)
+            {
+                string anonymized = content;
+
+                if (RuntimeFeatures.AnonymizeTokens)
+                {
+                    anonymized = AnonymizationUtilities.AnonymizeTokens(anonymized);
+                }
+
+                if (RuntimeFeatures.AnonymizeContents)
+                {
+                    anonymized = AnonymizationUtilities.AnonymizeContents(anonymized);
+                }
+
+                this.logger.LogTrace("Request {TraceId}: {Content}", traceId, anonymized);
+            }
 
             switch (response.StatusCode)
             {

--- a/docs/articles/advanced_topics/trace_logs.md
+++ b/docs/articles/advanced_topics/trace_logs.md
@@ -1,0 +1,51 @@
+---
+uid: articles.advanced_topics.trace
+title: Trace Logging
+---
+
+# Introduction
+
+Trace logs are a very useful debugging feature. They will reveal all information your bot sends to Discord and Discord sends to your bot, both through rest and the real-time gateway, as well as information about the library's internal state and what the library is attempting to do at any given moment.
+
+We recommend you do not enable trace logging with the built-in logger provider, but to register a custom logger and, importantly, to enable logging to files: trace logs are very lengthy and will very quickly hit console length limits. For enabling trace logging, please refer to the documentation of your chosen logger - Serilog, for example, calls it "Verbose" logging.
+
+## Controlling Trace Contents
+
+DSharpPlus offers several options to configure what specific data should be logged to traces. These options live in `runtimeconfig.json`, unlike most other configuration the library offers, due to their nature as hosting-specific rather than development/functionality-specific switches. They may be specified as follows:
+
+1. In `runtimeconfig.json`, switches are specified in the `"configProperties"` section:
+
+```json
+{
+    "runtimeOptions": {
+        "tfm": "net8.0",
+        // ...,
+        "configProperties": {
+            "DSharpPlus.Trace.EnableInboundGatewayLogging": true
+        }
+    }
+}
+```
+
+2. In your `.csproj` file:
+
+```xml
+<PropertyGroup>
+    <RuntimeHostConfigurationOption Include="DSharpPlus.Trace.EnableInboundGatewayLogging" Value="true" />
+</PropertyGroup>
+```
+
+DSharpPlus supports the following switches for controlling trace log contents: 
+- `DSharpPlus.Trace.EnableRestRequestLogging`, controlling whether payloads from REST should be logged;
+- `DSharpPlus.Trace.EnableInboundGatewayLogging`, controlling whether incoming gateway events should be logged;
+- `DSharpPlus.Trace.EnableOutboundGatewayLogging`, controlling whether outgoing gateway events should be logged.
+
+Each of these options defaults to `true` - by default, DSharpPlus logs as much information as possible.
+
+### Anonymizing Trace Contents
+
+Trace logs contain huge amounts of potentially sensitive data, such as user IDs, message contents and tokens - everything Discord sends us, and everything we send to Discord. DSharpPlus offers additional feature switches to restrict sensitive information ending up in trace logs:
+
+First, `DSharpPlus.Trace.AnonymizeTokens`. This switch is enabled by default and will hide your bot and webhook tokens in trace logs. As a library consumer, you should typically not turn this off.
+
+Second, `DSharpPlus.Trace.AnonymizeContents`. This switch is disabled by default and will hide snowflake IDs, message contents and usernames in your logs. Since this significantly reduces the quality of debug information in your trace logs, you should evaluate whether you should use this switch on a case-by-case basis.

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -95,6 +95,8 @@
     topicUid: articles.advanced_topics.generic_host
   - name: Metrics and Profiling
     topicUid: articles.advanced_topics.metrics_profiling
+  - name: Trace Logging
+    topicUid: articles.advanced_topics.trace
 - name: Hosting
   topicUid: articles.hosting
 - name: Version Migration


### PR DESCRIPTION
As per [this vote](https://canary.discord.com/channels/379378609942560770/379386730538860554/1282614751737675841), implements feature switches for disabling some trace logs and for redacting tokens, IDs, usernames and message contents automatically.