### PR TITLE
Fix .csproj example in docs trace_logs.md

### DIFF
--- a/docs/articles/advanced_topics/trace_logs.md
+++ b/docs/articles/advanced_topics/trace_logs.md
@@ -30,9 +30,9 @@ DSharpPlus offers several options to configure what specific data should be logg
 2. In your `.csproj` file:
 
 ```xml
-<PropertyGroup>
+<ItemGroup>
     <RuntimeHostConfigurationOption Include="DSharpPlus.Trace.EnableInboundGatewayLogging" Value="true" />
-</PropertyGroup>
+</ItemGroup>
 ```
 
 DSharpPlus supports the following switches for controlling trace log contents: 


### PR DESCRIPTION

# Summary
Simple fix. `<RuntimeHostConfigurationOption/>` should be inside `<ItemGroup/>` instead of `<PropertyGroup/>`.

[Example from Microsoft docs](https://learn.microsoft.com/en-us/dotnet/core/runtime-config/#msbuild-properties)