### PR TITLE
Remove unnecessary null check

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/InteractionConverterContext.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/InteractionConverterContext.cs
@@ -32,9 +32,6 @@ public record InteractionConverterContext : ConverterContext
     public new DiscordInteractionDataOption? Argument { get; protected set; }
 
     /// <inheritdoc/>
-    public override bool NextParameter() => this.Interaction.Data.Options is not null && base.NextParameter();
-
-    /// <inheritdoc/>
     public override bool NextArgument()
     {
         // Support for variadic-argument parameters


### PR DESCRIPTION
# Summary
This null check breaks when a command with one parameter that has a default value with no arguments passed. Reported by @InvixGG 

# Notes
Tested with and without args.