### PR TITLE
improve logging of resumes and reconnects

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -718,7 +718,6 @@ public sealed partial class DiscordClient
 
     internal async Task OnResumedAsync(int shardId)
     {
-        this.Logger.LogInformation(LoggerEvents.SessionUpdate, "Session resumed");
         await this.dispatcher.DispatchAsync<SessionResumedEventArgs>
         (
             this,

--- a/DSharpPlus/Net/Gateway/DefaultGatewayController.cs
+++ b/DSharpPlus/Net/Gateway/DefaultGatewayController.cs
@@ -18,6 +18,9 @@ internal class DefaultGatewayController : IGatewayController
     public Task ReconnectRequestedAsync(IGatewayClient client) => Task.CompletedTask;
 
     /// <inheritdoc/>
+    public Task ResumeAttemptedAsync(IGatewayClient client) => Task.CompletedTask;
+
+    /// <inheritdoc/>
     public Task SessionInvalidatedAsync(IGatewayClient client) => Task.CompletedTask;
 
     /// <inheritdoc/>

--- a/DSharpPlus/Net/Gateway/IGatewayController.cs
+++ b/DSharpPlus/Net/Gateway/IGatewayController.cs
@@ -20,6 +20,12 @@ public interface IGatewayController
     public Task HeartbeatedAsync(IGatewayClient client);
 
     /// <summary>
+    /// Called when DSharpPlus attempts to resume a gateway session.
+    /// </summary>
+    /// <param name="client">The gateway client attempting to resume a session.</param>
+    public Task ResumeAttemptedAsync(IGatewayClient client);
+
+    /// <summary>
     /// Called when Discord requests a reconnect. This does not imply that DSharpPlus' reconnection attempt failed.
     /// </summary>
     /// <param name="client">The gateway client reconnection was requested from.</param>

--- a/DSharpPlus/Net/Gateway/ReconnectingGatewayController.cs
+++ b/DSharpPlus/Net/Gateway/ReconnectingGatewayController.cs
@@ -17,6 +17,9 @@ public sealed class ReconnectingGatewayController : IGatewayController
     public Task ReconnectRequestedAsync(IGatewayClient client) => Task.CompletedTask;
 
     /// <inheritdoc/>
+    public Task ResumeAttemptedAsync(IGatewayClient client) => Task.CompletedTask;
+
+    /// <inheritdoc/>
     public async Task SessionInvalidatedAsync(IGatewayClient client) => await client.ReconnectAsync();
 
     /// <inheritdoc/>


### PR DESCRIPTION
- moves a couple logs from Trace to Debug for better visibility
- moves a log from Information to Debug for consistency and makes it clearer
- adds an IGatewayController hook for attempting to resume, but its usefulness is somewhat limited since tracking gateway state through an attempt is very difficult
- also fixes a bug where resumes wouldn't have their shard IDs communicated because we hooked the wrong opcode (:ioa:)