### PR TITLE
fixes #1958

### DIFF
--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
+
 using DSharpPlus.AsyncEvents;
 using DSharpPlus.Commands.ContextChecks;
 using DSharpPlus.Commands.ContextChecks.ParameterChecks;
@@ -24,15 +25,20 @@ using DSharpPlus.Commands.Trees;
 using DSharpPlus.Commands.Trees.Metadata;
 using DSharpPlus.Entities;
 using DSharpPlus.Exceptions;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using CheckFunc = System.Func<
+
+using CheckFunc = System.Func
+<
     object,
     DSharpPlus.Commands.ContextChecks.ContextCheckAttribute,
     DSharpPlus.Commands.CommandContext,
     System.Threading.Tasks.ValueTask<string?>
 >;
-using ParameterCheckFunc = System.Func<
+
+using ParameterCheckFunc = System.Func
+<
     object,
     DSharpPlus.Commands.ContextChecks.ParameterChecks.ParameterCheckAttribute,
     DSharpPlus.Commands.ContextChecks.ParameterChecks.ParameterCheckInfo,
@@ -193,8 +199,8 @@ public sealed class CommandsExtension
     public void AddCommands(params CommandBuilder[] commands) => this.commandBuilders.AddRange(commands);
     public void AddCommands(Type type, params ulong[] guildIds) => AddCommands([type], guildIds);
     public void AddCommands(Type type) => AddCommands([type]);
-    public void AddCommands<T>() => this.commandBuilders.Add(CommandBuilder.From<T>());
-    public void AddCommands<T>(params ulong[] guildIds) => this.commandBuilders.Add(CommandBuilder.From<T>(guildIds));
+    public void AddCommands<T>() => AddCommands([typeof(T)]);
+    public void AddCommands<T>(params ulong[] guildIds) => AddCommands([typeof(T)], guildIds);
     public void AddCommands(IEnumerable<Type> types, params ulong[] guildIds)
     {
         foreach (Type type in types)

--- a/DSharpPlus.Commands/ContextChecks/RequireGuildCheck.cs
+++ b/DSharpPlus.Commands/ContextChecks/RequireGuildCheck.cs
@@ -6,6 +6,6 @@ internal sealed class RequireGuildCheck : IContextCheck<RequireGuildAttribute>
 {
     internal const string ErrorMessage = "This command must be executed in a guild.";
 
-    public ValueTask<string?> ExecuteCheckAsync(RequireGuildAttribute attribute, CommandContext context) =>
-        ValueTask.FromResult(context.Guild is null ? ErrorMessage : null);
+    public ValueTask<string?> ExecuteCheckAsync(RequireGuildAttribute attribute, CommandContext context) 
+        => ValueTask.FromResult(context.Guild is null ? ErrorMessage : null);
 }

--- a/DSharpPlus.Commands/Trees/CommandBuilder.cs
+++ b/DSharpPlus.Commands/Trees/CommandBuilder.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using DSharpPlus.Commands.ContextChecks;
 
 namespace DSharpPlus.Commands.Trees;
 
@@ -279,6 +280,7 @@ public class CommandBuilder
             return type is null 
                 ? []
                 : type.GetCustomAttributes(true)
+                    .Where(obj => obj is ContextCheckAttribute)
                     .Concat(AggregateCustomAttributesFromType(type.DeclaringType))
                     .Cast<Attribute>();
         }


### PR DESCRIPTION
previously, only attributes that could be translated to discord features would be respected from parent types, now this applies to checks too

closes #1958 