### PR TITLE
try to stream deserialization when we don't need to log anything

### DIFF
--- a/DSharpPlus/Net/Gateway/GatewayClientOptions.cs
+++ b/DSharpPlus/Net/Gateway/GatewayClientOptions.cs
@@ -1,5 +1,7 @@
 using System;
 
+using DSharpPlus.Logging;
+
 namespace DSharpPlus.Net.Gateway;
 
 /// <summary>
@@ -40,4 +42,17 @@ public sealed class GatewayClientOptions
     /// intents for. Defaults to <see cref="DiscordIntents.AllUnprivileged"/>.
     /// </summary>
     public DiscordIntents Intents { get; set; } = DiscordIntents.AllUnprivileged;
+
+    /// <summary>
+    /// Toggles the use of streams for deserializing inbound gateway events. Enabling this will increase the total
+    /// allocation volume of the gateway, but decrease the maximum size of allocations and may reduce object
+    /// longevity.
+    /// </summary>
+    /// <remarks>
+    /// This option will be automatically disabled if trace logs are enabled and 
+    /// <see cref="RuntimeFeatures.EnableInboundGatewayLogging"/> is enabled (as it is by default). Please refer to
+    /// <see href="https://dsharpplus.github.io/DSharpPlus/articles/advanced_topics/trace_logs.html">our article
+    /// on trace logging</see> to learn how to modify this option.
+    /// </remarks>
+    public bool EnableStreamingDeserialization { get; set; } = true;
 }

--- a/DSharpPlus/Net/Gateway/TransportFrame.cs
+++ b/DSharpPlus/Net/Gateway/TransportFrame.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 
 namespace DSharpPlus.Net.Gateway;
 
@@ -13,7 +14,7 @@ public readonly record struct TransportFrame
     /// <summary>
     /// Indicates whether reading this gateway frame was successful.
     /// </summary>
-    public readonly bool IsSuccess => this.value is string;
+    public readonly bool IsSuccess => this.value is string or MemoryStream;
 
     /// <summary>
     /// Attempts to retrieve the string message received.
@@ -23,6 +24,23 @@ public readonly record struct TransportFrame
         message = null;
 
         if (this.value is string str)
+        {
+            message = str;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to retrieve a message wrapped in a MemoryStream. This is only permissible if the log level
+    /// is higher than Trace or if inbound gateway logging is disabled.
+    /// </summary>
+    public readonly bool TryGetStreamMessage([NotNullWhen(true)] out MemoryStream? message)
+    {
+        message = null;
+
+        if (this.value is MemoryStream str)
         {
             message = str;
             return true;


### PR DESCRIPTION
this increases allocation volume, but the GC is better at handling gen0 allocations so it ends up winning out in *most* cases (in case of my test bot, a memory reduction of 4-7%, but it's not that simple if the GC is under stress)

this only kicks in when trace logging is disabled, or when inbound gateway events aren't being logged - otherwise, this presents a memory and CPU time regression. this also regresses error cases, but error cases are rare enough for this to not outweigh successful cases

implements #1941 