### PR TITLE
Fix nullability on `DiscordUser`-based `Equals` methods/operators

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordMember.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMember.cs
@@ -546,20 +546,6 @@ public class DiscordMember : DiscordUser, IEquatable<DiscordMember>
     public override string ToString() => $"Member {this.Id}; {this.Username}#{this.Discriminator} ({this.DisplayName})";
 
     /// <summary>
-    /// Checks whether this <see cref="DiscordMember"/> is equal to another object.
-    /// </summary>
-    /// <param name="obj">Object to compare to.</param>
-    /// <returns>Whether the object is equal to this <see cref="DiscordMember"/>.</returns>
-    public override bool Equals(object obj) => Equals(obj as DiscordMember);
-
-    /// <summary>
-    /// Checks whether this <see cref="DiscordMember"/> is equal to another <see cref="DiscordMember"/>.
-    /// </summary>
-    /// <param name="e"><see cref="DiscordMember"/> to compare to.</param>
-    /// <returns>Whether the <see cref="DiscordMember"/> is equal to this <see cref="DiscordMember"/>.</returns>
-    public bool Equals(DiscordMember e) => e is not null && (ReferenceEquals(this, e) || (this.Id == e.Id && this.guild_id == e.guild_id));
-
-    /// <summary>
     /// Gets the hash code for this <see cref="DiscordMember"/>.
     /// </summary>
     /// <returns>The hash code for this <see cref="DiscordMember"/>.</returns>
@@ -574,28 +560,34 @@ public class DiscordMember : DiscordUser, IEquatable<DiscordMember>
     }
 
     /// <summary>
+    /// Checks whether this <see cref="DiscordMember"/> is equal to another object.
+    /// </summary>
+    /// <param name="obj">Object to compare to.</param>
+    /// <returns>Whether the object is equal to this <see cref="DiscordMember"/>.</returns>
+    public override bool Equals(object? obj) => Equals(obj as DiscordMember);
+
+    /// <summary>
+    /// Checks whether this <see cref="DiscordMember"/> is equal to another <see cref="DiscordMember"/>.
+    /// </summary>
+    /// <param name="other"><see cref="DiscordMember"/> to compare to.</param>
+    /// <returns>Whether the <see cref="DiscordMember"/> is equal to this <see cref="DiscordMember"/>.</returns>
+    public bool Equals(DiscordMember? other) => base.Equals(other) && this.guild_id == other?.guild_id;
+
+    /// <summary>
     /// Gets whether the two <see cref="DiscordMember"/> objects are equal.
     /// </summary>
-    /// <param name="e1">First member to compare.</param>
-    /// <param name="e2">Second member to compare.</param>
+    /// <param name="obj">First member to compare.</param>
+    /// <param name="other">Second member to compare.</param>
     /// <returns>Whether the two members are equal.</returns>
-    public static bool operator ==(DiscordMember e1, DiscordMember e2)
-    {
-        object? o1 = e1;
-        object? o2 = e2;
-
-        return (o1 != null || o2 == null) && (o1 == null || o2 != null)
-&& ((o1 == null && o2 == null) || (e1.Id == e2.Id && e1.guild_id == e2.guild_id));
-    }
+    public static bool operator ==(DiscordMember obj, DiscordMember other) => obj?.Equals(other) ?? other is null;
 
     /// <summary>
     /// Gets whether the two <see cref="DiscordMember"/> objects are not equal.
     /// </summary>
-    /// <param name="e1">First member to compare.</param>
-    /// <param name="e2">Second member to compare.</param>
+    /// <param name="obj">First member to compare.</param>
+    /// <param name="other">Second member to compare.</param>
     /// <returns>Whether the two members are not equal.</returns>
-    public static bool operator !=(DiscordMember e1, DiscordMember e2)
-        => !(e1 == e2);
+    public static bool operator !=(DiscordMember obj, DiscordMember other) => !(obj == other);
 
     /// <summary>
     /// Get's the current member's roles based on the sum of the permissions of their given roles.

--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -245,7 +245,7 @@ public class DiscordUser : SnowflakeObject, IEquatable<DiscordUser>
             return $"https://cdn.discordapp.com/embed/{Endpoints.AVATARS}/{defaultAvatarType}.{stringImageFormat}?size={stringImageSize}";
         }
     }
-    
+
     /// <summary>
     /// Creates a direct message channel to this member.
     /// </summary>
@@ -264,7 +264,7 @@ public class DiscordUser : SnowflakeObject, IEquatable<DiscordUser>
         {
             return await this.Discord.ApiClient.CreateDmAsync(this.Id);
         }
-        
+
         DiscordDmChannel? dm = default;
 
         if (this.Discord is DiscordClient dc)
@@ -379,47 +379,40 @@ public class DiscordUser : SnowflakeObject, IEquatable<DiscordUser>
     public override string ToString() => $"User {this.Id}; {this.Username}#{this.Discriminator}";
 
     /// <summary>
-    /// Checks whether this <see cref="DiscordUser"/> is equal to another object.
-    /// </summary>
-    /// <param name="obj">Object to compare to.</param>
-    /// <returns>Whether the object is equal to this <see cref="DiscordUser"/>.</returns>
-    public override bool Equals(object obj) => Equals(obj as DiscordUser);
-
-    /// <summary>
-    /// Checks whether this <see cref="DiscordUser"/> is equal to another <see cref="DiscordUser"/>.
-    /// </summary>
-    /// <param name="e"><see cref="DiscordUser"/> to compare to.</param>
-    /// <returns>Whether the <see cref="DiscordUser"/> is equal to this <see cref="DiscordUser"/>.</returns>
-    public bool Equals(DiscordUser e) => e is not null && (ReferenceEquals(this, e) || this.Id == e.Id);
-
-    /// <summary>
     /// Gets the hash code for this <see cref="DiscordUser"/>.
     /// </summary>
     /// <returns>The hash code for this <see cref="DiscordUser"/>.</returns>
     public override int GetHashCode() => this.Id.GetHashCode();
 
     /// <summary>
+    /// Checks whether this <see cref="DiscordUser"/> is equal to another object.
+    /// </summary>
+    /// <param name="obj">Object to compare to.</param>
+    /// <returns>Whether the object is equal to this <see cref="DiscordUser"/>.</returns>
+    public override bool Equals(object? obj) => Equals(obj as DiscordUser);
+
+    /// <summary>
+    /// Checks whether this <see cref="DiscordUser"/> is equal to another <see cref="DiscordUser"/>.
+    /// </summary>
+    /// <param name="other"><see cref="DiscordUser"/> to compare to.</param>
+    /// <returns>Whether the <see cref="DiscordUser"/> is equal to this <see cref="DiscordUser"/>.</returns>
+    public bool Equals(DiscordUser? other) => this.Id == other?.Id;
+
+    /// <summary>
     /// Gets whether the two <see cref="DiscordUser"/> objects are equal.
     /// </summary>
-    /// <param name="e1">First user to compare.</param>
-    /// <param name="e2">Second user to compare.</param>
+    /// <param name="obj">First user to compare.</param>
+    /// <param name="other">Second user to compare.</param>
     /// <returns>Whether the two users are equal.</returns>
-    public static bool operator ==(DiscordUser e1, DiscordUser e2)
-    {
-        object? o1 = e1;
-        object? o2 = e2;
-
-        return (o1 != null || o2 == null) && (o1 == null || o2 != null) && ((o1 == null && o2 == null) || e1.Id == e2.Id);
-    }
+    public static bool operator ==(DiscordUser? obj, DiscordUser? other) => obj?.Equals(other) ?? other is null;
 
     /// <summary>
     /// Gets whether the two <see cref="DiscordUser"/> objects are not equal.
     /// </summary>
-    /// <param name="e1">First user to compare.</param>
-    /// <param name="e2">Second user to compare.</param>
+    /// <param name="obj">First user to compare.</param>
+    /// <param name="other">Second user to compare.</param>
     /// <returns>Whether the two users are not equal.</returns>
-    public static bool operator !=(DiscordUser e1, DiscordUser e2)
-        => !(e1 == e2);
+    public static bool operator !=(DiscordUser? obj, DiscordUser? other) => !(obj == other);
 }
 
 internal class DiscordUserComparer : IEqualityComparer<DiscordUser>


### PR DESCRIPTION
# Summary
Rewrites the logic within the `Equals` method/operators to be cleaner. Changes `DiscordMember.Equals` implementation to check if the member of the same id is within the same guild as the other member.

# Notes
Tested.

![image](https://github.com/user-attachments/assets/fbbce6c4-8194-4aba-a152-44fc1815e618)