### PR TITLE
Text aliases on group commands no longer break subcommands

### DIFF
--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -270,7 +270,7 @@ public sealed class TextCommandProcessor : BaseCommandProcessor<ITextArgumentCon
                 if (aliasAttribute is not null && aliasAttribute.Aliases.Any(alias => this.Configuration.CommandNameComparer.Equals(alias, rootCommandText)))
                 {
                     command = officialCommand;
-                    return true;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
# Summary
Text aliases on group commands no longer break subcommands

# Details
Take the following command:
```cs
[Command("guild_settings"), TextAlias("guild_config")]
public sealed class GuildSettingsCommand
{
    [Command("show")]
    public static async ValueTask ShowAsync(CommandContext context, string argument) => context.RespondAsync("Works");
}
```
- `>>guild_settings show test` would work fine.
- `>>guild_config show test` would fail with
  - `Unable to execute a command that has no method. Is this command a group command?`

Closes #2089

# Notes
Tested.