### PR TITLE
Add DiscordThreadChannel.AppliedTagIds property

### DIFF
--- a/DSharpPlus/Entities/Channel/Thread/DiscordThreadChannel.cs
+++ b/DSharpPlus/Entities/Channel/Thread/DiscordThreadChannel.cs
@@ -61,7 +61,7 @@ public class DiscordThreadChannel : DiscordChannel
     /// <summary>
     /// Gets the IDs of the tags applied to this forum post.
     /// </summary>
-    public IReadOnlyList<ulong> AppliedTagIds => appliedTagIds;
+    public IReadOnlyList<ulong> AppliedTagIds => this.appliedTagIds;
 
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value null
     // Justification: Used by JSON.NET

--- a/DSharpPlus/Entities/Channel/Thread/DiscordThreadChannel.cs
+++ b/DSharpPlus/Entities/Channel/Thread/DiscordThreadChannel.cs
@@ -58,6 +58,11 @@ public class DiscordThreadChannel : DiscordChannel
             ? parent.AvailableTags.Where(pt => this.appliedTagIds.Contains(pt.Id)).ToArray()
             : [];
 
+    /// <summary>
+    /// Gets the IDs of the tags applied to this forum post.
+    /// </summary>
+    public IReadOnlyList<ulong> AppliedTagIds => appliedTagIds;
+
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value null
     // Justification: Used by JSON.NET
     [JsonProperty("applied_tags")]


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Create a `DiscordThreadChannel.AppliedTagIds` property.

# Details
When missing the `DiscordIntents.Guilds` intent, the `AppliedTags` property of a `DiscordThreadChannel` will always be an empty list, as this property depends on the `Parent` property being non-null (which itself depends on the `DiscordGuild` object having a populated `channels` dictionary). Exposing the applied IDs directly will still work in such cases.

# Changes proposed
* Create a `DiscordThreadChannel.AppliedTagIds` property.

# Notes
No additional notes.