### PR TITLE
wait and retry if we hit a 429 rather than abandoning

### DIFF
--- a/DSharpPlus.Rest/DiscordRestClient.cs
+++ b/DSharpPlus.Rest/DiscordRestClient.cs
@@ -45,8 +45,8 @@ public class DiscordRestClient : BaseDiscordClient
             options.Timeout,
             logger ?? NullLogger.Instance,
             options.MaximumRatelimitRetries,
-            options.RatelimitRetryDelayFallback,
-            options.InitialRequestTimeout,
+            (int)options.RatelimitRetryDelayFallback.TotalMilliseconds,
+            (int)options.InitialRequestTimeout.TotalMilliseconds,
             options.MaximumConcurrentRestRequests
         ));
 

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -92,7 +92,7 @@ public sealed partial class RestClient : IDisposable
                     return ValueTask.FromResult<TimeSpan?>(result.Outcome.Exception switch
                     {
                         PreemptiveRatelimitException preemptive => preemptive.ResetAfter,
-                        RateLimitException real => real.ResetAfter,
+                        RetryableRatelimitException real => real.ResetAfter,
                         _ => TimeSpan.FromMilliseconds(retryDelayFallback)
                     });
                 },

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -46,8 +46,8 @@ public sealed partial class RestClient : IDisposable
             options.Value.Timeout,
             logger,
             options.Value.MaximumRatelimitRetries,
-            options.Value.RatelimitRetryDelayFallback,
-            options.Value.InitialRequestTimeout,
+            (int)options.Value.RatelimitRetryDelayFallback.TotalMilliseconds,
+            (int)options.Value.InitialRequestTimeout.TotalMilliseconds,
             options.Value.MaximumConcurrentRestRequests
         )
     {
@@ -64,7 +64,7 @@ public sealed partial class RestClient : IDisposable
         TimeSpan timeout,
         ILogger logger,
         int maxRetries = int.MaxValue,
-        double retryDelayFallback = 2.5,
+        int retryDelayFallback = 2500,
         int waitingForHashMilliseconds = 200,
         int maximumRequestsPerSecond = 15
     )
@@ -88,8 +88,14 @@ public sealed partial class RestClient : IDisposable
             new()
             {
                 DelayGenerator = result =>
-                    ValueTask.FromResult<TimeSpan?>((result.Outcome.Exception as PreemptiveRatelimitException)?.ResetAfter
-                        ?? TimeSpan.FromSeconds(retryDelayFallback)),
+                {
+                    return ValueTask.FromResult<TimeSpan?>(result.Outcome.Exception switch
+                    {
+                        PreemptiveRatelimitException preemptive => preemptive.ResetAfter,
+                        RateLimitException real => real.ResetAfter,
+                        _ => TimeSpan.FromMilliseconds(retryDelayFallback)
+                    });
+                },
                 MaxRetryAttempts = maxRetries
             }
         )

--- a/DSharpPlus/Net/Rest/RestClientOptions.cs
+++ b/DSharpPlus/Net/Rest/RestClientOptions.cs
@@ -24,12 +24,12 @@ public sealed class RestClientOptions
     /// <summary>
     /// Specifies the delay to use when there was no delay information passed to the rest client. Defaults to 2.5 seconds.
     /// </summary>
-    public double RatelimitRetryDelayFallback { get; set; } = 2.5;
+    public TimeSpan RatelimitRetryDelayFallback { get; set; } = TimeSpan.FromMilliseconds(2500);
 
     /// <summary>
-    /// Specifies the amount of milliseconds we should be waiting for a ratelimit bucket hash to initialize.
+    /// Specifies the time we should be waiting for a ratelimit bucket hash to initialize.
     /// </summary>
-    public int InitialRequestTimeout { get; set; } = 200;
+    public TimeSpan InitialRequestTimeout { get; set; } = TimeSpan.FromMilliseconds(200);
 
     /// <summary>
     /// Specifies the maximum rest requests to attempt concurrently. Defaults to 15.

--- a/DSharpPlus/Net/Rest/RetryableRatelimitException.cs
+++ b/DSharpPlus/Net/Rest/RetryableRatelimitException.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace DSharpPlus.Net;
+
+internal sealed class RetryableRatelimitException : Exception
+{
+    public required TimeSpan ResetAfter { get; set; }
+
+    [SetsRequiredMembers]
+    public RetryableRatelimitException(TimeSpan resetAfter) 
+        => this.ResetAfter = resetAfter;
+}


### PR DESCRIPTION
closes #1909 

this is imperative to implement for forwarding support - in the future we could consider refining the logging to account for ratelimiting special-cases, but this does the job