### PR TITLE
Correct some "WeakEquals" when comparing remote to local commands

### DIFF
--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.WeakEquals.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.WeakEquals.cs
@@ -187,6 +187,7 @@ partial class DiscordApplicationCommand
             long value => long.TryParse(b.ToString(), out long other) && value == other,
             double value => double.TryParse(b.ToString(), out double other) && value == other,
             string value => b is string other && value == other,
+            DiscordApplicationCommandOptionChoice value => b is DiscordApplicationCommandOptionChoice other && ChoiceValuesMatch(value.Value, other.Value),
             _ => false
         };
     }

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.WeakEquals.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.WeakEquals.cs
@@ -183,9 +183,9 @@ partial class DiscordApplicationCommand
     {
         return a switch
         {
-            int value => b is int other && value == other,
-            long value => b is long other && value == other,
-            double value => b is double other && value == other,
+            int value => int.TryParse(b.ToString(), out int other) && value == other,
+            long value => long.TryParse(b.ToString(), out long other) && value == other,
+            double value => double.TryParse(b.ToString(), out double other) && value == other,
             string value => b is string other && value == other,
             _ => false
         };

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.WeakEquals.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.WeakEquals.cs
@@ -119,7 +119,6 @@ partial class DiscordApplicationCommand
                     && (option.MaxLength ?? 4000) == (other.MaxLength ?? 4000)
                     && (option.MinLength ?? 0) == (other.MinLength ?? 0)
                     && (option.Required ?? false) == (other.Required ?? false)
-                    && (option.AutoComplete ?? false) == (other.AutoComplete ?? false)
                     && BoxedIntegersMatch(option.MinValue, other.MinValue)
                     && BoxedIntegersMatch(option.MaxValue, other.MaxValue)
                     && EnumListsMatch(option.ChannelTypes, other.ChannelTypes)

--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.WeakEquals.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.WeakEquals.cs
@@ -118,7 +118,7 @@ partial class DiscordApplicationCommand
                     && (option.AutoComplete ?? false) == (other.AutoComplete ?? false)
                     && (option.MaxLength ?? 4000) == (other.MaxLength ?? 4000)
                     && (option.MinLength ?? 0) == (other.MinLength ?? 0)
-                    && (option.Required ?? true) == (other.Required ?? true)
+                    && (option.Required ?? false) == (other.Required ?? false)
                     && (option.AutoComplete ?? false) == (other.AutoComplete ?? false)
                     && BoxedIntegersMatch(option.MinValue, other.MinValue)
                     && BoxedIntegersMatch(option.MaxValue, other.MaxValue)


### PR DESCRIPTION
# Summary
Fixes some WeakEquals operations in which incorrectly cause the equality check to fail.
A failed equality check in this instance is the difference between PATCHing a command on bot startup and not.

# Changes proposed
* According to [Discord Documentation](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure), the default value for "Required" is false, soo, when `null`, use false instead of true? I'm not actually sure on this one and could use some veteran help. I decided to change this becuase In my testing i was getting `null` on commands that are existing and are not required.
* Removed duplicate equality check on Autocomplete
* Changed the Choice value comparisons to use TryParse, so that we can compare objects of different types, such as Int64 and int32 and yield an accurate result. (This can occur in the EnumChoiceProvider and during JSON.net deserialization)

# Details
I tried a few methods before choosing TryParse, although IConvertable looks good, if it cannot convert and throws, it gets bad pretty quick.

| Method                        | Mean         | Error      | StdDev     | Gen0   | Gen1   | Allocated |
|------------------------------ |-------------:|-----------:|-----------:|-------:|-------:|----------:|
| IConvertable                  |     2.112 ns |  0.0055 ns |  0.0049 ns |      - |      - |         - |
| IConvertableException         | 3,432.478 ns | 12.6139 ns | 11.1819 ns | 0.0534 |      - |     680 B |
| TryParse                      |     3.312 ns |  0.0133 ns |  0.0111 ns |      - |      - |         - |
| UsingTypeDescriptorException  | 4,083.498 ns | 16.0299 ns | 14.9944 ns | 0.0534 |      - |     680 B |
| UsingTypeDescriptorValidation | 1,744.796 ns | 20.2759 ns | 17.9741 ns | 0.4520 | 0.0057 |    5680 B |

I also compared the current check against checking for both and against Type.TryParse for every single one.
| Method                               | Mean     | Error     | StdDev    | Gen0   | Allocated |
|------------------------------------- |---------:|----------:|----------:|-------:|----------:|
| LongDefaultCheck                     | 2.636 ns | 0.0677 ns | 0.0601 ns | 0.0019 |      24 B |
| LongBaseTypeCheckFirst               | 2.834 ns | 0.0769 ns | 0.0790 ns | 0.0019 |      24 B |
| LongTryParsingAll                    | 6.239 ns | 0.0481 ns | 0.0450 ns | 0.0019 |      24 B |
| IntDefaultCheck                      | 2.618 ns | 0.0626 ns | 0.0488 ns | 0.0019 |      24 B |
| IntBaseTypeCheckFirst                | 6.767 ns | 0.1041 ns | 0.0812 ns | 0.0019 |      24 B |
| IntTryParsingAll                     | 6.013 ns | 0.0827 ns | 0.0773 ns | 0.0019 |      24 B |
| StringDefaultCheck                   | 2.797 ns | 0.0769 ns | 0.0642 ns | 0.0019 |      24 B |
| StringTryParsingAll                  | 5.599 ns | 0.0682 ns | 0.0605 ns | 0.0019 |      24 B |
| StringBaseTypeCheckFirst             | 5.998 ns | 0.0855 ns | 0.0758 ns | 0.0019 |      24 B |
| NonNumericalStringDefaultCheck       | 2.633 ns | 0.0626 ns | 0.0555 ns | 0.0019 |      24 B |
| NonNumericalStringBaseTypeCheckFirst | 5.916 ns | 0.1416 ns | 0.2860 ns | 0.0019 |      24 B |
| NonNumericalStringTryParsingAll      | 5.372 ns | 0.1280 ns | 0.1664 ns | 0.0019 |      24 B |

Here is the Benchmark Used:
```cs
private static object LongAsObject = (long)7;
private static object IntAsObject = (int)7;
private static object StringAsObject = "7";

private static long LongAsLong = (long)7;
private static int IntAsInt = (int)7;
private static object NonNumericalStringAsObject = (string)"Some invalid string that cannot be casted to long";

private static bool TryParsingAll(object a, object b)
{
	return a switch
	{
		int value => int.TryParse(b.ToString(), out int other) && value == other,
		long value => long.TryParse(b.ToString(), out long other) && value == other,
		double value => double.TryParse(b.ToString(), out double other) && value == other,
		string value => b is string other && value == other,
		_ => false
	};
}

private static bool BaseTypeCheckFirst(object a, object b)
{
	return a switch
	{
		int value => (b is int other && value == other) || (int.TryParse(b.ToString(), out int otherParsed) && value == otherParsed),
		long value => (b is long other && value == other) || (long.TryParse(b.ToString(), out long otherParsed) && value == otherParsed),
		double value => (b is double other && value == other) || (double.TryParse(b.ToString(), out double otherParsed) && value == otherParsed),
		string value => b is string other && value == other,
		_ => false
	};
}

private static bool DefaultCheck(object a, object b)
{
	return a switch
	{
		int value => b is int other && value == other,
		long value => b is long other && value == other,
		double value => b is double other && value == other,
		string value => b is string other && value == other,
		_ => false
	};
}


[Benchmark]
public bool LongDefaultCheck()
{
	return DefaultCheck(LongAsLong, LongAsObject);
}
[Benchmark]
public bool LongBaseTypeCheckFirst()
{
	return BaseTypeCheckFirst(LongAsLong, LongAsObject);
}
[Benchmark]
public bool LongTryParsingAll()
{
	return TryParsingAll(LongAsLong, LongAsObject);
}











[Benchmark]
public bool IntDefaultCheck()
{
	return DefaultCheck(LongAsLong, IntAsObject);
}
[Benchmark]
public bool IntBaseTypeCheckFirst()
{
	return BaseTypeCheckFirst(LongAsLong, IntAsObject);
}
[Benchmark]
public bool IntTryParsingAll()
{
	return TryParsingAll(LongAsLong, IntAsObject);
}








[Benchmark]
public bool StringDefaultCheck()
{
	return DefaultCheck(LongAsLong, StringAsObject);
}
[Benchmark]
public bool StringTryParsingAll()
{
	return TryParsingAll(LongAsLong, StringAsObject);
}
[Benchmark]
public bool StringBaseTypeCheckFirst()
{
	return BaseTypeCheckFirst(LongAsLong, StringAsObject);
}








[Benchmark]
public bool NonNumericalStringDefaultCheck()
{
	return DefaultCheck(LongAsLong, NonNumericalStringAsObject);
}
[Benchmark]
public bool NonNumericalStringBaseTypeCheckFirst()
{
	return BaseTypeCheckFirst(LongAsLong, NonNumericalStringAsObject);
}
[Benchmark]
public bool NonNumericalStringTryParsingAll()
{
	return TryParsingAll(LongAsLong, NonNumericalStringAsObject);
}


```



# Notes
Very small niche case Tested OK, went from PATCHing every single command, to now only PUTing the guild specific commands on every startup.