### PR TITLE
Cleanup `DiscordOverwriteBuilder`

### DIFF
--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -317,11 +317,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
             throw new InvalidOperationException("Non-guild channels cannot be cloned.");
         }
 
-        List<DiscordOverwriteBuilder> ovrs = [];
-        foreach (DiscordOverwrite ovr in this.permissionOverwrites)
-        {
-            ovrs.Add(await DiscordOverwriteBuilder.FromAsync(ovr));
-        }
+        List<DiscordOverwriteBuilder> ovrs = [.. this.permissionOverwrites.Select(DiscordOverwriteBuilder.From)];
 
         int? bitrate = this.Bitrate;
         int? userLimit = this.UserLimit;

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -320,7 +320,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
         List<DiscordOverwriteBuilder> ovrs = [];
         foreach (DiscordOverwrite ovr in this.permissionOverwrites)
         {
-            ovrs.Add(await new DiscordOverwriteBuilder(member: null).FromAsync(ovr));
+            ovrs.Add(await DiscordOverwriteBuilder.FromAsync(ovr));
         }
 
         int? bitrate = this.Bitrate;

--- a/DSharpPlus/Entities/Channel/DiscordOverwriteType.cs
+++ b/DSharpPlus/Entities/Channel/DiscordOverwriteType.cs
@@ -7,12 +7,17 @@ namespace DSharpPlus.Entities;
 public enum DiscordOverwriteType : int
 {
     /// <summary>
+    /// The overwrite type is not currently defined.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
     /// Specifies that this overwrite applies to a role.
     /// </summary>
-    Role,
+    Role = 1,
 
     /// <summary>
     /// Specifies that this overwrite applies to a member.
     /// </summary>
-    Member
+    Member = 2
 }

--- a/DSharpPlus/Entities/Channel/DiscordOverwriteType.cs
+++ b/DSharpPlus/Entities/Channel/DiscordOverwriteType.cs
@@ -9,15 +9,15 @@ public enum DiscordOverwriteType : int
     /// <summary>
     /// The overwrite type is not currently defined.
     /// </summary>
-    None = 0,
+    None = -1,
 
     /// <summary>
     /// Specifies that this overwrite applies to a role.
     /// </summary>
-    Role = 1,
+    Role = 0,
 
     /// <summary>
     /// Specifies that this overwrite applies to a member.
     /// </summary>
-    Member = 2
+    Member = 1
 }

--- a/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwriteBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwriteBuilder.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 
@@ -6,7 +7,7 @@ namespace DSharpPlus.Entities;
 /// <summary>
 /// Represents a Discord permission overwrite builder.
 /// </summary>
-public sealed class DiscordOverwriteBuilder
+public sealed record DiscordOverwriteBuilder
 {
     /// <summary>
     /// Gets or sets the allowed permissions for this overwrite.
@@ -21,24 +22,32 @@ public sealed class DiscordOverwriteBuilder
     /// <summary>
     /// Gets the type of this overwrite's target.
     /// </summary>
-    public DiscordOverwriteType Type { get; private set; }
+    public required DiscordOverwriteType Type { get; init; }
 
     /// <summary>
     /// Gets the target for this overwrite.
     /// </summary>
-    public SnowflakeObject Target { get; private set; }
+    public required SnowflakeObject Target { get; init; }
+
+    /// <summary>
+    /// Creates a new Discord permission overwrite builder. This class can be used to construct permission overwrites for guild channels, used when creating channels.
+    /// </summary>
+    public DiscordOverwriteBuilder() { }
 
     /// <summary>
     /// Creates a new Discord permission overwrite builder for a member. This class can be used to construct permission overwrites for guild channels, used when creating channels.
     /// </summary>
+    [SetsRequiredMembers]
     public DiscordOverwriteBuilder(DiscordMember member)
     {
         this.Target = member;
         this.Type = DiscordOverwriteType.Member;
     }
+
     /// <summary>
     /// Creates a new Discord permission overwrite builder for a role. This class can be used to construct permission overwrites for guild channels, used when creating channels.
     /// </summary>
+    [SetsRequiredMembers]
     public DiscordOverwriteBuilder(DiscordRole role)
     {
         this.Target = role;
@@ -68,43 +77,17 @@ public sealed class DiscordOverwriteBuilder
     }
 
     /// <summary>
-    /// Sets the member to which this overwrite applies.
-    /// </summary>
-    /// <param name="member">Member to which apply this overwrite's permissions.</param>
-    /// <returns>This builder.</returns>
-    public DiscordOverwriteBuilder For(DiscordMember member)
-    {
-        this.Target = member;
-        this.Type = DiscordOverwriteType.Member;
-        return this;
-    }
-
-    /// <summary>
-    /// Sets the role to which this overwrite applies.
-    /// </summary>
-    /// <param name="role">Role to which apply this overwrite's permissions.</param>
-    /// <returns>This builder.</returns>
-    public DiscordOverwriteBuilder For(DiscordRole role)
-    {
-        this.Target = role;
-        this.Type = DiscordOverwriteType.Role;
-        return this;
-    }
-
-    /// <summary>
     /// Populates this builder with data from another overwrite object.
     /// </summary>
     /// <param name="other">Overwrite from which data will be used.</param>
     /// <returns>This builder.</returns>
-    public async Task<DiscordOverwriteBuilder> FromAsync(DiscordOverwrite other)
+    public static async Task<DiscordOverwriteBuilder> FromAsync(DiscordOverwrite other) => new()
     {
-        this.Allowed = other.Allowed;
-        this.Denied = other.Denied;
-        this.Type = other.Type;
-        this.Target = this.Type == DiscordOverwriteType.Member ? await other.GetMemberAsync() : await other.GetRoleAsync();
-
-        return this;
-    }
+        Allowed = other.Allowed,
+        Denied = other.Denied,
+        Type = other.Type,
+        Target = other.Type == DiscordOverwriteType.Member ? await other.GetMemberAsync() : await other.GetRoleAsync()
+    };
 
     /// <summary>
     /// Builds this DiscordOverwrite.

--- a/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwriteBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Overwrite/DiscordOverwriteBuilder.cs
@@ -89,7 +89,7 @@ public sealed record DiscordOverwriteBuilder
     /// <returns>Use this object for creation of new overwrites.</returns>
     internal DiscordRestOverwrite Build()
     {
-        return this.Target == null ? throw new InvalidOperationException("Target must be set.") : new()
+        return this.Target is null ? throw new InvalidOperationException("Target must be set.") : new()
         {
             Allow = this.Allowed,
             Deny = this.Denied,


### PR DESCRIPTION
# Summary
The `DiscordOverwriteBuilder` was written when specific language features were not made available. As time has passed, it's time to cleanup the class to be a bit more useful.

- `FromAsync` is now static.
- There is now an empty constructor to be used with object initialization syntax.

# Notes
Tested.