### PR TITLE
Fix SnowflakeObjectConverter

### DIFF
--- a/DSharpPlus.Commands/Converters/DiscordRoleConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordRoleConverter.cs
@@ -24,6 +24,7 @@ public partial class DiscordRoleConverter : ISlashArgumentConverter<DiscordRole>
         if (context is InteractionConverterContext interactionContext
             && interactionContext.Interaction.Data.Resolved is not null
             && ulong.TryParse(interactionContext.Argument?.RawValue, CultureInfo.InvariantCulture, out ulong roleId)
+            && interactionContext.Interaction.Data.Resolved.Roles is not null
             && interactionContext.Interaction.Data.Resolved.Roles.TryGetValue(roleId, out DiscordRole? role))
         {
             return Task.FromResult(Optional.FromValue(role));


### PR DESCRIPTION
# Summary
SnoflakeObjectConverter fails when trying to convert anything other than a DiscordRole with an NRE.

# Details
The failure occurs within the DiscordRoleConverter since the InteractionConverterContext.Interaction.Data.Resolved.Roles is null

Although I'm all for S.R.P, this does call to change the DiscordRoleConverter instead of the SnowflakeObjectConverter in preference of performance since any modification in SnowflakeObjectConverter alone would need some kind of a try/catch.

# Notes
Tested on 1 bot, NRE exception disappears and SnowflakeObjectConverter works as indented.