### PR TITLE
Fix leaking result on required remaining text (Attempt 2)

### DIFF
--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -173,7 +173,7 @@ public sealed class TextCommandProcessor : BaseCommandProcessor<ITextArgumentCon
         {
             if (argument.Value is ArgumentFailedConversionResult || argument.Value is Optional<ArgumentFailedConversionResult>)
             {
-                ArgumentFailedConversionResult argumentFailedConversionResultValue = null;
+                ArgumentFailedConversionResult? argumentFailedConversionResultValue = null;
                 if (argument.Value is ArgumentFailedConversionResult argumentFailedConversionResult)
                 {
                     argumentFailedConversionResultValue = argumentFailedConversionResult;


### PR DESCRIPTION
When having a command like so:
```csharp
[Command("test")]
public async Task ApproveAsync(TextCommandContext ctx, [RemainingText] string text)
```

When attempting to just run something like `!test` (with no remaining text), the object provided is not a string and can cause catastrophic failures:

![Photos_rMlcKUow5h](https://github.com/user-attachments/assets/d549d0c7-cb1e-49f2-b97e-a62c0a5807bb)

This is because in some cases, the `ArgumentNotParsedResult` object is wrapped around an `Optional<>`. This should cause the command to fail, but continues anyway.
