### PR TITLE
Give user and message commands their own command contexts

### DIFF
--- a/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandContext.cs
+++ b/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandContext.cs
@@ -1,0 +1,8 @@
+using DSharpPlus.Commands.Processors.SlashCommands;
+
+namespace DSharpPlus.Commands.Processors.MessageCommands;
+
+/// <summary>
+/// Indicates that the command was invoked via a message interaction.
+/// </summary>
+public record MessageCommandContext : SlashCommandContext;

--- a/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandProcessor.cs
@@ -117,7 +117,7 @@ public sealed class MessageCommandProcessor : ICommandProcessor
         {
             await this.extension.commandErrored.InvokeAsync(this.extension, new CommandErroredEventArgs()
             {
-                Context = new SlashCommandContext()
+                Context = new MessageCommandContext()
                 {
                     Arguments = new Dictionary<CommandParameter, object?>(),
                     Channel = eventArgs.Interaction.Channel,
@@ -149,7 +149,7 @@ public sealed class MessageCommandProcessor : ICommandProcessor
             arguments.Add(command.Parameters[i], command.Parameters[i].DefaultValue.Value);
         }
 
-        SlashCommandContext commandContext = new()
+        MessageCommandContext commandContext = new()
         {
             Arguments = arguments,
             Channel = eventArgs.Interaction.Channel,

--- a/DSharpPlus.Commands/Processors/UserCommands/UserCommandContext.cs
+++ b/DSharpPlus.Commands/Processors/UserCommands/UserCommandContext.cs
@@ -1,0 +1,8 @@
+using DSharpPlus.Commands.Processors.SlashCommands;
+
+namespace DSharpPlus.Commands.Processors.UserCommands;
+
+/// <summary>
+/// Indicates that the command was invoked via a user interaction.
+/// </summary>
+public record UserCommandContext : SlashCommandContext;

--- a/DSharpPlus.Commands/Processors/UserCommands/UserCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/UserCommands/UserCommandProcessor.cs
@@ -117,7 +117,7 @@ public sealed class UserCommandProcessor : ICommandProcessor
         {
             await this.extension.commandErrored.InvokeAsync(this.extension, new CommandErroredEventArgs()
             {
-                Context = new SlashCommandContext()
+                Context = new UserCommandContext()
                 {
                     Arguments = new Dictionary<CommandParameter, object?>(),
                     Channel = eventArgs.Interaction.Channel,
@@ -149,7 +149,7 @@ public sealed class UserCommandProcessor : ICommandProcessor
             arguments.Add(command.Parameters[i], command.Parameters[i].DefaultValue.Value);
         }
 
-        SlashCommandContext commandContext = new()
+        UserCommandContext commandContext = new()
         {
             Arguments = arguments,
             Channel = eventArgs.Interaction.Channel,


### PR DESCRIPTION
# Summary
Gives commands invoked via user and message interactions their own command contexts for more control to the dev. Currently, as far as I am aware, there is not a way for the dev to figure out *how*  the command was invoked, thus cannot make user-command invocations ephemeral while still having slash commands be non-ephemeral.

```cs
if (context is UserCommandContext userCommandContext)
{
    await userCommandContext.RespondAsync(message, ephemeral: true);
}
else
{
    await context.RespondAsync(message);
}
```

# Notes
Unable to test since my project relies on other unmerged PR's. Will test when those get merged.