### PR TITLE
solve two permissions usability issues

### DIFF
--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -109,4 +109,6 @@ jobs:
         uses: actions/deploy-pages@v1
       - name: Reload Discord documentation
         run: |
-          curl -X POST -H 'Authorization: Bot {{ secrets.DISCORD_TOKEN }}' -d '{"content":"<@341606460720939008> reload"}' 'https://discord.com/api/v10/channels/379379415475552276/messages'
+          curl -X POST -H 'Authorization: Bot $TOKEN' -d '{"content":"<@341606460720939008> reload"}' 'https://discord.com/api/v10/channels/379379415475552276/messages'
+        env:
+          TOKEN: ${{ secrets.DISCORD_TOKEN }}

--- a/DSharpPlus/Entities/DiscordPermissions.cs
+++ b/DSharpPlus/Entities/DiscordPermissions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Buffers.Binary;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -46,6 +47,17 @@ public readonly partial struct DiscordPermissions
     /// Creates a new instance of this type from the specified permissions.
     /// </summary>
     public DiscordPermissions(params ReadOnlySpan<DiscordPermission> permissions)
+    {
+        foreach (DiscordPermission permission in permissions)
+        {
+            this.data.SetFlag((int)permission, true);
+        }
+    }
+
+    /// <summary>
+    /// Creates a new instance of this type from the specified permissions.
+    /// </summary>
+    public DiscordPermissions(params IReadOnlyList<DiscordPermission> permissions)
     {
         foreach (DiscordPermission permission in permissions)
         {

--- a/DSharpPlus/Entities/DiscordPermissions.cs
+++ b/DSharpPlus/Entities/DiscordPermissions.cs
@@ -46,6 +46,7 @@ public readonly partial struct DiscordPermissions
     /// <summary>
     /// Creates a new instance of this type from the specified permissions.
     /// </summary>
+    [OverloadResolutionPriority(1)]
     public DiscordPermissions(params ReadOnlySpan<DiscordPermission> permissions)
     {
         foreach (DiscordPermission permission in permissions)
@@ -57,6 +58,7 @@ public readonly partial struct DiscordPermissions
     /// <summary>
     /// Creates a new instance of this type from the specified permissions.
     /// </summary>
+    [OverloadResolutionPriority(0)]
     public DiscordPermissions(params IReadOnlyList<DiscordPermission> permissions)
     {
         foreach (DiscordPermission permission in permissions)

--- a/obsolete/DSharpPlus.SlashCommands/Attributes/SlashCommandPermissionsAttribute.cs
+++ b/obsolete/DSharpPlus.SlashCommands/Attributes/SlashCommandPermissionsAttribute.cs
@@ -6,7 +6,7 @@ namespace DSharpPlus.SlashCommands;
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
 public class SlashCommandPermissionsAttribute : Attribute
 {
-    public DiscordPermissions Permissions { get; }
+    public DiscordPermission[] Permissions { get; }
 
-    public SlashCommandPermissionsAttribute(DiscordPermissions permissions) => this.Permissions = permissions;
+    public SlashCommandPermissionsAttribute(params DiscordPermission[] permissions) => this.Permissions = permissions;
 }

--- a/obsolete/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/obsolete/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -210,9 +210,9 @@ public sealed partial class SlashCommandsExtension : IDisposable
 
                         bool allowDMs =
                             subclassinfo.GetCustomAttribute<GuildOnlyAttribute>() is null;
-                        DiscordPermissions? v2Permissions = subclassinfo
+                        DiscordPermissions? v2Permissions = new(subclassinfo
                             .GetCustomAttribute<SlashCommandPermissionsAttribute>()
-                            ?.Permissions;
+                            ?.Permissions ?? []);
 
                         SlashCommandGroupAttribute? groupAttribute =
                             subclassinfo.GetCustomAttribute<SlashCommandGroupAttribute>();
@@ -494,10 +494,10 @@ public sealed partial class SlashCommandsExtension : IDisposable
                                     ?? method.DeclaringType.GetCustomAttribute<GuildOnlyAttribute>()
                                 )
                                     is null;
-                            DiscordPermissions? v2Permissions = (
+                            DiscordPermissions? v2Permissions = new((
                                 method.GetCustomAttribute<SlashCommandPermissionsAttribute>()
                                 ?? method.DeclaringType.GetCustomAttribute<SlashCommandPermissionsAttribute>()
-                            )?.Permissions;
+                            )?.Permissions ?? []);
 
                             DiscordApplicationCommand payload =
                                 new(
@@ -545,10 +545,10 @@ public sealed partial class SlashCommandsExtension : IDisposable
                                     ?? contextMethod.DeclaringType.GetCustomAttribute<GuildOnlyAttribute>()
                                 )
                                     is null;
-                            DiscordPermissions? permissions = (
+                            DiscordPermissions? permissions = new((
                                 contextMethod.GetCustomAttribute<SlashCommandPermissionsAttribute>()
                                 ?? contextMethod.DeclaringType.GetCustomAttribute<SlashCommandPermissionsAttribute>()
-                            )?.Permissions;
+                            )?.Permissions ?? []);
                             IReadOnlyList<DiscordApplicationIntegrationType>? integrationTypes =
                                 GetInteractionCommandInstallTypes(contextMethod);
                             IReadOnlyList<DiscordInteractionContextType>? contexts =


### PR DESCRIPTION
- updates `SlashCommandPermissionsAttribute`
- adds a constructor overload for IReadOnlyList, since we're running into overload resolution issues in some contexts
- (ideally) fixes doc reloading in discord