### PR TITLE
add a null check before relying on guildId being set

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -2639,7 +2639,7 @@ public sealed partial class DiscordClient
         interaction.Discord = this;
         interaction.Data.Discord = this;
 
-        if (member != null)
+        if (member is not null && guildId is not null)
         {
             usr = new DiscordMember(member) { guild_id = guildId.Value, Discord = this };
             UpdateUser(usr, guildId, interaction.Guild, member);


### PR DESCRIPTION
issue reported on discord.
mildly surprised this code was written like that in the first place, but oh well.