### PR TITLE
Add new guild member chunk method

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -582,16 +582,16 @@ public sealed partial class DiscordClient
                 await OnAutoModerationRuleExecutedAsync(dat.ToDiscordObject<DiscordAutoModerationActionExecution>());
                 break;
                 #endregion
-            
+
             #region Entitlements
             case "entitlement_create":
                 await OnEntitlementCreatedAsync(dat.ToDiscordObject<DiscordEntitlement>());
                 break;
-            
+
             case "entitlement_update":
                 await OnEntitlementUpdatedAsync(dat.ToDiscordObject<DiscordEntitlement>());
                 break;
-            
+
             case "entitlement_delete":
                 await OnEntitlementDeletedAsync(dat.ToDiscordObject<DiscordEntitlement>());
                 break;
@@ -1569,6 +1569,8 @@ public sealed partial class DiscordClient
             ISet<ulong> nf = dat["not_found"].ToDiscordObject<ISet<ulong>>();
             ea.NotFound = new ReadOnlySet<ulong>(nf);
         }
+
+        _ = this.DispatchGuildMembersChunkForIteratorsAsync(ea);
 
         await this.dispatcher.DispatchAsync(this, ea);
     }
@@ -2877,14 +2879,14 @@ public sealed partial class DiscordClient
     #endregion
 
     #region Entitlements
-    
-    private async Task OnEntitlementCreatedAsync(DiscordEntitlement entitlement) 
+
+    private async Task OnEntitlementCreatedAsync(DiscordEntitlement entitlement)
         => await this.dispatcher.DispatchAsync(this, new EntitlementCreatedEventArgs { Entitlement = entitlement });
 
-    private async Task OnEntitlementUpdatedAsync(DiscordEntitlement entitlement) 
+    private async Task OnEntitlementUpdatedAsync(DiscordEntitlement entitlement)
         => await this.dispatcher.DispatchAsync(this, new EntitlementUpdatedEventArgs { Entitlement = entitlement });
 
-    private async Task OnEntitlementDeletedAsync(DiscordEntitlement entitlement) 
+    private async Task OnEntitlementDeletedAsync(DiscordEntitlement entitlement)
         => await this.dispatcher.DispatchAsync(this,  new EntitlementDeletedEventArgs { Entitlement = entitlement });
 
     #endregion


### PR DESCRIPTION
Adds a new method that returns an iterator so that users can aggregate chunks instead of hooking the event

There's also missing validation for the nonce - it can only be 32 bytes, but then comes the question of throw or truncate. Out of scope for this PR.