### PR TITLE
Return rented buffers in DSP.Http.AspNetCore

### DIFF
--- a/DSharpPlus.Http.AspNetCore/EndpointRouteBuilderExtensions.cs
+++ b/DSharpPlus.Http.AspNetCore/EndpointRouteBuilderExtensions.cs
@@ -88,7 +88,10 @@ public static class EndpointRouteBuilderExtensions
 
         ArraySegment<byte> body = new(bodyBuffer, 0, length);
 
-        _ = transportService.HandleWebhookEventAsync(body);
+        
+        // ReSharper disable MethodSupportsCancellation => we dont care if the request was canceld and always want to return the buffer
+        _ = transportService.HandleWebhookEventAsync(body).ContinueWith(x => ArrayPool<byte>.Shared.Return(bodyBuffer));
+        // ReSharper restore MethodSupportsCancellation
         
         httpContext.Response.StatusCode = (int) HttpStatusCode.NoContent;
     }

--- a/DSharpPlus.Http.AspNetCore/EndpointRouteBuilderExtensions.cs
+++ b/DSharpPlus.Http.AspNetCore/EndpointRouteBuilderExtensions.cs
@@ -113,12 +113,14 @@ public static class EndpointRouteBuilderExtensions
         if (!TryExtractHeaders(httpContext.Request.Headers, out string? timestamp, out string? key))
         {
             httpContext.Response.StatusCode = 401;
+            ArrayPool<byte>.Shared.Return(bodyBuffer);
             return (-1, null);
         }
 
         if (!DiscordHeaders.VerifySignature(bodyBuffer.AsSpan(..length), timestamp!, key!, client.CurrentApplication.VerifyKey))
         {
             httpContext.Response.StatusCode = 401;
+            ArrayPool<byte>.Shared.Return(bodyBuffer);
             return (-1, null);
         }
 


### PR DESCRIPTION
# Summary
We didnt return the buffers back to the array pool