### PR TITLE
Support AEAD AES-256 GCM encryption in VNext

### DIFF
--- a/DSharpPlus.VoiceNext/Codec/Interop.cs
+++ b/DSharpPlus.VoiceNext/Codec/Interop.cs
@@ -15,17 +15,14 @@ internal static unsafe partial class Interop
     /// <summary>
     /// Gets the Sodium key size for xsalsa20_poly1305 algorithm.
     /// </summary>
-    public static int SodiumKeySize { get; } = (int)SodiumSecretBoxKeySize();
+    public static int SodiumKeySize { get; } = (int)crypto_aead_aes256gcm_keybytes();
 
     /// <summary>
     /// Gets the Sodium nonce size for xsalsa20_poly1305 algorithm.
     /// </summary>
-    public static int SodiumNonceSize { get; } = (int)SodiumSecretBoxNonceSize();
+    public static int SodiumNonceSize { get; } = (int)crypto_aead_aes256gcm_npubbytes();
 
-    /// <summary>
-    /// Gets the Sodium MAC size for xsalsa20_poly1305 algorithm.
-    /// </summary>
-    public static int SodiumMacSize { get; } = (int)SodiumSecretBoxMacSize();
+    public static int SodiumMacSize { get; } = (int)crypto_aead_aes256gcm_abytes();
 
     /// <summary>
     /// Indicates whether the current hardware is AEAD AES-256 GCM compatible.
@@ -38,10 +35,16 @@ internal static unsafe partial class Interop
     private static partial int crypto_aead_aes256gcm_is_available();
 
     [LibraryImport(SodiumLibraryName)]
+    private static partial nuint crypto_aead_aes256gcm_npubbytes();
+
+    [LibraryImport(SodiumLibraryName)]
+    private static partial nuint crypto_aead_aes256gcm_abytes();
+
+    [LibraryImport(SodiumLibraryName)]
     private static partial nuint crypto_aead_aes256gcm_keybytes();
 
     [LibraryImport(SodiumLibraryName)]
-    private static partial nuint crypto_aead_aes256gcm_encrypt
+    private static partial int crypto_aead_aes256gcm_encrypt
     (
         byte* encrypted,                                        // unsigned char *c
         ulong *encryptedLength,                                 // unsigned long long *clen_p
@@ -57,7 +60,7 @@ internal static unsafe partial class Interop
     );
 
     [LibraryImport(SodiumLibraryName)]
-    private static partial nuint crypto_aead_aes256gcm_decrypt
+    private static partial int crypto_aead_aes256gcm_decrypt
     (
         byte* message,                                          // unsigned char *m
         ulong* messageLength,                                   // unsigned long long *mlen_p
@@ -101,7 +104,7 @@ internal static unsafe partial class Interop
     /// <param name="key">Key to use for decryption.</param>
     /// <param name="nonce">Nonce to use for decryption.</param>
     /// <returns>Decryption status.</returns>
-    public static unsafe void Decrypt(ReadOnlySpan<byte> source, Span<byte> target, ReadOnlySpan<byte> key, ReadOnlySpan<byte> nonce)
+    public static unsafe int Decrypt(ReadOnlySpan<byte> source, Span<byte> target, ReadOnlySpan<byte> key, ReadOnlySpan<byte> nonce)
     {
         ulong targetLength = (ulong)target.Length;
 
@@ -110,7 +113,7 @@ internal static unsafe partial class Interop
         fixed (byte* pKey = key)
         fixed (byte* pNonce = nonce)
         {
-            crypto_aead_aes256gcm_decrypt(pTarget, &targetLength, null, pSource, (ulong)source.Length, null, 0, pNonce, pKey);
+            return crypto_aead_aes256gcm_decrypt(pTarget, &targetLength, null, pSource, (ulong)source.Length, null, 0, pNonce, pKey);
         }
     }
     #endregion

--- a/DSharpPlus.VoiceNext/Codec/Interop.cs
+++ b/DSharpPlus.VoiceNext/Codec/Interop.cs
@@ -7,7 +7,7 @@ namespace DSharpPlus.VoiceNext.Codec;
 /// <summary>
 /// This is an interop class. It contains wrapper methods for Opus and Sodium.
 /// </summary>
-internal static partial class Interop
+internal static unsafe partial class Interop
 {
     #region Sodium wrapper
     private const string SodiumLibraryName = "libsodium";
@@ -27,23 +27,50 @@ internal static partial class Interop
     /// </summary>
     public static int SodiumMacSize { get; } = (int)SodiumSecretBoxMacSize();
 
-    [LibraryImport(SodiumLibraryName, EntryPoint = "crypto_secretbox_xsalsa20poly1305_keybytes")]
-    [return: MarshalAs(UnmanagedType.SysUInt)]
-    private static partial UIntPtr SodiumSecretBoxKeySize();
+    /// <summary>
+    /// Indicates whether the current hardware is AEAD AES-256 GCM compatible.
+    /// </summary>
+    /// <returns></returns>
+    public static bool IsAeadAes256GcmCompatible()
+        => crypto_aead_aes256gcm_is_available() == 0;
 
-    [LibraryImport(SodiumLibraryName, EntryPoint = "crypto_secretbox_xsalsa20poly1305_noncebytes")]
-    [return: MarshalAs(UnmanagedType.SysUInt)]
-    private static partial UIntPtr SodiumSecretBoxNonceSize();
+    [LibraryImport(SodiumLibraryName)]
+    private static partial int crypto_aead_aes256gcm_is_available();
 
-    [LibraryImport(SodiumLibraryName, EntryPoint = "crypto_secretbox_xsalsa20poly1305_macbytes")]
-    [return: MarshalAs(UnmanagedType.SysUInt)]
-    private static partial UIntPtr SodiumSecretBoxMacSize();
+    [LibraryImport(SodiumLibraryName)]
+    private static partial nuint crypto_aead_aes256gcm_keybytes();
 
-    [LibraryImport(SodiumLibraryName, EntryPoint = "crypto_secretbox_easy")]
-    private static unsafe partial int SodiumSecretBoxCreate(byte* buffer, byte* message, ulong messageLength, byte* nonce, byte* key);
+    [LibraryImport(SodiumLibraryName)]
+    private static partial nuint crypto_aead_aes256gcm_encrypt
+    (
+        byte* encrypted,                                        // unsigned char *c
+        ulong *encryptedLength,                                 // unsigned long long *clen_p
+        byte* message,                                          // const unsigned char *m
+        ulong messageLength,                                    // unsigned long long mlen
+        // non-confidential data appended to the message
+        byte* ad,                                               // const unsigned char *ad
+        ulong adLength,                                         // unsigned long long adlen
+        // unused, should be null
+        byte* nonceSecret,                                      // const unsigned char *nsec
+        byte* noncePublic,                                      // const unsigned char *npub
+        byte* key                                               // const unsigned char *k
+    );
 
-    [LibraryImport(SodiumLibraryName, EntryPoint = "crypto_secretbox_open_easy")]
-    private static unsafe partial int SodiumSecretBoxOpen(byte* buffer, byte* encryptedMessage, ulong encryptedLength, byte* nonce, byte* key);
+    [LibraryImport(SodiumLibraryName)]
+    private static partial nuint crypto_aead_aes256gcm_decrypt
+    (
+        byte* message,                                          // unsigned char *m
+        ulong* messageLength,                                   // unsigned long long *mlen_p
+        // unused, should be null
+        byte* nonceSecret,                                      // unsigned char *nsec
+        byte* encrypted,                                        // const unsigned char *c
+        ulong encryptedLength,                                  // unsigned long long clen
+        // non-confidential data appended to the message
+        byte* ad,                                               // const unsigned char *ad
+        ulong adLength,                                         // unsigned long long adlen
+        byte* noncePublic,                                      // const unsigned char *npub
+        byte* key                                               // const unsigned char *p
+    );
 
     /// <summary>
     /// Encrypts supplied buffer using xsalsa20_poly1305 algorithm, using supplied key and nonce to perform encryption.
@@ -53,18 +80,17 @@ internal static partial class Interop
     /// <param name="key">Key to use for encryption.</param>
     /// <param name="nonce">Nonce to use for encryption.</param>
     /// <returns>Encryption status.</returns>
-    public static unsafe int Encrypt(ReadOnlySpan<byte> source, Span<byte> target, ReadOnlySpan<byte> key, ReadOnlySpan<byte> nonce)
+    public static unsafe void Encrypt(ReadOnlySpan<byte> source, Span<byte> target, ReadOnlySpan<byte> key, ReadOnlySpan<byte> nonce)
     {
-        int status = 0;
-        fixed (byte* sourcePtr = &source.GetPinnableReference())
-        fixed (byte* targetPtr = &target.GetPinnableReference())
-        fixed (byte* keyPtr = &key.GetPinnableReference())
-        fixed (byte* noncePtr = &nonce.GetPinnableReference())
-        {
-            status = SodiumSecretBoxCreate(targetPtr, sourcePtr, (ulong)source.Length, noncePtr, keyPtr);
-        }
+        ulong targetLength = (ulong)target.Length;
 
-        return status;
+        fixed (byte* pSource = source)
+        fixed (byte* pTarget = target)
+        fixed (byte* pKey = key)
+        fixed (byte* pNonce = nonce)
+        {
+            crypto_aead_aes256gcm_encrypt(pTarget, &targetLength, pSource, (ulong)source.Length, null, 0, null, pNonce, pKey); 
+        }
     }
 
     /// <summary>
@@ -75,18 +101,17 @@ internal static partial class Interop
     /// <param name="key">Key to use for decryption.</param>
     /// <param name="nonce">Nonce to use for decryption.</param>
     /// <returns>Decryption status.</returns>
-    public static unsafe int Decrypt(ReadOnlySpan<byte> source, Span<byte> target, ReadOnlySpan<byte> key, ReadOnlySpan<byte> nonce)
+    public static unsafe void Decrypt(ReadOnlySpan<byte> source, Span<byte> target, ReadOnlySpan<byte> key, ReadOnlySpan<byte> nonce)
     {
-        int status = 0;
-        fixed (byte* sourcePtr = &source.GetPinnableReference())
-        fixed (byte* targetPtr = &target.GetPinnableReference())
-        fixed (byte* keyPtr = &key.GetPinnableReference())
-        fixed (byte* noncePtr = &nonce.GetPinnableReference())
-        {
-            status = SodiumSecretBoxOpen(targetPtr, sourcePtr, (ulong)source.Length, noncePtr, keyPtr);
-        }
+        ulong targetLength = (ulong)target.Length;
 
-        return status;
+        fixed (byte* pSource = source)
+        fixed (byte* pTarget = target)
+        fixed (byte* pKey = key)
+        fixed (byte* pNonce = nonce)
+        {
+            crypto_aead_aes256gcm_decrypt(pTarget, &targetLength, null, pSource, (ulong)source.Length, null, 0, pNonce, pKey);
+        }
     }
     #endregion
 

--- a/DSharpPlus.VoiceNext/Codec/Rtp.cs
+++ b/DSharpPlus.VoiceNext/Codec/Rtp.cs
@@ -54,9 +54,7 @@ internal sealed class Rtp : IDisposable
 
     public static int CalculatePacketSize(int encryptedLength, EncryptionMode encryptionMode) => encryptionMode switch
     {
-        EncryptionMode.XSalsa20_Poly1305 => HeaderSize + encryptedLength,
-        EncryptionMode.XSalsa20_Poly1305_Suffix => HeaderSize + encryptedLength + Interop.SodiumNonceSize,
-        EncryptionMode.XSalsa20_Poly1305_Lite => HeaderSize + encryptedLength + 4,
+        EncryptionMode.AeadAes256GcmRtpSize => HeaderSize + encryptedLength + Interop.SodiumNonceSize,
         _ => throw new ArgumentException("Unsupported encryption mode.", nameof(encryptionMode)),
     };
 
@@ -64,17 +62,9 @@ internal sealed class Rtp : IDisposable
     {
         switch (encryptionMode)
         {
-            case EncryptionMode.XSalsa20_Poly1305:
-                data = packet[HeaderSize..];
-                return;
-
-            case EncryptionMode.XSalsa20_Poly1305_Suffix:
+            case EncryptionMode.AeadAes256GcmRtpSize:
                 data = packet.Slice(HeaderSize, packet.Length - HeaderSize - Interop.SodiumNonceSize);
                 return;
-
-            case EncryptionMode.XSalsa20_Poly1305_Lite:
-                data = packet.Slice(HeaderSize, packet.Length - HeaderSize - 4);
-                break;
 
             default:
                 throw new ArgumentException("Unsupported encryption mode.", nameof(encryptionMode));

--- a/DSharpPlus.VoiceNext/DiscordClientExtensions.cs
+++ b/DSharpPlus.VoiceNext/DiscordClientExtensions.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 using DSharpPlus.Entities;
 using DSharpPlus.Extensions;
-
+using DSharpPlus.VoiceNext.Codec;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DSharpPlus.VoiceNext;
@@ -22,6 +22,11 @@ public static class DiscordClientExtensions
         VoiceNextConfiguration configuration
     )
     {
+        if (!Interop.IsAeadAes256GcmCompatible())
+        {
+            throw new InvalidOperationException("The current hardware is not compatible with AEAD AES-256 GCM, a requirement for VoiceNext support.");
+        }
+
         services.ConfigureEventHandlers(b => b.AddEventHandlers<VoiceNextEventHandler>())
             .AddSingleton(provider =>
             {

--- a/DSharpPlus.VoiceNext/VoiceNextConnection.cs
+++ b/DSharpPlus.VoiceNext/VoiceNextConnection.cs
@@ -320,15 +320,7 @@ public sealed class VoiceNextConnection : IDisposable
         Span<byte> nonce = stackalloc byte[Sodium.NonceSize];
         switch (this.SelectedEncryptionMode)
         {
-            case EncryptionMode.XSalsa20_Poly1305:
-                Sodium.GenerateNonce(packet[..Rtp.HeaderSize], nonce);
-                break;
-
-            case EncryptionMode.XSalsa20_Poly1305_Suffix:
-                this.Sodium.GenerateNonce(nonce);
-                break;
-
-            case EncryptionMode.XSalsa20_Poly1305_Lite:
+            case EncryptionMode.AeadAes256GcmRtpSize:
                 Sodium.GenerateNonce(this.Nonce++, nonce);
                 break;
 


### PR DESCRIPTION
it does appear to be slightly accelerating audio (by a factor of ~1.01-1.04x), but other than that, works:tm: - i was able to play audio, with some difficulty considering it *is* VoiceNext

tomorrow, the 18th of November, this will be mandatory - unupdated VoiceNext will break. we should consider backporting this as alpha.2 (there are no problems with that, the code is .NET 8 safe - just not .NET Standard safe, although it shouldn't be terribly difficult if 4.5.1 becomes a highly-requested version)