### PR TITLE
Added missing exception to GetMemberAsync summary comment

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -1731,6 +1731,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     /// <param name="updateCache">Whether to always make a REST request and update the member cache.</param>
     /// <returns>The requested member.</returns>
     /// <exception cref="ServerErrorException">Thrown when Discord is unable to process the request.</exception>
+    /// <exception cref="NotFoundException">Thrown when the member does not exist in this guild.</exception>
     public async Task<DiscordMember> GetMemberAsync(ulong userId, bool updateCache = false)
     {
         if (!updateCache && this.members != null && this.members.TryGetValue(userId, out DiscordMember? mbr))


### PR DESCRIPTION
I have also tested that this is the exception thrown when members do not exist:

![image](https://github.com/user-attachments/assets/fa9ea52a-e9c5-473c-ade1-d68df2e76010)
