### PR TITLE
implement a distinction between naming policies and naming fixers

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/InteractionConverterContext.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/InteractionConverterContext.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using DSharpPlus.Commands.Converters;
-using DSharpPlus.Commands.Processors.SlashCommands.NamingPolicies;
+using DSharpPlus.Commands.Processors.SlashCommands.InteractionNamingPolicies;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.Commands.Processors.SlashCommands;

--- a/DSharpPlus.Commands/Processors/SlashCommands/InteractionNamingPolicies/CaseImplHelpers.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/InteractionNamingPolicies/CaseImplHelpers.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Globalization;
+
+using CommunityToolkit.HighPerformance;
+using CommunityToolkit.HighPerformance.Buffers;
+
+namespace DSharpPlus.Commands.Processors.SlashCommands.InteractionNamingPolicies;
+
+internal static class CaseImplHelpers
+{
+    public static void LowercaseCore(ReadOnlySpan<char> raw, ArrayPoolBufferWriter<char> result, CultureInfo culture)
+    {
+        for (int i = 0; i < raw.Length; i++)
+        {
+            char character = raw[i];
+            result.Write(char.ToLower(character, culture));
+        }
+    }
+
+    public static void KebabCaseCore(ReadOnlySpan<char> raw, ArrayPoolBufferWriter<char> result, CultureInfo culture)
+    {
+        for (int i = 0; i < raw.Length; i++)
+        {
+            char character = raw[i];
+
+            // camelCase, PascalCase
+            if (i != 0 && char.IsUpper(character) && result.WrittenSpan[^1] is not ('-' or '_'))
+            {
+                result.Write('-');
+            }
+
+            result.Write(char.ToLower(character, culture));
+        }
+    }
+
+    public static void SnakeCaseCore(ReadOnlySpan<char> raw, ArrayPoolBufferWriter<char> result, CultureInfo culture)
+    {
+        for (int i = 0; i < raw.Length; i++)
+        {
+            char character = raw[i];
+
+            // camelCase, PascalCase
+            if (i != 0 && char.IsUpper(character) && result.WrittenSpan[^1] is not ('-' or '_'))
+            {
+                result.Write('_');
+            }
+
+            result.Write(char.ToLower(character, culture));
+        }
+    }
+}

--- a/DSharpPlus.Commands/Processors/SlashCommands/InteractionNamingPolicies/IInteractionNamingPolicy.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/InteractionNamingPolicies/IInteractionNamingPolicy.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Globalization;
 using DSharpPlus.Commands.Trees;
 
-namespace DSharpPlus.Commands.Processors.SlashCommands.NamingPolicies;
+namespace DSharpPlus.Commands.Processors.SlashCommands.InteractionNamingPolicies;
 
 /// <summary>
 /// Represents a policy for naming parameters. This is used to determine the

--- a/DSharpPlus.Commands/Processors/SlashCommands/InteractionNamingPolicies/KebabCaseNamingFixer.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/InteractionNamingPolicies/KebabCaseNamingFixer.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+using CommunityToolkit.HighPerformance.Buffers;
+
+using DSharpPlus.Commands.Trees;
+
+namespace DSharpPlus.Commands.Processors.SlashCommands.InteractionNamingPolicies;
+
+/// <summary>
+/// Transforms parameter names into kebab-case.
+/// </summary>
+public sealed class KebabCaseNamingFixer : IInteractionNamingPolicy
+{
+    /// <summary>
+    /// Transforms the parameter name into it's kebab-case equivalent.
+    /// </summary>
+    /// <inheritdoc />
+    public string GetParameterName(CommandParameter parameter, CultureInfo culture, int arrayIndex)
+    {
+        if (string.IsNullOrWhiteSpace(parameter.Name))
+        {
+            throw new InvalidOperationException("Parameter name cannot be null or empty.");
+        }
+
+        StringBuilder stringBuilder = new(TransformText(parameter.Name, culture));
+        if (arrayIndex > -1)
+        {
+            stringBuilder.Append('-');
+            stringBuilder.Append(arrayIndex.ToString(culture));
+        }
+
+        return stringBuilder.ToString();
+    }
+
+    /// <inheritdoc />
+    public string TransformText(ReadOnlySpan<char> text, CultureInfo culture)
+    {
+        ArrayPoolBufferWriter<char> writer = new(32);
+
+        CaseImplHelpers.KebabCaseCore(text, writer, culture);
+
+        return new string(writer.WrittenSpan);
+    }
+}

--- a/DSharpPlus.Commands/Processors/SlashCommands/InteractionNamingPolicies/LowercaseNamingFixer.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/InteractionNamingPolicies/LowercaseNamingFixer.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+using CommunityToolkit.HighPerformance.Buffers;
+
+using DSharpPlus.Commands.Trees;
+
+namespace DSharpPlus.Commands.Processors.SlashCommands.InteractionNamingPolicies;
+
+/// <summary>
+/// Transforms parameter names into lowercase.
+/// </summary>
+public sealed class LowercaseNamingFixer : IInteractionNamingPolicy
+{
+    /// <summary>
+    /// Transforms the parameter name into it's lowercase equivalent.
+    /// </summary>
+    /// <inheritdoc />
+    public string GetParameterName(CommandParameter parameter, CultureInfo culture, int arrayIndex)
+    {
+        if (string.IsNullOrWhiteSpace(parameter.Name))
+        {
+            throw new InvalidOperationException("Parameter name cannot be null or empty.");
+        }
+
+        StringBuilder stringBuilder = new(TransformText(parameter.Name, culture));
+        if (arrayIndex > -1)
+        {
+            stringBuilder.Append(arrayIndex.ToString(culture));
+        }
+
+        return stringBuilder.ToString();
+    }
+
+    /// <inheritdoc />
+    public string TransformText(ReadOnlySpan<char> text, CultureInfo culture)
+    {
+        ArrayPoolBufferWriter<char> writer = new(32);
+
+        CaseImplHelpers.LowercaseCore(text, writer, culture);
+
+        return new string(writer.WrittenSpan);
+    }
+}

--- a/DSharpPlus.Commands/Processors/SlashCommands/InteractionNamingPolicies/SnakeCaseNamingFixer.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/InteractionNamingPolicies/SnakeCaseNamingFixer.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+using CommunityToolkit.HighPerformance.Buffers;
+
+using DSharpPlus.Commands.Trees;
+
+namespace DSharpPlus.Commands.Processors.SlashCommands.InteractionNamingPolicies;
+
+/// <summary>
+/// Transforms parameter names into snake_case.
+/// </summary>
+public class SnakeCaseNamingFixer : IInteractionNamingPolicy
+{
+    /// <summary>
+    /// Transforms the parameter name into it's snake_case equivalent.
+    /// </summary>
+    /// <inheritdoc />
+    public string GetParameterName(CommandParameter parameter, CultureInfo culture, int arrayIndex)
+    {
+        if (string.IsNullOrWhiteSpace(parameter.Name))
+        {
+            throw new InvalidOperationException("Parameter name cannot be null or empty.");
+        }
+
+        StringBuilder stringBuilder = new(TransformText(parameter.Name, culture));
+        if (arrayIndex > -1)
+        {
+            stringBuilder.Append('_');
+            stringBuilder.Append(arrayIndex);
+        }
+
+        return stringBuilder.ToString();
+    }
+
+    /// <inheritdoc />
+    public string TransformText(ReadOnlySpan<char> text, CultureInfo culture)
+    {
+        ArrayPoolBufferWriter<char> writer = new(32);
+
+        CaseImplHelpers.SnakeCaseCore(text, writer, culture);
+
+        return new string(writer.WrittenSpan);
+    }
+}

--- a/DSharpPlus.Commands/Processors/SlashCommands/InteractionNamingPolicies/SnakeCaseNamingPolicy.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/InteractionNamingPolicies/SnakeCaseNamingPolicy.cs
@@ -1,9 +1,13 @@
 using System;
+using System.Buffers;
 using System.Globalization;
 using System.Text;
+
+using CommunityToolkit.HighPerformance.Buffers;
+
 using DSharpPlus.Commands.Trees;
 
-namespace DSharpPlus.Commands.Processors.SlashCommands.NamingPolicies;
+namespace DSharpPlus.Commands.Processors.SlashCommands.InteractionNamingPolicies;
 
 /// <summary>
 /// Transforms parameter names into snake_case.
@@ -34,25 +38,11 @@ public class SnakeCaseNamingPolicy : IInteractionNamingPolicy
     /// <inheritdoc />
     public string TransformText(ReadOnlySpan<char> text, CultureInfo culture)
     {
-        StringBuilder stringBuilder = new();
-        for (int i = 0; i < text.Length; i++)
-        {
-            char character = text[i];
+        ArrayPoolBufferWriter<char> writer = new(32);
 
-            // camelCase, PascalCase
-            if (i != 0 && char.IsUpper(character))
-            {
-                stringBuilder.Append('_');
-            }
-            else if (character == '-')
-            {
-                stringBuilder.Append('_');
-                continue;
-            }
+        CaseImplHelpers.SnakeCaseCore(text, writer, culture);
+        ((IMemoryOwner<char>)writer).Memory.Span.Replace('-', '_');
 
-            stringBuilder.Append(char.ToLower(character, culture));
-        }
-
-        return stringBuilder.ToString();
+        return new string(writer.WrittenSpan);
     }
 }

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandConfiguration.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandConfiguration.cs
@@ -1,4 +1,4 @@
-using DSharpPlus.Commands.Processors.SlashCommands.NamingPolicies;
+using DSharpPlus.Commands.Processors.SlashCommands.InteractionNamingPolicies;
 using DSharpPlus.Commands.Processors.SlashCommands.RemoteRecordRetentionPolicies;
 
 namespace DSharpPlus.Commands.Processors.SlashCommands;


### PR DESCRIPTION
naming "policies" will make names consistent with one another, naming "fixers" will respect user input as far as possible and only do what is necessary to make the name valid
closes ##2139