### PR TITLE
correctly check parameter types for message/user context commands

### DIFF
--- a/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandProcessor.cs
@@ -65,7 +65,7 @@ public sealed class MessageCommandProcessor : ICommandProcessor
                 MessageCommandLogging.messageCommandCannotHaveSubcommands(logger, command.FullName, null);
                 continue;
             }
-            else if (!command.Method!.GetParameters()[0].ParameterType.IsAssignableFrom(typeof(SlashCommandContext)))
+            else if (!command.Method!.GetParameters()[0].ParameterType.IsAssignableFrom(typeof(MessageCommandContext)))
             {
                 MessageCommandLogging.messageCommandContextParameterType(logger, command.FullName, null);
                 continue;

--- a/DSharpPlus.Commands/Processors/UserCommands/UserCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/UserCommands/UserCommandProcessor.cs
@@ -64,7 +64,7 @@ public sealed class UserCommandProcessor : ICommandProcessor
                 UserCommandLogging.userCommandCannotHaveSubcommands(logger, command.FullName, null);
                 continue;
             }
-            else if (!command.Method!.GetParameters()[0].ParameterType.IsAssignableFrom(typeof(SlashCommandContext)))
+            else if (!command.Method!.GetParameters()[0].ParameterType.IsAssignableFrom(typeof(UserCommandContext)))
             {
                 UserCommandLogging.userCommandContextParameterType(logger, command.FullName, null);
                 continue;


### PR DESCRIPTION
they, ironically, previously rejected UserCommandContext and MessageCommandContext.

unlike the PR adding support, tested.