### PR TITLE
fixes creating a permission overwrite

### DIFF
--- a/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
@@ -281,7 +281,7 @@ internal sealed class RestChannelPermissionEditPayload
     public DiscordPermissions Deny { get; set; }
 
     [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]
-    public string Type { get; set; }
+    public int Type { get; set; }
 }
 
 internal sealed class RestChannelGroupDmRecipientAddPayload : IOAuth2Payload

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -2702,7 +2702,12 @@ public sealed class DiscordApiClient
     {
         RestChannelPermissionEditPayload pld = new()
         {
-            Type = type,
+            Type = type switch
+            {
+                "role" => 0,
+                "member" => 1,
+                _ => throw new InvalidOperationException("Unrecognized permission overwrite target type.")
+            },
             Allow = allow & DiscordPermissions.All,
             Deny = deny & DiscordPermissions.All
         };


### PR DESCRIPTION
not entirely sure as to how this happened, but, that's an integer, not a string