### PR TITLE
Only update user cache in interactions if guild is in cache

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -2763,7 +2763,7 @@ public sealed partial class DiscordClient
         interaction.Discord = this;
         interaction.Data.Discord = this;
 
-        if (member is not null && guildId is not null)
+        if (member is not null && guildId is not null && interaction.Guild is not null)
         {
             usr = new DiscordMember(member) { guild_id = guildId.Value, Discord = this };
             UpdateUser(usr, guildId, interaction.Guild, member);


### PR DESCRIPTION
# Summary
If the guild is not in cache (bot is not in guild) we cant update its user cache in interactions.

## Note
I checked all callsites of the update method and its all in gw events you cant get without beeing in the guild