### PR TITLE
fix: tokens containing underscores not being anonymized

### DIFF
--- a/DSharpPlus/Logging/AnonymizationUtilities.cs
+++ b/DSharpPlus/Logging/AnonymizationUtilities.cs
@@ -4,7 +4,7 @@ namespace DSharpPlus.Logging;
 
 internal static partial class AnonymizationUtilities
 {
-    [GeneratedRegex(@"""token"":""[a-zA-Z0-9\-\. ]+""")]
+    [GeneratedRegex(@"""token"":""[a-zA-Z0-9_\-\. ]+""")]
     private static partial Regex GetJsonEncodedTokenRegex();
 
     [GeneratedRegex(@"\/webhooks\/[0-9]+\/[a-zA-Z0-9\-\. ]+\/")]


### PR DESCRIPTION
# Summary

Fix tokens containing underscores not being anonymized

# Details

Fixes token redaction breaking if the token contains an underscore character, which is common in the outbound gateway event logs.

# Changes proposed
- Updated Regex to include underscores when searching for a token

# Notes
Thank you to @akiraveliara for helping me diagnose this problem