### PR TITLE
properly report application command registration errors

### DIFF
--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -509,6 +509,7 @@ public sealed class CommandsExtension
         stringBuilder.Append(eventArgs.Exception switch
         {
             CommandNotFoundException commandNotFoundException => $"Command ``{commandNotFoundException.CommandName}`` was not found.",
+            CommandRegistrationFailedException => $"Application commands failed to register.",
             ArgumentParseException argumentParseException when argumentParseException.ConversionResult?.Value is not null =>
                 $"Failed to parse argument ``{argumentParseException.Parameter.Name}``: ``{argumentParseException.ConversionResult.Value.ToString() ?? "<null>"}`` is not a valid value. {argumentParseException.Message}",
             ArgumentParseException argumentParseException =>

--- a/DSharpPlus.Commands/Exceptions/ChoiceProviderFailedException.cs
+++ b/DSharpPlus.Commands/Exceptions/ChoiceProviderFailedException.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace DSharpPlus.Commands.Exceptions;
+
+/// <summary>
+/// Thrown if a choice provider failed to execute.
+/// </summary>
+public class ChoiceProviderFailedException : Exception
+{
+    public Type ProviderType { get; private set; }
+
+    public ChoiceProviderFailedException(Type providerType, Exception? innerException) 
+        : base($"Choice provider {providerType} failed.", innerException)
+        => this.ProviderType = providerType;
+
+    public override string ToString() 
+        => $"Choice provider {this.ProviderType} failed with exception {this.InnerException}";
+}

--- a/DSharpPlus.Commands/Exceptions/CommandRegistrationFailedException.cs
+++ b/DSharpPlus.Commands/Exceptions/CommandRegistrationFailedException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace DSharpPlus.Commands.Exceptions;
+
+/// <summary>
+/// Thrown if the extension failed to register application commands and an attempt was made to execute an application command.
+/// </summary>
+public class CommandRegistrationFailedException : Exception;

--- a/DSharpPlus.Commands/Processors/SlashCommands/ArgumentModifiers/SlashChoiceProviderAttribute.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/ArgumentModifiers/SlashChoiceProviderAttribute.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DSharpPlus.Commands.Exceptions;
 using DSharpPlus.Commands.Trees;
 using DSharpPlus.Entities;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,7 +47,18 @@ public class SlashChoiceProviderAttribute : Attribute
         }
 
         List<DiscordApplicationCommandOptionChoice> choices = new(25);
-        foreach (DiscordApplicationCommandOptionChoice choice in await choiceProvider.ProvideAsync(parameter))
+        IEnumerable<DiscordApplicationCommandOptionChoice> userProvidedChoices;
+
+        try
+        {
+            userProvidedChoices = await choiceProvider.ProvideAsync(parameter);
+        }
+        catch(Exception e)
+        {
+            throw new ChoiceProviderFailedException(this.ProviderType, e);
+        }
+
+        foreach (DiscordApplicationCommandOptionChoice choice in userProvidedChoices)
         {
             if (choices.Count == 25)
             {


### PR DESCRIPTION
previously, this would fail with a nondescript stack trace and no further diagnostic information; commands would then proceed to return "not found" errors not indicative of the problem at hand.