### PR TITLE
Add debug symbols to build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,6 +32,8 @@
     <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp</PackageTags>
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/DSharpPlus/DSharpPlus</RepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <!-- Resource Files -->


### PR DESCRIPTION
# Summary
The debug symbols were not published anymore. This change adds publishing the symbols when using the dotnet cli or msbuild