### PR TITLE
Fix ZlibStreamCompressor throwing NullReferenceException

### DIFF
--- a/DSharpPlus/Net/Gateway/Compression/Zlib/ZlibStreamDecompressor.cs
+++ b/DSharpPlus/Net/Gateway/Compression/Zlib/ZlibStreamDecompressor.cs
@@ -33,7 +33,13 @@ public sealed class ZlibStreamDecompressor : IPayloadDecompressor
     }
 
     /// <inheritdoc/>
-    public void Dispose() => this.wrapper.Dispose();
+    public void Dispose()
+    {
+        if (this.wrapper != default)
+        {
+            this.wrapper.Dispose();    
+        }
+    }
 
     /// <inheritdoc/>
     public void Reset()


### PR DESCRIPTION
# Summary
This PR should fix ZlibStreamCompressor.Dispose() throwing a NullReferenceException after ZlibStreamCompressor.Reset() was called. 

# Details

This error can happen if the DiscordClient is used in a GenericHost and the application is being shut down.
In that case TransportService.DisconnectAsync calls ZlibStreamCompressor.Reset() here and the Compressor is later getting disposed by the ServiceCollection its registered to.

# Changes proposed
* Check ZlibStreamDecompressor.wrapper for being default before calling dispose on it

# Notes
None. 