### PR TITLE
Update GH Actions versions

### DIFF
--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -101,12 +101,12 @@ jobs:
           dotnet tool update -g docfx --prerelease
           docfx docs/docfx.json
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/_site/
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4
       - name: Reload Discord documentation
         run: |
           curl -X POST -H 'Authorization: Bot ${{ secrets.DISCORD_TOKEN }}' -H 'Content-Type: application/json' -d '{"content":"<@341606460720939008> reload"}' 'https://discord.com/api/v10/channels/379379415475552276/messages'


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Updates `upload-pages-artifact` from v1 to v3, and `deploy-pages` from v1 to v4. Simple, really.
Everything should be fine, because we already use those newer versions in other actions for same purposes.

