### PR TITLE
Keep all data in original json in ready payload object

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -81,11 +81,8 @@ public sealed partial class DiscordClient
             #region Gateway Status
 
             case "ready":
-                JArray? glds = (JArray)dat["guilds"];
-                JArray? dmcs = (JArray)dat["private_channels"];
-
-                dat.Remove("guilds");
-                dat.Remove("private_channels");
+                JArray? glds = (JArray?)dat["guilds"];
+                JArray? dmcs = (JArray?)dat["private_channels"];
 
                 int readyShardId = payload is ShardIdContainingGatewayPayload { ShardId: { } id } ? id : 0;
 
@@ -3029,7 +3026,7 @@ public sealed partial class DiscordClient
         );
     }
 
-    private async Task OnEntitlementUpdatedAsync(DiscordEntitlement entitlement) 
+    private async Task OnEntitlementUpdatedAsync(DiscordEntitlement entitlement)
         => await this.dispatcher.DispatchAsync(this, new EntitlementUpdatedEventArgs { Entitlement = entitlement });
 
     private async Task OnEntitlementDeletedAsync(DiscordEntitlement entitlement)


### PR DESCRIPTION
I may have done an oopsies - there are other places that're probably broken, but those only raise subtle issues with stale caching. This should fix an actual issue, since we present data directly reliant on the information deserialized here. See commit message for more detail.