### PR TITLE
fix IsLocalizationSupported() logic

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.Registration.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.Registration.cs
@@ -691,13 +691,19 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<ISlashA
 
     internal static bool IsLocalizationSupported()
     {
-        bool specifiedInAssembly = AppContext.TryGetSwitch("System.Globalization.Invariant", out bool invariant);
+        string? invariantEnvValue = Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT");
 
-        if (specifiedInAssembly)
+        if (invariantEnvValue is not null)
         {
-            return !invariant;
+            if (invariantEnvValue == "1" || invariantEnvValue.Equals("true", StringComparison.InvariantCultureIgnoreCase)) {
+                return false;
+            }
+            
+            if (invariantEnvValue == "0" || invariantEnvValue.Equals("false", StringComparison.InvariantCultureIgnoreCase)) {
+                return true;
+            }
         }
 
-        return Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT") != "1";
+        return !AppContext.TryGetSwitch("System.Globalization.Invariant", out bool value) || !value;
     }
 }


### PR DESCRIPTION
# Summary

Fixes the logic behind `IsLocalizationSupported()` to work correctly in Dotnet Alpine containers.

# Details
When I started using DSharpPlus.Commands, I encountered the following error only when running in an Alpine Docker container.

```
bot-1    | [2025-01-15 19:19:47 +00:00] [Error] Event handler exception for event "DSharpPlus.EventArgs.InteractionCreatedEventArgs" thrown from "System.Threading.Tasks.Task lambda_method141(System.Runtime.CompilerServices.Closure, DSharpPlus.DiscordClient, DSharpPlus.EventArgs.InteractionCreatedEventArgs, System.IServiceProvider)" (defined in null).
bot-1    | System.Globalization.CultureNotFoundException: Only the invariant culture is supported in globalization-invariant mode. See https://aka.ms/GlobalizationInvariantMode for more information. (Parameter 'name')                                                                         
bot-1    | en-gb is an invalid culture identifier.
bot-1    |    at System.Globalization.CultureInfo.GetCultureInfo(String name)                                                                    
bot-1    |    at DSharpPlus.Commands.Processors.SlashCommands.SlashCommandProcessor.ResolveCulture(DiscordInteraction interaction) in /app/DSharpPlus-orig/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.Registration.cs:line 682                                            
bot-1    |    at DSharpPlus.Commands.Processors.SlashCommands.SlashCommandProcessor.TryFindCommand(DiscordInteraction interaction, Command& command, IReadOnlyList`1& options) in /app/DSharpPlus-orig/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs:line 208             
bot-1    |    at DSharpPlus.Commands.Processors.SlashCommands.SlashCommandProcessor.ExecuteInteractionAsync(DiscordClient client, InteractionCreatedEventArgs eventArgs) in /app/DSharpPlus-orig/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.cs:line 106                   
bot-1    |    at DSharpPlus.Commands.ProcessorInvokingHandlers.HandleEventAsync(DiscordClient sender, InteractionCreatedEventArgs eventArgs) in /app/DSharpPlus-orig/DSharpPlus.Commands/ProcessorInvokingHandlers.cs:line 39                                                                     
bot-1    |    at DSharpPlus.Clients.DefaultEventDispatcher.<>c__DisplayClass6_0`1.<<DispatchAsync>b__0>d.MoveNext() in /app/DSharpPlus-orig/DSharpPlus/Clients/DefaultEventDispatcher.cs:line 68                                                                                                  
```

Adding `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false` did fix it, but then I tried to use `<InvariantGlobalization>false</InvariantGlobalization>` instead and that didn't work.

If it was working properly, the logic introduced by @VelvetToroyashi in #2155 should have averted this even without those settings changes. Turns out there's two flaws in that logic:

* It prioritizes the `AppContext.TryGetSwitch` result over the environment variable, while Microsoft [does the opposite](https://github.com/dotnet/runtime/blob/1ce82e73932b8bc98f6395b0169c21f17f71268b/src/libraries/System.Private.CoreLib/src/System/AppContextConfigHelper.cs#L13-L29).
* It only checks the environment variable for `1`, and not a value of `true`.

This becomes significant in the Alpine Docker case because Microsoft sets the environment variable to `true` [in the container image](https://github.com/dotnet/dotnet-docker/blob/main/src/runtime-deps/9.0/alpine3.21/amd64/Dockerfile#L11), which Velvet's logic doesn't handle for the above reasons and so the above error happens even without any settings changes on the project-level. Changing the `InvariantGlobalization` in the project to `false` does nothing because the environment variable Microsoft oh-so-helpfully provided overrides it. 

This PR fixes the logic of `IsLocalizationSupported()` to match what it should be.

# Changes proposed
Logic that better matches Microsoft's: https://github.com/dotnet/runtime/blob/1ce82e73932b8bc98f6395b0169c21f17f71268b/src/libraries/System.Private.CoreLib/src/System/AppContextConfigHelper.cs#L13-L29

# Notes
This is extensively tested working with every combination of `InvariantGlobalization` settings both on Windows and in Alpine Docker containers.