### PR TITLE
fix a stray error message when encountering an invalid session in trying to resume

### DIFF
--- a/DSharpPlus/Net/Gateway/GatewayClient.cs
+++ b/DSharpPlus/Net/Gateway/GatewayClient.cs
@@ -344,7 +344,7 @@ public sealed class GatewayClient : IGatewayClient
                             _ = this.controller.SessionInvalidatedAsync(this);
                         }
 
-                        break;
+                        continue;
 
                     case GatewayOpCode.Reconnect:
 
@@ -362,7 +362,7 @@ public sealed class GatewayClient : IGatewayClient
 
                 if (CheckShouldBeEnqueued(payload))
                 {
-                    await this.eventWriter.WriteAsync(payload, ct);
+                    await this.eventWriter.WriteAsync(payload, CancellationToken.None);
                 }
             }
         }


### PR DESCRIPTION
it was a completely inconsequential error message, but it was still something we can just handle