### PR TITLE
`RequirePermissions`: Use `DiscordPermissions`

### DIFF
--- a/DSharpPlus.Commands/ContextChecks/RequirePermissionsAttribute.cs
+++ b/DSharpPlus.Commands/ContextChecks/RequirePermissionsAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using DSharpPlus.Entities;
 
 namespace DSharpPlus.Commands.ContextChecks;
@@ -6,13 +7,13 @@ namespace DSharpPlus.Commands.ContextChecks;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Delegate)]
 public class RequirePermissionsAttribute : RequireGuildAttribute
 {
-    public DiscordPermission[] BotPermissions { get; init; }
-    public DiscordPermission[] UserPermissions { get; init; }
+    public DiscordPermissions BotPermissions { get; init; }
+    public DiscordPermissions UserPermissions { get; init; }
 
-    public RequirePermissionsAttribute(params DiscordPermission[] permissions) => this.BotPermissions = this.UserPermissions = permissions;
+    public RequirePermissionsAttribute(params DiscordPermission[] permissions) => this.BotPermissions = this.UserPermissions = new((IReadOnlyList<DiscordPermission>)permissions);
     public RequirePermissionsAttribute(DiscordPermission[] botPermissions, DiscordPermission[] userPermissions)
     {
-        this.BotPermissions = botPermissions;
-        this.UserPermissions = userPermissions;
+        this.BotPermissions = new((IReadOnlyList<DiscordPermission>)botPermissions);
+        this.UserPermissions = new((IReadOnlyList<DiscordPermission>)userPermissions);
     }
 }

--- a/DSharpPlus.Commands/ContextChecks/RequirePermissionsCheck.cs
+++ b/DSharpPlus.Commands/ContextChecks/RequirePermissionsCheck.cs
@@ -3,7 +3,6 @@
 using System.Threading.Tasks;
 
 using DSharpPlus.Commands.Processors.SlashCommands;
-using DSharpPlus.Entities;
 
 namespace DSharpPlus.Commands.ContextChecks;
 
@@ -11,12 +10,9 @@ internal sealed class RequirePermissionsCheck : IContextCheck<RequirePermissions
 {
     public ValueTask<string?> ExecuteCheckAsync(RequirePermissionsAttribute attribute, CommandContext context)
     {
-        DiscordPermissions requiredBotPermissions = new(attribute.BotPermissions);
-        DiscordPermissions requiredUserPermissions = new(attribute.UserPermissions);
-
         if (context is SlashCommandContext slashContext)
         {
-            if (!slashContext.Interaction.AppPermissions.HasAllPermissions(requiredBotPermissions))
+            if (!slashContext.Interaction.AppPermissions.HasAllPermissions(attribute.BotPermissions))
             {
                 return ValueTask.FromResult<string?>("The bot did not have the needed permissions to execute this command.");
             }
@@ -27,11 +23,11 @@ internal sealed class RequirePermissionsCheck : IContextCheck<RequirePermissions
         {
             return ValueTask.FromResult<string?>(RequireGuildCheck.ErrorMessage);
         }
-        else if (!context.Guild!.CurrentMember.PermissionsIn(context.Channel).HasAllPermissions(requiredBotPermissions))
+        else if (!context.Guild!.CurrentMember.PermissionsIn(context.Channel).HasAllPermissions(attribute.BotPermissions))
         {
             return ValueTask.FromResult<string?>("The bot did not have the needed permissions to execute this command.");
         }
-        else if (!context.Member!.PermissionsIn(context.Channel).HasAllPermissions(requiredUserPermissions))
+        else if (!context.Member!.PermissionsIn(context.Channel).HasAllPermissions(attribute.UserPermissions))
         {
             return ValueTask.FromResult<string?>("The executing user did not have the needed permissions to execute this command.");
         }

--- a/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandProcessor.cs
@@ -177,7 +177,7 @@ public sealed class MessageCommandProcessor : ICommandProcessor
             nameLocalizations = await this.slashCommandProcessor.ExecuteLocalizerAsync(localizerAttribute.LocalizerType, $"{command.FullName}.name");
         }
 
-        DiscordPermission[]? userPermissions = command.Attributes.OfType<RequirePermissionsAttribute>().FirstOrDefault()?.UserPermissions;
+        DiscordPermissions? userPermissions = command.Attributes.OfType<RequirePermissionsAttribute>().FirstOrDefault()?.UserPermissions;
 
         return new
         (
@@ -187,7 +187,7 @@ public sealed class MessageCommandProcessor : ICommandProcessor
             name_localizations: nameLocalizations,
             allowDMUsage: command.Attributes.Any(x => x is AllowDMUsageAttribute),
             defaultMemberPermissions: userPermissions is not null
-                ? new(userPermissions)
+                ? userPermissions
                 : new DiscordPermissions(DiscordPermission.UseApplicationCommands),
             nsfw: command.Attributes.Any(x => x is RequireNsfwAttribute),
             contexts: command.Attributes.OfType<InteractionAllowedContextsAttribute>().FirstOrDefault()?.AllowedContexts,

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.Registration.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.Registration.cs
@@ -266,7 +266,7 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<ISlashA
             description = "No description provided.";
         }
 
-        DiscordPermission[]? userPermissions = command.Attributes.OfType<RequirePermissionsAttribute>().FirstOrDefault()?.UserPermissions;
+        DiscordPermissions? userPermissions = command.Attributes.OfType<RequirePermissionsAttribute>().FirstOrDefault()?.UserPermissions;
 
         // Create the top level application command.
         return new
@@ -279,8 +279,8 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<ISlashA
             description_localizations: descriptionLocalizations,
             allowDMUsage: command.Attributes.Any(x => x is AllowDMUsageAttribute),
             defaultMemberPermissions: userPermissions is not null
-                ? new(userPermissions)
-                : new DiscordPermissions(DiscordPermission.UseApplicationCommands), 
+                ? userPermissions
+                : new DiscordPermissions(DiscordPermission.UseApplicationCommands),
             nsfw: command.Attributes.Any(x => x is RequireNsfwAttribute),
             contexts: command.Attributes.OfType<InteractionAllowedContextsAttribute>().FirstOrDefault()?.AllowedContexts,
             integrationTypes: command.Attributes.OfType<InteractionInstallTypeAttribute>().FirstOrDefault()?.InstallTypes
@@ -695,11 +695,13 @@ public sealed partial class SlashCommandProcessor : BaseCommandProcessor<ISlashA
 
         if (invariantEnvValue is not null)
         {
-            if (invariantEnvValue == "1" || invariantEnvValue.Equals("true", StringComparison.InvariantCultureIgnoreCase)) {
+            if (invariantEnvValue == "1" || invariantEnvValue.Equals("true", StringComparison.InvariantCultureIgnoreCase))
+            {
                 return false;
             }
-            
-            if (invariantEnvValue == "0" || invariantEnvValue.Equals("false", StringComparison.InvariantCultureIgnoreCase)) {
+
+            if (invariantEnvValue == "0" || invariantEnvValue.Equals("false", StringComparison.InvariantCultureIgnoreCase))
+            {
                 return true;
             }
         }

--- a/DSharpPlus.Commands/Processors/UserCommands/UserCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/UserCommands/UserCommandProcessor.cs
@@ -177,7 +177,7 @@ public sealed class UserCommandProcessor : ICommandProcessor
             nameLocalizations = await this.slashCommandProcessor.ExecuteLocalizerAsync(localizerAttribute.LocalizerType, $"{command.FullName}.name");
         }
 
-        DiscordPermission[]? userPermissions = command.Attributes.OfType<RequirePermissionsAttribute>().FirstOrDefault()?.UserPermissions;
+        DiscordPermissions? userPermissions = command.Attributes.OfType<RequirePermissionsAttribute>().FirstOrDefault()?.UserPermissions;
 
         return new
         (
@@ -187,7 +187,7 @@ public sealed class UserCommandProcessor : ICommandProcessor
             name_localizations: nameLocalizations,
             allowDMUsage: command.Attributes.Any(x => x is AllowDMUsageAttribute),
             defaultMemberPermissions: userPermissions is not null
-                ? new(userPermissions)
+                ? userPermissions
                 : new DiscordPermissions(DiscordPermission.UseApplicationCommands),
             nsfw: command.Attributes.Any(x => x is RequireNsfwAttribute),
             contexts: command.Attributes.OfType<InteractionAllowedContextsAttribute>().FirstOrDefault()?.AllowedContexts,


### PR DESCRIPTION
# Summary
Instead of having an array of `DiscordPermission`'s, we turn it into `DiscordPermissions` instead. All usage's of `DiscordPermission[]` are turned into a `DiscordPermissions` anyways.

# Notes
`DiscordPermissions` probably should've been called `DiscordPermissionSet`.