### PR TITLE
account for dm permissions when checking command equality

### DIFF
--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.WeakEquals.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.WeakEquals.cs
@@ -19,6 +19,7 @@ partial class DiscordApplicationCommand
             && this.Description == other.Description
             && (this.DefaultMemberPermissions ?? DiscordPermissions.None) 
                 == (other.DefaultMemberPermissions ?? DiscordPermissions.None)
+            && (this.AllowDMUsage ?? true) == (other.AllowDMUsage ?? true)
             && (this.NSFW ?? false) == (other.NSFW ?? false)
             && this.Type == other.Type
             && IntegrationTypesMatch(this.IntegrationTypes, other.IntegrationTypes)


### PR DESCRIPTION
as the title says. we should probably migrate to using contexts in the near future, this field is deprecated