### PR TITLE
`DiscordAttachmentConverter`: Fix `OutOfBoundsException`

### DIFF
--- a/DSharpPlus.Commands/Converters/DiscordAttachmentConverter.cs
+++ b/DSharpPlus.Commands/Converters/DiscordAttachmentConverter.cs
@@ -40,7 +40,10 @@ public class AttachmentConverter : ISlashArgumentConverter<DiscordAttachment>, I
             }
 
             // Add the currently parsed attachment count to the index
-            currentAttachmentArgumentIndex += context.VariadicArgumentParameterIndex;
+            if (context.VariadicArgumentParameterIndex != -1)
+            {
+                currentAttachmentArgumentIndex += context.VariadicArgumentParameterIndex;
+            }
 
             // Return the attachment from the original message
             return textConverterContext.Message.Attachments.Count <= currentAttachmentArgumentIndex


### PR DESCRIPTION
# Summary
When `DiscordAttachment` is used as a standalone parameter instead of as a `params DiscordAttachment[]` parameter, an `OutOfBoundsException` is thrown due to `VaradicArgumentIndex` being uninitialized (`-1`).

# Notes
Tested.