### PR TITLE
Automatically determine if paginated response have to be an edit

### DIFF
--- a/DSharpPlus.Interactivity/Extensions/InteractionExtensions.cs
+++ b/DSharpPlus.Interactivity/Extensions/InteractionExtensions.cs
@@ -11,9 +11,6 @@ public static class InteractionExtensions
 {
     /// <summary>
     /// Sends a paginated message in response to an interaction.
-    /// <para>
-    /// <b>Pass the interaction directly. Interactivity will ACK it.</b>
-    /// </para>
     /// </summary>
     /// <param name="interaction">The interaction to create a response to.</param>
     /// <param name="ephemeral">Whether the response should be ephemeral.</param>
@@ -22,8 +19,18 @@ public static class InteractionExtensions
     /// <param name="buttons">Optional: custom buttons</param>
     /// <param name="behaviour">Pagination behaviour.</param>
     /// <param name="deletion">Deletion behaviour</param>
-    /// <param name="asEditResponse">If the response as edit of previous response.</param>
     /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-    public static Task SendPaginatedResponseAsync(this DiscordInteraction interaction, bool ephemeral, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons = null, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, bool asEditResponse = false, CancellationToken token = default)
-        => ChannelExtensions.GetInteractivity(interaction.Channel).SendPaginatedResponseAsync(interaction, ephemeral, user, pages, buttons, behaviour, deletion, asEditResponse, default, default, token);
+    public static Task SendPaginatedResponseAsync
+    (
+        this DiscordInteraction interaction,
+        bool ephemeral,
+        DiscordUser user,
+        IEnumerable<Page> pages,
+        PaginationButtons buttons = null,
+        PaginationBehaviour? behaviour = default,
+        ButtonPaginationBehavior? deletion = default,
+        CancellationToken token = default
+    )
+        => ChannelExtensions.GetInteractivity(interaction.Channel)
+            .SendPaginatedResponseAsync(interaction, ephemeral, user, pages, buttons, behaviour, deletion, default, default, token);
 }

--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -539,7 +539,7 @@ public class InteractivityExtension : IDisposable
 
         if (message.FilterComponents<DiscordComponent>().Where(IsSelect).All(c => c.CustomId != id))
         {
-            throw new ArgumentException($"Provided message does not contain button with Id of '{id}'.");
+            throw new ArgumentException($"Provided message does not contain select component with Id of '{id}'.");
         }
 
         ComponentInteractionCreatedEventArgs? result = await
@@ -862,11 +862,22 @@ public class InteractivityExtension : IDisposable
     /// <param name="buttons">Optional: custom buttons</param>
     /// <param name="behaviour">Pagination behaviour.</param>
     /// <param name="deletion">Deletion behaviour</param>
-    /// <param name="asEditResponse">If the response as edit of previous response.</param>
     /// <param name="disableBehavior">Whether to disable or remove the buttons if there is only one page</param>
     /// <param name="disabledButtons">Disabled buttons</param>
     /// <param name="token">A custom cancellation token that can be cancelled at any point.</param>
-    public async Task SendPaginatedResponseAsync(DiscordInteraction interaction, bool ephemeral, DiscordUser user, IEnumerable<Page> pages, PaginationButtons buttons = null, PaginationBehaviour? behaviour = default, ButtonPaginationBehavior? deletion = default, bool asEditResponse = false, ButtonDisableBehavior disableBehavior = ButtonDisableBehavior.Disable, List<PaginationButtonType> disabledButtons = null, CancellationToken token = default)
+    public async Task SendPaginatedResponseAsync
+    (
+        DiscordInteraction interaction,
+        bool ephemeral,
+        DiscordUser user,
+        IEnumerable<Page> pages,
+        PaginationButtons buttons = null,
+        PaginationBehaviour? behaviour = default,
+        ButtonPaginationBehavior? deletion = default,
+        ButtonDisableBehavior disableBehavior = ButtonDisableBehavior.Disable,
+        List<PaginationButtonType> disabledButtons = null,
+        CancellationToken token = default
+    )
     {
         PaginationBehaviour bhv = behaviour ?? this.Config.PaginationBehaviour;
         ButtonPaginationBehavior del = deletion ?? this.Config.ButtonBehavior;
@@ -949,7 +960,7 @@ public class InteractivityExtension : IDisposable
 
         Page[] pageArray = pages.ToArray();
 
-        if (asEditResponse)
+        if (interaction.ResponseState != DiscordInteractionResponseState.Unacknowledged)
         {
             DiscordWebhookBuilder builder = new DiscordWebhookBuilder()
                 .WithContent(pageArray[0].Content)


### PR DESCRIPTION
# Summary
Interaction responsestate is stored on the interaction nowadays so we can infer from that if the send message has to be an edit or a new response