### PR TITLE
Removed unused variable

### DIFF
--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -543,7 +543,6 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
             throw new InvalidOperationException("Cannot get more than 100 messages around the specified ID.");
         }
 
-        List<DiscordMessage> msgs = new(limit);
         int remaining = limit;
         ulong? last = null;
         bool isbefore = before != null;


### PR DESCRIPTION
Removed unused list allocation. The JIT didn't seem to be able to strip this automatically even during release (probably because this is an IAsyncEnumerable?), so it allocated quite a significant amount of memory unnecessarily.