### PR TITLE
fix ratelimit state corruption and a race in first-request handling

### DIFF
--- a/DSharpPlus/Net/Rest/RateLimitBucket.cs
+++ b/DSharpPlus/Net/Rest/RateLimitBucket.cs
@@ -132,6 +132,17 @@ internal sealed class RateLimitBucket
 
     internal void UpdateBucket(int maximum, int remaining, DateTime reset)
     {
+        if (reset == this.Reset && this.remaining <= remaining)
+        {
+            // we're out of sync, just decrement the reservation - we trust the most pessimistic data.
+            if (this.reserved > 0)
+            {
+                Interlocked.Decrement(ref this.reserved);
+            }
+
+            return;
+        }
+
         Interlocked.Exchange(ref this.maximum, maximum);
         Interlocked.Exchange(ref this.remaining, remaining);
 

--- a/DSharpPlus/Net/Rest/RestClientOptions.cs
+++ b/DSharpPlus/Net/Rest/RestClientOptions.cs
@@ -32,12 +32,7 @@ public sealed class RestClientOptions
     public TimeSpan InitialRequestTimeout { get; set; } = TimeSpan.FromMilliseconds(200);
 
     /// <summary>
-    /// Specifies the maximum rest requests to attempt concurrently. Defaults to 15.
+    /// Specifies the maximum rest requests to attempt concurrently. Defaults to 50. Only increase this if Discord has approved you to do so.
     /// </summary>
-    /// <remarks>
-    /// This is a band-aid for large bots and will be removed in a future version. Do not set this value above 50 unless Discord has
-    /// approved you for an increase, and only increase it if your bot is flooding many different endpoints on different guilds and
-    /// channels. If your bot is heavily flooding very few endpoints, you may even reduce this limit.
-    /// </remarks>
-    public int MaximumConcurrentRestRequests { get; set; } = 15;
+    public int MaximumConcurrentRestRequests { get; set; } = 50;
 }


### PR DESCRIPTION
On 2024-02-17, the last major changes to the ratelimiter occurred, introducing a bug that has mystified us for a year. Reported on 2024-02-21, 371 days ago, we would occasionally under unknown circumstances see ratelimit buckets misbehaving and allowing requests even if the remaining capacity was zero or in the negatives. Whenever the state of a bucket was thus corrupted, it would stay corrupt and keep allowing too many requests until it went unused for long enough to be destroyed, which isn't typically the case for very spammy buckets.

Yesterday, we learnt that this happens whenever we receive responses from Discord in inverse order to them being given their ratelimit bucket information. Part of the ratelimiter would trust the "older" data received later, while part of the ratelimiter does its own - correct - state tracking. This divergence would manifest in letting requests pass through, but is trivially fixed by erring in favour of our own state tracking if we receive irreconcilable responses.

Furthermore, this pull request fixes a race condition in first-request handling. The first request to a route we don't know the bucket for is always allowed (naturally), but previously, two different requests made at exactly the same time to the same new route could both be classified as first requests. This is unproblematic if it's only two requests, but it gets problematic when it's more requests than the bucket would permit, especially since we don't know its capacity until we get a response from the first request.

---

i could cry it's finally done 