### PR TITLE
🎉 Components V2 Support ✨

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageBuilder.cs
@@ -262,12 +262,24 @@ public sealed class DiscordMessageBuilder : BaseDiscordMessageBuilder<DiscordMes
             throw new ArgumentException("You must specify content, an embed, a sticker, a poll, or at least one file.");
         }
 
-        if (this.Components.Count > 5)
+        if (!this.Flags.HasMessageFlag(DiscordMessageFlags.IsComponentsV2) && this.Components.Count > 5)
         {
             throw new InvalidOperationException("You can only have 5 action rows per message.");
         }
+        else if (this.Components.Count > 10)
+        {
+            throw new InvalidOperationException("You can only have 10 surface-level components per message.");
+        }
 
-        if (this.Components.Any(c => c.Components.Count > 5))
+        if (!this.Flags.HasMessageFlag(DiscordMessageFlags.IsComponentsV2) && this.Components.Any(c => c is not DiscordActionRowComponent))
+        {
+            throw new InvalidOperationException
+            (
+                "This builder does support V2 components. Call EnableV2Components(), or remove V2 components from this builder."
+            );
+        }
+
+        if (this.Components.OfType<DiscordActionRowComponent>().Any(c => c.Components.Count > 5))
         {
             throw new InvalidOperationException("Action rows can only have 5 components");
         }

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageFlags.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageFlags.cs
@@ -77,5 +77,11 @@ public enum DiscordMessageFlags
     /// Indicates that this message will supress push notifications.
     /// Mentions in the message will still have a mention indicator, however.
     /// </summary>
-    SuppressNotifications = 1 << 12
+    SuppressNotifications = 1 << 12,
+    
+    /// <summary>
+    /// Indicates that this message is/will support Components V2.
+    /// Messages that are upgraded to components V2 cannot be downgraded.
+    /// </summary>
+    IsComponentsV2 = 1 << 15,
 }

--- a/DSharpPlus/Entities/Interaction/Components/DiscordComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordComponent.cs
@@ -20,6 +20,14 @@ public class DiscordComponent
     /// </summary>
     [JsonProperty("custom_id", NullValueHandling = NullValueHandling.Ignore)]
     public string CustomId { get; internal set; }
+    
+    /// <summary>
+    /// The ID of the component - not to be confused with <see cref="CustomId"/>; this is a numeric ID only used for identifying the component within an array.
+    ///
+    /// If this field is not set, it is generated in an auto-incrementing manner server-side.
+    /// </summary>
+    [JsonProperty("id", NullValueHandling = NullValueHandling.Ignore)]
+    public int Id { get; set; }
 
     internal DiscordComponent() { }
 }

--- a/DSharpPlus/Entities/Interaction/Components/DiscordComponentType.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordComponentType.cs
@@ -45,4 +45,40 @@ public enum DiscordComponentType
     /// A select menu that allows channels to be selected.
     /// </summary>
     ChannelSelect = 8,
+    
+    /// <summary>
+    /// A section of text with optional media (button, thumbnail) accessory.
+    /// </summary>
+    Section = 9,
+    
+    /// <summary>
+    /// A display of text, up to 4000 characters (unified).
+    /// </summary>
+    TextDisplay = 10,
+    
+    /// <summary>
+    /// A thumbnail.
+    /// </summary>
+    Thumbnail = 11,
+    
+    /// <summary>
+    /// A gallery of media.
+    /// </summary>
+    MediaGallery = 12,
+    
+    /// <summary>
+    /// A singular, arbitrary file.
+    /// </summary>
+    File = 13,
+    
+    /// <summary>
+    /// A separator between other components.
+    /// </summary>
+    Separator = 14,
+    
+    /// <summary>
+    /// A container for other components; can be styled with an accent color like embeds.
+    /// </summary>
+    Container = 17
+    
 }

--- a/DSharpPlus/Entities/Interaction/Components/DiscordContainerComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordContainerComponent.cs
@@ -37,6 +37,7 @@ public class DiscordContainerComponent : DiscordComponent
     /// <see cref="DiscordMediaGalleryComponent"/>
     /// <see cref="DiscordSeparatorComponent"/>
     /// <see cref="DiscordFileComponent"/>
+    /// <see cref="DiscordSectionComponent"/>
     /// </list>
     /// </remarks>
     [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]

--- a/DSharpPlus/Entities/Interaction/Components/DiscordContainerComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordContainerComponent.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Entities.Interaction.Components;
+
+/// <summary>
+/// A container for other components. 
+/// </summary>
+public class DiscordContainerComponent : DiscordComponent
+{
+    public new DiscordComponentType Type => DiscordComponentType.Container;
+    
+    /// <summary>
+    /// The accent color for this container, similar to an embed.
+    /// </summary>
+    public DiscordColor? Color => this.color.HasValue
+        ? (DiscordColor)this.color.Value
+        : null;
+
+    [JsonProperty("accent_color", NullValueHandling = NullValueHandling.Include)]
+    internal Optional<int> color;
+
+    /// <summary>
+    /// Gets whether this container is spoilered.
+    /// </summary>
+    [JsonProperty("spoiler", NullValueHandling = NullValueHandling.Ignore)]
+    public bool IsSpoilered { get; internal set; }
+    
+    /// <summary>
+    /// Gets the components of this container.
+    /// </summary>
+    /// <remarks>
+    /// At this time, only the following components are allowed:
+    /// <list type="bullet">
+    /// <see cref="DiscordActionRowComponent"/>
+    /// <see cref="DiscordTextDisplayComponent"/>
+    /// <see cref="DiscordMediaGalleryComponent"/>
+    /// <see cref="DiscordSeparatorComponent"/>
+    /// <see cref="DiscordFileComponent"/>
+    /// </list>
+    /// </remarks>
+    [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
+    public IReadOnlyList<DiscordComponent> Components { get; internal set; }
+
+    public DiscordContainerComponent
+    (
+        IReadOnlyList<DiscordComponent> components,
+        bool isSpoilered = false,
+        DiscordColor? color = null
+    )
+    {
+        this.Components = components;
+        this.IsSpoilered = isSpoilered;
+        this.color = color?.Value ?? default;
+    }
+    
+    internal DiscordContainerComponent() => this.Type = DiscordComponentType.Container;
+    
+
+}

--- a/DSharpPlus/Entities/Interaction/Components/DiscordContainerComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordContainerComponent.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace DSharpPlus.Entities.Interaction.Components;
+namespace DSharpPlus.Entities;
 
 /// <summary>
 /// A container for other components. 

--- a/DSharpPlus/Entities/Interaction/Components/DiscordFileComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordFileComponent.cs
@@ -5,14 +5,16 @@ namespace DSharpPlus.Entities.Interaction.Components;
 /// <summary>
 /// Represents a component that will display a single file.
 /// </summary>
-public sealed class DiscordFileServerComponent : DiscordComponent
+public sealed class DiscordFileComponent : DiscordComponent
 {
+    public DiscordComponentType Type => DiscordComponentType.File;
+    
     public DiscordUnfurledMediaItem File { get; internal set; }
 
     [JsonProperty("spoilered")]
     public bool IsSpoilered { get; internal set; }
 
-    public DiscordFileServerComponent(string url, bool isSpoilered)
+    public DiscordFileComponent(string url, bool isSpoilered)
     {
         this.File = new(url);
         this.IsSpoilered = isSpoilered;

--- a/DSharpPlus/Entities/Interaction/Components/DiscordFileComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordFileComponent.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace DSharpPlus.Entities.Interaction.Components;
+namespace DSharpPlus.Entities;
 
 /// <summary>
 /// Represents a component that will display a single file.

--- a/DSharpPlus/Entities/Interaction/Components/DiscordFileServerComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordFileServerComponent.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Entities.Interaction.Components;
+
+/// <summary>
+/// Represents a component that will display a single file.
+/// </summary>
+public sealed class DiscordFileServerComponent : DiscordComponent
+{
+    public DiscordUnfurledMediaItem File { get; internal set; }
+
+    [JsonProperty("spoilered")]
+    public bool IsSpoilered { get; internal set; }
+
+    public DiscordFileServerComponent(string url, bool isSpoilered)
+    {
+        this.File = new(url);
+        this.IsSpoilered = isSpoilered;
+    }
+
+}

--- a/DSharpPlus/Entities/Interaction/Components/DiscordMediaGalleryComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordMediaGalleryComponent.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace DSharpPlus.Entities.Interaction.Components;
+namespace DSharpPlus.Entities;
 
 /// <summary>
 /// Represents a gallery of various media.

--- a/DSharpPlus/Entities/Interaction/Components/DiscordMediaGalleryComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordMediaGalleryComponent.cs
@@ -6,8 +6,10 @@ namespace DSharpPlus.Entities.Interaction.Components;
 /// <summary>
 /// Represents a gallery of various media.
 /// </summary>
-public sealed class DiscordMediaGalleryComponent
+public sealed class DiscordMediaGalleryComponent : DiscordComponent
 {
+    public new DiscordComponentType Type => DiscordComponentType.MediaGallery;
+    
     /// <summary>
     /// Gets the items in the gallery.
     /// </summary>
@@ -23,4 +25,6 @@ public sealed class DiscordMediaGalleryComponent
         this.Items = items.ToArray();
         this.Id = id;
     }
+    
+    internal DiscordMediaGalleryComponent() => this.Type = DiscordComponentType.MediaGallery;
 }

--- a/DSharpPlus/Entities/Interaction/Components/DiscordMediaGalleryComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordMediaGalleryComponent.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DSharpPlus.Entities.Interaction.Components;
+
+/// <summary>
+/// Represents a gallery of various media.
+/// </summary>
+public sealed class DiscordMediaGalleryComponent
+{
+    /// <summary>
+    /// Gets the items in the gallery.
+    /// </summary>
+    public IReadOnlyList<DiscordMediaGalleryItem> Items { get; internal set; }
+
+    /// <summary>
+    /// Constructs a new media gallery component.
+    /// </summary>
+    /// <param name="items">The items of the gallery.</param>
+    /// <param name="id">The optional ID of the component.</param>
+    public DiscordMediaGalleryComponent(IEnumerable<DiscordMediaGalleryItem> items, uint id=0)
+    {
+        this.Items = items.ToArray();
+        this.Id = id;
+    }
+}

--- a/DSharpPlus/Entities/Interaction/Components/DiscordMediaGalleryItem.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordMediaGalleryItem.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace DSharpPlus.Entities.Interaction.Components;
+namespace DSharpPlus.Entities;
 
 /// <summary>
 /// Represents an item in a media gallery.

--- a/DSharpPlus/Entities/Interaction/Components/DiscordMediaGalleryItem.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordMediaGalleryItem.cs
@@ -1,0 +1,38 @@
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Entities.Interaction.Components;
+
+/// <summary>
+/// Represents an item in a media gallery.
+/// </summary>
+public sealed class DiscordMediaGalleryItem
+{
+    /// <summary>
+    /// Gets the media item in the gallery.
+    /// </summary>
+    public DiscordUnfurledMediaItem Media { get; internal set; }
+
+    /// <summary>
+    /// Gets the description (alt text) of the media item.
+    /// </summary>
+    public string Description { get; internal set; }
+
+    /// <summary>
+    /// Gets whether the media item is spoilered.
+    /// </summary>
+    [JsonProperty("spoilered")]
+    public bool IsSpoilered { get; internal set; }
+
+    /// <summary>
+    /// Constructs a new media gallery item.
+    /// </summary>
+    /// <param name="url">The URL of the media item. This must be a direct link to media, or an attachment:// reference.</param>
+    /// <param name="description">The description (alt text) of the media item.</param>
+    /// <param name="isSpoilered">Whether the attachment is spoilered.</param>
+    public DiscordMediaGalleryItem(string url, string description, bool isSpoilered)
+    {
+        this.Media = new(url);
+        this.Description = description;
+        this.IsSpoilered = isSpoilered;
+    }
+}

--- a/DSharpPlus/Entities/Interaction/Components/DiscordSectionComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordSectionComponent.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Entities.Interaction.Components;
+
+public class DiscordSectionComponent : DiscordComponent
+{
+    public new DiscordComponentType Type => DiscordComponentType.Section;
+
+    /// <summary>
+    /// Gets the accessory for this section.
+    ///
+    /// Accessories take the place of a thumbnail (that is, are positioned as a thumbnail would be) regardless of component.
+    /// At this time, only <see cref="DiscordButtonComponent"/> and <see cref="DiscordThumbnailComponent"/> are supported.
+    /// </summary>
+    [JsonProperty("accessory", NullValueHandling = NullValueHandling.Ignore)]
+    public DiscordComponent? Accessory { get; internal set; }
+    
+    /// <summary>
+    /// Gets the components for this section.
+    /// As of now, this is only text components, but may allow for more components in the future.
+    /// </summary>
+    /// <remarks>This is a Discord limitation.</remarks>
+    // To the chagrin of Dv8, we're hard-coding this to be text components
+    // Because I honestly have no idea what he expects us to do otherwise;
+    // runtime validation has the same issue (unchangeable without updating) but worse (needs to be validated everywhere).
+    [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
+    public IReadOnlyList<DiscordTextDisplayComponent> Components { get; internal set; }
+    
+    /// <summary>
+    /// Constructs a new section component.
+    /// </summary>
+    /// <param name="sections">The sections (generally text) that this section contains.</param>
+    /// <param name="accessory">The accessory to this section. At this time, this must either be a <see cref="DiscordThumbnailComponent"/> or a <see cref="DiscordButtonComponent"/>.</param>
+    public DiscordSectionComponent(IEnumerable<DiscordTextDisplayComponent> sections, DiscordComponent accessory)
+    {
+        this.Accessory = accessory;
+        this.Components = sections.ToArray();
+    }
+    
+    internal DiscordSectionComponent() => this.Type = DiscordComponentType.Section;
+
+}

--- a/DSharpPlus/Entities/Interaction/Components/DiscordSectionComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordSectionComponent.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
 
-namespace DSharpPlus.Entities.Interaction.Components;
+namespace DSharpPlus.Entities;
 
 public class DiscordSectionComponent : DiscordComponent
 {

--- a/DSharpPlus/Entities/Interaction/Components/DiscordSeparatorComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordSeparatorComponent.cs
@@ -1,0 +1,20 @@
+namespace DSharpPlus.Entities.Interaction.Components;
+
+/// <summary>
+/// Represents a division between components. Can optionally be rendered as a dividing line.
+/// </summary>
+public class DiscordSeparatorComponent : DiscordComponent
+{
+    public new DiscordComponentType ComponentType => DiscordComponentType.Separator;
+
+    /// <summary>
+    /// Whether the separator renders as a dividing line.
+    /// </summary>
+    public bool Divider { get; internal set; }
+    
+    /// <summary>
+    /// The spacing for the separator. Defaults to <see cref="DiscordSeparatorComponent"/>
+    /// </summary>
+    public DiscordSeparatorSpacing Spacing { get; internal set; }
+
+}

--- a/DSharpPlus/Entities/Interaction/Components/DiscordSeparatorComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordSeparatorComponent.cs
@@ -1,4 +1,4 @@
-namespace DSharpPlus.Entities.Interaction.Components;
+namespace DSharpPlus.Entities;
 
 /// <summary>
 /// Represents a division between components. Can optionally be rendered as a dividing line.

--- a/DSharpPlus/Entities/Interaction/Components/DiscordSeparatorSpacing.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordSeparatorSpacing.cs
@@ -1,0 +1,17 @@
+namespace DSharpPlus.Entities.Interaction.Components;
+
+/// <summary>
+/// Represents the spacing for a separator.
+/// </summary>
+public enum DiscordSeparatorSpacing
+{
+    /// <summary>
+    /// A small spacing.
+    /// </summary>
+    Small = 1,
+    
+    /// <summary>
+    /// A large spacing.
+    /// </summary>
+    Large = 2,
+}

--- a/DSharpPlus/Entities/Interaction/Components/DiscordSeparatorSpacing.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordSeparatorSpacing.cs
@@ -1,4 +1,4 @@
-namespace DSharpPlus.Entities.Interaction.Components;
+namespace DSharpPlus.Entities;
 
 /// <summary>
 /// Represents the spacing for a separator.

--- a/DSharpPlus/Entities/Interaction/Components/DiscordTextDisplayComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordTextDisplayComponent.cs
@@ -18,4 +18,6 @@ public sealed class DiscordTextDisplayComponent : DiscordComponent
         this.Content = content;
         this.Id = id;
     }
+    
+    internal DiscordTextDisplayComponent() => this.Type = DiscordComponentType.TextDisplay;
 }

--- a/DSharpPlus/Entities/Interaction/Components/DiscordTextDisplayComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordTextDisplayComponent.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Entities.Interaction.Components;
+
+/// <summary>
+/// Represents a block of text.
+/// </summary>
+public sealed class DiscordTextDisplayComponent : DiscordComponent
+{
+    [JsonProperty("content")]
+    public string Content { get; internal set; }
+
+    /// <inheritdoc cref="DiscordComponent.Type"/>
+    public new DiscordComponentType Type => DiscordComponentType.TextDisplay;
+
+    public DiscordTextDisplayComponent(string content, uint id = default)
+    {
+        this.Content = content;
+        this.Id = id;
+    }
+}

--- a/DSharpPlus/Entities/Interaction/Components/DiscordTextDisplayComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordTextDisplayComponent.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace DSharpPlus.Entities.Interaction.Components;
+namespace DSharpPlus.Entities;
 
 /// <summary>
 /// Represents a block of text.

--- a/DSharpPlus/Entities/Interaction/Components/DiscordThumbnailComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordThumbnailComponent.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace DSharpPlus.Entities.Interaction.Components;
+namespace DSharpPlus.Entities;
 
 /// <summary>
 /// Represents a thumbnail.

--- a/DSharpPlus/Entities/Interaction/Components/DiscordThumbnailComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordThumbnailComponent.cs
@@ -1,0 +1,38 @@
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Entities.Interaction.Components;
+
+/// <summary>
+/// Represents a thumbnail.
+/// </summary>
+public class DiscordThumbnailComponent : DiscordComponent
+{
+    public new DiscordComponentType Type => DiscordComponentType.Thumbnail;
+    /// <summary>
+    /// The image for this thumbnail.
+    /// </summary>
+    [JsonProperty("media", NullValueHandling = NullValueHandling.Ignore)]
+    public DiscordUnfurledMediaItem Media { get; internal set; }
+    
+    /// <summary>
+    /// Gets the description (alt-text) for this thumbnail.
+    /// </summary>
+    [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
+    public string? Description { get; internal set; }
+    
+    /// <summary>
+    /// Gets whether this thumbnail is spoilered.
+    /// </summary>
+    [JsonProperty("spoilered", NullValueHandling = NullValueHandling.Ignore)]
+    public bool Spoiler { get; internal set; }
+
+    public DiscordThumbnailComponent(DiscordUnfurledMediaItem media, string? description = null, bool spoiler = false)
+    {
+        Media = media;
+        Description = description;
+        Spoiler = spoiler;
+    }
+
+    internal DiscordThumbnailComponent() => this.Type = DiscordComponentType.Thumbnail;
+
+}

--- a/DSharpPlus/Entities/Interaction/Components/DiscordUnfurledMediaItem.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordUnfurledMediaItem.cs
@@ -1,4 +1,4 @@
-namespace DSharpPlus.Entities.Interaction.Components;
+namespace DSharpPlus.Entities;
 
 /// <summary>
 /// Represents an unfurled url; can be arbitrary URL or attachment:// schema. 

--- a/DSharpPlus/Entities/Interaction/Components/DiscordUnfurledMediaItem.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordUnfurledMediaItem.cs
@@ -1,0 +1,14 @@
+namespace DSharpPlus.Entities.Interaction.Components;
+
+public sealed class DiscordUnfurledMediaItem
+{
+    /// <summary>
+    /// Gets the URL of the media item.
+    /// </summary>
+    public string Url { get; internal set; }
+
+    public DiscordUnfurledMediaItem(string url)
+    {
+        this.Url = url;
+    }
+}

--- a/DSharpPlus/Entities/Interaction/Components/DiscordUnfurledMediaItem.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordUnfurledMediaItem.cs
@@ -1,5 +1,8 @@
 namespace DSharpPlus.Entities.Interaction.Components;
 
+/// <summary>
+/// Represents an unfurled url; can be arbitrary URL or attachment:// schema. 
+/// </summary>
 public sealed class DiscordUnfurledMediaItem
 {
     /// <summary>

--- a/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordFollowupMessageBuilder.cs
@@ -11,10 +11,21 @@ public sealed class DiscordFollowupMessageBuilder : BaseDiscordMessageBuilder<Di
     /// <summary>
     /// Whether this followup message should be ephemeral.
     /// </summary>
-    public bool IsEphemeral { get; set; }
-
-    internal int? flags
-        => this.IsEphemeral ? (int?)(this.Flags | DiscordMessageFlags.Ephemeral) : null;
+    public bool IsEphemeral
+    {
+        get => this.Flags.HasMessageFlag(DiscordMessageFlags.Ephemeral);
+        set
+        {
+            if (value)
+            {
+                this.Flags |= DiscordMessageFlags.Ephemeral;
+            }
+            else
+            {
+                this.Flags &= ~DiscordMessageFlags.Ephemeral;
+            }
+        }
+    }
 
     /// <summary>
     /// Constructs a new followup message builder

--- a/DSharpPlus/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordInteractionApplicationCommandCallbackData.cs
@@ -28,7 +28,7 @@ internal class DiscordInteractionApplicationCommandCallbackData
     public DiscordMessageFlags? Flags { get; internal set; }
 
     [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
-    public IReadOnlyList<DiscordActionRowComponent> Components { get; internal set; }
+    public IReadOnlyList<DiscordComponent> Components { get; internal set; }
 
     [JsonProperty("choices")]
     public IReadOnlyList<DiscordAutoCompleteChoice> Choices { get; internal set; }

--- a/DSharpPlus/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestApplicationCommandPayloads.cs
@@ -117,10 +117,10 @@ internal class RestFollowupMessageCreatePayload
     public DiscordMentions? Mentions { get; set; }
 
     [JsonProperty("flags", NullValueHandling = NullValueHandling.Ignore)]
-    public int? Flags { get; set; }
+    public DiscordMessageFlags Flags { get; set; }
 
     [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
-    public IReadOnlyList<DiscordActionRowComponent> Components { get; set; }
+    public IReadOnlyList<DiscordComponent> Components { get; set; }
 }
 
 internal class RestEditApplicationCommandPermissionsPayload

--- a/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
@@ -182,7 +182,7 @@ internal class RestChannelMessageEditPayload
     public DiscordMentions? Mentions { get; set; }
 
     [JsonProperty("components", NullValueHandling = NullValueHandling.Ignore)]
-    public IReadOnlyList<DiscordActionRowComponent>? Components { get; set; }
+    public IReadOnlyList<DiscordComponent>? Components { get; set; }
 
     [JsonProperty("flags", NullValueHandling = NullValueHandling.Ignore)]
     public DiscordMessageFlags? Flags { get; set; }

--- a/DSharpPlus/Net/Rest/DiscordApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordApiClient.cs
@@ -2439,7 +2439,7 @@ public sealed class DiscordApiClient
         Optional<string> content = default,
         Optional<IEnumerable<DiscordEmbed>> embeds = default,
         Optional<IEnumerable<IMention>> mentions = default,
-        IReadOnlyList<DiscordActionRowComponent>? components = null,
+        IReadOnlyList<DiscordComponent>? components = null,
         IReadOnlyList<DiscordMessageFile>? files = null,
         DiscordMessageFlags? flags = null,
         IEnumerable<DiscordAttachment>? attachments = null
@@ -6162,7 +6162,7 @@ public sealed class DiscordApiClient
             Content = builder.Content,
             IsTTS = builder.IsTTS,
             Embeds = builder.Embeds,
-            Flags = builder.flags,
+            Flags = builder.Flags,
             Components = builder.Components
         };
 

--- a/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using DSharpPlus.Entities;
+using DSharpPlus.Entities.Interaction.Components;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -30,6 +31,12 @@ internal sealed class DiscordComponentJsonConverter : JsonConverter
             DiscordComponentType.RoleSelect => new DiscordRoleSelectComponent(),
             DiscordComponentType.MentionableSelect => new DiscordMentionableSelectComponent(),
             DiscordComponentType.ChannelSelect => new DiscordChannelSelectComponent(),
+            DiscordComponentType.Section => new DiscordSectionComponent(),
+            DiscordComponentType.TextDisplay => new DiscordTextDisplayComponent(),
+            DiscordComponentType.Thumbnail => new DiscordThumbnailComponent(),
+            DiscordComponentType.MediaGallery => new DiscordMediaGalleryComponent(),
+            DiscordComponentType.Separator => new DiscordSeparatorComponent(),
+            DiscordComponentType.Container => new DiscordContainerComponent(),
             _ => new DiscordComponent() { Type = type.Value }
         };
 

--- a/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
@@ -1,6 +1,6 @@
 using System;
 using DSharpPlus.Entities;
-using DSharpPlus.Entities.Interaction.Components;
+using DSharpPlus.Entities;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 


### PR DESCRIPTION
# Summary
Adds support for components V2 (unreleased)

# Details
This PR adds all the new components (v2), requisite changes to builders (namely, a new method to allow for adding components directly),

# Changes proposed
- Change `DiscordMessageBuilder#Components` to `IReadOnlyList<DiscordComponent>`
- Change all internal rest payloads to also be `IReadOnlyList<DiscordComponent>`
- Add new component types
- Tidy up some builder code and utilize new .NET 9/C#13 features

# Notes
This feature is currently unreleased (soon:tm:); this PR is being opened for review purposes, so that we may merge this on release day.

There may be some open questions added here as they appear.