### PR TITLE
HeartbeatAsync Race Condition Causes ObjectDisposedException

### DIFF
--- a/DSharpPlus/Net/Gateway/TransportService.cs
+++ b/DSharpPlus/Net/Gateway/TransportService.cs
@@ -229,13 +229,16 @@ internal sealed class TransportService : ITransportService
             this.logger.LogTrace("Payload for the last outbound gateway event: {event}", anonymized);
         }
 
-        await this.socket.SendAsync
-        (
-            buffer: payload,
-            messageType: WebSocketMessageType.Text,
-            endOfMessage: true,
-            cancellationToken: CancellationToken.None
-        );
+        if (!this.isDisposed)
+        {
+            await this.socket.SendAsync
+            (
+                buffer: payload,
+                messageType: WebSocketMessageType.Text,
+                endOfMessage: true,
+                cancellationToken: CancellationToken.None
+            );
+        }
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
https://github.com/DSharpPlus/DSharpPlus/issues/2247

# Summary

An ObjectDisposedException is periodically thrown from GatewayClient when Internet connectivity is lost. 

It does not happen consistently and it appears to be a race condition based on heartbeat periodicity and disposed state of the underlying socket connection. 

Here is the relevant stack trace:

2025-02-22 08:29:24 [Error] - System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Cannot access a disposed object.
Object name: 'System.Net.WebSockets.ClientWebSocket'.)
---> System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Net.WebSockets.ClientWebSocket'.
at DSharpPlus.Net.Gateway.TransportService.WriteAsync(Byte[] payload)
at DSharpPlus.Net.Gateway.GatewayClient.WriteAsync(Byte[] payload)
at DSharpPlus.Net.Gateway.GatewayClient.HeartbeatAsync(Int32 heartbeatInterval, CancellationToken ct)
--- End of inner exception stack trace --- (UnobservedTaskException)

# Details
This change prevents writes to the socket when the socket is disposed.

