### PR TITLE
Restart heartbeat task during resumes

### DIFF
--- a/DSharpPlus/Net/Gateway/GatewayClient.cs
+++ b/DSharpPlus/Net/Gateway/GatewayClient.cs
@@ -422,9 +422,26 @@ public sealed class GatewayClient : IGatewayClient
                 try
                 {
                     this.IsConnected = false;
+                    
+                    // Ensure we cancel the heartbeat task, as well as anything else relying on this token.
+                    this.gatewayTokenSource.Cancel();
+                    this.gatewayTokenSource = new CancellationTokenSource();
 
                     await this.transportService.DisconnectAsync(WebSocketCloseStatus.NormalClosure);
                     await this.transportService.ConnectAsync(this.resumeUrl, this.shardInfo?.ShardId);
+                    
+                    TransportFrame initialFrame = await this.transportService.ReadAsync();
+                    GatewayPayload? helloEvent = await ProcessAndDeserializeTransportFrameAsync(initialFrame);
+
+                    if (helloEvent is not { OpCode: GatewayOpCode.Hello })
+                    {
+                        throw new InvalidDataException($"Expected HELLO payload from Discord");
+                    }
+
+                    GatewayHello helloPayload = ((JObject)helloEvent.Data).ToDiscordObject<GatewayHello>();
+                    
+                    // Restart the heartbeat task, synced to the new token
+                    _ = HeartbeatAsync(helloPayload.HeartbeatInterval, this.gatewayTokenSource.Token);
 
                     await WriteAsync
                     (


### PR DESCRIPTION
In addendum to #2257; I do believe this is the root cause of the issue, and that the exception spawns from a very unfortunate set of circumstances occuring.

- The client needs to reconnect for some reason (often a network blip)
- Heartbeat task is running in background
- Client calls `transportService.DisconnectAsync`
 - This disposes the underlying socket
- Heartbeat task attempts to send a heartbeat through the currently-disposed socket
- Client calls `transportService.ConnectAsync`, which reinitializes the underlying socket

The issue occurs when heartbeating manages to happen in this small interval between disconencting and reconnecting, as far as I understand it.