### PR TITLE
Revert "HeartbeatAsync Race Condition Causes ObjectDisposedException"

### DIFF
--- a/DSharpPlus/Net/Gateway/TransportService.cs
+++ b/DSharpPlus/Net/Gateway/TransportService.cs
@@ -229,16 +229,13 @@ internal sealed class TransportService : ITransportService
             this.logger.LogTrace("Payload for the last outbound gateway event: {event}", anonymized);
         }
 
-        if (!this.isDisposed)
-        {
-            await this.socket.SendAsync
-            (
-                buffer: payload,
-                messageType: WebSocketMessageType.Text,
-                endOfMessage: true,
-                cancellationToken: CancellationToken.None
-            );
-        }
+        await this.socket.SendAsync
+        (
+            buffer: payload,
+            messageType: WebSocketMessageType.Text,
+            endOfMessage: true,
+            cancellationToken: CancellationToken.None
+        );
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Reverts DSharpPlus/DSharpPlus#2257

caused issues with DSharpPlus detecting transient connection failures and instead manifested them as gateway hangs or escalating the error, as the erroring task could now be dropped