### PR TITLE
Fix nested group commands

### DIFF
--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -192,8 +192,8 @@ public sealed class CommandsExtension
     public void AddCommand(Delegate commandDelegate) => this.commandBuilders.Add(CommandBuilder.From(commandDelegate));
     public void AddCommand(Type type, params ulong[] guildIds) => this.commandBuilders.Add(CommandBuilder.From(type, guildIds));
     public void AddCommand(Type type) => this.commandBuilders.Add(CommandBuilder.From(type));
-    public void AddCommands(Assembly assembly, params ulong[] guildIds) => AddCommands(assembly.GetTypes(), guildIds);
-    public void AddCommands(Assembly assembly) => AddCommands(assembly.GetTypes());
+    public void AddCommands(Assembly assembly, params ulong[] guildIds) => AddCommands(assembly.GetTypes().Where(type => !type.IsNested), guildIds);
+    public void AddCommands(Assembly assembly) => AddCommands(assembly.GetTypes().Where(type => !type.IsNested));
     public void AddCommands(IEnumerable<CommandBuilder> commands) => this.commandBuilders.AddRange(commands);
     public void AddCommands(IEnumerable<Type> types) => AddCommands(types, []);
     public void AddCommands(params CommandBuilder[] commands) => this.commandBuilders.AddRange(commands);
@@ -207,6 +207,7 @@ public sealed class CommandsExtension
         {
             if (type.GetCustomAttribute<CommandAttribute>() is not null)
             {
+                this.Client.Logger.LogInformation("Adding command from type {Type}", type.FullName ?? type.Name);
                 this.commandBuilders.Add(CommandBuilder.From(type, guildIds));
                 continue;
             }
@@ -215,6 +216,7 @@ public sealed class CommandsExtension
             {
                 if (method.GetCustomAttribute<CommandAttribute>() is not null)
                 {
+                    this.Client.Logger.LogInformation("Adding command from type {Type}", type.FullName ?? type.Name);
                     this.commandBuilders.Add(CommandBuilder.From(method, guildIds: guildIds));
                 }
             }

--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -207,7 +207,7 @@ public sealed class CommandsExtension
         {
             if (type.GetCustomAttribute<CommandAttribute>() is not null)
             {
-                this.Client.Logger.LogInformation("Adding command from type {Type}", type.FullName ?? type.Name);
+                this.Client.Logger.LogDebug("Adding command from type {Type}", type.FullName ?? type.Name);
                 this.commandBuilders.Add(CommandBuilder.From(type, guildIds));
                 continue;
             }
@@ -216,7 +216,7 @@ public sealed class CommandsExtension
             {
                 if (method.GetCustomAttribute<CommandAttribute>() is not null)
                 {
-                    this.Client.Logger.LogInformation("Adding command from type {Type}", type.FullName ?? type.Name);
+                    this.Client.Logger.LogDebug("Adding command from type {Type}", type.FullName ?? type.Name);
                     this.commandBuilders.Add(CommandBuilder.From(method, guildIds: guildIds));
                 }
             }

--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -215,7 +215,7 @@ public sealed class CommandsExtension
         {
             if (type.GetCustomAttribute<CommandAttribute>() is not null)
             {
-                this.Client.Logger.LogInformation("Adding command from type {Type}", type.FullName ?? type.Name);
+                this.Client.Logger.LogDebug("Adding command from type {Type}", type.FullName ?? type.Name);
                 this.commandBuilders.Add(CommandBuilder.From(type, guildIds));
                 continue;
             }
@@ -224,7 +224,7 @@ public sealed class CommandsExtension
             {
                 if (method.GetCustomAttribute<CommandAttribute>() is not null)
                 {
-                    this.Client.Logger.LogInformation("Adding command from type {Type}", type.FullName ?? type.Name);
+                    this.Client.Logger.LogDebug("Adding command from type {Type}", type.FullName ?? type.Name);
                     this.commandBuilders.Add(CommandBuilder.From(method, guildIds: guildIds));
                 }
             }

--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -490,7 +490,7 @@ public sealed class CommandsExtension
             }
             catch (Exception error)
             {
-                this.logger.LogError(error, "Failed to build command '{CommandBuilder}'", commandBuilder.Name);
+                this.logger.LogError(error, "Failed to build command '{CommandBuilder}'", commandBuilder.FullName);
             }
         }
 

--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -192,8 +192,16 @@ public sealed class CommandsExtension
     public void AddCommand(Delegate commandDelegate) => this.commandBuilders.Add(CommandBuilder.From(commandDelegate));
     public void AddCommand(Type type, params ulong[] guildIds) => this.commandBuilders.Add(CommandBuilder.From(type, guildIds));
     public void AddCommand(Type type) => this.commandBuilders.Add(CommandBuilder.From(type));
-    public void AddCommands(Assembly assembly, params ulong[] guildIds) => AddCommands(assembly.GetTypes().Where(type => !type.IsNested), guildIds);
-    public void AddCommands(Assembly assembly) => AddCommands(assembly.GetTypes().Where(type => !type.IsNested));
+
+    // !type.IsNested || type.DeclaringType?.GetCustomAttribute<CommandAttribute>() is null
+    // This is done to prevent nested classes from being added as commands, while still allowing non-command classes containing commands to be added.
+    // See https://github.com/DSharpPlus/DSharpPlus/pull/2273#discussion_r2009114568 for more information.
+    public void AddCommands(Assembly assembly, params ulong[] guildIds) => AddCommands(assembly.GetTypes().Where(type =>
+        !type.IsNested || type.DeclaringType?.GetCustomAttribute<CommandAttribute>() is null), guildIds);
+
+    public void AddCommands(Assembly assembly) => AddCommands(assembly.GetTypes().Where(type =>
+        !type.IsNested || type.DeclaringType?.GetCustomAttribute<CommandAttribute>() is null));
+
     public void AddCommands(IEnumerable<CommandBuilder> commands) => this.commandBuilders.AddRange(commands);
     public void AddCommands(IEnumerable<Type> types) => AddCommands(types, []);
     public void AddCommands(params CommandBuilder[] commands) => this.commandBuilders.AddRange(commands);
@@ -207,7 +215,7 @@ public sealed class CommandsExtension
         {
             if (type.GetCustomAttribute<CommandAttribute>() is not null)
             {
-                this.Client.Logger.LogDebug("Adding command from type {Type}", type.FullName ?? type.Name);
+                this.Client.Logger.LogInformation("Adding command from type {Type}", type.FullName ?? type.Name);
                 this.commandBuilders.Add(CommandBuilder.From(type, guildIds));
                 continue;
             }
@@ -216,7 +224,7 @@ public sealed class CommandsExtension
             {
                 if (method.GetCustomAttribute<CommandAttribute>() is not null)
                 {
-                    this.Client.Logger.LogDebug("Adding command from type {Type}", type.FullName ?? type.Name);
+                    this.Client.Logger.LogInformation("Adding command from type {Type}", type.FullName ?? type.Name);
                     this.commandBuilders.Add(CommandBuilder.From(method, guildIds: guildIds));
                 }
             }

--- a/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/TextCommands/TextCommandProcessor.cs
@@ -312,7 +312,7 @@ public sealed class TextCommandProcessor : BaseCommandProcessor<ITextArgumentCon
             }
 
             // If there was no space found after the subcommand, break
-            nextIndex = commandText.IndexOf(' ', nextIndex);
+            nextIndex = commandText.IndexOf(' ', nextIndex + 1);
             if (nextIndex == -1)
             {
                 // No more spaces. Search the rest of the string to see if there is a subcommand that matches.
@@ -320,11 +320,11 @@ public sealed class TextCommandProcessor : BaseCommandProcessor<ITextArgumentCon
             }
 
             // Resolve subcommands
-            string subcommandName = commandText[index..nextIndex];
+            string subCommandName = commandText[index..nextIndex];
 
             // Try searching for the subcommand by name, then by alias
             // We prioritize the name over the aliases to avoid a poor dev debugging experience
-            Command? foundCommand = command.Subcommands.FirstOrDefault(subCommand => subCommand.Name.Equals(subcommandName, StringComparison.OrdinalIgnoreCase));
+            Command? foundCommand = command.Subcommands.FirstOrDefault(subCommand => this.Configuration.CommandNameComparer.Equals(subCommand.Name, subCommandName.Trim()));
             if (foundCommand is null)
             {
                 // Search for any aliases that the subcommand may have
@@ -339,12 +339,22 @@ public sealed class TextCommandProcessor : BaseCommandProcessor<ITextArgumentCon
 
                         foreach (string alias in aliasAttribute.Aliases)
                         {
-                            if (this.Configuration.CommandNameComparer.Equals(alias, subcommandName))
+                            if (this.Configuration.CommandNameComparer.Equals(alias, subCommandName))
                             {
                                 foundCommand = subcommand;
                                 break;
                             }
                         }
+
+                        if (foundCommand is not null)
+                        {
+                            break;
+                        }
+                    }
+
+                    if (foundCommand is not null)
+                    {
+                        break;
                     }
                 }
 

--- a/DSharpPlus.Commands/Trees/Command.cs
+++ b/DSharpPlus.Commands/Trees/Command.cs
@@ -47,9 +47,13 @@ public record Command
     {
         StringBuilder stringBuilder = new();
         stringBuilder.Append(this.FullName);
-        stringBuilder.Append('(');
-        stringBuilder.AppendJoin(", ", this.Parameters.Select(x => $"{x.Type.Name} {x.Name}"));
-        stringBuilder.Append(')');
+        if (this.Subcommands.Count == 0)
+        {
+            stringBuilder.Append('(');
+            stringBuilder.AppendJoin(", ", this.Parameters.Select(x => $"{x.Type.Name} {x.Name}"));
+            stringBuilder.Append(')');
+        }
+
         return stringBuilder.ToString();
     }
 }

--- a/DSharpPlus.Commands/Trees/CommandBuilder.cs
+++ b/DSharpPlus.Commands/Trees/CommandBuilder.cs
@@ -262,11 +262,11 @@ public class CommandBuilder
         StringBuilder stringBuilder = new();
         if (this.Parent is not null)
         {
-            stringBuilder.Append(this.Parent.Name);
+            stringBuilder.Append(this.Parent.FullName);
             stringBuilder.Append('.');
         }
 
-        stringBuilder.Append(this.Name ?? "Unnamed Command");
+        stringBuilder.Append(this.Name ?? "<Unnamed Command>");
         return stringBuilder.ToString();
     }
 

--- a/DSharpPlus.Commands/Trees/CommandBuilder.cs
+++ b/DSharpPlus.Commands/Trees/CommandBuilder.cs
@@ -156,7 +156,7 @@ public class CommandBuilder
     }
 
     /// <inheritdoc cref="From(Type, ulong[])"/>
-    public static CommandBuilder From<T>() => From(typeof(T), []);
+    public static CommandBuilder From<T>() => From<T>([]);
 
     /// <inheritdoc cref="From(Type, ulong[])"/>
     /// <typeparam name="T">The type that'll be searched for subcommands.</typeparam>
@@ -181,7 +181,7 @@ public class CommandBuilder
 
         // Add subcommands
         List<CommandBuilder> subCommandBuilders = [];
-        foreach (Type subCommand in type.GetNestedTypes(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+        foreach (Type subCommand in type.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
         {
             if (subCommand.GetCustomAttribute<CommandAttribute>() is null)
             {
@@ -192,7 +192,7 @@ public class CommandBuilder
         }
 
         // Add methods
-        foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+        foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
         {
             if (method.GetCustomAttribute<CommandAttribute>() is null)
             {
@@ -277,7 +277,7 @@ public class CommandBuilder
 
         static IEnumerable<Attribute> AggregateCustomAttributesFromType(Type? type)
         {
-            return type is null 
+            return type is null
                 ? []
                 : type.GetCustomAttributes(true)
                     .Where(obj => obj is ContextCheckAttribute)


### PR DESCRIPTION
# Summary
At the time of writing, you may find using nested group commands to be difficult as they are nigh nonfunctional. This PR fixes 6 bugs separated into their own commits, each one tested.

# Details
- When using nested group commands, if the nested types are not public, they will be skipped.
- When using `AddCommands(Assembly assembly)`, nested types are included. This is no longer the case. Nested types can still be added explicitly.
- Text commands: Subcommands of nested group commands would fail to parse due to an off by one bug that stopped when the sub(group) command was found.
- `CommandBuilder.ToString()` now prints the full name instead of it's parents base name.
- `Command.ToString()` will now only add parenthesis and parameters when it's an executable command.
- When failing to build a command, the command builder's fullname is now printed into console instead of it's base name.

# Notes
Closes #2272. Tested.