### PR TITLE
Fix GetMessagesAsync when provinding no before, after or around

### DIFF
--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -545,7 +545,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
 
         int remaining = limit;
         ulong? last = null;
-        bool isbefore = before != null;
+        bool isbefore = before != null || (before is null && after is null && around is null);
 
         int lastCount;
         do


### PR DESCRIPTION
# Summary
The api does newest to oldest like when providing a `before` value if only a limit is provided