### PR TITLE
Update deps

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,12 +13,12 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="NetEscapades.EnumGenerators" Version="1.0.0-beta12" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NUnit" Version="4.2.2" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.3.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageVersion Include="NUnit" Version="4.3.2" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.6.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="Polly.Core" Version="8.5.2" />
     <PackageVersion Include="Raffinert.FuzzySharp" Version="2.0.3" />
     <PackageVersion Include="Ulid" Version="1.3.4" />


### PR DESCRIPTION
```
» DSharpPlus.Tests                                                                                                                                                                            
  [net9.0]
  Microsoft.NET.Test.Sdk  17.11.1 -> 17.13.0
  NUnit                   4.2.2   -> 4.3.2  
  NUnit.Analyzers         4.3.0   -> 4.6.0  
  NUnit3TestAdapter       4.6.0   -> 5.0.0
```

# Notes
We should consider enabling dependabot.