### PR TITLE
Publisize `DiscordHttpInteraction` methods

### DIFF
--- a/DSharpPlus/Entities/Interaction/DiscordHttpInteraction.cs
+++ b/DSharpPlus/Entities/Interaction/DiscordHttpInteraction.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -13,19 +13,19 @@ public class DiscordHttpInteraction : DiscordInteraction
 {
     [JsonIgnore]
     internal readonly TaskCompletionSource taskCompletionSource = new();
-    
+
     [JsonIgnore]
     internal byte[] response;
 
-    internal bool Cancel() => this.taskCompletionSource.TrySetCanceled();
+    public bool CancelHttpInteractionResponse() => this.taskCompletionSource.TrySetCanceled();
 
-    internal async Task<byte[]> GetResponseAsync()
+    public async Task<byte[]> GetHttpResponseAsync()
     {
         await this.taskCompletionSource.Task;
 
         return this.response;
     }
-    
+
     /// <inheritdoc/>
     public override Task CreateResponseAsync(DiscordInteractionResponseType type, DiscordInteractionResponseBuilder? builder = null)
     {
@@ -34,7 +34,7 @@ public class DiscordHttpInteraction : DiscordInteraction
             throw new InvalidOperationException(
                 "Discord closed the connection. This is likely due to exeeding the limit of 3 seconds to the response.");
         }
-        
+
         if (this.ResponseState is not DiscordInteractionResponseState.Unacknowledged)
         {
             throw new InvalidOperationException("A response has already been made to this interaction.");
@@ -43,7 +43,7 @@ public class DiscordHttpInteraction : DiscordInteraction
         this.ResponseState = type == DiscordInteractionResponseType.DeferredChannelMessageWithSource
             ? DiscordInteractionResponseState.Deferred
             : DiscordInteractionResponseState.Replied;
-        
+
         DiscordInteractionResponsePayload payload = new()
         {
             Type = type,
@@ -66,7 +66,7 @@ public class DiscordHttpInteraction : DiscordInteraction
 
         this.response = Encoding.UTF8.GetBytes(DiscordJson.SerializeObject(payload));
         this.taskCompletionSource.SetResult();
-        
+
         return Task.CompletedTask;
     }
 }

--- a/DSharpPlus/Net/InboundWebhooks/Transport/InteractionTransportService.cs
+++ b/DSharpPlus/Net/InboundWebhooks/Transport/InteractionTransportService.cs
@@ -46,14 +46,14 @@ public sealed class InteractionTransportService : IInteractionTransportService
 
         JObject data = JObject.Parse(bodyString);
 
-        DiscordHttpInteraction? interaction = data.ToDiscordObject<DiscordHttpInteraction>() 
+        DiscordHttpInteraction? interaction = data.ToDiscordObject<DiscordHttpInteraction>()
             ?? throw new ArgumentException("Unable to parse provided request body to DiscordHttpInteraction");
 
         if (interaction.Type is DiscordInteractionType.Ping)
         {
-            DiscordInteractionResponsePayload responsePayload = new() 
-            { 
-                Type = DiscordInteractionResponseType.Pong 
+            DiscordInteractionResponsePayload responsePayload = new()
+            {
+                Type = DiscordInteractionResponseType.Pong
             };
 
             string responseString = DiscordJson.SerializeObject(responsePayload);
@@ -62,10 +62,10 @@ public sealed class InteractionTransportService : IInteractionTransportService
             return responseBytes;
         }
 
-        token.Register(() => interaction.Cancel());
+        token.Register(() => interaction.CancelHttpInteractionResponse());
 
         await this.writer.WriteAsync(new(interaction, data), token);
 
-        return await interaction.GetResponseAsync();
+        return await interaction.GetHttpResponseAsync();
     }
 }


### PR DESCRIPTION
# Summary
Allows for `DiscordHttpInteraction` methods to be used when the default gateway is not acceptable for the current application.