### PR TITLE
fix `DiscordPermissions.ToString("name")` performance

### DIFF
--- a/DSharpPlus/Entities/DiscordPermissions.Enumeration.cs
+++ b/DSharpPlus/Entities/DiscordPermissions.Enumeration.cs
@@ -37,7 +37,7 @@ partial struct DiscordPermissions
     /// </summary>
     public struct DiscordPermissionEnumerator : IEnumerator<DiscordPermission>
     {
-        private readonly DiscordPermissionContainer data;
+        private DiscordPermissionContainer data;
 
         internal DiscordPermissionEnumerator(DiscordPermissionContainer data)
             => this.data = data;

--- a/DSharpPlus/Entities/DiscordPermissions.Enumeration.cs
+++ b/DSharpPlus/Entities/DiscordPermissions.Enumeration.cs
@@ -3,6 +3,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 
 using CommunityToolkit.HighPerformance.Helpers;
 
@@ -54,7 +55,7 @@ partial struct DiscordPermissions
             for (; this.block < ContainerElementCount; this.block++)
             {
                 this.bit++;
-                uint value = this.data[this.block];
+                uint value = Unsafe.Add(ref Unsafe.As<DiscordPermissionContainer, uint>(ref this.data), this.block);
 
                 if (value == 0)
                 {

--- a/DSharpPlus/Entities/DiscordPermissions.cs
+++ b/DSharpPlus/Entities/DiscordPermissions.cs
@@ -35,6 +35,9 @@ public readonly partial struct DiscordPermissions
     private const int ContainerElementCount = ContainerWidth * 4;
     private const int ContainerByteCount = ContainerWidth * 16;
 
+    private static readonly string[] permissionNames = CreatePermissionNameArray();
+    private static readonly int highestDefinedValue = (int)DiscordPermissionExtensions.GetValues()[^1];
+
     private readonly DiscordPermissionContainer data;
 
     /// <summary>
@@ -232,13 +235,19 @@ public readonly partial struct DiscordPermissions
                 pop += BitOperations.PopCount(this.data[i + 3]);
             }
 
-            string[] names = new string[pop];
+            if (pop == 0)
+            {
+                return "None";
+            }
+
+            Span<string> names = new string[pop];
             DiscordPermissionEnumerator enumerator = new(this.data);
 
             for (int i = 0; i < pop; i++)
             {
                 _ = enumerator.MoveNext();
-                names[i] = enumerator.Current.ToStringFast();
+                int flag = (int)enumerator.Current;
+                names[i] = flag <= highestDefinedValue ? permissionNames[flag] : flag.ToString(CultureInfo.InvariantCulture);
             }
 
             return string.Join(", ", names);
@@ -273,6 +282,19 @@ public readonly partial struct DiscordPermissions
 
     public static bool operator ==(DiscordPermissions left, DiscordPermissions right) => left.Equals(right);
     public static bool operator !=(DiscordPermissions left, DiscordPermissions right) => !(left == right);
+
+    private static string[] CreatePermissionNameArray()
+    {
+        int highest = (int)DiscordPermissionExtensions.GetValues()[^1];
+        string[] names = new string[highest + 1];
+    
+        for (int i = 0; i <= highest; i++)
+        {
+            names[i] = ((DiscordPermission)i).ToStringFast(true);
+        }
+    
+        return names;
+    }
 
     // we will be using an inline array from the start here so that further increases in the bit width
     // only require increasing this number instead of switching to a new backing implementation strategy.


### PR DESCRIPTION
due to a number of factors, this method performed rather poorly when faced with values not defined in the `DiscordPermission` enum. by caching the names and using a faster fallback than `Enum.ToString()` otherwise, we can save substantial performance in such cases (see the attached benchmark results). this also comes with a handful of other performance optimizations shaving off a few percentage points each (though, there were more optimizations considered that either significantly degraded code readability or proved detrimental running against higher bitwidths than the current 128-bit).

using the tests available on the v6 branch, all optimizations have been verified to still work.
if there were no permissions set, we now return `"None"` for better UX.

benchmarks taken on Ryzen 7950X @ ~5850MHz, 64GB memory @ 5600MT/s, `15f22b0` refers to the latest commit at the time of benchmarking, `Current` to the new implementation provided
![image](https://github.com/user-attachments/assets/ad6124e7-afb2-49f7-88de-f4ca544bbe51)
