### PR TITLE
correct lambda syntax in message handler example

### DIFF
--- a/docs/articles/basics/first_bot.md
+++ b/docs/articles/basics/first_bot.md
@@ -168,7 +168,7 @@ Then, add an `if` statement into the body of your event lambda that will check i
 ```cs
 builder.ConfigureEventHandlers
 (
-    b => b.HandleMessageCreated(async s, e) => 
+    b => b.HandleMessageCreated(async (s, e) => 
     {
         if (e.Message.Content.ToLower().StartsWith("ping"))
         {


### PR DESCRIPTION
# Summary
correct lambda syntax
# Details
This pull request includes a small change to the `docs/articles/basics/first_bot.md` file. The change corrects the syntax of the lambda expression in the event handler configuration in `first_bot.md`

# Changes proposed

the code block should be 
```csharp
builder.ConfigureEventHandlers
(
    //                                ^missing left parenthesis
    b => b.HandleMessageCreated(async (s, e) => 
    {
        if (e.Message.Content.ToLower().StartsWith("ping"))
        {
            await e.Message.RespondAsync("pong!");
        }
    })
);
```
instead of the source
```csharp
builder.ConfigureEventHandlers
(
    b => b.HandleMessageCreated(async s, e) => 
    {
        if (e.Message.Content.ToLower().StartsWith("ping"))
        {
            await e.Message.RespondAsync("pong!");
        }
    })
);
```

