### PR TITLE
The Singel Most Imprtant Pull Requst in All of DSharpPlus Historee

### DIFF
--- a/DSharpPlus.Interactivity/InteractivityExtension.cs
+++ b/DSharpPlus.Interactivity/InteractivityExtension.cs
@@ -132,7 +132,7 @@ public class InteractivityExtension : IDisposable
     }
 
     /// <summary>
-    /// Waits for a modal with the specificed custom id to be submitted by the given user.
+    /// Waits for a modal with the specified custom id to be submitted by the given user.
     /// </summary>
     /// <param name="modal_id">The id of the modal to wait for. Should be unique to avoid issues.</param>
     /// <param name="user">The user to wait for the modal from.</param>
@@ -142,7 +142,7 @@ public class InteractivityExtension : IDisposable
         => WaitForModalAsync(modal_id, user, GetCancellationToken(timeoutOverride));
 
     /// <summary>
-    /// Waits for a modal with the specificed custom id to be submitted by the given user.
+    /// Waits for a modal with the specified custom id to be submitted by the given user.
     /// </summary>
     /// <param name="modal_id">The id of the modal to wait for. Should be unique to avoid issues.</param>
     /// <param name="user">The user to wait for the modal from.</param>


### PR DESCRIPTION
# Summery
Behold. I hav sumbitted a Pull Requst of such monumentel gravitty that the very fabric of XMLDocs trembles beneath its awsome corection. A singel spelin eror in WaitForModalAsync has bean… DEFEETED.

# Wut Was Wrong??
An unspekable atrosity had crept into the XML dokumantation. A typo. A vile mispelling. A word, twisted and curropted, leding brave devs into confushion and dispair.

> "Waht dose this mean??" – said no one ever, because they prolly jus ignored it. BUT STILL.

# The Fix??
With the precishun of a lazer-sharp eagle armed with grammarly, I have fixed teh typo.

This was not just a fix. It was a spiritual cleansing.
A rite of passige.
A moment of inner peace 4 all who dare read the XML summerys.

# Perfomance Impak
🔥 9000x more readable
📉 Reduces dev braindamage by up to 1.3%
🧙‍♂️ Improoves documantashun IQ by 87 spellpoints
🧼 Washes away teh sins of poor gramer

# Wider Implicashuns
- The codebase is now 33% holier
- All other typos now fear they’re next
- Grammarly’s servers are releived and thank me
- This PR is a message 2 future generashuns:
> We wuz here. We cared. We fixeded the docs.

# Next Steps
I recomed an emergancy patch release (vX.Y.Z+DocFix++)
Maybe even a full version bumb: `7.0.0-LTS-TYPOLESS`

# Plz Merge
Fo every moment this PR remains unmerged, an `await` weeps silently in a cold, undocumented corner. Don’t let this typo continue its rain of teror.

📝 Spellchecked on a potato. Trust me.