### PR TITLE
fix deserializing context menus with a description

### DIFF
--- a/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
+++ b/DSharpPlus/Entities/Interaction/Application/DiscordApplicationCommand.cs
@@ -151,13 +151,8 @@ public sealed partial class DiscordApplicationCommand : SnowflakeObject, IEquata
                 throw new ArgumentException("Slash command description cannot exceed 100 characters.", nameof(description));
             }
         }
-        else
+        else if (type is DiscordApplicationCommandType.UserContextMenu or DiscordApplicationCommandType.MessageContextMenu)
         {
-            if (!string.IsNullOrWhiteSpace(description))
-            {
-                throw new ArgumentException("Context menus do not support descriptions.");
-            }
-
             if (options?.Any() ?? false)
             {
                 throw new ArgumentException("Context menus do not support options.");


### PR DESCRIPTION
discord can for some unfathomable reason send this, so... gotta handle it

also fixes the check to only apply to context menus and not other kinds of as-of-yet unhandled command types