### PR TITLE
feat: Up cv2 limit & add validation for containers

### DIFF
--- a/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
@@ -655,8 +655,9 @@ public abstract class BaseDiscordMessageBuilder<T> : IDiscordMessageBuilder wher
         DiscordComponent component
     )
     {
-        int maxTopComponents = this.Flags.HasFlag(DiscordMessageFlags.IsComponentsV2) ? 10 : 5;
-        int maxAllComponents = this.Flags.HasFlag(DiscordMessageFlags.IsComponentsV2) ? 30 : 25;
+        const int CV2_MAX_TOTAL_COMPONENTS = 40;
+        int maxTopComponents = this.Flags.HasFlag(DiscordMessageFlags.IsComponentsV2) ? CV2_MAX_TOTAL_COMPONENTS : 5;
+        int maxAllComponents = this.Flags.HasFlag(DiscordMessageFlags.IsComponentsV2) ? CV2_MAX_TOTAL_COMPONENTS : 25;
         
         int allComponentCount = this.Components.Sum
         (

--- a/DSharpPlus/Entities/Interaction/Components/DiscordContainerComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/DiscordContainerComponent.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Newtonsoft.Json;
 
 namespace DSharpPlus.Entities;
@@ -59,8 +61,27 @@ public class DiscordContainerComponent : DiscordComponent
         this.Components = components;
         this.IsSpoilered = isSpoilered;
         this.color = color?.Value;
+        
+        ThrowIfUnwrappedComponentsDetected();
     }
     
     internal DiscordContainerComponent() => this.Type = DiscordComponentType.Container;
 
+    [StackTraceHidden]
+    [DebuggerStepThrough]
+    private void ThrowIfUnwrappedComponentsDetected()
+    {
+        for (int i = 0; i < this.Components.Count; i++)
+        {
+            DiscordComponent comp = this.Components[i];
+
+            if (comp is not (DiscordButtonComponent or DiscordSelectComponent))
+            {
+                continue;
+            }
+
+            string compType = comp is DiscordButtonComponent ? "Buttons" : "Selects";
+            throw new ArgumentException($"{compType} must be wrapped in an action row. Index: {i}");
+        }
+    }
 }


### PR DESCRIPTION
CV2 now supports a unified limit of 40 components; top level and in containers.

See https://github.com/discord/discord-api-docs/pull/7534 for more info.

Also added validation so that people know that Cv1 components must be wrapped in action rows for containers; sorry folk!

The justification behind throwing instead of trying to wrap them behind the scenes is that we could accidentally break intended layouts by chunking buttons (current behavior by AddButtons and future layout builder)