### PR TITLE
fix: associate Discord instance with http interaction in interactionE…

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -623,6 +623,7 @@ public sealed partial class DiscordClient
         {
             DiscordHttpInteractionPayload payload = await this.interactionEventReader.ReadAsync();
             DiscordHttpInteraction interaction = payload.ProtoInteraction;
+            interaction.Discord = this;
 
             ulong? guildId = interaction.GuildId;
             ulong channelId = interaction.ChannelId;


### PR DESCRIPTION
…ventReader loop

# Note
This killed all incoming interactions because it lead to an NRE. Untested - im opening this pr to get the artifacts because local `dotnet pack` was weird and im to tired to fix that