### PR TITLE
refactor: Formalized Public Access to Previously Internal Logic

### DIFF
--- a/DSharpPlus.Commands/Converters/StringConverter.cs
+++ b/DSharpPlus.Commands/Converters/StringConverter.cs
@@ -34,7 +34,7 @@ public class StringConverter : ISlashArgumentConverter<string>, ITextArgumentCon
         return Task.FromResult(Optional.FromValue(argument));
     }
 
-    private static bool TryGetCodeBlock(string input, CodeType expectedCodeType, [NotNullWhen(true)] out string? code)
+    public static bool TryGetCodeBlock(string input, CodeType expectedCodeType, [NotNullWhen(true)] out string? code)
     {
         code = null;
         ReadOnlySpan<char> inputSpan = input.AsSpan();


### PR DESCRIPTION
# Summary
Adjusted access control level of key method from private confinement to public availability, thereby expanding the component's external interaction surface area.

# Details
I methodically navigated the DSharpPlus source code in search of a troubling and perplexing issue: `Converters.TryGetCodeBlock` being marked as a *private* method (how preposterous).

# Changes proposed
I changed `Converters.TryGetCodeBlock` from being a private method to being a public method.