### PR TITLE
add a dependency on sodium to dsharpplus.http.aspnetcore

### DIFF
--- a/DSharpPlus.Http.AspNetCore/DSharpPlus.Http.AspNetCore.csproj
+++ b/DSharpPlus.Http.AspNetCore/DSharpPlus.Http.AspNetCore.csproj
@@ -9,6 +9,9 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj"/>
+    <PackageReference Include="DSharpPlus.Natives.Sodium" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DSharpPlus\DSharpPlus.csproj" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,8 @@
   <ItemGroup>
     <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
     <PackageVersion Include="ConcurrentHashSet" Version="1.3.0" />
+    <PackageVersion Include="DSharpPlus.Natives.Sodium" Version="1.0.20.17" />
+    <PackageVersion Include="DSharpPlus.Natives.Zstd" Version="1.5.7.21" />
     <PackageVersion Include="DSharpPlus.VoiceNext.Natives" Version="1.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
@@ -11,6 +13,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />


### PR DESCRIPTION
sodium is always required for this to work, so, i think it'd do well to include it by default similar to how we handle voice dependencies today (ignoring the fact voicenext is... not in a good state.)

it is possible to remove the default-included sodium by wiping it from the build output in a post-build step or manually if so desired (which is rather unlikely), and this of course will not provide sodium for targets not supported by the native package.