### PR TITLE
Fix typo in documentation code block

### DIFF
--- a/docs/articles/commands/processors/slash_commands/choice_provider_vs_autocomplete.md
+++ b/docs/articles/commands/processors/slash_commands/choice_provider_vs_autocomplete.md
@@ -89,7 +89,7 @@ public class TagNameAutoCompleteProvider : IAutoCompleteProvider
 
     public TagNameAutoCompleteProvider(ITagService tagService) => tagService = tagService;
 
-    public ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context);
+    public ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {
         var tags = tagService
             .GetTags()


### PR DESCRIPTION
Removes extra semicolon

The last line was changed by github itself, I assume it added/removed a newline or something.