### PR TITLE
Refactor voice region handling in DiscordGuild and related classes

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1298,7 +1298,7 @@ public sealed partial class DiscordClient
                 VerificationLevel = gld.VerificationLevel,
                 RulesChannelId = gld.RulesChannelId,
                 PublicUpdatesChannelId = gld.PublicUpdatesChannelId,
-                voiceRegionId = gld.voiceRegionId,
+                VoiceRegionId = gld.VoiceRegionId,
                 PremiumProgressBarEnabled = gld.PremiumProgressBarEnabled,
                 IsNSFW = gld.IsNSFW,
                 channels = new ConcurrentDictionary<ulong, DiscordChannel>(),

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -1234,7 +1234,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
         guild.IconHash = newGuild.IconHash;
         guild.MfaLevel = newGuild.MfaLevel;
         guild.OwnerId = newGuild.OwnerId;
-        guild.voiceRegionId = newGuild.voiceRegionId;
+        guild.VoiceRegionId = newGuild.VoiceRegionId;
         guild.SplashHash = newGuild.SplashHash;
         guild.VerificationLevel = newGuild.VerificationLevel;
         guild.WidgetEnabled = newGuild.WidgetEnabled;

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -407,7 +407,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
             mdl.Bitrate,
             mdl.Userlimit,
             mdl.PerUserRateLimit,
-            mdl.RtcRegion.IfPresent(r => r?.Id),
+            mdl.RtcRegion.IfPresent(r => r.Id),
             mdl.QualityMode,
             mdl.Type,
             mdl.PermissionOverwrites,

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -103,14 +103,26 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     /// Gets the guild's voice region ID.
     /// </summary>
     [JsonProperty("region", NullValueHandling = NullValueHandling.Ignore)]
-    internal string voiceRegionId { get; set; }
+    public string VoiceRegionId { get; internal set; }
 
     /// <summary>
     /// Gets the guild's voice region.
     /// </summary>
-    [JsonIgnore]
-    public DiscordVoiceRegion VoiceRegion
-        => this.Discord.VoiceRegions[this.voiceRegionId];
+    public async ValueTask<DiscordVoiceRegion> GetVoiceRegionAsync()
+    {
+        if (this.Discord.VoiceRegions.TryGetValue(this.VoiceRegionId, out DiscordVoiceRegion? currentRegion))
+        {
+            return currentRegion;
+        }
+
+        IReadOnlyList<DiscordVoiceRegion> regions = await this.Discord.ApiClient.ListVoiceRegionsAsync();
+        foreach (DiscordVoiceRegion region in regions)
+        {
+            this.Discord.InternalVoiceRegions.TryAdd(region.Id, region);
+        }
+
+        return this.Discord.InternalVoiceRegions[this.VoiceRegionId];
+    }
 
     /// <summary>
     /// Gets the guild's AFK voice channel ID.

--- a/DSharpPlus/Entities/Voice/DiscordVoiceRegion.cs
+++ b/DSharpPlus/Entities/Voice/DiscordVoiceRegion.cs
@@ -20,24 +20,6 @@ public class DiscordVoiceRegion
     public string Name { get; internal set; }
 
     /// <summary>
-    /// Gets an example server hostname for this region.
-    /// </summary>
-    [JsonProperty("sample_hostname", NullValueHandling = NullValueHandling.Ignore)]
-    public string SampleHostname { get; internal set; }
-
-    /// <summary>
-    /// Gets an example server port for this region.
-    /// </summary>
-    [JsonProperty("sample_port", NullValueHandling = NullValueHandling.Ignore)]
-    public int SamplePort { get; internal set; }
-
-    /// <summary>
-    /// Gets whether this is a VIP-only region.
-    /// </summary>
-    [JsonProperty("vip", NullValueHandling = NullValueHandling.Ignore)]
-    public bool IsVIP { get; internal set; }
-
-    /// <summary>
     /// Gets whether this region is the most optimal for the current user.
     /// </summary>
     [JsonProperty("optimal", NullValueHandling = NullValueHandling.Ignore)]
@@ -63,8 +45,10 @@ public class DiscordVoiceRegion
     public bool Equals(DiscordVoiceRegion region)
         => this == region;
 
+    /// <inheritdoc />
     public override bool Equals(object obj) => Equals(obj as DiscordVoiceRegion);
 
+    /// <inheritdoc />
     public override int GetHashCode() => this.Id.GetHashCode();
 
     /// <summary>
@@ -74,12 +58,7 @@ public class DiscordVoiceRegion
     /// <param name="right">Second voice region to compare.</param>
     /// <returns>Whether the two voice regions are equal.</returns>
     public static bool operator ==(DiscordVoiceRegion left, DiscordVoiceRegion right)
-    {
-        object? o1 = left;
-        object? o2 = right;
-
-        return (o1 != null || o2 == null) && (o1 == null || o2 != null) && ((o1 == null && o2 == null) || left.Id == right.Id);
-    }
+        => left.Equals(right);
 
     /// <summary>
     /// Gets whether the two <see cref="DiscordVoiceRegion"/> objects are not equal.


### PR DESCRIPTION
# Note
Formerly the handling of the VoiceRegion lead to an NRE when accessed on a DiscordGuild fetched from an OAuth ApiClient which VoiceRegions cache doesnt get initialized.