### PR TITLE
Add DiscordFileComponent to json deserialization of incoming v2 components

### DIFF
--- a/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/DiscordComponentJsonConverter.cs
@@ -35,6 +35,7 @@ internal sealed class DiscordComponentJsonConverter : JsonConverter
             DiscordComponentType.Thumbnail => new DiscordThumbnailComponent(),
             DiscordComponentType.MediaGallery => new DiscordMediaGalleryComponent(),
             DiscordComponentType.Separator => new DiscordSeparatorComponent(),
+            DiscordComponentType.File => new DiscordFileComponent(),
             DiscordComponentType.Container => new DiscordContainerComponent(),
             _ => new DiscordComponent() { Type = type.Value }
         };


### PR DESCRIPTION
# Summary
Fixes a bug where `DiscordFileComponent`s were not correctly parsed out of incoming v2 components

# Details
`DiscordComponentType.File` was not present in the component type switch statement, causing relevant fields not to be populated. All this PR does is include that type in the switch statement.