### PR TITLE
fix(interactivity): Do not respond to the same interaction more than once

### DIFF
--- a/DSharpPlus.Interactivity/EventHandling/ComponentBased/ComponentEventWaiter.cs
+++ b/DSharpPlus.Interactivity/EventHandling/ComponentBased/ComponentEventWaiter.cs
@@ -97,7 +97,7 @@ internal class ComponentEventWaiter : IDisposable
                             new() { Content = responseMessage, IsEphemeral = true }
                         );
                     }
-                    else
+                    else if (args.Interaction.ResponseState is DiscordInteractionResponseState.Deferred)
                     {
                         await args.Interaction.CreateFollowupMessageAsync
                         (
@@ -136,7 +136,7 @@ internal class ComponentEventWaiter : IDisposable
                                 new() { Content = responseMessage, IsEphemeral = true }
                             );
                         }
-                        else
+                        else if (args.Interaction.ResponseState is DiscordInteractionResponseState.Deferred)
                         {
                             await args.Interaction.CreateFollowupMessageAsync
                             (


### PR DESCRIPTION
Fixes an issue that'd gone unseen in testing wherein interactivity would respond multiple times to the same interaction if there were multiple events being waited on (up to N responses)

Now, it checks if the interaction is unacknowledged or *deferred*, rather than just unacknowledged, and unconditionally following up.