### PR TITLE
Replaced old lock-object with the new System.Threading.Lock

### DIFF
--- a/DSharpPlus/Logging/DefaultLogger.cs
+++ b/DSharpPlus/Logging/DefaultLogger.cs
@@ -1,5 +1,5 @@
 using System;
-
+using System.Threading;
 using Microsoft.Extensions.Logging;
 
 namespace DSharpPlus.Logging;
@@ -11,7 +11,7 @@ internal sealed class DefaultLogger : ILogger
 {
     private readonly string name;
     private readonly LogLevel minimumLogLevel;
-    private readonly object @lock = new();
+    private readonly Lock @lock = new();
     private readonly string timestampFormat;
 
     public DefaultLogger(string name, LogLevel minimumLogLevel, string timestampFormat)
@@ -21,8 +21,8 @@ internal sealed class DefaultLogger : ILogger
         this.timestampFormat = timestampFormat;
     }
 
-    public IDisposable? BeginScope<TState>(TState state) 
-        where TState : notnull 
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull
         => default;
 
     public bool IsEnabled(LogLevel logLevel)


### PR DESCRIPTION
# Summary
Replaced old lock-object with the new System.Threading.Lock.

# Details
The original lock object has been replaced with a `System.Threading.Lock`.

# Changes proposed
* Replacing `object` with `Lock` ✨ 

# Notes
With the removal of `object`, my formatter also removed some trailing whitespace from lines 24 and 25 without my notice. Hopefully, this will not be like the TF2 coconut and halt all builds.