### PR TITLE
Refactor component filtering logic in DiscordMessage to support CV2

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -462,37 +462,19 @@ public class DiscordMessage : SnowflakeObject, IEquatable<DiscordMessage>
 
         foreach (DiscordComponent component in this.Components)
         {
-            if (component is DiscordActionRowComponent actionRowComponent)
+            switch (component)
             {
-                foreach (DiscordComponent subComponent in actionRowComponent.Components)
-                {
-                    if (subComponent is T subFilteredComponent)
-                    {
-                        components.Add(subFilteredComponent);
-                    }
-                }
+                case DiscordActionRowComponent actionRowComponent:
+                    components.AddRange(FilterComponents<T>(actionRowComponent.Components));
+                    break;
+                case DiscordContainerComponent containerComponent:
+                    components.AddRange(FilterComponents<T>(containerComponent.Components));
+                    break;
+                case DiscordSectionComponent sectionComponent:
+                    components.AddRange(FilterComponents<T>(sectionComponent.Components));
+                    break;
             }
-            else if (component is DiscordContainerComponent containerComponent)
-            {
-                foreach (DiscordComponent subComponent in containerComponent.Components)
-                {
-                    if (subComponent is T subFilteredComponent)
-                    {
-                        components.Add(subFilteredComponent);
-                    }
-                }
-            }
-            else if (component is DiscordSectionComponent sectionComponent)
-            {
-                foreach (DiscordComponent subComponent in sectionComponent.Components)
-                {
-                    if (subComponent is T subFilteredComponent)
-                    {
-                        components.Add(subFilteredComponent);
-                    }
-                }
-            }
-            
+
             if (component is T filteredComponent)
             {
                 components.Add(filteredComponent);
@@ -502,6 +484,35 @@ public class DiscordMessage : SnowflakeObject, IEquatable<DiscordMessage>
         return components;
     }
 
+    private static List<T> FilterComponents<T>(IReadOnlyList<DiscordComponent> components)
+        where T : DiscordComponent
+    {
+        List<T> filteredComponents = [];
+
+        foreach (DiscordComponent component in components)
+        {
+            switch (component)
+            {
+                case DiscordActionRowComponent actionRowComponent:
+                    filteredComponents.AddRange(FilterComponents<T>(actionRowComponent.Components));
+                    break;
+                case DiscordContainerComponent containerComponent:
+                    filteredComponents.AddRange(FilterComponents<T>(containerComponent.Components));
+                    break;
+                case DiscordSectionComponent sectionComponent:
+                    filteredComponents.AddRange(FilterComponents<T>(sectionComponent.Components));
+                    break;
+            }
+            
+            if (component is T filteredComponent)
+            {
+                filteredComponents.Add(filteredComponent);
+            }
+        }
+
+        return filteredComponents;
+    }
+    
     /// <summary>
     /// Edits the message.
     /// </summary>

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -466,13 +466,34 @@ public class DiscordMessage : SnowflakeObject, IEquatable<DiscordMessage>
             {
                 foreach (DiscordComponent subComponent in actionRowComponent.Components)
                 {
-                    if (subComponent is T filteredComponent)
+                    if (subComponent is T subFilteredComponent)
                     {
-                        components.Add(filteredComponent);
+                        components.Add(subFilteredComponent);
                     }
                 }
             }
-            else if (component is T filteredComponent)
+            else if (component is DiscordContainerComponent containerComponent)
+            {
+                foreach (DiscordComponent subComponent in containerComponent.Components)
+                {
+                    if (subComponent is T subFilteredComponent)
+                    {
+                        components.Add(subFilteredComponent);
+                    }
+                }
+            }
+            else if (component is DiscordSectionComponent sectionComponent)
+            {
+                foreach (DiscordComponent subComponent in sectionComponent.Components)
+                {
+                    if (subComponent is T subFilteredComponent)
+                    {
+                        components.Add(subFilteredComponent);
+                    }
+                }
+            }
+            
+            if (component is T filteredComponent)
             {
                 components.Add(filteredComponent);
             }


### PR DESCRIPTION
Adds searching in v2 components when filtering components of a message. Idk if we need to make this recursive afaik there it is not possible to have a component with other components in it in a section or container.