### PR TITLE
load the xrefmap from microsoft docs

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -40,6 +40,9 @@
         ]
       }
     ],
+    "xref": [
+      "https://learn.microsoft.com/en-us/dotnet/.xrefmap.json"
+    ],
     "resource": [
       {
         "files": [


### PR DESCRIPTION

# Summary
Adds XREFmap from Microsoft Docs which now resolves most types in API docs.
# Details
In the past this *was* there, but got removed for reasons i cannot remember.

# Notes
More PRs about docs might be opened if i get enough motivation to do them.