### PR TITLE
Refactor format detection and fix initial value

### DIFF
--- a/DSharpPlus/InlineMediaTool.cs
+++ b/DSharpPlus/InlineMediaTool.cs
@@ -81,8 +81,8 @@ public sealed class InlineMediaTool : IDisposable
         long originalPosition = this.SourceStream.Position;
         this.SourceStream.Seek(0, SeekOrigin.Begin);
 
-        byte[] first16 = ArrayPool<byte>.Shared.Rent(MAX_SIGNATURE_LENGTH);
-        this.SourceStream.ReadExactly(first16, 0, MAX_SIGNATURE_LENGTH);
+        Span<byte> first16 = stackalloc byte[MAX_SIGNATURE_LENGTH];
+        this.SourceStream.ReadExactly(first16);
 
         try
         {
@@ -114,7 +114,6 @@ public sealed class InlineMediaTool : IDisposable
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(first16);
             this.SourceStream.Seek(originalPosition, SeekOrigin.Begin);
         }
     }


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
- Fix a 2 year old bug that made `GetFormat` return `Png` without running any checks
- Use an easily updatable list of byte sequences to check file type instead of using a bunch of int consts