### PR TITLE
add support for handling poll completion messages

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1815,7 +1815,7 @@ public sealed partial class DiscordClient
 
             MessagePollCompletedEventArgs pollEventArgs = new()
             {
-                Message = (DiscordPollCompletionMessage)message
+                PollCompletion = (DiscordPollCompletionMessage)message
             };
 
             await this.dispatcher.DispatchAsync(this, pollEventArgs);

--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -1809,6 +1809,18 @@ public sealed partial class DiscordClient
             sticker.Discord = this;
         }
 
+        if (message.MessageType == DiscordMessageType.PollResult)
+        {
+            message = new DiscordPollCompletionMessage(message);
+
+            MessagePollCompletedEventArgs pollEventArgs = new()
+            {
+                Message = (DiscordPollCompletionMessage)message
+            };
+
+            await this.dispatcher.DispatchAsync(this, pollEventArgs);
+        }
+
         MessageCreatedEventArgs ea = new()
         {
             Message = message,

--- a/DSharpPlus/Clients/EventHandlingBuilder.cs
+++ b/DSharpPlus/Clients/EventHandlingBuilder.cs
@@ -464,6 +464,15 @@ public sealed class EventHandlingBuilder
     }
 
     /// <summary>
+    /// Fired when a poll completes and a poll result message is created. For this event to fire you need the <see cref="DiscordIntents.GuildMessages"/> intent.
+    /// </summary>
+    public EventHandlingBuilder HandleMessagePollCompleted(Func<DiscordClient, MessagePollCompletedEventArgs, Task> handler)
+    {
+        this.Services.Configure<EventHandlerCollection>(c => c.Register(handler));
+        return this;
+    }
+
+    /// <summary>
     /// Fired when a message is updated.
     /// For this event to fire you need the <see cref="DiscordIntents.GuildMessages"/> or 
     /// <see cref="DiscordIntents.DirectMessages"/> intent.

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageType.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageType.cs
@@ -133,4 +133,10 @@ public enum DiscordMessageType : int
     StageSpeaker = 29,
     StageTopic = 31,
     GuildApplicationPremiumSubscription = 32,
+    GuildIncidentAlertModeEnabled = 36,
+    GuildIncidentAlertModeDisabled = 37,
+    GuildIncidentReportRaid = 38,
+    GuildIncidentReportFalseAlarm = 39,
+    PurchaseNotification = 44,
+    PollResult = 46
 }

--- a/DSharpPlus/Entities/Channel/Message/Poll/DiscordPollCompletionMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/Poll/DiscordPollCompletionMessage.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Diagnostics;
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Entities;
+
+public class DiscordPollCompletionMessage : DiscordMessage
+{
+    internal DiscordPollCompletionMessage(DiscordMessage other) : base(other)
+    {
+        Debug.Assert(other.MessageType == DiscordMessageType.PollResult);
+
+        if (other.Embeds is not [DiscordEmbed embed])
+        {
+            throw new ArgumentException("The provided poll completion message had no embeds.");
+        }
+
+        if (embed.Type != "poll_result" || embed.Fields.Count == 0)
+        {
+            throw new ArgumentException("The provided poll completion message's embed was malformed and does not represent poll results.");
+        }
+
+        ulong winningAnswerEmojiId = 0;
+        string? winningAnswerEmojiName = null;
+
+        // https://discord.com/developers/docs/resources/message#embed-fields-by-embed-type-poll-result-embed-fields
+        // i asked the devil whether they understood what the thought process here was, they said no.
+        foreach (DiscordEmbedField field in embed.Fields)
+        {
+            switch (field.Name)
+            {
+                case "poll_question_text":
+                    this.PollQuestionText = field.Value!;
+                    break;
+
+                case "victor_answer_votes":
+                    this.WinningAnswerVoteCount = int.Parse(field.Value!);
+                    break;
+
+                case "total_votes":
+                    this.TotalVotes = int.Parse(field.Value!);
+                    break;
+
+                case "victor_answer_id":
+                    this.WinningAnswerId = int.Parse(field.Value!);
+                    break;
+
+                case "victor_answer_text":
+                    this.WinningAnswerText = field.Value!;
+                    break;
+
+                case "victor_answer_emoji_id":
+                    winningAnswerEmojiId = ulong.Parse(field.Value)!;
+                    break;
+
+                case "victor_answer_emoji_name":
+                    winningAnswerEmojiName = field.Value!;
+                    break;
+
+                default:
+                    continue;
+            }
+        }
+
+        if (winningAnswerEmojiId != 0)
+        {
+            this.WinningAnswerEmoji = DiscordEmoji.FromGuildEmote(this.Discord, winningAnswerEmojiId);
+        }
+        else if (winningAnswerEmojiName is not null)
+        {
+            this.WinningAnswerEmoji = DiscordEmoji.FromUnicode(this.Discord, winningAnswerEmojiName);
+        }
+        else
+        {
+            this.WinningAnswerEmoji = null;
+        }
+    }
+
+    /// <summary>
+    /// The text of the original poll question.
+    /// </summary>
+    [JsonIgnore]
+    public string PollQuestionText { get; private set; }
+
+    /// <summary>
+    /// Indicates whether the poll ended in a draw
+    /// </summary>
+    [JsonIgnore]
+    public bool IsDraw => this.WinningAnswerId is null;
+
+    /// <summary>
+    /// The amount of votes cast for the winning answer.
+    /// </summary>
+    [JsonIgnore]
+    public int WinningAnswerVoteCount { get; private set; }
+
+    /// <summary>
+    /// The amounts of votes cast in total, across all answers.
+    /// </summary>
+    [JsonIgnore]
+    public int TotalVotes { get; private set; }
+
+    /// <summary>
+    /// The <see cref="DiscordPollAnswer.AnswerId"/> of the winning answer.
+    /// </summary>
+    [JsonIgnore]
+    public int? WinningAnswerId { get; private set; }
+
+    /// <summary>
+    /// The text of the winning answer.
+    /// </summary>
+    [JsonIgnore]
+    public string? WinningAnswerText { get; private set; }
+
+    /// <summary>
+    /// The emoji associated with the winning answer.
+    /// </summary>
+    [JsonIgnore]
+    public DiscordEmoji? WinningAnswerEmoji { get; private set; }
+
+    /// <summary>
+    /// The original poll message.
+    /// </summary>
+    [JsonIgnore]
+    public DiscordMessage? PollMessage => this.Reference!.Message;
+
+    /// <summary>
+    /// A message link pointing to the poll message.
+    /// </summary>
+    [JsonIgnore]
+    public string PollMessageLink => $"https://discord.com/channels/{this.guildId}/{this.ChannelId}/{this.Reference!.Message.Id}";
+}

--- a/DSharpPlus/EventArgs/Message/MessagePollCompletedEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/MessagePollCompletedEventArgs.cs
@@ -1,0 +1,26 @@
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs;
+
+/// <summary>
+/// Fired when a poll completes and results are available.
+/// </summary>
+public sealed class MessagePollCompletedEventArgs : DiscordEventArgs
+{
+    /// <summary>
+    /// The message containing the poll results.
+    /// </summary>
+    public DiscordPollCompletionMessage PollCompletion { get; internal set; }
+
+    /// <summary>
+    /// Gets the channel this message belongs to.
+    /// </summary>
+    public DiscordChannel Channel
+        => this.PollCompletion.Channel;
+
+    /// <summary>
+    /// Gets the guild this message belongs to.
+    /// </summary>
+    public DiscordGuild Guild
+        => this.Channel.Guild;
+}


### PR DESCRIPTION
adds a new synthetic event that contains a poll completion message parsed from the weird secret:tm: embed (see https://discord.com/developers/docs/resources/message#embed-fields-by-embed-type-poll-result-embed-fields for more information)