### PR TITLE
Add DiscordMemberFlags.AutomodQuarantinedGuildTag

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordMemberFlags.cs
+++ b/DSharpPlus/Entities/Guild/DiscordMemberFlags.cs
@@ -52,4 +52,9 @@ public enum DiscordMemberFlags
     /// Member has dismissed the DM settings upsell
     /// </summary>
     DmSettingsUpsellAcknowledged = 1 << 9,
+
+    /// <summary>
+    /// Member's guild tag is blocked by AutoMod
+    /// </summary>
+    AutomodQuarantinedGuildTag = 1 << 10,
 }


### PR DESCRIPTION
# Summary
Adds `AutomodQuarantinedGuildTag` to `DiscordMemberFlags`.

# Details
This adds support for the `AUTOMOD_QUARANTINED_GUILD_TAG` member flag as `DiscordMemberFlags.AutomodQuarantinedGuildTag`. This is documented, see https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-flags