### PR TITLE
Add SuppressEmbeds method and update DiscordMessageFlags for embed su…

### DIFF
--- a/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
+++ b/DSharpPlus/Entities/BaseDiscordMessageBuilder.cs
@@ -34,9 +34,23 @@ public abstract class BaseDiscordMessageBuilder<T> : IDiscordMessageBuilder wher
 
     public DiscordMessageFlags Flags { get; internal set; }
 
+    /// <summary>
+    /// Suppresses notifications for this message.
+    /// </summary>
+    /// <returns>The builder to chain calls with.</returns>
     public T SuppressNotifications()
     {
         this.Flags |= DiscordMessageFlags.SuppressNotifications;
+        return (T)this;
+    }
+    
+    /// <summary>
+    /// Suppresses embeds for this message.
+    /// </summary>
+    /// <returns>The builder to chain calls with.</returns>
+    public T SuppressEmbeds()
+    {
+        this.Flags |= DiscordMessageFlags.SuppressEmbeds;
         return (T)this;
     }
 
@@ -82,7 +96,7 @@ public abstract class BaseDiscordMessageBuilder<T> : IDiscordMessageBuilder wher
     /// <summary>
     /// Gets or sets a poll for this message.
     /// </summary>
-    public DiscordPollBuilder? Poll { get; set => SetIfV2Disabled(ref field, value, nameof(Poll)); }
+    public DiscordPollBuilder? Poll { get; set => SetIfV2Disabled(ref field, value, nameof(this.Poll)); }
 
     /// <summary>
     /// Embeds to send on this webhook request.
@@ -731,20 +745,21 @@ public abstract class BaseDiscordMessageBuilder<T> : IDiscordMessageBuilder wher
         }
     }
     
-    IDiscordMessageBuilder IDiscordMessageBuilder.EnableV2Components() => this.EnableV2Components();
-    IDiscordMessageBuilder IDiscordMessageBuilder.DisableV2Components() => this.DisableV2Components();
-    IDiscordMessageBuilder IDiscordMessageBuilder.AddActionRowComponent(DiscordActionRowComponent component) => this.AddActionRowComponent(component);
-    IDiscordMessageBuilder IDiscordMessageBuilder.AddActionRowComponent(DiscordSelectComponent selectMenu) => this.AddActionRowComponent(selectMenu);
-    IDiscordMessageBuilder IDiscordMessageBuilder.AddActionRowComponent(params IEnumerable<DiscordButtonComponent> buttons) => this.AddActionRowComponent(buttons);
-    IDiscordMessageBuilder IDiscordMessageBuilder.AddMediaGalleryComponent(params IEnumerable<DiscordMediaGalleryItem> galleryItems) => this.AddMediaGalleryComponent(galleryItems);
-    IDiscordMessageBuilder IDiscordMessageBuilder.AddSectionComponent(DiscordSectionComponent section) => this.AddSectionComponent(section);
-    IDiscordMessageBuilder IDiscordMessageBuilder.AddTextDisplayComponent(DiscordTextDisplayComponent component) => this.AddTextDisplayComponent(component);
-    IDiscordMessageBuilder IDiscordMessageBuilder.AddTextDisplayComponent(string content) => this.AddTextDisplayComponent(content);
-    IDiscordMessageBuilder IDiscordMessageBuilder.AddTextInputComponent(DiscordTextInputComponent component) => this.AddTextInputComponent(component);
-    IDiscordMessageBuilder IDiscordMessageBuilder.AddSeparatorComponent(DiscordSeparatorComponent component) => this.AddSeparatorComponent(component);
-    IDiscordMessageBuilder IDiscordMessageBuilder.AddFileComponent(DiscordFileComponent component) => this.AddFileComponent(component);
-    IDiscordMessageBuilder IDiscordMessageBuilder.AddContainerComponent(DiscordContainerComponent component) => this.AddContainerComponent(component);
+    IDiscordMessageBuilder IDiscordMessageBuilder.EnableV2Components() => EnableV2Components();
+    IDiscordMessageBuilder IDiscordMessageBuilder.DisableV2Components() => DisableV2Components();
+    IDiscordMessageBuilder IDiscordMessageBuilder.AddActionRowComponent(DiscordActionRowComponent component) => AddActionRowComponent(component);
+    IDiscordMessageBuilder IDiscordMessageBuilder.AddActionRowComponent(DiscordSelectComponent selectMenu) => AddActionRowComponent(selectMenu);
+    IDiscordMessageBuilder IDiscordMessageBuilder.AddActionRowComponent(params IEnumerable<DiscordButtonComponent> buttons) => AddActionRowComponent(buttons);
+    IDiscordMessageBuilder IDiscordMessageBuilder.AddMediaGalleryComponent(params IEnumerable<DiscordMediaGalleryItem> galleryItems) => AddMediaGalleryComponent(galleryItems);
+    IDiscordMessageBuilder IDiscordMessageBuilder.AddSectionComponent(DiscordSectionComponent section) => AddSectionComponent(section);
+    IDiscordMessageBuilder IDiscordMessageBuilder.AddTextDisplayComponent(DiscordTextDisplayComponent component) => AddTextDisplayComponent(component);
+    IDiscordMessageBuilder IDiscordMessageBuilder.AddTextDisplayComponent(string content) => AddTextDisplayComponent(content);
+    IDiscordMessageBuilder IDiscordMessageBuilder.AddTextInputComponent(DiscordTextInputComponent component) => AddTextInputComponent(component);
+    IDiscordMessageBuilder IDiscordMessageBuilder.AddSeparatorComponent(DiscordSeparatorComponent component) => AddSeparatorComponent(component);
+    IDiscordMessageBuilder IDiscordMessageBuilder.AddFileComponent(DiscordFileComponent component) => AddFileComponent(component);
+    IDiscordMessageBuilder IDiscordMessageBuilder.AddContainerComponent(DiscordContainerComponent component) => AddContainerComponent(component);
     IDiscordMessageBuilder IDiscordMessageBuilder.SuppressNotifications() => SuppressNotifications();
+    IDiscordMessageBuilder IDiscordMessageBuilder.SuppressEmbeds() => SuppressEmbeds();
     IDiscordMessageBuilder IDiscordMessageBuilder.WithContent(string content) => WithContent(content);
     IDiscordMessageBuilder IDiscordMessageBuilder.WithTTS(bool isTTS) => WithTTS(isTTS);
     IDiscordMessageBuilder IDiscordMessageBuilder.AddEmbed(DiscordEmbed embed) => AddEmbed(embed);
@@ -1058,6 +1073,8 @@ public interface IDiscordMessageBuilder : IDisposable, IAsyncDisposable
     /// Clears this builder.
     /// </summary>
     public void Clear();
+
+    IDiscordMessageBuilder SuppressEmbeds();
 }
 
 /*

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -592,7 +592,7 @@ public class DiscordMessage : SnowflakeObject, IEquatable<DiscordMessage>
     public async Task<DiscordMessage> ModifyAsync(DiscordMessageBuilder builder, bool suppressEmbeds = false, IEnumerable<DiscordAttachment>? attachments = default)
     {
         builder.Validate();
-        return await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, builder.Content, new Optional<IEnumerable<DiscordEmbed>>(builder.Embeds), builder.mentions, builder.Components, builder.Files, suppressEmbeds ? DiscordMessageFlags.SuppressedEmbeds : null, attachments);
+        return await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, builder.Content, new Optional<IEnumerable<DiscordEmbed>>(builder.Embeds), builder.mentions, builder.Components, builder.Files, suppressEmbeds ? DiscordMessageFlags.SuppressEmbeds : null, attachments);
     }
 
     /// <summary>
@@ -611,7 +611,7 @@ public class DiscordMessage : SnowflakeObject, IEquatable<DiscordMessage>
         DiscordMessageBuilder builder = new(this);
         action(builder);
         builder.Validate();
-        return await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, builder.Content, new Optional<IEnumerable<DiscordEmbed>>(builder.Embeds), builder.mentions, builder.Components, builder.Files, suppressEmbeds ? DiscordMessageFlags.SuppressedEmbeds : null, attachments);
+        return await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, builder.Content, new Optional<IEnumerable<DiscordEmbed>>(builder.Embeds), builder.mentions, builder.Components, builder.Files, suppressEmbeds ? DiscordMessageFlags.SuppressEmbeds : null, attachments);
     }
 
     /// <summary>
@@ -624,7 +624,7 @@ public class DiscordMessage : SnowflakeObject, IEquatable<DiscordMessage>
     /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
     /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
     public async Task ModifyEmbedSuppressionAsync(bool hideEmbeds)
-        => await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, default, default, default, default, [], hideEmbeds ? DiscordMessageFlags.SuppressedEmbeds : null, default);
+        => await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, default, default, default, default, [], hideEmbeds ? DiscordMessageFlags.SuppressEmbeds : null, default);
 
     /// <summary>
     /// Deletes the message.

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageFlags.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageFlags.cs
@@ -23,8 +23,7 @@ public enum DiscordMessageFlags
     /// <summary>
     /// Whether any embeds in the message are hidden.
     /// </summary>
-    /// <remarks>This flag is inbound only (it cannot be set).</remarks>
-    SuppressedEmbeds = 1 << 2,
+    SuppressEmbeds = 1 << 2,
 
     /// <summary>
     /// The source message for this crosspost has been deleted.

--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageFlags.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageFlags.cs
@@ -38,6 +38,11 @@ public enum DiscordMessageFlags
     Urgent = 1 << 4,
 
     /// <summary>
+    /// This message has an associated thread, with the same id as the message
+    /// </summary>
+    HasThread = 1 << 5,
+
+    /// <summary>
     /// The message is only visible to the user who invoked the interaction.
     /// </summary>
     Ephemeral = 1 << 6,
@@ -66,6 +71,16 @@ public enum DiscordMessageFlags
     /// Mentions in the message will still have a mention indicator, however.
     /// </summary>
     SuppressNotifications = 1 << 12,
+
+    /// <summary>
+    /// This message is a voice message
+    /// </summary>
+    IsVoiceMessage = 1 << 13,
+    
+    /// <summary>
+    /// This message has a snapshot (via Message Forwarding)
+    /// </summary>
+    HasSnapshot = 1 << 14,
     
     /// <summary>
     /// Indicates that this message is/will support Components V2.


### PR DESCRIPTION
…ppression on BaseDiscordMessageBuilder

Tested

# Notes
Contains breaking change: renamed `DiscordMessageFlags.SuppressedEmbeds` to `DiscordMessageFlags.SuppressEmbeds`according to the docs
Also this pr updates the `DiscordMessageFlags` enum with missing flags. Not sure what i do with `ContainsSuspiciousThirdPartyLink` which isnt documented (anymore?)