### PR TITLE
Correct the documentation version in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can install the library from following sources:
 
 # Documentation
 
-The documentation for the latest stable version is available at [dsharpplus.github.io](https://dsharpplus.github.io/DSharpPlus).
+The documentation for the latest nightly version is available at [dsharpplus.github.io](https://dsharpplus.github.io/DSharpPlus).
 
 ## Resources
 


### PR DESCRIPTION
# Summary
Fixes #2368: Documentation is listed as for stable when it is for nightly.

# Details
The documentation listed on the README states it is for stable, when it is for nightly.

# Changes proposed
* Replaced stable with nightly in the documentation description.

# Notes
No additional notes.