### PR TITLE
Documentation changes for choice provider vs. autocomplete provider

### DIFF
--- a/docs/articles/commands/processors/slash_commands/choice_provider_vs_autocomplete.md
+++ b/docs/articles/commands/processors/slash_commands/choice_provider_vs_autocomplete.md
@@ -85,13 +85,14 @@ Auto-complete is very similar in design to choice providers. Our class will impl
 ```cs
 public class TagNameAutoCompleteProvider : IAutoCompleteProvider
 {
-    private readonly ITagService tagService;
+    // Note: This is just en example data source. It does not exist in DSharpPlus.
+    private readonly ITagExampleService exampleTagService;
 
-    public TagNameAutoCompleteProvider(ITagService tagService) => tagService = tagService;
+    public TagNameAutoCompleteProvider(ITagExampleService tagService) => exampleTagService = tagService;
 
     public ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {
-        var tags = tagService
+        var tags = exampleTagService
             .GetTags()
             .Where(x => x.Name.StartsWith(context.UserInput, StringComparison.OrdinalIgnoreCase))
             .ToDictionary(x => x.Name, x => x.Id);


### PR DESCRIPTION
# Summary
Changes `ITagService` to `ITagExampleService`, and adds a note explaining that this type does not exist in DSharpPlus.