### PR TITLE
Update slash command verification to allow changing interaction types

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.Registration.Remote.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.Registration.Remote.cs
@@ -24,8 +24,7 @@ public sealed partial class SlashCommandProcessor
             DiscordApplicationCommand remote;
 
             // if name and type didnt change check for updates to command, else delete and recreate the command with new name/type
-            if ((remote = remoteTracking.SingleOrDefault(x => x.Name == command.Name)) is not null
-                && command.Type == remote.Type)
+            if ((remote = remoteTracking.SingleOrDefault(x => x.Name == command.Name && x.Type == command.Type)) is not null)
             {
                 if (command.WeakEquals(remote))
                 {

--- a/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.Registration.Remote.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/SlashCommandProcessor.Registration.Remote.cs
@@ -23,7 +23,9 @@ public sealed partial class SlashCommandProcessor
         {
             DiscordApplicationCommand remote;
 
-            if ((remote = remoteTracking.SingleOrDefault(x => x.Name == command.Name)) is not null)
+            // if name and type didnt change check for updates to command, else delete and recreate the command with new name/type
+            if ((remote = remoteTracking.SingleOrDefault(x => x.Name == command.Name)) is not null
+                && command.Type == remote.Type)
             {
                 if (command.WeakEquals(remote))
                 {


### PR DESCRIPTION
Didn't create an issue, just found this bug - when changing a command from one type to another DSP would try to send an edit request - [the api doesn't allow for edit requests to change the type of a command](https://discord.com/developers/docs/interactions/application-commands#edit-global-application-command)
Instead type changes are treated like name changes with this, deleting and recreating the command.

Added a condition in ``VerifyAndUpdateRemoteCommandsAsync`` to check for name and type instead of just name before checking for modifications.