### PR TITLE
Make InteractionAllowedContextsAttribute an unsealed type

### DIFF
--- a/DSharpPlus.Commands/Processors/SlashCommands/Metadata/InteractionAllowedContextsAttribute.cs
+++ b/DSharpPlus.Commands/Processors/SlashCommands/Metadata/InteractionAllowedContextsAttribute.cs
@@ -8,7 +8,7 @@ namespace DSharpPlus.Commands.Processors.SlashCommands.Metadata;
 /// Specifies the allowed interaction contexts for a command.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
-public sealed class InteractionAllowedContextsAttribute(params DiscordInteractionContextType[] allowedContexts) : Attribute
+public class InteractionAllowedContextsAttribute(params DiscordInteractionContextType[] allowedContexts) : Attribute
 {
     /// <summary>
     /// The contexts the command is allowed to be used in.


### PR DESCRIPTION
# Details
Makes `InteractionAllowedContextsAttribute` an unsealed type, much like `InteractionInstallTypeAttribute`. Allows for creating another attribute with prepopulated context types.