### PR TITLE
fix: make localizer execution not dependent on extension

### DIFF
--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -462,6 +462,7 @@ public sealed class CommandsExtension
             this.processors.TryAdd(typeof(UserCommandProcessor), new UserCommandProcessor());
         }
 
+        // Configure processors in a specific order to ensure dependencies are met
         if (this.processors.TryGetValue(typeof(UserCommandProcessor), out ICommandProcessor? userProcessor))
         {
             await userProcessor.ConfigureAsync(this);

--- a/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/MessageCommands/MessageCommandProcessor.cs
@@ -174,7 +174,7 @@ public sealed class MessageCommandProcessor : ICommandProcessor
         IReadOnlyDictionary<string, string> nameLocalizations = FrozenDictionary<string, string>.Empty;
         if (command.Attributes.OfType<InteractionLocalizerAttribute>().FirstOrDefault() is InteractionLocalizerAttribute localizerAttribute)
         {
-            nameLocalizations = await this.slashCommandProcessor.ExecuteLocalizerAsync(localizerAttribute.LocalizerType, $"{command.FullName}.name");
+            nameLocalizations = await SlashCommandProcessor.ExecuteLocalizerAsync(localizerAttribute.LocalizerType, $"{command.FullName}.name", this.extension!.ServiceProvider);
         }
 
         DiscordPermissions? userPermissions = command.Attributes.OfType<RequirePermissionsAttribute>().FirstOrDefault()?.UserPermissions;

--- a/DSharpPlus.Commands/Processors/UserCommands/UserCommandProcessor.cs
+++ b/DSharpPlus.Commands/Processors/UserCommands/UserCommandProcessor.cs
@@ -174,7 +174,7 @@ public sealed class UserCommandProcessor : ICommandProcessor
         IReadOnlyDictionary<string, string> nameLocalizations = FrozenDictionary<string, string>.Empty;
         if (command.Attributes.OfType<InteractionLocalizerAttribute>().FirstOrDefault() is InteractionLocalizerAttribute localizerAttribute)
         {
-            nameLocalizations = await this.slashCommandProcessor.ExecuteLocalizerAsync(localizerAttribute.LocalizerType, $"{command.FullName}.name");
+            nameLocalizations = await SlashCommandProcessor.ExecuteLocalizerAsync(localizerAttribute.LocalizerType, $"{command.FullName}.name", this.extension!.ServiceProvider);
         }
 
         DiscordPermissions? userPermissions = command.Attributes.OfType<RequirePermissionsAttribute>().FirstOrDefault()?.UserPermissions;


### PR DESCRIPTION
The context menu command processors called into the slashcommandsprocessor for localization but that is initialized **after** both processors. (Init sequence dictated by the slashcommandprocessore beeing the one to register all interactionbased commands with discord)