### PR TITLE
[ci skip] Push users towards using v5.0 nightlies instead of v4.5.X

### DIFF
--- a/docs/articles/basics/first_bot.md
+++ b/docs/articles/basics/first_bot.md
@@ -66,6 +66,9 @@ then click the `Install` button to the right (after verifing that you will be in
 
 ![Install DSharpPlus][10]
 
+>[!NOTE]
+> Please activate the 'Include prerelease' checkbox and use v5.0 nightlies instead of v4.5.X. v5.0 is a major rewrite of the library and no support will be provided for v4.5.X.
+
 You're now ready to write some code!
 
 ## First Lines of Code

--- a/docs/articles/preamble.md
+++ b/docs/articles/preamble.md
@@ -4,7 +4,7 @@ title: Article Preamble
 ---
 
 >[!NOTE]
-> These articles and the [API documentation][11] are built for the latest [nightly][18] version (`v5.0`)
+> These articles and the [API documentation][11] are built for the latest [nightly][18] version (`v5.0`). Please use v5.0 nightlies instead of v4.5.X. v5.0 is a major rewrite of the library and no support will be provided for v4.5.X.
 
 ## Knowledge Prerequisites
 


### PR DESCRIPTION
# Summary
Appends note on preamble to prompt users to use v5.0 nightlies. Adds a note to the "first bot" article below the "Install Package" section.