### PR TITLE
downgrade the docfx version to last working in the action

### DIFF
--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Build Project
         run: |
           dotnet build
-          dotnet tool update -g docfx --prerelease
+          dotnet tool install -g docfx --version 2.78.3 --allow-downgrade
           docfx docs/docfx.json
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines.

# Summary
Downgrades the DocFX version to the last working in our commit action. 
I will make an issue in the DocFX repo about this eventually, because it's.. weird. 
All the issues like those seem to be related to slnx, and they seem to be fixed. Maybe something is just weirdly outdated in DocFX itself.

My source is this [issue](https://github.com/NuGet/Home/issues/14136)


# Notes
i hate docfx