### PR TITLE
Add Pin Messages and Bypass Slowmode permissions

### DIFF
--- a/DSharpPlus/Entities/DiscordPermission.cs
+++ b/DSharpPlus/Entities/DiscordPermission.cs
@@ -302,6 +302,18 @@ public enum DiscordPermission
     /// Allows members to use external, user-installable apps.
     /// </summary>
     [Display(Name = "Use External Apps")]
-    UseExternalApps = 50
+    UseExternalApps = 50,
+
+    /// <summary>
+    /// Allows members to pin and unpin messages.
+    /// </summary>
+    [Display(Name = "Pin Messages")]
+    PinMessages = 51,
+
+    /// <summary>
+    /// Allows members to bypass slowmode.
+    /// </summary>
+    [Display(Name = "Bypass Slowmode")]
+    BypassSlowmode = 52
 }
 


### PR DESCRIPTION
# Summary
Adds `PinMessages` and `BypassSlowmode` to `DiscordPermission`

# Details
This adds support for the Pin Messages and Bypass Slowmode permissions, as `DiscordPermission.PinMessages` and `DiscordPermission.BypassSlowmode`. Documented here https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags