### PR TITLE
Allow updating cached DiscordForumChannels on CHANNEL_UPDATE

### DIFF
--- a/DSharpPlus/Entities/Channel/Thread/Forum/DiscordForumChannel.cs
+++ b/DSharpPlus/Entities/Channel/Thread/Forum/DiscordForumChannel.cs
@@ -28,13 +28,11 @@ public sealed class DiscordForumChannel : DiscordChannel
     /// <summary>
     /// Gets the available tags for the forum.
     /// </summary>
-    public IReadOnlyList<DiscordForumTag> AvailableTags => this.availableTags;
+    public IReadOnlyList<DiscordForumTag> AvailableTags => this.availableTagsInternal;
 
-#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value null
     // Justification: Used by JSON.NET
     [JsonProperty("available_tags")]
-    private readonly List<DiscordForumTag> availableTags;
-#pragma warning restore CS0649
+    internal List<DiscordForumTag> availableTagsInternal;
 
     /// <summary>
     /// The default reaction shown on posts when they are created.


### PR DESCRIPTION
# Summary
Enabled gateway `CHANNEL_UPDATE` event to also update forum channel properties if the updated channel is a forum channel.

# Details
I've moved the forum channel update in a separate method, so its somewhat easier to read.

# Notes
In order to be able to access `DiscordForumChannel.AvailableTags` I had to switch the backing property to internal.
To make sure its not confusing I've renamed the internal property to `availableTagsInternal` so it's hopefully clear this is not the normal property to use, even inside the library codebase.