### PR TITLE
Updated Nullability for MessageReaction* Events and InternalGetCachedGuild

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -2248,7 +2248,7 @@ public sealed partial class DiscordClient
 
     internal async Task OnMessageReactionRemoveEmojiAsync(ulong messageId, ulong channelId, ulong guildId, JToken dat)
     {
-        DiscordGuild guild = InternalGetCachedGuild(guildId);
+        DiscordGuild? guild = InternalGetCachedGuild(guildId);
         DiscordChannel? channel = InternalGetCachedChannel(channelId, guildId) ?? InternalGetCachedThread(channelId, guildId);
 
         if (channel == null)

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -1040,7 +1040,7 @@ public sealed partial class DiscordClient : BaseDiscordClient
         return InternalGetCachedChannel(channelId);
     }
 
-    internal DiscordGuild InternalGetCachedGuild(ulong? guildId)
+    internal DiscordGuild? InternalGetCachedGuild(ulong? guildId)
     {
         if (this.guilds != null && guildId.HasValue)
         {

--- a/DSharpPlus/EventArgs/Message/Reaction/MessageReactionAddedEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/Reaction/MessageReactionAddedEventArgs.cs
@@ -25,7 +25,7 @@ public class MessageReactionAddedEventArgs : DiscordEventArgs
     /// <summary>
     /// Gets the guild in which the reaction was added.
     /// </summary>
-    public DiscordGuild Guild { get; internal set; }
+    public DiscordGuild? Guild { get; internal set; }
 
     /// <summary>
     /// Gets the user who created the reaction.

--- a/DSharpPlus/EventArgs/Message/Reaction/MessageReactionRemovedEmojiEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/Reaction/MessageReactionRemovedEmojiEventArgs.cs
@@ -15,7 +15,7 @@ public sealed class MessageReactionRemovedEmojiEventArgs : DiscordEventArgs
     /// <summary>
     /// Gets the guild the removed reactions were in.
     /// </summary>
-    public DiscordGuild Guild { get; internal set; }
+    public DiscordGuild? Guild { get; internal set; }
 
     /// <summary>
     /// Gets the message that had the removed reactions.

--- a/DSharpPlus/EventArgs/Message/Reaction/MessageReactionRemovedEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/Reaction/MessageReactionRemovedEventArgs.cs
@@ -30,7 +30,7 @@ public class MessageReactionRemovedEventArgs : DiscordEventArgs
     /// <summary>
     /// Gets the guild in which the reaction was deleted.
     /// </summary>
-    public DiscordGuild Guild { get; internal set; }
+    public DiscordGuild? Guild { get; internal set; }
 
     /// <summary>
     /// Gets the emoji used for this reaction.

--- a/DSharpPlus/EventArgs/Message/Reaction/MessageReactionsClearedEventArgs.cs
+++ b/DSharpPlus/EventArgs/Message/Reaction/MessageReactionsClearedEventArgs.cs
@@ -25,8 +25,8 @@ public class MessageReactionsClearedEventArgs : DiscordEventArgs
     /// <summary>
     /// Gets the guild in which the reactions were cleared.
     /// </summary>
-    public DiscordGuild Guild
-        => this.Channel.Guild;
+    public DiscordGuild? Guild
+        => this.Channel?.Guild;
 
     internal MessageReactionsClearedEventArgs() : base() { }
 }


### PR DESCRIPTION
# Summary
This PR updates the nullability annotations for the MessageReaction* events and for InternalGetCachedGuild.

# Details
This PR updates the Nullability annotations for:
- MessageReactionAdded
- MessageReactionRemoved
- MessageReactionRemovedEmoji
- MessageReactionsCleared
- InternalGetCachedGuild

# Notes
I'm not sure if MessageReactionsCleared can even fire for non guild channels, but Discord's  api docs mention the guild id as potentially null, so the annotations reflect this.