### PR TITLE
Make GlobalName nullable in DiscordUser and TransportUser

### DIFF
--- a/DSharpPlus/Entities/User/DiscordUser.cs
+++ b/DSharpPlus/Entities/User/DiscordUser.cs
@@ -49,7 +49,7 @@ public class DiscordUser : SnowflakeObject, IEquatable<DiscordUser>
     /// Nicknames in servers however still take precedence over global names, which take precedence over usernames.
     /// </remarks>
     [JsonProperty("global_name", NullValueHandling = NullValueHandling.Ignore)]
-    public virtual string GlobalName { get; internal set; }
+    public virtual string? GlobalName { get; internal set; }
 
     /// <summary>
     /// Gets the user's 4-digit discriminator.

--- a/DSharpPlus/Net/Abstractions/Transport/TransportUser.cs
+++ b/DSharpPlus/Net/Abstractions/Transport/TransportUser.cs
@@ -12,7 +12,7 @@ internal class TransportUser
     public string Username { get; internal set; }
 
     [JsonProperty("global_name", NullValueHandling = NullValueHandling.Ignore)]
-    public string GlobalDisplayName { get; internal set; }
+    public string? GlobalDisplayName { get; internal set; }
 
     [JsonProperty("discriminator", NullValueHandling = NullValueHandling.Ignore)]
     public string Discriminator { get; set; }


### PR DESCRIPTION
# Summary
Made GlobalName nullable in both DiscordUser and TransportUser. The global_name field can be null when users have not set a display name

# Details
Same as above

# Changes proposed
* Changed `GlobalName` property from `string` to `string?` in `DiscordUser.cs`
* Changed `GlobalDisplayName` property from `string` to `string?` in `TransportUser.cs`

# Notes
N/A