### PR TITLE
fix selects not exposing required

### DIFF
--- a/DSharpPlus/Entities/Interaction/Components/Selects/BaseDiscordSelectComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/Selects/BaseDiscordSelectComponent.cs
@@ -25,7 +25,7 @@ public abstract class BaseDiscordSelectComponent : DiscordComponent
     /// Whether this component is required. Only affects usage in modals. Defaults to <c>true</c>.
     /// </summary>
     [JsonProperty("required", NullValueHandling = NullValueHandling.Ignore)]
-    public bool Required { get; internal set; } = true; // Align with Discord's default
+    public bool Required { get; internal set; }
 
     /// <summary>
     /// The minimum amount of options that can be selected. Must be less than or equal to <see cref="MaximumSelectedValues"/>. Defaults to one.
@@ -58,14 +58,14 @@ public abstract class BaseDiscordSelectComponent : DiscordComponent
         bool disabled = false,
         int minOptions = 1,
         int maxOptions = 1,
-        bool required = true
+        bool? required = null
     )
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(minOptions, 0);
         ArgumentOutOfRangeException.ThrowIfLessThan(maxOptions, 1);
         ArgumentOutOfRangeException.ThrowIfGreaterThan(minOptions, maxOptions);
 
-        if (this.Required)
+        if (required ?? false)
         {
             ArgumentOutOfRangeException.ThrowIfEqual(minOptions, 0);
         }
@@ -76,6 +76,6 @@ public abstract class BaseDiscordSelectComponent : DiscordComponent
         this.Disabled = disabled;
         this.MinimumSelectedValues = minOptions;
         this.MaximumSelectedValues = maxOptions;
-        this.Required = required;
+        this.Required = required ?? minOptions != 0;
     }
 }

--- a/DSharpPlus/Entities/Interaction/Components/Selects/DiscordChannelSelectComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/Selects/DiscordChannelSelectComponent.cs
@@ -110,7 +110,7 @@ public sealed class DiscordChannelSelectComponent : BaseDiscordSelectComponent
         bool disabled = false,
         int minOptions = 1,
         int maxOptions = 1,
-        bool required = true
+        bool? required = null
     ) 
         : base(DiscordComponentType.ChannelSelect, customId, placeholder, disabled, minOptions, maxOptions, required) 
         => this.ChannelTypes = channelTypes?.ToList();

--- a/DSharpPlus/Entities/Interaction/Components/Selects/DiscordMentionableSelectComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/Selects/DiscordMentionableSelectComponent.cs
@@ -83,6 +83,6 @@ public sealed class DiscordMentionableSelectComponent : BaseDiscordSelectCompone
     /// <param name="minOptions">The minimum amount of options to be selected.</param>
     /// <param name="maxOptions">The maximum amount of options to be selected, up to 25.</param>
     /// <param name="required">Indicates whether this component, in a modal, requires user input.</param>
-    public DiscordMentionableSelectComponent(string customId, string placeholder, bool disabled = false, int minOptions = 1, int maxOptions = 1, bool required = true)
+    public DiscordMentionableSelectComponent(string customId, string placeholder, bool disabled = false, int minOptions = 1, int maxOptions = 1, bool? required = null)
     : base(DiscordComponentType.MentionableSelect, customId, placeholder, disabled, minOptions, maxOptions, required) { }
 }

--- a/DSharpPlus/Entities/Interaction/Components/Selects/DiscordRoleSelectComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/Selects/DiscordRoleSelectComponent.cs
@@ -96,6 +96,6 @@ public sealed class DiscordRoleSelectComponent : BaseDiscordSelectComponent
     /// <param name="minOptions">The minimum amount of options to be selected.</param>
     /// <param name="maxOptions">The maximum amount of options to be selected, up to 25.</param>
     /// <param name="required">Indicates whether this component, in a modal, requires user input.</param>
-    public DiscordRoleSelectComponent(string customId, string placeholder, bool disabled = false, int minOptions = 1, int maxOptions = 1, bool required = true)
+    public DiscordRoleSelectComponent(string customId, string placeholder, bool disabled = false, int minOptions = 1, int maxOptions = 1, bool? required = null)
         : base(DiscordComponentType.RoleSelect, customId, placeholder, disabled, minOptions, maxOptions, required) { }
 }

--- a/DSharpPlus/Entities/Interaction/Components/Selects/DiscordSelectComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/Selects/DiscordSelectComponent.cs
@@ -56,7 +56,7 @@ public sealed class DiscordSelectComponent : BaseDiscordSelectComponent
         bool disabled = false, 
         int minOptions = 1, 
         int maxOptions = 1,
-        bool required = false
+        bool? required = null
     )
         : base(DiscordComponentType.StringSelect, customId, placeholder, disabled, minOptions, maxOptions, required)
         => this.Options = options.ToArray();

--- a/DSharpPlus/Entities/Interaction/Components/Selects/DiscordUserSelectComponent.cs
+++ b/DSharpPlus/Entities/Interaction/Components/Selects/DiscordUserSelectComponent.cs
@@ -100,6 +100,6 @@ public sealed class DiscordUserSelectComponent : BaseDiscordSelectComponent
     /// <param name="minOptions">The minimum amount of options to be selected.</param>
     /// <param name="maxOptions">The maximum amount of options to be selected, up to 25.</param>
     /// <param name="required">Indicates whether this component, in a modal, requires user input.</param>
-    public DiscordUserSelectComponent(string customId, string placeholder, bool disabled = false, int minOptions = 1, int maxOptions = 1, bool required = true)
+    public DiscordUserSelectComponent(string customId, string placeholder, bool disabled = false, int minOptions = 1, int maxOptions = 1, bool? required = null)
     : base(DiscordComponentType.UserSelect, customId, placeholder, disabled, minOptions, maxOptions, required) { }
 }


### PR DESCRIPTION
and throw if a select is required but specifies min_values = 0, which is illegal

- [x] This pull request did not involve AI in any way

- [x] All features in this pull request were tested.