### PR TITLE
fix: mark VanityUrlCode property as nullable

### DIFF
--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -481,7 +481,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
     /// Gets the vanity URL code for this guild, when applicable.
     /// </summary>
     [JsonProperty("vanity_url_code")]
-    public string VanityUrlCode { get; internal set; }
+    public string? VanityUrlCode { get; internal set; }
 
     /// <summary>
     /// Gets the guild description, when applicable.


### PR DESCRIPTION
- [ ] This pull request was written by AI
- [ ] This pull request was assisted by AI, but you wrote the final code
- [x] This pull request did not involve AI in any way

# Summary
Mark `VanityUrlCode` as nullable in `DiscordGuild` model

# Details


# Changes proposed
* Mark VanityUrlCode as nullable in `DiscordGuild` model

# Notes


- [ ] All features in this pull request were tested.