### PR TITLE
fix: handle null user_id and deleted channels in AuditLogParser

### DIFF
--- a/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
+++ b/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
@@ -507,11 +507,14 @@ internal static class AuditLogParser
         entry.Reason = auditLogAction.Reason;
         entry.Discord = guild.Discord;
 
-        entry.UserResponsible = members.TryGetValue(auditLogAction.UserId!.Value, out DiscordMember? member)
-            ? member
-            : guild.Discord.UserCache.TryGetValue(auditLogAction.UserId!.Value, out DiscordUser? discordUser)
-                ? discordUser
-                : new DiscordUser { Id = auditLogAction.UserId!.Value, Discord = guild.Discord };
+        if (auditLogAction.UserId.HasValue)
+        {
+            entry.UserResponsible = members.TryGetValue(auditLogAction.UserId.Value, out DiscordMember? member)
+                ? member
+                : guild.Discord.UserCache.TryGetValue(auditLogAction.UserId.Value, out DiscordUser? discordUser)
+                    ? discordUser
+                    : new DiscordUser { Id = auditLogAction.UserId.Value, Discord = guild.Discord };
+        }
 
         return entry;
     }
@@ -1087,13 +1090,18 @@ internal static class AuditLogParser
     internal static DiscordAuditLogOverwriteEntry ParseOverwriteEntry(DiscordGuild guild,
         AuditLogAction auditLogAction)
     {
+        DiscordChannel? channel = guild.GetChannel(auditLogAction.TargetId!.Value);
         DiscordAuditLogOverwriteEntry entry = new()
         {
-            Target = guild
-                .GetChannel(auditLogAction.TargetId!.Value)
+            Target = channel?
                 .PermissionOverwrites
                 .FirstOrDefault(xo => xo.Id == auditLogAction.Options.Id),
-            Channel = guild.GetChannel(auditLogAction.TargetId.Value)
+            Channel = channel ?? new DiscordChannel
+            {
+                Id = auditLogAction.TargetId.Value,
+                Discord = guild.Discord,
+                GuildId = guild.Id
+            }
         };
 
         foreach (AuditLogActionChange? change in auditLogAction.Changes)


### PR DESCRIPTION
- [ ] This pull request was written by AI
- [ ] This pull request was assisted by AI, but you wrote the final code
- [x] This pull request did not involve AI in any way

# Summary
Fixes #2399, fixes #2396 (also related to #2243)

The `AuditLogParser` crashes in two separate scenarios involving null references. This PR handles both.

# Details
**Null user_id (fixes #2399 / #2243):**
Discord sends audit log entries with `"user_id": null` for certain auto-moderation actions (like "Block Words in Member Profile Names"). The parser assumed `UserId` always had a value, causing an `InvalidOperationException` at the end of `ParseAuditLogEntryAsync` when it tried to resolve the responsible user.

The fix wraps the `UserResponsible` assignment in a `HasValue` check. When `UserId` is null, `UserResponsible` stays null — which is already its declared type (`DiscordUser?`).

**Deleted channel in overwrite entry (fixes #2396):**
When fetching audit log entries for permission overwrites on a deleted channel, `GetChannel()` returns null, and the code immediately accessed `.PermissionOverwrites` on that null result.

The fix stores the `GetChannel()` result first, then uses null-conditional access for `PermissionOverwrites` lookup. If the channel isn't found, a placeholder `DiscordChannel` with just the ID is used instead — same pattern already used elsewhere in the parser (e.g. `MessageDelete`, `MemberMove`).

# Changes proposed
* Wrapped `UserResponsible` assignment in a null check for `auditLogAction.UserId`
* Stored `GetChannel()` result in a local variable before accessing `PermissionOverwrites`
* Fall back to a placeholder `DiscordChannel` when the channel no longer exists

# Notes
Both changes are minimal and only affect the crash paths. No behavior change for entries that already worked fine.

- [x] All features in this pull request were tested.