### PR TITLE
fix: handle multiple IContextCheck interfaces in AddChecks

### DIFF
--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -322,7 +322,7 @@ public sealed class CommandsExtension
     {
         foreach (Type t in assembly.GetTypes())
         {
-            if (t.GetInterface("DSharpPlus.Commands.ContextChecks.IContextCheck`1") is not null)
+            if (t.GetInterfaces().Any(i => i.Namespace == "DSharpPlus.Commands.ContextChecks" && i.Name == "IContextCheck`1"))
             {
                 AddCheck(t);
             }


### PR DESCRIPTION
When a class implements more than one `IContextCheck<T>` interface, `AddChecks(Assembly)` throws an `AmbiguousMatchException` because it uses `Type.GetInterface()` which only expects a single match.

This switches to `GetInterfaces()` with a predicate to find the right interface by namespace and name, which is the same approach already used in the single-type `AddCheck(Type)` overload. Keeps things consistent and fixes the crash.

Fixes #2262