### PR TITLE
fix disposed stream access in exception handling

### DIFF
--- a/DSharpPlus/Net/Rest/MultipartRestRequest.cs
+++ b/DSharpPlus/Net/Rest/MultipartRestRequest.cs
@@ -126,8 +126,6 @@ internal readonly record struct MultipartRestRequest : IRestRequest
 
                 writer.Dispose();
 
-                PostprocessAddedFiles(current);
-
                 if (current.ContentType is not null)
                 {
                     file.Headers.ContentType = MediaTypeHeaderValue.Parse(current.ContentType);
@@ -155,22 +153,25 @@ internal readonly record struct MultipartRestRequest : IRestRequest
         return request;
     }
 
-    private static void PostprocessAddedFiles(DiscordFile file)
+    public void PostprocessAddedFiles()
     {
-        if (file.FileOptions.HasFlag(AddFileOptions.CloseStream))
+        foreach (DiscordFile file in this.Files)
         {
-            if (file.Stream is RequestStreamWrapper wrapper)
+            if (file.FileOptions.HasFlag(AddFileOptions.CloseStream))
             {
-                wrapper.UnderlyingStream.Dispose();
+                if (file.Stream is RequestStreamWrapper wrapper)
+                {
+                    wrapper.UnderlyingStream.Dispose();
+                }
+                else
+                {
+                    file.Stream.Dispose();
+                }
             }
-            else
+            else if (file.ResetPositionTo.HasValue)
             {
-                file.Stream.Dispose();
+                file.Stream.Seek(file.ResetPositionTo!.Value, SeekOrigin.Begin);
             }
-        } 
-        else if (file.ResetPositionTo.HasValue)
-        {
-            file.Stream.Seek(file.ResetPositionTo!.Value, SeekOrigin.Begin);
         }
     }
 }

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -174,27 +174,27 @@ public sealed partial class RestClient : IDisposable
                 case HttpStatusCode.BadRequest or HttpStatusCode.MethodNotAllowed:
 
                     this.metrics.RegisterBadRequest();
-                    throw new BadRequestException(request.Build(), response, content);
+                    throw new BadRequestException(response.RequestMessage!, response, content);
 
                 case HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden:
 
                     this.metrics.RegisterForbidden();
-                    throw new UnauthorizedException(request.Build(), response, content);
+                    throw new UnauthorizedException(response.RequestMessage!, response, content);
 
                 case HttpStatusCode.NotFound:
 
                     this.metrics.RegisterNotFound();
-                    throw new NotFoundException(request.Build(), response, content);
+                    throw new NotFoundException(response.RequestMessage!, response, content);
 
                 case HttpStatusCode.RequestEntityTooLarge:
 
                     this.metrics.RegisterRequestTooLarge();
-                    throw new RequestSizeException(request.Build(), response, content);
+                    throw new RequestSizeException(response.RequestMessage!, response, content);
 
                 case HttpStatusCode.TooManyRequests:
 
                     this.metrics.RegisterRatelimitHit(response.Headers);
-                    throw new RateLimitException(request.Build(), response, content);
+                    throw new RateLimitException(response.RequestMessage!, response, content);
 
                 case HttpStatusCode.InternalServerError
                     or HttpStatusCode.BadGateway
@@ -202,7 +202,7 @@ public sealed partial class RestClient : IDisposable
                     or HttpStatusCode.GatewayTimeout:
 
                     this.metrics.RegisterServerError();
-                    throw new ServerErrorException(request.Build(), response, content);
+                    throw new ServerErrorException(response.RequestMessage!, response, content);
 
                 default:
 

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -174,27 +174,27 @@ public sealed partial class RestClient : IDisposable
                 case HttpStatusCode.BadRequest or HttpStatusCode.MethodNotAllowed:
 
                     this.metrics.RegisterBadRequest();
-                    throw new BadRequestException(response.RequestMessage!, response, content);
+                    throw new BadRequestException(request.Build(), response, content);
 
                 case HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden:
 
                     this.metrics.RegisterForbidden();
-                    throw new UnauthorizedException(response.RequestMessage!, response, content);
+                    throw new UnauthorizedException(request.Build(), response, content);
 
                 case HttpStatusCode.NotFound:
 
                     this.metrics.RegisterNotFound();
-                    throw new NotFoundException(response.RequestMessage!, response, content);
+                    throw new NotFoundException(request.Build(), response, content);
 
                 case HttpStatusCode.RequestEntityTooLarge:
 
                     this.metrics.RegisterRequestTooLarge();
-                    throw new RequestSizeException(response.RequestMessage!, response, content);
+                    throw new RequestSizeException(request.Build(), response, content);
 
                 case HttpStatusCode.TooManyRequests:
 
                     this.metrics.RegisterRatelimitHit(response.Headers);
-                    throw new RateLimitException(response.RequestMessage!, response, content);
+                    throw new RateLimitException(request.Build(), response, content);
 
                 case HttpStatusCode.InternalServerError
                     or HttpStatusCode.BadGateway
@@ -202,7 +202,7 @@ public sealed partial class RestClient : IDisposable
                     or HttpStatusCode.GatewayTimeout:
 
                     this.metrics.RegisterServerError();
-                    throw new ServerErrorException(response.RequestMessage!, response, content);
+                    throw new ServerErrorException(request.Build(), response, content);
 
                 default:
 
@@ -246,6 +246,13 @@ public sealed partial class RestClient : IDisposable
             }
 
             throw;
+        } 
+        finally
+        {
+            if (request is MultipartRestRequest multipartRequest)
+            {
+                multipartRequest.PostprocessAddedFiles();
+            }
         }
     }
 


### PR DESCRIPTION
- [ ] This pull request was written by AI
- [ ] This pull request was assisted by AI, but you wrote the final code
- [x] This pull request did not involve AI in any way

# Summary
Post process all DiscordFiles of the mulitpartrequests after the streams are not needed for exception handling

# Details
if a DiscordFile with the AddFileOption.Close is used in a request the stream is disposed before the exception is thrown. Therefore the request cannot be rebuild. This is fixed by postprocessing the files after the HttpRequestMessage has been rebuilt in case of a exception.

# Changes proposed
* Moved the postprocessing of DiscordFiles after the exception handling


- [x] All features in this pull request were tested.