### PR TITLE
fix: remove decommissioned ActiveDeveloper user flag

### DIFF
--- a/DSharpPlus/Entities/User/DiscordUserFlags.cs
+++ b/DSharpPlus/Entities/User/DiscordUserFlags.cs
@@ -86,10 +86,5 @@ public enum DiscordUserFlags
     /// <summary>
     /// The bot receives interactions via HTTP.
     /// </summary>
-    HttpInteractionsBot = 1 << 19,
-
-    /// <summary>
-    /// The user is an active bot developer.
-    /// </summary>
-    ActiveDeveloper = 1 << 22
+    HttpInteractionsBot = 1 << 19
 }


### PR DESCRIPTION
Make sure you familiarize yourself with our contributing guidelines. (delete this line afterwards)

- [ ] This pull request was written by AI
- [ ] This pull request was assisted by AI, but you wrote the final code
- [X] This pull request did not involve AI in any way

# Summary
Removed ActiveDeveloper user flag. It has been decommissioned and is no longer available.

Sources: 
- https://github.com/discord/discord-api-docs/pull/8249
- https://support-dev.discord.com/hc/en-us/articles/10113997751447-Active-Developer-Badge

# Details
Removed the ActiveDeveloper flag from UserFlags

# Changes proposed
* Remove ActiveDeveloper flag from UserFlags

# Notes
Any additional notes go here.

- [ ] All features in this pull request were tested.