### PR TITLE
Fix Permissions being changed from string array to singular Role

### DIFF
--- a/DSharpPlus/Entities/DiscordTeam.cs
+++ b/DSharpPlus/Entities/DiscordTeam.cs
@@ -93,7 +93,7 @@ public sealed class DiscordTeamMember : IEquatable<DiscordTeamMember>
     /// <summary>
     /// Gets the member's permissions within the team.
     /// </summary>
-    public IReadOnlyList<string> Permissions { get; internal set; }
+    public string Role { get; internal set; }
 
     /// <summary>
     /// Gets the team this member belongs to.
@@ -108,7 +108,7 @@ public sealed class DiscordTeamMember : IEquatable<DiscordTeamMember>
     internal DiscordTeamMember(TransportTeamMember ttm)
     {
         this.MembershipStatus = (DiscordTeamMembershipStatus)ttm.MembershipState;
-        this.Permissions = new ReadOnlySet<string>(new HashSet<string>(ttm.Permissions));
+        this.Role = ttm.Role;
     }
 
     /// <summary>

--- a/DSharpPlus/Net/Abstractions/Transport/TransportTeam.cs
+++ b/DSharpPlus/Net/Abstractions/Transport/TransportTeam.cs
@@ -28,8 +28,8 @@ internal sealed class TransportTeamMember
     [JsonProperty("membership_state")]
     public int MembershipState { get; set; }
 
-    [JsonProperty("permissions", NullValueHandling = NullValueHandling.Include)]
-    public IEnumerable<string> Permissions { get; set; }
+    [JsonProperty("role", NullValueHandling = NullValueHandling.Include)]
+    public string Role { get; set; }
 
     [JsonProperty("team_id")]
     public ulong TeamId { get; set; }


### PR DESCRIPTION
- [ ] This pull request was written by AI
- [ ] This pull request was assisted by AI, but you wrote the final code
- [x] This pull request did not involve AI in any way

# Summary
Fixes #2432
Changes `IEnumerable<string> Permissions` to `string Role` in TransportTeam, and usage in DiscordTeam

# Details
You can put detailed description of the changes in here.

# Notes
Any additional notes go here.

- [x] All features in this pull request were tested.
Bot under a team was able to connect when it wasnt able to before.