### PR TITLE
add support for voice channel status and time events

### DIFF
--- a/DSharpPlus/Clients/DiscordClient.Dispatch.cs
+++ b/DSharpPlus/Clients/DiscordClient.Dispatch.cs
@@ -121,6 +121,25 @@ public sealed partial class DiscordClient
                 await OnChannelPinsUpdateAsync((ulong?)dat["guild_id"], cid, ts != null ? DateTimeOffset.Parse(ts, CultureInfo.InvariantCulture) : default(DateTimeOffset?));
                 break;
 
+            case "channel_info":
+                VoiceChannelInfo[] info = dat["channels"].ToDiscordObject<VoiceChannelInfo[]>();
+                await OnChannelInfoAsync((ulong)dat["guild_id"], info);
+                break;
+
+            case "voice_channel_status_update":
+                await OnVoiceChannelStatusUpdateAsync((ulong)dat["guild_id"], (ulong)dat["id"], (string?)dat["status"]);
+                break;
+
+            case "voice_channel_start_time_update":
+                long? unixTimestamp = (long?)dat["voice_start_time"];
+                await OnVoiceChannelStartTimeUpdateAsync
+                (
+                    (ulong)dat["guild_id"],
+                    (ulong)dat["id"],
+                    unixTimestamp is not null ? DateTimeOffset.FromUnixTimeSeconds(unixTimestamp.Value) : null
+                );
+                break;
+
             #endregion
 
             #region Scheduled Guild Events
@@ -1071,6 +1090,54 @@ public sealed partial class DiscordClient
         };
 
         await this.dispatcher.DispatchAsync<ChannelPinsUpdatedEventArgs>(this, ea);
+    }
+
+    internal async Task OnChannelInfoAsync(ulong guildId, IReadOnlyList<VoiceChannelInfo> channelInfo)
+    {
+        DiscordGuild guild = InternalGetCachedGuild(guildId);
+
+        foreach (VoiceChannelInfo info in channelInfo)
+        {
+            info.Channel = InternalGetCachedChannel(info.Id, guildId);
+        }
+
+        ChannelInfoEventArgs ea = new()
+        {
+            Guild = guild,
+            ChannelInfo = channelInfo
+        };
+
+        await this.dispatcher.DispatchAsync(this, ea);
+    }
+
+    internal async Task OnVoiceChannelStatusUpdateAsync(ulong guildId, ulong channelId, string? status)
+    {
+        DiscordGuild guild = InternalGetCachedGuild(guildId);
+        DiscordChannel channel = InternalGetCachedChannel(channelId, guildId);
+
+        VoiceChannelStatusUpdatedEventArgs ea = new()
+        {
+            Guild = guild,
+            Channel = channel,
+            Status = status
+        };
+
+        await this.dispatcher.DispatchAsync(this, ea);
+    }
+
+    internal async Task OnVoiceChannelStartTimeUpdateAsync(ulong guildId, ulong channelId, DateTimeOffset? startTime)
+    {
+        DiscordGuild guild = InternalGetCachedGuild(guildId);
+        DiscordChannel channel = InternalGetCachedChannel(channelId, guildId);
+
+        VoiceChannelStartTimeUpdatedEventArgs ea = new()
+        {
+            Guild = guild,
+            Channel = channel,
+            StartTime = startTime
+        };
+
+        await this.dispatcher.DispatchAsync(this, ea);
     }
 
     #endregion

--- a/DSharpPlus/Clients/DiscordClient.cs
+++ b/DSharpPlus/Clients/DiscordClient.cs
@@ -232,6 +232,15 @@ public sealed partial class DiscordClient : BaseDiscordClient
 
     #endregion
 
+    /// <summary>
+    /// Creates a new event waiter for an event of the specified type.
+    /// </summary>
+    /// <param name="condition">The condition an event needs to match before it fulfils the event waiter.</param>
+    /// <param name="timeout">A timeout for this event waiter.</param>
+    public EventWaiter<T> CreateEventWaiter<T>(Func<T, bool> condition, TimeSpan timeout)
+        where T : DiscordEventArgs
+        => this.dispatcher.CreateEventWaiter(condition, timeout);
+
     #region Public REST Methods
 
     /// <summary>

--- a/DSharpPlus/Clients/EventHandlingBuilder.cs
+++ b/DSharpPlus/Clients/EventHandlingBuilder.cs
@@ -926,4 +926,31 @@ public sealed class EventHandlingBuilder
 
         return this;
     }
+
+    /// <summary>
+    /// Fired in response to voice channel info being requested over the gateway.
+    /// </summary>
+    public EventHandlingBuilder HandleChannelInfo(Func<DiscordClient, ChannelInfoEventArgs, Task> handler)
+    {
+        this.Services.Configure<EventHandlerCollection>(c => c.Register(handler));
+        return this;
+    }
+
+    /// <summary>
+    /// Fired when the status of a voice channel was updated.
+    /// </summary>
+    public EventHandlingBuilder HandleVoiceChannelStatusUpdated(Func<DiscordClient, VoiceChannelStatusUpdatedEventArgs, Task> handler)
+    {
+        this.Services.Configure<EventHandlerCollection>(c => c.Register(handler));
+        return this;
+    }
+
+    /// <summary>
+    /// Fired when the start time of a voice channel was updated.
+    /// </summary>
+    public EventHandlingBuilder HandleVoiceChannelStartTimeUpdated(Func<DiscordClient, VoiceChannelStartTimeUpdatedEventArgs, Task> handler)
+    {
+        this.Services.Configure<EventHandlerCollection>(c => c.Register(handler));
+        return this;
+    }
 }

--- a/DSharpPlus/Entities/AuditLogs/AuditLogActionType.cs
+++ b/DSharpPlus/Entities/AuditLogs/AuditLogActionType.cs
@@ -300,5 +300,15 @@ public enum DiscordAuditLogActionType
     /// <summary>
     /// Member was timed out by Auto Moderation
     /// </summary>
-    AutoModerationUserCommunicationDisabled = 145
+    AutoModerationUserCommunicationDisabled = 145,
+
+    /// <summary>
+    /// Voice channel status was updated.
+    /// </summary>
+    VoiceChannelStatusUpdate = 192,
+
+    /// <summary>
+    /// Voice channel status was cleared.
+    /// </summary>
+    VoiceChannelStatusDelete = 193
 }

--- a/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
+++ b/DSharpPlus/Entities/AuditLogs/AuditLogParser.cs
@@ -1,14 +1,16 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+
 using DSharpPlus.Net.Abstractions;
 using DSharpPlus.Net.Serialization;
+
 using Microsoft.Extensions.Logging;
+
 using Newtonsoft.Json.Linq;
 
 namespace DSharpPlus.Entities.AuditLogs;
@@ -463,6 +465,21 @@ internal static class AuditLogParser
                 entry = ParseAutoModerationRuleUpdateEntry(guild, auditLogAction);
                 break;
 
+            case DiscordAuditLogActionType.VoiceChannelStatusUpdate:
+            case DiscordAuditLogActionType.VoiceChannelStatusDelete:
+
+                entry = new DiscordAuditLogVoiceChannelStatusEntry();
+                DiscordAuditLogVoiceChannelStatusEntry voiceChannelStatusEntry =
+                    (DiscordAuditLogVoiceChannelStatusEntry)entry;
+
+                voiceChannelStatusEntry.Status = auditLogAction.Options.Status is not null
+                    ? new()
+                    : PropertyChange<string?>.From(null, auditLogAction.Options.Status);
+
+                voiceChannelStatusEntry.Target = guild.GetChannel(auditLogAction.Options.ChannelId);
+
+                break;
+
             default:
                 if (guild.Discord.Configuration.LogUnknownAuditlogs)
                 {
@@ -485,14 +502,16 @@ internal static class AuditLogParser
                 or DiscordAuditLogActionType.OverwriteCreate or DiscordAuditLogActionType.RoleCreate
                 or DiscordAuditLogActionType.WebhookCreate or DiscordAuditLogActionType.IntegrationCreate
                 or DiscordAuditLogActionType.StickerCreate
-                or DiscordAuditLogActionType.AutoModerationRuleCreate => DiscordAuditLogActionCategory.Create,
+                or DiscordAuditLogActionType.AutoModerationRuleCreate
+                or DiscordAuditLogActionType.VoiceChannelStatusUpdate => DiscordAuditLogActionCategory.Create,
 
             DiscordAuditLogActionType.ChannelDelete or DiscordAuditLogActionType.EmojiDelete or DiscordAuditLogActionType.InviteDelete
                 or DiscordAuditLogActionType.MessageDelete or DiscordAuditLogActionType.MessageBulkDelete
                 or DiscordAuditLogActionType.OverwriteDelete or DiscordAuditLogActionType.RoleDelete
                 or DiscordAuditLogActionType.WebhookDelete or DiscordAuditLogActionType.IntegrationDelete
                 or DiscordAuditLogActionType.StickerDelete
-                or DiscordAuditLogActionType.AutoModerationRuleDelete => DiscordAuditLogActionCategory.Delete,
+                or DiscordAuditLogActionType.AutoModerationRuleDelete
+                or DiscordAuditLogActionType.VoiceChannelStatusDelete => DiscordAuditLogActionCategory.Delete,
 
             DiscordAuditLogActionType.ChannelUpdate or DiscordAuditLogActionType.EmojiUpdate or DiscordAuditLogActionType.InviteUpdate
                 or DiscordAuditLogActionType.MemberRoleUpdate or DiscordAuditLogActionType.MemberUpdate

--- a/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogVoiceChannelStatusEntry.cs
+++ b/DSharpPlus/Entities/AuditLogs/Entries/DiscordAuditLogVoiceChannelStatusEntry.cs
@@ -1,0 +1,17 @@
+namespace DSharpPlus.Entities.AuditLogs;
+
+/// <summary>
+/// Represents an audit log entry retaining to a voice channel status being changed.
+/// </summary>
+public sealed class DiscordAuditLogVoiceChannelStatusEntry : DiscordAuditLogEntry
+{
+    /// <summary>
+    /// The voice channel affected by this.
+    /// </summary>
+    public DiscordChannel Target { get; internal set; }
+
+    /// <summary>
+    /// The status of this voice channel.
+    /// </summary>
+    public PropertyChange<string?> Status { get; internal set; }
+}

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -1205,7 +1205,7 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
     /// Gets the status and start time of the currently active voice session, if available.
     /// Returns <c>(null, null)</c> if there was no active voice session.
     /// </summary>
-    public async Task<(string? status, DateTimeOffset? startTime)?> GetVoiceChannelInfoAsync()
+    public async Task<(string? status, DateTimeOffset? startTime)> GetVoiceChannelInfoAsync()
     {
         if (this.Discord is not DiscordClient discordClient)
         {

--- a/DSharpPlus/Entities/Channel/DiscordChannel.cs
+++ b/DSharpPlus/Entities/Channel/DiscordChannel.cs
@@ -6,7 +6,10 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using DSharpPlus.Clients;
+using DSharpPlus.EventArgs;
 using DSharpPlus.Exceptions;
+using DSharpPlus.Net.Abstractions;
 using DSharpPlus.Net.Abstractions.Rest;
 using DSharpPlus.Net.Models;
 using DSharpPlus.Net.Serialization;
@@ -1196,6 +1199,71 @@ public class DiscordChannel : SnowflakeObject, IEquatable<DiscordChannel>
         perms |= roleOverwrites.Allowed;
 
         return perms;
+    }
+
+    /// <summary>
+    /// Gets the status and start time of the currently active voice session, if available.
+    /// Returns <c>(null, null)</c> if there was no active voice session.
+    /// </summary>
+    public async Task<(string? status, DateTimeOffset? startTime)?> GetVoiceChannelInfoAsync()
+    {
+        if (this.Discord is not DiscordClient discordClient)
+        {
+            throw new InvalidOperationException("This is not available on rest-only connections.");
+        }
+
+        if (this.Type is not DiscordChannelType.Voice and not DiscordChannelType.Stage)
+        {
+            throw new InvalidOperationException("This can only be called on voice channels.");
+        }
+
+        GatewayRequestChannelInfo request = new()
+        {
+            GuildId = this.GuildId.Value,
+            Fields = ["status", "voice_start_time"]
+        };
+
+        EventWaiter<ChannelInfoEventArgs> eventWaiter = discordClient.CreateEventWaiter<ChannelInfoEventArgs>
+        (
+            condition: (eventArgs) => eventArgs.Guild.Id == this.GuildId.Value,
+            timeout: TimeSpan.FromSeconds(100)
+        );
+
+#pragma warning disable DSP0004
+        await discordClient.SendPayloadAsync(GatewayOpCode.RequestChannelInfo, request, this.GuildId.Value);
+#pragma warning restore DSP0004
+
+        EventWaiterResult<ChannelInfoEventArgs> result = await eventWaiter.Task;
+
+        if (result.TimedOut)
+        {
+            throw new TimeoutException("The request for voice channel info timed out.");
+        }
+
+        VoiceChannelInfo? voiceChannelInfo = result.Value.ChannelInfo.FirstOrDefault(x => x.Channel.Id == this.Id);
+
+        return voiceChannelInfo is null
+            ? (null, null)
+            : (voiceChannelInfo.Status, voiceChannelInfo.StartTime);
+    }
+
+    /// <summary>
+    /// Updates the status for this voice channel. Requires the <see cref="DiscordPermission.SetVoiceChannelStatus"/>
+    /// permission, and additionally the <see cref="DiscordPermission.ManageChannels"/> permission if the current user
+    /// is not connected to the voice channel.  
+    /// </summary>
+    /// <param name="status">The new status for this voice channel, or null to clear it.</param>
+    /// <param name="reason">An optional audit log reason for this operation.</param>
+    public async Task SetVoiceChannelStatusAsync(string? status, string? reason = null)
+    {
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(status?.Length ?? 0, 500, "status.Length");
+
+        if (this.Type is not DiscordChannelType.Voice and not DiscordChannelType.Stage)
+        {
+            throw new InvalidOperationException("This can only be called on voice channels.");
+        }
+
+        await this.Discord.ApiClient.SetVoiceChannelStatusAsync(this.Id, status, reason);
     }
 
     /// <summary>

--- a/DSharpPlus/Entities/DiscordPermission.cs
+++ b/DSharpPlus/Entities/DiscordPermission.cs
@@ -293,6 +293,13 @@ public enum DiscordPermission
     SendVoiceMessages = 46,
 
     /// <summary>
+    /// Allows members to set the status of a voice channel they are currently connected to, or all voice channels in conjunction
+    /// with the <see cref="ManageChannels"/> permission. 
+    /// </summary>
+    [Display(Name = "Set Voice Channel Status")]
+    SetVoiceChannelStatus = 48,
+
+    /// <summary>
     /// Allows members to send polls.
     /// </summary>
     [Display(Name = "Send Polls")]

--- a/DSharpPlus/Entities/Guild/DiscordGuild.cs
+++ b/DSharpPlus/Entities/Guild/DiscordGuild.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using DSharpPlus.Clients;
 using DSharpPlus.Entities.AuditLogs;
 using DSharpPlus.EventArgs;
 using DSharpPlus.Exceptions;
@@ -2602,7 +2603,7 @@ public class DiscordGuild : SnowflakeObject, IEquatable<DiscordGuild>
             return null;
         }
     }
-    
+
     #endregion
 
     /// <summary>

--- a/DSharpPlus/EventArgs/Channel/ChannelInfoEventArgs.cs
+++ b/DSharpPlus/EventArgs/Channel/ChannelInfoEventArgs.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs;
+
+/// <summary>
+/// Represents the information received with a channel info event.
+/// </summary>
+public sealed class ChannelInfoEventArgs : DiscordEventArgs
+{
+    /// <summary>
+    /// The guild this event pertains to.
+    /// </summary>
+    public DiscordGuild Guild { get; internal set; }
+
+    /// <summary>
+    /// The information provided for voice channels in this guild.
+    /// </summary>
+    public IReadOnlyList<VoiceChannelInfo> ChannelInfo { get; internal set; }
+}

--- a/DSharpPlus/EventArgs/Channel/VoiceChannelInfo.cs
+++ b/DSharpPlus/EventArgs/Channel/VoiceChannelInfo.cs
@@ -1,0 +1,36 @@
+using System;
+
+using DSharpPlus.Entities;
+using DSharpPlus.Net.Serialization;
+
+using Newtonsoft.Json;
+
+namespace DSharpPlus.EventArgs;
+
+/// <summary>
+/// Represents information about a voice channel.
+/// </summary>
+public sealed class VoiceChannelInfo
+{
+    [JsonProperty("id")]
+    internal ulong Id { get; set; }
+
+    /// <summary>
+    /// The channel this info relates to.
+    /// </summary>
+    [JsonIgnore]
+    public DiscordChannel Channel { get; internal set; }
+
+    /// <summary>
+    /// The voice channel status of this channel.
+    /// </summary>
+    [JsonProperty("status")]
+    public string? Status { get; internal set; }
+
+    /// <summary>
+    /// The time whereat this voice session started.
+    /// </summary>
+    [JsonProperty("voice_start_time")]
+    [JsonConverter(typeof(UnixTimeSecondsAsDateTimeOffsetJsonConverter))]
+    public DateTimeOffset? StartTime { get; internal set; }
+}

--- a/DSharpPlus/EventArgs/Channel/VoiceChannelStartTimeUpdatedEventArgs.cs
+++ b/DSharpPlus/EventArgs/Channel/VoiceChannelStartTimeUpdatedEventArgs.cs
@@ -1,0 +1,26 @@
+using System;
+
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs;
+
+/// <summary>
+/// Provides the time at which a voice channel session started.
+/// </summary>
+public sealed class VoiceChannelStartTimeUpdatedEventArgs : DiscordEventArgs
+{
+    /// <summary>
+    /// The voice channel whose start time was updated.
+    /// </summary>
+    public DiscordChannel Channel { get; internal set; }
+
+    /// <summary>
+    /// The containing guild.
+    /// </summary>
+    public DiscordGuild Guild { get; internal set; }
+
+    /// <summary>
+    /// The updated voice channel start time. Null if the session ended.
+    /// </summary>
+    public DateTimeOffset? StartTime { get; internal set; }
+}

--- a/DSharpPlus/EventArgs/Channel/VoiceChannelStatusUpdatedEventArgs.cs
+++ b/DSharpPlus/EventArgs/Channel/VoiceChannelStatusUpdatedEventArgs.cs
@@ -1,0 +1,24 @@
+using DSharpPlus.Entities;
+
+namespace DSharpPlus.EventArgs;
+
+/// <summary>
+/// Provides the updated voice channel status.
+/// </summary>
+public sealed class VoiceChannelStatusUpdatedEventArgs : DiscordEventArgs
+{
+    /// <summary>
+    /// The voice channel whose status was updated.
+    /// </summary>
+    public DiscordChannel Channel { get; internal set; }
+
+    /// <summary>
+    /// The containing guild.
+    /// </summary>
+    public DiscordGuild Guild { get; internal set; }
+
+    /// <summary>
+    /// The updated voice channel status. Null if the status was cleared.
+    /// </summary>
+    public string? Status { get; internal set; }
+}

--- a/DSharpPlus/Net/Abstractions/AuditLogAbstractions.cs
+++ b/DSharpPlus/Net/Abstractions/AuditLogAbstractions.cs
@@ -96,6 +96,9 @@ internal sealed class AuditLogActionOptions
 
     [JsonProperty("type")]
     public object Type { get; set; }
+
+    [JsonProperty("status")]
+    public string? Status { get; set; }
 }
 
 internal sealed class AuditLogAction

--- a/DSharpPlus/Net/Abstractions/Gateway/GatewayOpCode.cs
+++ b/DSharpPlus/Net/Abstractions/Gateway/GatewayOpCode.cs
@@ -69,5 +69,10 @@ public enum GatewayOpCode : int
     /// <summary>
     /// Used to request guild synchronization.
     /// </summary>
-    GuildSync = 12
+    GuildSync = 12,
+
+    /// <summary>
+    /// Used to request specific information about a channel.
+    /// </summary>
+    RequestChannelInfo = 43,
 }

--- a/DSharpPlus/Net/Abstractions/Gateway/GatewayRequestChannelInfo.cs
+++ b/DSharpPlus/Net/Abstractions/Gateway/GatewayRequestChannelInfo.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace DSharpPlus.Net.Abstractions;
+
+internal sealed class GatewayRequestChannelInfo
+{
+    [JsonProperty("guild_id")]
+    public ulong GuildId { get; internal set; }
+
+    // https://docs.discord.com/developers/events/gateway-events#request-channel-info
+    [JsonProperty("fields")]
+    public IReadOnlyList<string> Fields { get; internal set; }
+}

--- a/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestChannelPayloads.cs
@@ -331,3 +331,9 @@ internal sealed class RestBecomeStageSpeakerInstancePayload
     [JsonProperty("suppress", NullValueHandling = NullValueHandling.Ignore)]
     public bool? Suppress { get; set; }
 }
+
+internal sealed class RestSetVoiceChannelStatusPayload
+{
+    [JsonProperty("status")]
+    public string? Status { get; set; }
+}

--- a/DSharpPlus/Net/Rest/DiscordRestApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordRestApiClient.cs
@@ -3229,6 +3229,34 @@ public sealed class DiscordRestApiClient
         await this.rest.ExecuteRequestAsync(request);
     }
 
+    public async ValueTask SetVoiceChannelStatusAsync(ulong channelId, string? newStatus, string? reason = null)
+    {
+        Dictionary<string, string> headers = [];
+        if (!string.IsNullOrWhiteSpace(reason))
+        {
+            headers[REASON_HEADER_NAME] = reason;
+        }
+
+        string route = $"{Endpoints.CHANNELS}/{channelId}/{Endpoints.VOICE_STATUS}";
+        string url = $"{Endpoints.CHANNELS}/{channelId}/{Endpoints.VOICE_STATUS}";
+
+        RestSetVoiceChannelStatusPayload payload = new()
+        {
+            Status = newStatus
+        };
+
+        RestRequest request = new()
+        {
+            Route = route,
+            Url = url,
+            Method = HttpMethod.Put,
+            Headers = headers,
+            Payload = DiscordJson.SerializeObject(payload)
+        };
+
+        await this.rest.ExecuteRequestAsync(request);
+    }
+
     #endregion
 
     #region Threads

--- a/DSharpPlus/Net/Rest/Endpoints.cs
+++ b/DSharpPlus/Net/Rest/Endpoints.cs
@@ -75,6 +75,7 @@ internal static class Endpoints
     public const string VANITY_URL = "vanity-url";
     public const string VOICE = "voice";
     public const string VOICE_STATES = "voice-states";
+    public const string VOICE_STATUS = "voice-status";
     public const string WEBHOOKS = "webhooks";
     public const string WELCOME_SCREEN = "welcome-screen";
     public const string WIDGET = "widget";

--- a/DSharpPlus/Net/Serialization/UnixTimeSecondsAsDateTimeOffsetJsonConverter.cs
+++ b/DSharpPlus/Net/Serialization/UnixTimeSecondsAsDateTimeOffsetJsonConverter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Globalization;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace DSharpPlus.Net.Serialization;
+
+/// <summary>
+/// Json converter for de/serializing DateTimeOffset as unix time in seconds.
+/// </summary>
+internal sealed class UnixTimeSecondsAsDateTimeOffsetJsonConverter : JsonConverter
+{
+    public override bool CanConvert(Type objectType) => objectType == typeof(DateTimeOffset);
+
+    public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+    {
+        JToken jr = JToken.Load(reader);
+
+        long unixTimestamp = jr.ToObject<long>();
+        return DateTimeOffset.FromUnixTimeSeconds(unixTimestamp);
+    }
+
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        long unixTimestamp = ((DateTimeOffset)value!).ToUnixTimeSeconds();
+        writer.WriteValue(unixTimestamp.ToString(CultureInfo.InvariantCulture));
+    }
+}


### PR DESCRIPTION
- [x] This pull request did not involve AI in any way
- [x] All features in this pull request were tested.

adds support for the events `CHANNEL_INFO`, `VOICE_CHANNEL_STATUS_UPDATE` and `VOICE_CHANNEL_START_TIME_UPDATE`, as well as methods on `DiscordChannel` to access the channel's start time and status and set the channel's status