### PR TITLE
fix: AddGuildMemberAsync make Nickname payload field nullable

### DIFF
--- a/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
+++ b/DSharpPlus/Net/Abstractions/Rest/RestGuildPayloads.cs
@@ -118,7 +118,7 @@ internal sealed class RestGuildMemberAddPayload : IOAuth2Payload
     public string AccessToken { get; set; }
 
     [JsonProperty("nick", NullValueHandling = NullValueHandling.Ignore)]
-    public string Nickname { get; set; }
+    public string? Nickname { get; set; }
 
     [JsonProperty("roles", NullValueHandling = NullValueHandling.Ignore)]
     public IEnumerable<ulong> Roles { get; set; }

--- a/DSharpPlus/Net/Rest/DiscordRestApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordRestApiClient.cs
@@ -677,7 +677,7 @@ public sealed class DiscordRestApiClient
         RestGuildMemberAddPayload payload = new()
         {
             AccessToken = accessToken,
-            Nickname = nick ?? "",
+            Nickname = nick,
             Roles = roles ?? [],
             Deaf = deafened ?? false,
             Mute = muted ?? false


### PR DESCRIPTION
- [ ] This pull request was written by AI
- [ ] This pull request was assisted by AI, but you wrote the final code
- [x] This pull request did not involve AI in any way

# Summary
Fixes issue with AddGuildMemberAsync in DiscordRestApiClient. This function was setting Nickname property in the payload to empty string, not null resulting in setting user's nickname to empty string when this method was executed

# Details
If there was no nick parameter passed to AddGuildMemberAsync , it was substituted for "", and final JSON contained this property with value set to "", which resulted to setting users username to "" when they were added to the guild by this method.

# Changes proposed
- Make Nickname property in RestGuildMemberAddPayload nullable in order to allow serializer to ignore this property when serializing
- Removed nick null check in AddGuildMemberAsync 

- [x] All features in this pull request were tested.