### PR TITLE
Improve logic for the DSP0007 analyzer

### DIFF
--- a/DSharpPlus.Analyzers/DSharpPlus.Analyzers.Test/MultipleOverwriteTest.cs
+++ b/DSharpPlus.Analyzers/DSharpPlus.Analyzers.Test/MultipleOverwriteTest.cs
@@ -192,4 +192,124 @@ public static class MultipleOverwriteTest
 
         await test.RunAsync();
     }
+
+    [Test]
+    public static async Task IfElseDiagnosticAsync()
+    {
+        CSharpAnalyzerTest<MultipleOverwriteAnalyzer, DefaultVerifier> test
+            = Utility.CreateAnalyzerTest<MultipleOverwriteAnalyzer>();
+
+        test.TestCode = """
+                        using DSharpPlus.Entities;
+                        using System.Threading.Tasks;
+                        using System.Collections.Generic;
+
+                        public class OverwriteTest
+                        {
+                            public async Task AddOverwritesAsync(DiscordChannel channel, DiscordMember member, bool isKick)
+                            {
+                                if (isKick)
+                                {
+                                    await channel.AddOverwriteAsync(member, DiscordPermission.KickMembers);
+                                }
+                                else
+                                {
+                                    await channel.AddOverwriteAsync(member, DiscordPermission.BanMembers);
+                                }
+                            }
+                        }
+                        """;
+
+        await test.RunAsync();
+    }
+
+    [Test]
+    public static async Task ChannelForEachLoopDiagnosticAsync()
+    {
+        CSharpAnalyzerTest<MultipleOverwriteAnalyzer, DefaultVerifier> test
+            = Utility.CreateAnalyzerTest<MultipleOverwriteAnalyzer>();
+
+        test.TestCode = """
+                        using DSharpPlus.Entities;
+                        using System.Threading.Tasks;
+                        using System.Collections.Generic;
+
+                        public record Test(DiscordChannel Channel);
+
+                        public class OverwriteTest
+                        {
+                            public async Task AddOverwritesAsync(IReadOnlyList<Test> channels, DiscordMember member)
+                            {
+                                foreach (Test test in channels) 
+                                {
+                                    await test.Channel.AddOverwriteAsync(member, DiscordPermission.KickMembers);
+                                }
+                            }
+                        }
+                        """;
+
+        await test.RunAsync();
+    }
+
+    [Test]
+    public static async Task ChannelForLoopDiagnosticAsync()
+    {
+        CSharpAnalyzerTest<MultipleOverwriteAnalyzer, DefaultVerifier> test
+            = Utility.CreateAnalyzerTest<MultipleOverwriteAnalyzer>();
+
+        test.TestCode = """
+                        using DSharpPlus.Entities;
+                        using System.Threading.Tasks;
+                        using System.Collections.Generic;
+
+                        public class OverwriteTest
+                        {
+                            public async Task AddOverwritesAsync(IReadOnlyList<DiscordChannel> channels, DiscordMember member)
+                            {
+                                for (int i = 0; i < channels.Count; i++)
+                                {
+                                    DiscordChannel channel = channels[i];
+                                    await channel.AddOverwriteAsync(member, DiscordPermission.KickMembers);
+                                }
+                            }
+                        }
+                        """;
+
+        await test.RunAsync();
+    }
+
+
+    [Test]
+    public static async Task NestedCallsDiagnosticAsync()
+    {
+        CSharpAnalyzerTest<MultipleOverwriteAnalyzer, DefaultVerifier> test
+            = Utility.CreateAnalyzerTest<MultipleOverwriteAnalyzer>();
+
+        test.TestCode = """
+                        using DSharpPlus.Entities;
+                        using System.Threading.Tasks;
+
+                        public class OverwriteTest
+                        {
+                            public async Task AddOverwritesAsync(DiscordChannel channel, DiscordMember member, bool addBan)
+                            {
+                                await channel.AddOverwriteAsync(member, DiscordPermission.KickMembers);
+                                if (addBan)
+                                {
+                                    await channel.AddOverwriteAsync(member, DiscordPermission.BanMembers);
+                                }
+                            }
+                        }
+                        """;
+
+        test.ExpectedDiagnostics.Add
+        (
+            Verifier.Diagnostic()
+                .WithLocation(11, 19)
+                .WithSeverity(DiagnosticSeverity.Warning)
+                .WithMessage("Use one 'channel.ModifyAsync(..)' instead of multiple 'channel.AddOverwriteAsync(..)'")
+        );
+
+        await test.RunAsync();
+    }
 }

--- a/DSharpPlus.Analyzers/DSharpPlus.Analyzers/Core/MultipleOverwriteAnalyzer.cs
+++ b/DSharpPlus.Analyzers/DSharpPlus.Analyzers/Core/MultipleOverwriteAnalyzer.cs
@@ -1,5 +1,7 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -13,22 +15,19 @@ public class MultipleOverwriteAnalyzer : DiagnosticAnalyzer
     public const string DiagnosticId = "DSP0007";
     public const string Category = "Design";
 
-    private static readonly LocalizableString title = new LocalizableResourceString
-    (
+    private static readonly LocalizableString title = new LocalizableResourceString(
         nameof(Resources.DSP0007Title),
         Resources.ResourceManager,
         typeof(Resources)
     );
 
-    private static readonly LocalizableString description = new LocalizableResourceString
-    (
+    private static readonly LocalizableString description = new LocalizableResourceString(
         nameof(Resources.DSP0007Description),
         Resources.ResourceManager,
         typeof(Resources)
     );
 
-    private static readonly LocalizableString messageFormat = new LocalizableResourceString
-    (
+    private static readonly LocalizableString messageFormat = new LocalizableResourceString(
         nameof(Resources.DSP0007MessageFormat),
         Resources.ResourceManager,
         typeof(Resources)
@@ -45,8 +44,6 @@ public class MultipleOverwriteAnalyzer : DiagnosticAnalyzer
         helpLinkUri: $"{Utility.BaseDocsUrl}/articles/analyzers/core.html#usage-error-dsp0007"
     );
 
-    // This might need to be a concurrent dictionary cause of line 51
-    private readonly Dictionary<MethodDeclarationSyntax, HashSet<string>> invocations = new();
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
 
@@ -54,10 +51,17 @@ public class MultipleOverwriteAnalyzer : DiagnosticAnalyzer
     {
         ctx.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         ctx.EnableConcurrentExecution();
-        ctx.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+        ctx.RegisterCompilationStartAction(CompilationStart);
     }
 
-    private void Analyze(SyntaxNodeAnalysisContext ctx)
+    private void CompilationStart(CompilationStartAnalysisContext ctx)
+    {
+        ConcurrentDictionary<BlockSyntax, HashSet<ISymbol>> invocations = new();
+
+        ctx.RegisterSyntaxNodeAction((c) => Analyze(c, invocations), SyntaxKind.InvocationExpression);
+    }
+
+    private void Analyze(SyntaxNodeAnalysisContext ctx, ConcurrentDictionary<BlockSyntax, HashSet<ISymbol>> invocations)
     {
         if (ctx.Node is not InvocationExpressionSyntax invocation)
         {
@@ -80,18 +84,69 @@ public class MultipleOverwriteAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        MethodDeclarationSyntax? method = FindMethodDecl(invocation);
-        if (method is null)
+        SymbolInfo symbolInfo = ctx.SemanticModel.GetSymbolInfo(memberAccess.Expression);
+        if (symbolInfo.Symbol is null)
         {
             return;
         }
 
-        string memberText = memberAccess.GetText().ToString();
-        bool isInLoop = IsInLoop(invocation);
-        if (!this.invocations.TryGetValue(method, out HashSet<string> hashSet))
+        BlockSyntax? block = FindBlock(invocation);
+        if (block is null)
         {
-            this.invocations.Add(method, [memberText]);
-            if (isInLoop)
+            return;
+        }
+
+        bool recursivelyCalled = false;
+
+
+        ISymbol? localSymbol = symbolInfo.Symbol as ILocalSymbol ??
+                               symbolInfo.Symbol as IParameterSymbol ??
+                               (ISymbol?)FindLocalSymbol(memberAccess.Expression, ctx.SemanticModel);
+
+        SyntaxReference? declaringSyntax = symbolInfo.Symbol.DeclaringSyntaxReferences.FirstOrDefault();
+        if (IsInLoop(invocation) && declaringSyntax is not null && localSymbol is not null)
+        {
+            if (block.Parent is ForEachStatementSyntax forEachStmnt)
+            {
+                recursivelyCalled = forEachStmnt != declaringSyntax.GetSyntax();
+            }
+            else
+            {
+                DataFlowAnalysis? dataFlow = ctx.SemanticModel.AnalyzeDataFlow(block);
+                if (dataFlow is not null)
+                {
+                    recursivelyCalled =
+                        !dataFlow.VariablesDeclared
+                            .Any(v => SymbolEqualityComparer.Default.Equals(symbolInfo.Symbol, v));
+                }
+            }
+        }
+
+        BlockSyntax? previousBlock = FindBlock(block.Parent);
+        while (previousBlock is not null)
+        {
+            if (invocations.TryGetValue(previousBlock, out HashSet<ISymbol> previousBlockSet) &&
+                previousBlockSet.Contains(symbolInfo.Symbol))
+            {
+                Diagnostic previousInvocationDiagnostic = Diagnostic.Create(
+                    rule,
+                    invocation.GetLocation(),
+                    memberAccess.Expression
+                );
+
+                ctx.ReportDiagnostic(previousInvocationDiagnostic);
+                break;
+            }
+
+            previousBlock = FindBlock(previousBlock.Parent);
+        }
+
+        if (!invocations.TryGetValue(block, out HashSet<ISymbol> hashSet))
+        {
+            HashSet<ISymbol> newSet = new([symbolInfo.Symbol], SymbolEqualityComparer.Default);
+
+            invocations.TryAdd(block, newSet);
+            if (recursivelyCalled)
             {
                 Diagnostic loopDiagnostic = Diagnostic.Create(
                     rule,
@@ -105,9 +160,9 @@ public class MultipleOverwriteAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (hashSet.Add(memberText))
+        if (hashSet.Add(symbolInfo.Symbol))
         {
-            if (isInLoop)
+            if (recursivelyCalled)
             {
                 Diagnostic loopDiagnostic = Diagnostic.Create(
                     rule,
@@ -117,7 +172,7 @@ public class MultipleOverwriteAnalyzer : DiagnosticAnalyzer
 
                 ctx.ReportDiagnostic(loopDiagnostic);
             }
-            
+
             return;
         }
 
@@ -130,20 +185,42 @@ public class MultipleOverwriteAnalyzer : DiagnosticAnalyzer
         ctx.ReportDiagnostic(diagnostic);
     }
 
-    private MethodDeclarationSyntax? FindMethodDecl(SyntaxNode? syntax)
+    private BlockSyntax? FindBlock(SyntaxNode? syntax)
     {
         if (syntax is null)
         {
             return null;
         }
 
-        if (syntax is MethodDeclarationSyntax method)
+        if (syntax is BlockSyntax block)
         {
-            return method;
+            return block;
         }
 
-        return FindMethodDecl(syntax.Parent);
+        return FindBlock(syntax.Parent);
     }
+
+    private ILocalSymbol? FindLocalSymbol(ExpressionSyntax? expression, SemanticModel model)
+    {
+        if (expression is null)
+        {
+            return null;
+        }
+
+        SymbolInfo symbolInfo = model.GetSymbolInfo(expression);
+        if (symbolInfo.Symbol is ILocalSymbol localSymbol)
+        {
+            return localSymbol;
+        }
+
+        if (expression.Parent is ExpressionSyntax parentExpression)
+        {
+            return FindLocalSymbol(parentExpression, model);
+        }
+
+        return null;
+    }
+
 
     private bool IsInLoop(SyntaxNode? syntax)
     {
@@ -166,7 +243,7 @@ public class MultipleOverwriteAnalyzer : DiagnosticAnalyzer
         {
             return true;
         }
-        
+
         return IsInLoop(syntax.Parent);
     }
 }

--- a/DSharpPlus.Analyzers/DSharpPlus.Analyzers/Core/SingleEntityGetRequestAnalyzer.cs
+++ b/DSharpPlus.Analyzers/DSharpPlus.Analyzers/Core/SingleEntityGetRequestAnalyzer.cs
@@ -13,22 +13,19 @@ public class SingleEntityGetRequestAnalyzer : DiagnosticAnalyzer
     public const string DiagnosticId = "DSP0008";
     public const string Category = "Design";
 
-    private static readonly LocalizableString title = new LocalizableResourceString
-    (
+    private static readonly LocalizableString title = new LocalizableResourceString(
         nameof(Resources.DSP0008Title),
         Resources.ResourceManager,
         typeof(Resources)
     );
 
-    private static readonly LocalizableString description = new LocalizableResourceString
-    (
+    private static readonly LocalizableString description = new LocalizableResourceString(
         nameof(Resources.DSP0008Description),
         Resources.ResourceManager,
         typeof(Resources)
     );
 
-    private static readonly LocalizableString messageFormat = new LocalizableResourceString
-    (
+    private static readonly LocalizableString messageFormat = new LocalizableResourceString(
         nameof(Resources.DSP0008MessageFormat),
         Resources.ResourceManager,
         typeof(Resources)
@@ -49,16 +46,16 @@ public class SingleEntityGetRequestAnalyzer : DiagnosticAnalyzer
 
     private static readonly IReadOnlyDictionary<string, string> methods = new Dictionary<string, string>()
     {
-        { "GetMessageAsync", "DSharpPlus.Entities.DiscordChannel" }, 
-        { "GetGuildAsync", "DSharpPlus.DiscordClient"},
-        { "GetMemberAsync", "DSharpPlus.Entities.Channel"}
+        { "GetMessageAsync", "DSharpPlus.Entities.DiscordChannel" },
+        { "GetGuildAsync", "DSharpPlus.DiscordClient" },
+        { "GetMemberAsync", "DSharpPlus.Entities.Channel" }
     };
 
     private static readonly IReadOnlyDictionary<string, string> preferredMethods = new Dictionary<string, string>()
     {
         { "GetMessageAsync", "GetMessagesAsync" },
-        {"GetGuildAsync", "GetGuildsAsync"},
-        { "GetMemberAsync", "GetAllMembersAsync"}
+        { "GetGuildAsync", "GetGuildsAsync" },
+        { "GetMemberAsync", "GetAllMembersAsync" }
     };
 
     public override void Initialize(AnalysisContext ctx)


### PR DESCRIPTION
- [ ] This pull request was written by AI
- [ ] This pull request was assisted by AI, but you wrote the final code
- [X] This pull request did not involve AI in any way

# Summary
Fixes #2388 

# Details
Change the DSP0007 analyzer to use symbol resolution instead of text to decide if invocation has already happened or not.
Invocation is only added per block level instead of per method level, this solves issues with branching.
Variables are also checked if they're declared inside the block of the loop to decide if a value only gets called once during the execution path.

- [X] All features in this pull request were tested.