### PR TITLE
Hide search on API pages

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -79,7 +79,8 @@
     "fileMetadataFiles": [],
     "template": [
       "default",
-      "modern"
+      "modern",
+      "templates/dsharpplus"
     ],
     "postProcessors": [
       "ExtractSearchIndex"

--- a/docs/templates/dsharpplus/public/main.css
+++ b/docs/templates/dsharpplus/public/main.css
@@ -1,0 +1,4 @@
+body:has(article[data-uid="apidocs"]) div#navbar > form#search,
+body:has(article[data-uid^="DSharpPlus"]) div#navbar > form#search {
+  display: none;
+}


### PR DESCRIPTION
Hides the article search bar in the navbar on the api docs page and all subpages

Make sure you familiarize yourself with our contributing guidelines. (delete this line afterwards)

- [ ] This pull request was written by AI
- [ ] This pull request was assisted by AI, but you wrote the final code
- [x] This pull request did not involve AI in any way

# Summary
Hides the article search bar in the navbar on the api docs page and all subpages

# Details
This one:
<img width="311" height="71" alt="image" src="https://github.com/user-attachments/assets/d7c401de-91c0-436d-a064-f528c15def96" />


# Changes proposed
Create a template that adds a single CSS rule to hide the search element

# Notes
Works fine with screenreaders, no aria-* stuff needed. Tested locally using `docfx serve docs/_site`

- [x] All features in this pull request were tested.