### PR TITLE
fix the gateway getting indeterminately stuck on linux if the connection was severed externally

### DIFF
--- a/DSharpPlus/Net/Gateway/GatewayClientOptions.cs
+++ b/DSharpPlus/Net/Gateway/GatewayClientOptions.cs
@@ -69,7 +69,7 @@ public sealed class GatewayClientOptions
 
     /// <summary>
     /// Specifies the timeout to use when sending a payload to the gateway and for websocket-level keepalive messages
-    /// (this is distinct from heartbeating). If this is exceeded, DSharpPlus will attemptbto reconnect and resume. 
+    /// (this is distinct from heartbeating). If this is exceeded, DSharpPlus will attempt to reconnect and resume. 
     /// Defaults to 5 seconds.
     /// </summary>
     /// <remarks>

--- a/DSharpPlus/Net/Gateway/GatewayClientOptions.cs
+++ b/DSharpPlus/Net/Gateway/GatewayClientOptions.cs
@@ -66,4 +66,15 @@ public sealed class GatewayClientOptions
     /// may be pruned if there is no user code handling them. Exercise caution with this option.
     /// </remarks>
     public bool EnableEventQueuePruning { get; set; } = false;
+
+    /// <summary>
+    /// Specifies the timeout to use when sending a payload to the gateway and for websocket-level keepalive messages
+    /// (this is distinct from heartbeating). If this is exceeded, DSharpPlus will attemptbto reconnect and resume. 
+    /// Defaults to 5 seconds.
+    /// </summary>
+    /// <remarks>
+    /// This is intended to detect transient connection failures where we need to reconnect, but will also come into
+    /// effect during Discord outages and if your internet connection is slow or prone to spikes in latency.
+    /// </remarks>
+    public TimeSpan SendingTimeout { get; set; } = TimeSpan.FromSeconds(5);
 }

--- a/DSharpPlus/Net/Gateway/TransportService.cs
+++ b/DSharpPlus/Net/Gateway/TransportService.cs
@@ -26,6 +26,7 @@ internal sealed class TransportService : ITransportService
     private readonly ILoggerFactory factory;
 
     private readonly bool streamingDeserialization;
+    private readonly TimeSpan sendingTimeout;
 
     private bool isConnected = false;
     private bool isDisposed = false;
@@ -43,6 +44,7 @@ internal sealed class TransportService : ITransportService
         this.decompressor = decompressor;
 
         this.streamingDeserialization = options.Value.EnableStreamingDeserialization;
+        this.sendingTimeout = options.Value.SendingTimeout;
 
         this.logger = factory.CreateLogger("DSharpPlus.Net.Gateway.ITransportService - invalid shard");
     }
@@ -50,20 +52,23 @@ internal sealed class TransportService : ITransportService
     /// <inheritdoc/>
     public async ValueTask ConnectAsync(string url, int? shardId)
     {
-        this.logger = shardId is null
-            ? this.factory.CreateLogger("DSharpPlus.Net.Gateway.ITransportService")
-            : this.factory.CreateLogger($"DSharpPlus.Net.Gateway.ITransportService - Shard {shardId}");
-
-        this.socket = new();
-        this.decompressor.Initialize();
-
-        ObjectDisposedException.ThrowIf(this.isDisposed, this);
-
         if (this.isConnected)
         {
             this.logger.LogWarning("Attempted to connect, but there already is a connection opened. Ignoring.");
             return;
         }
+        
+        this.logger = shardId is null
+            ? this.factory.CreateLogger("DSharpPlus.Net.Gateway.ITransportService")
+            : this.factory.CreateLogger($"DSharpPlus.Net.Gateway.ITransportService - Shard {shardId}");
+
+        this.socket = new();
+
+        this.socket.Options.KeepAliveTimeout = this.sendingTimeout;
+
+        this.decompressor.Initialize();
+
+        ObjectDisposedException.ThrowIf(this.isDisposed, this);
 
         this.logger.LogTrace("Connecting to the Discord gateway.");
 


### PR DESCRIPTION
this could happen if a reconnect was initiated (i.e. by an IGatewayController that reconnected on Zombied) while the system was disconnected from the internet and at least one event had been sent to the gateway since the system disconnected

might be distro-specific or stack-specific, but the underlying issue is that the system doesn't report that sending the event failed, so as far as CWS is concerned, it's just taking its sweet time and we end up building up events and partial state changes that never get resolved and get the gateway stuck

also moves the isConnected check to where it actually makes sense, as opposed to getting us into an invalid state that needs another reconnect to recover. that was kind of silly.