### PR TITLE
fix #2407

### DIFF
--- a/DSharpPlus.Commands/CommandsExtension.cs
+++ b/DSharpPlus.Commands/CommandsExtension.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Net;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -533,10 +534,10 @@ public sealed class CommandsExtension
                 $"The following error occurred: ``{checksFailedException.Errors[0].ErrorMessage}``",
             ParameterChecksFailedException checksFailedException =>
                 $"The following context checks failed: ```\n{string.Join("\n- ", checksFailedException.Errors.Select(x => x.ErrorMessage)).Trim()}\n```.",
-            DiscordException discordException when discordException.Response is not null && (int)discordException.Response.StatusCode >= 500 && (int)discordException.Response.StatusCode < 600 =>
-                $"Discord API error {discordException.Response.StatusCode} occurred: {discordException.JsonMessage ?? "No further information was provided."}",
-            DiscordException discordException when discordException.Response is not null =>
-                $"Discord API error {discordException.Response.StatusCode} occurred: {discordException.JsonMessage ?? discordException.Message}",
+            DiscordException discordException when discordException.Response is { ResponseCode: >= (HttpStatusCode)500 and < (HttpStatusCode)600} =>
+                $"Discord API error {discordException.Response.ResponseCode} occurred: {discordException.JsonMessage ?? "No further information was provided."}",
+            DiscordException discordException =>
+                $"Discord API error {discordException.Response.ResponseCode} occurred: {discordException.JsonMessage ?? discordException.Message}",
             _ => $"An unexpected error occurred: {eventArgs.Exception.Message}",
         });
 

--- a/DSharpPlus/Exceptions/BadRequestException.cs
+++ b/DSharpPlus/Exceptions/BadRequestException.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Text.Json;
+using DSharpPlus.Net;
 
 namespace DSharpPlus.Exceptions;
 
@@ -19,39 +20,28 @@ public class BadRequestException : DiscordException
     /// </summary>
     public string? Errors { get; internal set; }
 
-    internal BadRequestException(HttpRequestMessage request, HttpResponseMessage response, string content)
-        : base("Bad request: " + response.StatusCode)
+    internal BadRequestException(HttpRequestMessage request, RestResponse response)
+        : base("Bad request: " + response.ResponseCode)
     {
         this.Request = request;
         this.Response = response;
 
         try
         {
-            using JsonDocument document = JsonDocument.Parse(content);
+            using JsonDocument document = JsonDocument.Parse(response.Response);
             JsonElement responseModel = document.RootElement;
 
-            if
-            (
-                responseModel.TryGetProperty("code", out JsonElement code)
-                && code.ValueKind == JsonValueKind.Number
-            )
+            if (responseModel.TryGetProperty("code", out JsonElement code) && code.ValueKind == JsonValueKind.Number)
             {
                 this.Code = code.GetInt32();
             }
 
-            if
-            (
-                responseModel.TryGetProperty("message", out JsonElement message)
-                && message.ValueKind == JsonValueKind.String
-            )
+            if (responseModel.TryGetProperty("message", out JsonElement message) && message.ValueKind == JsonValueKind.String)
             {
                 this.JsonMessage = message.GetString();
             }
 
-            if
-            (
-                responseModel.TryGetProperty("errors", out JsonElement errors)
-            )
+            if (responseModel.TryGetProperty("errors", out JsonElement errors))
             {
                 this.Errors = JsonSerializer.Serialize(errors);
             }

--- a/DSharpPlus/Exceptions/DiscordException.cs
+++ b/DSharpPlus/Exceptions/DiscordException.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Net.Http;
 
+using DSharpPlus.Net;
+
 namespace DSharpPlus.Exceptions;
 
 public abstract class DiscordException : Exception
@@ -13,7 +15,7 @@ public abstract class DiscordException : Exception
     /// <summary>
     /// Gets the response to the request.
     /// </summary>
-    public virtual HttpResponseMessage? Response { get; internal set; }
+    public virtual RestResponse Response { get; internal set; }
 
     /// <summary>
     /// Gets the JSON message received.

--- a/DSharpPlus/Exceptions/NotFoundException.cs
+++ b/DSharpPlus/Exceptions/NotFoundException.cs
@@ -1,6 +1,8 @@
 using System.Net.Http;
 using System.Text.Json;
 
+using DSharpPlus.Net;
+
 namespace DSharpPlus.Exceptions;
 
 /// <summary>
@@ -8,22 +10,18 @@ namespace DSharpPlus.Exceptions;
 /// </summary>
 public class NotFoundException : DiscordException
 {
-    internal NotFoundException(HttpRequestMessage request, HttpResponseMessage response, string content)
-        : base("Not found: " + response.StatusCode)
+    internal NotFoundException(HttpRequestMessage request, RestResponse response)
+        : base("Not found: " + response.ResponseCode)
     {
         this.Request = request;
         this.Response = response;
 
         try
         {
-            using JsonDocument document = JsonDocument.Parse(content);
+            using JsonDocument document = JsonDocument.Parse(response.Response);
             JsonElement responseModel = document.RootElement;
 
-            if
-            (
-                responseModel.TryGetProperty("message", out JsonElement message)
-                && message.ValueKind == JsonValueKind.String
-            )
+            if (responseModel.TryGetProperty("message", out JsonElement message) && message.ValueKind == JsonValueKind.String)
             {
                 this.JsonMessage = message.GetString();
             }

--- a/DSharpPlus/Exceptions/RateLimitException.cs
+++ b/DSharpPlus/Exceptions/RateLimitException.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Net.Http;
 using System.Text.Json;
+
+using DSharpPlus.Net;
 
 namespace DSharpPlus.Exceptions;
 
@@ -8,24 +11,40 @@ namespace DSharpPlus.Exceptions;
 /// </summary>
 public class RateLimitException : DiscordException
 {
-    internal RateLimitException(HttpRequestMessage request, HttpResponseMessage response, string content)
-        : base("Rate limited: " + response.StatusCode)
+    /// <summary>
+    /// Specifies how long to wait until this ratelimit is lifted. Note that other requests may cause a repeat to be ratelimited again.
+    /// </summary>
+    public TimeSpan? RetryAfter { get; }
+
+    /// <summary>
+    /// Indicates whether the ratelimit is specific to this request or affects your entire bot.
+    /// </summary>
+    public bool IsGlobal { get; }
+
+    internal RateLimitException(HttpRequestMessage request, RestResponse response)
+        : base("Rate limited: " + response.ResponseCode)
     {
         this.Request = request;
         this.Response = response;
 
         try
         {
-            using JsonDocument document = JsonDocument.Parse(content);
+            using JsonDocument document = JsonDocument.Parse(response.Response);
             JsonElement responseModel = document.RootElement;
 
-            if
-            (
-                responseModel.TryGetProperty("message", out JsonElement message)
-                && message.ValueKind == JsonValueKind.String
-            )
+            if (responseModel.TryGetProperty("message", out JsonElement message) && message.ValueKind == JsonValueKind.String)
             {
                 this.JsonMessage = message.GetString();
+            }
+
+            if (responseModel.TryGetProperty("retry_after", out JsonElement retryAfter) && retryAfter.ValueKind == JsonValueKind.Number)
+            {
+                this.RetryAfter = TimeSpan.FromSeconds(retryAfter.GetSingle());
+            }
+
+            if (responseModel.TryGetProperty("global", out JsonElement global) && global.ValueKind is JsonValueKind.True or JsonValueKind.False)
+            {
+                this.IsGlobal = global.GetBoolean();
             }
         }
         catch { }

--- a/DSharpPlus/Exceptions/RequestSizeException.cs
+++ b/DSharpPlus/Exceptions/RequestSizeException.cs
@@ -1,6 +1,8 @@
 using System.Net.Http;
 using System.Text.Json;
 
+using DSharpPlus.Net;
+
 namespace DSharpPlus.Exceptions;
 
 /// <summary>
@@ -8,15 +10,15 @@ namespace DSharpPlus.Exceptions;
 /// </summary>
 public class RequestSizeException : DiscordException
 {
-    internal RequestSizeException(HttpRequestMessage request, HttpResponseMessage response, string content)
-        : base($"Request entity too large: {response.StatusCode}. Make sure the data sent is within Discord's upload limit.")
+    internal RequestSizeException(HttpRequestMessage request, RestResponse response)
+        : base($"Request entity too large: {response.ResponseCode}. Make sure the data sent is within Discord's upload limit.")
     {
         this.Request = request;
         this.Response = response;
 
         try
         {
-            using JsonDocument document = JsonDocument.Parse(content);
+            using JsonDocument document = JsonDocument.Parse(response.Response);
             JsonElement responseModel = document.RootElement;
 
             if

--- a/DSharpPlus/Exceptions/ServerErrorException.cs
+++ b/DSharpPlus/Exceptions/ServerErrorException.cs
@@ -1,6 +1,8 @@
 using System.Net.Http;
 using System.Text.Json;
 
+using DSharpPlus.Net;
+
 namespace DSharpPlus.Exceptions;
 
 /// <summary>
@@ -8,22 +10,18 @@ namespace DSharpPlus.Exceptions;
 /// </summary>
 public class ServerErrorException : DiscordException
 {
-    internal ServerErrorException(HttpRequestMessage request, HttpResponseMessage response, string content)
-        : base("Internal Server Error: " + response.StatusCode)
+    internal ServerErrorException(HttpRequestMessage request, RestResponse response)
+        : base("Internal Server Error: " + response.ResponseCode)
     {
         this.Request = request;
         this.Response = response;
 
         try
         {
-            using JsonDocument document = JsonDocument.Parse(content);
+            using JsonDocument document = JsonDocument.Parse(response.Response);
             JsonElement responseModel = document.RootElement;
 
-            if
-            (
-                responseModel.TryGetProperty("message", out JsonElement message)
-                && message.ValueKind == JsonValueKind.String
-            )
+            if (responseModel.TryGetProperty("message", out JsonElement message) && message.ValueKind == JsonValueKind.String)
             {
                 this.JsonMessage = message.GetString();
             }

--- a/DSharpPlus/Exceptions/UnauthorizedException.cs
+++ b/DSharpPlus/Exceptions/UnauthorizedException.cs
@@ -1,6 +1,8 @@
 using System.Net.Http;
 using System.Text.Json;
 
+using DSharpPlus.Net;
+
 namespace DSharpPlus.Exceptions;
 
 /// <summary>
@@ -8,22 +10,18 @@ namespace DSharpPlus.Exceptions;
 /// </summary>
 public class UnauthorizedException : DiscordException
 {
-    internal UnauthorizedException(HttpRequestMessage request, HttpResponseMessage response, string content)
-        : base("Unauthorized: " + response.StatusCode)
+    internal UnauthorizedException(HttpRequestMessage request, RestResponse response)
+        : base("Unauthorized: " + response.ResponseCode)
     {
         this.Request = request;
         this.Response = response;
 
         try
         {
-            using JsonDocument document = JsonDocument.Parse(content);
+            using JsonDocument document = JsonDocument.Parse(response.Response);
             JsonElement responseModel = document.RootElement;
 
-            if
-            (
-                responseModel.TryGetProperty("message", out JsonElement message)
-                && message.ValueKind == JsonValueKind.String
-            )
+            if (responseModel.TryGetProperty("message", out JsonElement message) && message.ValueKind == JsonValueKind.String)
             {
                 this.JsonMessage = message.GetString();
             }

--- a/DSharpPlus/Net/Rest/RestClient.cs
+++ b/DSharpPlus/Net/Rest/RestClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -149,6 +150,8 @@ public sealed partial class RestClient : IDisposable
             ResilienceContextPool.Shared.Return(context);
 
             string content = await response.Content.ReadAsStringAsync();
+            HttpResponseHeaders headers = response.Headers;
+            HttpStatusCode statusCode = response.StatusCode;
 
             // consider logging headers too
             if (this.logger.IsEnabled(LogLevel.Trace) && RuntimeFeatures.EnableRestRequestLogging)
@@ -170,55 +173,56 @@ public sealed partial class RestClient : IDisposable
 
             this.metrics.RegisterRestRequestOutcome(response.StatusCode, response.Headers);
 
+            RestResponse returnValue = new RestResponse()
+            {
+                Response = content,
+                ResponseCode = statusCode,
+                ResponseHeaders = headers
+            };
+
             return response.StatusCode switch
             {
-                HttpStatusCode.BadRequest or HttpStatusCode.MethodNotAllowed => throw new BadRequestException(request.Build(), response, content),
+                HttpStatusCode.BadRequest or HttpStatusCode.MethodNotAllowed => throw new BadRequestException(request.Build(), returnValue),
 
-                HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => throw new UnauthorizedException(request.Build(), response, content),
+                HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => throw new UnauthorizedException(request.Build(), returnValue),
 
-                HttpStatusCode.NotFound => throw new NotFoundException(request.Build(), response, content),
+                HttpStatusCode.NotFound => throw new NotFoundException(request.Build(), returnValue),
 
-                HttpStatusCode.RequestEntityTooLarge => throw new RequestSizeException(request.Build(), response, content),
+                HttpStatusCode.RequestEntityTooLarge => throw new RequestSizeException(request.Build(), returnValue),
 
-                HttpStatusCode.TooManyRequests => throw new RateLimitException(request.Build(), response, content),
+                HttpStatusCode.TooManyRequests => throw new RateLimitException(request.Build(), returnValue),
 
                 HttpStatusCode.InternalServerError
                     or HttpStatusCode.BadGateway
                     or HttpStatusCode.ServiceUnavailable
-                    or HttpStatusCode.GatewayTimeout => throw new ServerErrorException(request.Build(), response, content),
+                    or HttpStatusCode.GatewayTimeout => throw new ServerErrorException(request.Build(), returnValue),
 
-                _ => new RestResponse()
-                {
-                    Response = content,
-                    ResponseCode = response.StatusCode
-                },
+                _ => returnValue
             };
         }
-        catch (Exception ex)
+        catch (DiscordException ex)
         {
             if (ex is BadRequestException badRequest)
             {
-                this.logger.LogError
+                this.logger.LogWarning
                 (
                     "Request to {url} was rejected by the Discord API:\n" +
                     "  Error Code: {Code}\n" +
                     "  Errors: {Errors}\n" +
-                    "  Message: {JsonMessage}\n" +
-                    "  Stack trace: {Stacktrace}",
+                    "  Message: {JsonMessage}\n",
                     $"{Endpoints.BASE_URI}/{request.Url}",
                     badRequest.Code,
                     badRequest.Errors,
-                    badRequest.JsonMessage,
-                    badRequest.StackTrace
+                    badRequest.JsonMessage
                 );
             }
             else
             {
-                this.logger.LogError
+                this.logger.LogWarning
                 (
                     LoggerEvents.RestError,
-                    ex,
-                    "Request to {url} triggered an exception",
+                    "Received non-success status code {code} making a request to {url}",
+                    ex.Response.ResponseCode,
                     $"{Endpoints.BASE_URI}/{request.Url}"
                 );
             }

--- a/DSharpPlus/Net/Rest/RestResponse.cs
+++ b/DSharpPlus/Net/Rest/RestResponse.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 
 namespace DSharpPlus.Net;
 
@@ -10,10 +11,15 @@ public record struct RestResponse
     /// <summary>
     /// Gets the response code sent by the remote party.
     /// </summary>
-    public HttpStatusCode? ResponseCode { get; internal set; }
+    public HttpStatusCode ResponseCode { get; internal set; }
 
     /// <summary>
     /// Gets the contents of the response sent by the remote party.
     /// </summary>
     public string? Response { get; internal set; }
+
+    /// <summary>
+    /// Gets the headers received with this rest request.
+    /// </summary>
+    public HttpResponseHeaders? ResponseHeaders { get; internal set; }
 }


### PR DESCRIPTION
this stores our assembled RestResponse in the exception. RestResponse.Response (the content string) is a bit unideal naming, but i don't think it's worth renaming given that it's used about 150 times. also adds convenience fields to RateLimitException for the things you might want to inspect (RetryAfter, IsGlobal).

also reduces the space consumed by RestClient api error logging, which i found can be quite arduous and really doesn't need to be in the modern age where our library by default logs errors rather than swallowing them, as it did back when this was written

an alternative approach of just not disposing the HttpResponseMessage is a non-starter because the backing implementation might use pooled arrays that we absolutely want to return to the pool, otherwise we create double the allocations (from the leaked arrays and our content string that we take *anyway*)

closes #2407