### PR TITLE
fix the gateway marking itself as disconnected when resuming

### DIFF
--- a/DSharpPlus/Net/Gateway/GatewayClient.cs
+++ b/DSharpPlus/Net/Gateway/GatewayClient.cs
@@ -227,9 +227,7 @@ public sealed class GatewayClient : IGatewayClient
     /// <inheritdoc/>
     public async Task DisconnectAsync()
     {
-        this.closureRequested = true;
-        this.IsConnected = false;
-        await this.gatewayTokenSource.CancelAsync();
+        await TerminateCurrentFrameAsync(GatewayDisconnectReason.UserRequested);
         await this.transportService.DisconnectAsync(WebSocketCloseStatus.NormalClosure);
     }
 
@@ -460,7 +458,6 @@ public sealed class GatewayClient : IGatewayClient
 
         try
         {
-            this.IsConnected = false;
             await this.gatewayTokenSource.CancelAsync();
 
             this.gatewayTokenSource = new();


### PR DESCRIPTION
resuming is supposed to be transient and invisible to the user, so it shouldn't even mark itself as disconnected, but the arguably bigger issue was that it never marked itself as connected again

- [x] This pull request did not involve AI in any way
- [x] All features in this pull request were tested.