### PR TITLE
improve logging of irrecoverable errors

### DIFF
--- a/DSharpPlus/Clients/MultiShardOrchestrator.cs
+++ b/DSharpPlus/Clients/MultiShardOrchestrator.cs
@@ -22,7 +22,6 @@ namespace DSharpPlus.Clients;
 public sealed class MultiShardOrchestrator : IShardOrchestrator
 {
     private ConcurrentDictionary<int, IGatewayClient> shards;
-    private ConcurrentDictionary<int, Task<GatewayConnectionFrame>> gatewayTasks;
     private readonly DiscordRestApiClient apiClient;
     private readonly ShardingOptions options;
     private readonly IServiceProvider serviceProvider;
@@ -112,7 +111,6 @@ public sealed class MultiShardOrchestrator : IShardOrchestrator
         }
 
         this.shards = new(-1, (int)this.shardCount);
-        this.gatewayTasks = new(-1, (int)this.shardCount);
 
         // create all shard instances before starting any of them
         for (int i = 0; i < startShards; i++)
@@ -126,8 +124,9 @@ public sealed class MultiShardOrchestrator : IShardOrchestrator
 
             for (int j = i; j < i + info.SessionBucket.MaxConcurrency && j < startShards; j++)
             {
-                this.gatewayTasks.TryAdd(i, this.shards[j].ConnectAsync
+                _ = RunGatewayAsync
                 (
+                    i,
                     gwuri.Build(),
                     activity,
                     status,
@@ -137,7 +136,7 @@ public sealed class MultiShardOrchestrator : IShardOrchestrator
                         ShardCount = (int)totalShards,
                         ShardId = (int)stride + j
                     }
-                ));
+                );
             }
 
             TimeSpan diff = DateTimeOffset.UtcNow - startTime;
@@ -147,8 +146,6 @@ public sealed class MultiShardOrchestrator : IShardOrchestrator
                 await Task.Delay(TimeSpan.FromSeconds(5) - diff);
             }
         }
-
-        _ = RunGatewayAsync();
     }
 
     /// <inheritdoc/>
@@ -232,26 +229,29 @@ public sealed class MultiShardOrchestrator : IShardOrchestrator
         await Parallel.ForEachAsync(this.shards, async (shard, _) => await shard.Value.WriteAsync(payload));
     }
 
-    private async Task RunGatewayAsync()
+    private async Task RunGatewayAsync(int shardNumber, string uri, DiscordActivity? activity, DiscordUserStatus? status, DateTimeOffset? idleSince, ShardInfo shardInfo)
     {
+        Task<GatewayConnectionFrame> gatewayTask = this.shards[shardNumber].ConnectAsync(uri, activity, status, idleSince, shardInfo);
+
         while (true)
         {
-            Task<GatewayConnectionFrame> frame = await Task.WhenAny(this.gatewayTasks.Values);
+            GatewayConnectionFrame frame = await gatewayTask;
 
-            if (frame.Result.DisconnectReason is GatewayDisconnectReason.UserRequested or GatewayDisconnectReason.IrrecoverableCloseCode)
+            if (frame.DisconnectReason is GatewayDisconnectReason.UserRequested or GatewayDisconnectReason.IrrecoverableCloseCode)
             {
-                this.logger.LogInformation
+                this.logger.LogError
                 (
-                    "Shard {shardId} exited with disconnect reason {reason}, abandoning reconnecting.", 
-                    frame.Result.ShardId, 
-                    frame.Result.DisconnectReason
+                    frame.Exception,
+                    "Shard {shardId} exited with disconnect reason {reason} and close code {closeCode}, abandoning reconnecting.",
+                    frame.ShardId, 
+                    frame.DisconnectReason,
+                    frame.CloseCode ?? (GatewayCloseCode)1000
                 );
                 
                 break;
             }
 
-            Task<GatewayConnectionFrame> newTask = this.shards[frame.Result.ShardId].ReconnectAsync();
-            _ = this.gatewayTasks.AddOrUpdate(frame.Result.ShardId, newTask, (_, _) => newTask);
+            gatewayTask = this.shards[shardNumber].ReconnectAsync();
         }
     }
 

--- a/DSharpPlus/Clients/SingleShardOrchestrator.cs
+++ b/DSharpPlus/Clients/SingleShardOrchestrator.cs
@@ -21,8 +21,6 @@ public sealed class SingleShardOrchestrator : IShardOrchestrator
     private readonly IPayloadDecompressor decompressor;
     private readonly ILogger<IShardOrchestrator> logger;
 
-    private Task<GatewayConnectionFrame> gatewayTask;
-
     /// <summary>
     /// Creates a new instance of this type.
     /// </summary>
@@ -100,24 +98,31 @@ public sealed class SingleShardOrchestrator : IShardOrchestrator
             gwuri.AddParameter("compress", this.decompressor.Name);
         }
 
-        this.gatewayTask = this.gatewayClient.ConnectAsync(gwuri.Build(), activity, status, idleSince);
-
-        _ = RunGatewayAsync();
+        _ = RunGatewayAsync(gwuri.Build(), activity, status, idleSince);
     }
 
-    private async Task RunGatewayAsync()
+    private async Task RunGatewayAsync(string uri, DiscordActivity? activity, DiscordUserStatus? status, DateTimeOffset? idleSince)
     {
+        Task<GatewayConnectionFrame> gatewayTask = this.gatewayClient.ConnectAsync(uri, activity, status, idleSince);
+
         while (true)
         {
-            GatewayConnectionFrame frame = await this.gatewayTask;
+            GatewayConnectionFrame frame = await gatewayTask;
 
             if (frame.DisconnectReason is GatewayDisconnectReason.UserRequested or GatewayDisconnectReason.IrrecoverableCloseCode)
             {
-                this.logger.LogInformation("The gateway exited with disconnect reason {reason}, abandoning reconnecting.", frame.DisconnectReason);
+                this.logger.LogError
+                (
+                    frame.Exception,
+                    "The gateway exited with disconnect reason {reason} and close code {closeCode}, abandoning reconnecting.", 
+                    frame.DisconnectReason,
+                    frame.CloseCode ?? (GatewayCloseCode)1000
+                );
+
                 break;
             }
 
-            this.gatewayTask = this.gatewayClient.ReconnectAsync();
+            gatewayTask = this.gatewayClient.ReconnectAsync();
         }
     }
 

--- a/DSharpPlus/Net/Gateway/TransportService.cs
+++ b/DSharpPlus/Net/Gateway/TransportService.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.WebSockets;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.Unicode;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -175,7 +176,7 @@ internal sealed class TransportService : ITransportService
 
         if (this.logger.IsEnabled(LogLevel.Trace) && RuntimeFeatures.EnableInboundGatewayLogging)
         {
-            if (receiveResult.MessageType == WebSocketMessageType.Text)
+            if (receiveResult.MessageType == WebSocketMessageType.Text || Utf8.IsValid(this.decompressedWriter.WrittenSpan))
             {
                 string result = Encoding.UTF8.GetString(this.decompressedWriter.WrittenSpan);
 
@@ -201,7 +202,7 @@ internal sealed class TransportService : ITransportService
 
         return receiveResult.MessageType is WebSocketMessageType.Text or WebSocketMessageType.Binary
             ? new(this.decompressedWriter.WrittenSpan.ToArray(), receiveResult.MessageType)
-            : new(this.socket.CloseStatus!, WebSocketMessageType.Close);
+            : new((int)this.socket.CloseStatus!, WebSocketMessageType.Close);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
it failed to correctly log the errors because enums don't satisfy an `is` type check :sob: this code would be much improved if we had unions. 

this Might also fix an issue with error handling in bots with a shard startup concurrency greater than 1 (see the diff at MultiShardOrchestrator line 127~129, it used the wrong index to enregister a gateway task), but i don't have such a bot to test, and it is possible the observed issue is entirely coincidental to this logic bug 

- [x] This pull request did not involve AI in any way
- [x] All features in this pull request were tested.