### PR TITLE
improve gateway stability against new discord error conditions

### DIFF
--- a/DSharpPlus/Clients/MultiShardOrchestrator.cs
+++ b/DSharpPlus/Clients/MultiShardOrchestrator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.RateLimiting;
 using System.Threading.Tasks;
 
 using DSharpPlus.Entities;
@@ -27,6 +28,7 @@ public sealed class MultiShardOrchestrator : IShardOrchestrator
     private readonly IServiceProvider serviceProvider;
     private readonly IPayloadDecompressor decompressor;
     private readonly ILogger<IShardOrchestrator> logger;
+    private readonly ConcurrencyLimiter reconnectConcurrencyLimiter;
 
     private uint shardCount;
     private uint stride;
@@ -67,6 +69,12 @@ public sealed class MultiShardOrchestrator : IShardOrchestrator
         this.serviceProvider = serviceProvider;
         this.decompressor = decompressor;
         this.logger = logger;
+
+        this.reconnectConcurrencyLimiter = new(new()
+        {
+            PermitLimit = 1,
+            QueueLimit = int.MaxValue
+        });
     }
 
     /// <inheritdoc/>
@@ -251,6 +259,7 @@ public sealed class MultiShardOrchestrator : IShardOrchestrator
                 break;
             }
 
+            using RateLimitLease lease = await this.reconnectConcurrencyLimiter.AcquireAsync();
             gatewayTask = this.shards[shardNumber].ReconnectAsync();
         }
     }

--- a/DSharpPlus/Exceptions/InvalidGatewayStateException.cs
+++ b/DSharpPlus/Exceptions/InvalidGatewayStateException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace DSharpPlus.Exceptions;
+
+/// <summary>
+/// Indicates that the gateway has entered an invalid state and must reconnect.
+/// </summary>
+public sealed class InvalidGatewayStateException(string message) : Exception(message);

--- a/DSharpPlus/Net/Gateway/GatewayClient.cs
+++ b/DSharpPlus/Net/Gateway/GatewayClient.cs
@@ -608,7 +608,7 @@ public sealed class GatewayClient : IGatewayClient
             bool success = errorCode switch
             {
                 < 4000 => await HandleSystemErrorAsync(errorCode),
-                (>= 4000 and <= 4002) or 4005 or 4008 => await TryResumeAsync(),
+                (>= 4000 and <= 4002) or 4005 or 4008 or 5000 => await TryResumeAsync(),
                 _ => false
             };
 

--- a/DSharpPlus/Net/Gateway/GatewayClient.cs
+++ b/DSharpPlus/Net/Gateway/GatewayClient.cs
@@ -363,7 +363,8 @@ public sealed class GatewayClient : IGatewayClient
         }
     }
 
-    private async Task HandleEventCoreAsync(GatewayPayload payload)
+    [AsyncMethodBuilder(typeof(PoolingAsyncValueTaskMethodBuilder))]
+    private async ValueTask HandleEventCoreAsync(GatewayPayload payload)
     {
         switch (payload.OpCode)
         {
@@ -451,7 +452,7 @@ public sealed class GatewayClient : IGatewayClient
     /// </summary>
     private async Task<bool> TryResumeAsync()
     {
-        if (this.resumeUrl is null || this.sessionId is null)
+        if (this.resumeUrl is null || this.sessionId is null || !this.IsConnected)
         {
             return false;
         }

--- a/DSharpPlus/Net/Gateway/GatewayClient.cs
+++ b/DSharpPlus/Net/Gateway/GatewayClient.cs
@@ -11,6 +11,7 @@ using System.Threading.RateLimiting;
 using System.Threading.Tasks;
 
 using DSharpPlus.Entities;
+using DSharpPlus.Exceptions;
 using DSharpPlus.Net.Abstractions;
 using DSharpPlus.Net.Gateway.Compression;
 using DSharpPlus.Net.Serialization;
@@ -328,6 +329,8 @@ public sealed class GatewayClient : IGatewayClient
     /// </summary>
     private async Task HandleEventsAsync(CancellationToken ct)
     {
+        int consecutiveInvalidEvents = 0;
+
         try
         {
             while (!ct.IsCancellationRequested)
@@ -344,7 +347,30 @@ public sealed class GatewayClient : IGatewayClient
                     continue;
                 }
 
-                GatewayPayload? payload = await ProcessAndDeserializeTransportFrameAsync(frame);
+                GatewayPayload? payload = null;
+                
+                try
+                {
+                    payload = await ProcessAndDeserializeTransportFrameAsync(frame);
+                    consecutiveInvalidEvents = 0;
+                }
+                catch (JsonException)
+                {
+                    if (frame.TryGetMessage(out byte[]? message))
+                    {
+                        this.logger.LogError("Received undeserializable gateway payload: {payload}", Encoding.UTF8.GetString(message));
+                        consecutiveInvalidEvents++;
+                    }
+                    else
+                    {
+                        throw;
+                    }
+
+                    if (consecutiveInvalidEvents > 5)
+                    {
+                        throw new InvalidGatewayStateException("Received over five consecutive invalid events, the connection likely entered an invalid state and should reconnect.");
+                    }
+                }
 
                 if (payload is null)
                 {

--- a/DSharpPlus/Net/Gateway/TransportService.cs
+++ b/DSharpPlus/Net/Gateway/TransportService.cs
@@ -167,6 +167,11 @@ internal sealed class TransportService : ITransportService
 
         this.metrics.RecordGatewayEventReceived(this.writer.WrittenCount);
 
+        if (this.socket.CloseStatus is not null || this.writer.WrittenCount == 0)
+        {
+            return new(((int?)this.socket.CloseStatus) ?? 5000, WebSocketMessageType.Close);
+        }
+
         if (!this.decompressor.TryDecompress(this.writer.WrittenSpan, this.decompressedWriter))
         {
             throw new InvalidDataException("Failed to decompress a gateway payload.");

--- a/DSharpPlus/Net/Gateway/TransportService.cs
+++ b/DSharpPlus/Net/Gateway/TransportService.cs
@@ -125,6 +125,7 @@ internal sealed class TransportService : ITransportService
                 }
                 catch (WebSocketException) { }
                 catch (OperationCanceledException) { }
+                catch (InvalidOperationException) { }
 
                 break;
         }


### PR DESCRIPTION
- if we received an invalid HELLO (or probably also READY) event, DSharpPlus would trigger the resume procedure. if the shard never successfully connected, this is fine, because the resume URL and session ID will be null and it'll trigger a hard reconnect, but if it did successfully connect before, it would reuse that resume URL and session ID for a resume attempt that may now be invalid. this would cause shards to stall infinitely in an attempt to resume before a session was established in the first place
- if discord closed the gateway without an error code, DSharpPlus would crash the shard. we will now attempt to resume.
- if discord sent an invalid gateway payload, DSharpPlus would crash the shard to restart from a clean slate. it now waits for five consecutive invalid events before rendering judgement so as to allow for transient errors
- MultiShardOrchestrator would previously always immediately reconnect a failed shard without considering that many shards can fail at once. this adds a concurrency limit (currently of 1, since the actual gateway concurrency limit is more perfidious and 1 should guarantee success) to multi-sharded reconnects

- [x] This pull request did not involve AI in any way
- [x] All features in this pull request were tested.

this PR initially only intended to fix the first issue, but the list has grown