### PR TITLE
use trusted publishing instead of nuget api keys

### DIFF
--- a/.github/workflows/build-commit.yml
+++ b/.github/workflows/build-commit.yml
@@ -23,6 +23,8 @@ jobs:
     name: Package Commit
     runs-on: ubuntu-latest
     if: "!contains(format('{0} {1}', github.event.head_commit.message, github.event.pull_request.title), '[ci-skip]')"
+    permissions:
+      id-token: write # needed for trusted publishing
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,12 +42,17 @@ jobs:
       - name: Get Nightly Version
         id: nightly
         run: printf "version=%0*d" 5 $(( 1195 + 691 + ${{ github.run_number }} )) >> "$GITHUB_OUTPUT"
+      - name: Login to NuGet
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Package Project
         run: |
           # We add 1195 since it's the last build number AppVeyor used.
           # We add 686 since it's the last build number GitHub Actions used before the workflow was renamed.
           dotnet pack -c Release -o build -p:Nightly=${{ steps.nightly.outputs.version }}
-          dotnet nuget push "build/*" --skip-duplicate -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json
+          dotnet nuget push "build/*" --skip-duplicate -k ${{ steps.nuget-login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           DISCORD_GUILD_ID: ${{ secrets.DISCORD_GUILD_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Package Project
         run: |
           dotnet pack -c Release -o build
-          dotnet nuget push "build/*" --skip-duplicate -k ${{ steps.outputs.nuget-login.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
+          dotnet nuget push "build/*" --skip-duplicate -k ${{ steps.nuget-login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
           LATEST_STABLE_VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || echo '') dotnet run --project ./tools/AutoUpdateChannelDescription
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
     name: Package Commit
     runs-on: ubuntu-latest
     needs: build-commit
+    permissions:
+      id-token: write # needed for trusted publishing
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,10 +41,15 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8
+      - name: Login to NuGet
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Package Project
         run: |
           dotnet pack -c Release -o build
-          dotnet nuget push "build/*" --skip-duplicate -k ${{ secrets.NUGET_ORG_API_KEY }} -s https://api.nuget.org/v3/index.json
+          dotnet nuget push "build/*" --skip-duplicate -k ${{ steps.outputs.nuget-login.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json
           LATEST_STABLE_VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || echo '') dotnet run --project ./tools/AutoUpdateChannelDescription
         env:
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}


### PR DESCRIPTION
https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing

i'll configure the secrets if we agree on merging this (otherwise, i'll update the api keys). also i'll backport this to v4.5, surely we never need it but yknow