### PR TITLE
update the readme and use a shortened version for nuget packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     <PackageIcon>dsharpplus.png</PackageIcon>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/DSharpPlus/DSharpPlus</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>package-readme.md</PackageReadmeFile>
     <PackageTags>discord, discord-api, bots, discord-bots, chat, dsharp, dsharpplus, csharp, dotnet, vb-net, fsharp</PackageTags>
     <RepositoryType>Git</RepositoryType>
     <RepositoryUrl>https://github.com/DSharpPlus/DSharpPlus</RepositoryUrl>
@@ -39,7 +39,7 @@
   <!-- Resource Files -->
   <ItemGroup>
     <None Include="$(ProjectRoot)/LICENSE" Pack="true" PackagePath=""/>
-    <None Include="$(ProjectRoot)/README.md" Pack="true" PackagePath=""/>
+    <None Include="$(ProjectRoot)/package-readme.md" Pack="true" PackagePath=""/>
     <None Include="$(ProjectRoot)/logo/dsharpplus.png" Pack="true" PackagePath=""/>
     <!-- Remove the 'JSImportGenerator' analyzer by default to improve compilation time. +200ms is apparently enough to require this change. -->
     <RemoveAnalyzer Include="Microsoft.Interop.JavaScript.JSImportGenerator" />

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Mike Santiago
-Copyright (c) 2016-2025 DSharpPlus Development Team
+Copyright (c) 2016-2026 DSharpPlus Development Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 An unofficial .NET wrapper for the Discord API, the continuation of [DiscordSharp](https://github.com/suicvne/DiscordSharp).
 
-[![Nightly Build Status](https://github.com/DSharpPlus/DSharpPlus/actions/workflows/publish_nightly_master.yml/badge.svg?branch=master)](https://github.com/DSharpPlus/DSharpPlus/actions/workflows/build-commit.yml)
+[![Nightly Build Status](https://github.com/DSharpPlus/DSharpPlus/actions/workflows/publish_nightly_master.yml/badge.svg?branch=master)](https://github.com/DSharpPlus/DSharpPlus/actions/workflows/build-commit.yml/badge.svg)
 [![Discord Server](https://img.shields.io/discord/379378609942560770.svg?label=Discord&color=506de2)](https://discord.gg/dsharpplus)
 [![NuGet](https://img.shields.io/nuget/v/DSharpPlus.svg?label=NuGet)](https://nuget.org/packages/DSharpPlus)
 [![NuGet Latest Nightly/Prerelease](https://img.shields.io/nuget/vpre/DSharpPlus?color=505050&label=NuGet%20Latest%20Nightly%2FPrerelease)](https://nuget.org/packages/DSharpPlus)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,18 @@ Package | Description
 
 Want to see your extension in the list above? Send a pull request or talk to us on Discord!
 
+## Natives
+
+DSharpPlus also provides a number of native libraries that power certain features or extensions:
+
+Package | Description
+:---:|:---:
+`DSharpPlus.Natives.Zstd` | Enables zstd compression for the gateway. DSharpPlus will pick up on this by default and use it.
+`DSharpPlus.Natives.Sodium` | Provides the required encryption support for VoiceNext and for `DSharpPlus.Http.AspNetCore`.
+`DSharpPlus.Natives.Opus` | Provides the native audio encoder for VoiceNext.
+
+These are simply native libraries packaged as nuget packages, so you can use them from anywhere, not only DSharpPlus bots. They provide the targets `{win, linux, linux-musl, osx}-{x64, arm64}`. Note that `x64` packages are built for `x86_64_v2`, which is any CPU newer than about 2008-2012: if you use an older CPU, you may need to build the native libraries yourself.
+
 ## I want to throw my money at you
 
 If you want to give us some money as a thank you gesture, you can do so using one of these links:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 An unofficial .NET wrapper for the Discord API, the continuation of [DiscordSharp](https://github.com/suicvne/DiscordSharp).
 
-[![Nightly Build Status](https://github.com/DSharpPlus/DSharpPlus/actions/workflows/publish_nightly_master.yml/badge.svg?branch=master)](https://github.com/DSharpPlus/DSharpPlus/actions/workflows/build-commit.yml/badge.svg)
+[![Nightly Build Status](https://github.com/DSharpPlus/DSharpPlus/actions/workflows/build-commit.yml/badge.svg?branch=master)](https://github.com/DSharpPlus/DSharpPlus/actions/workflows/build-commit.yml)
 [![Discord Server](https://img.shields.io/discord/379378609942560770.svg?label=Discord&color=506de2)](https://discord.gg/dsharpplus)
 [![NuGet](https://img.shields.io/nuget/v/DSharpPlus.svg?label=NuGet)](https://nuget.org/packages/DSharpPlus)
 [![NuGet Latest Nightly/Prerelease](https://img.shields.io/nuget/vpre/DSharpPlus?color=505050&label=NuGet%20Latest%20Nightly%2FPrerelease)](https://nuget.org/packages/DSharpPlus)

--- a/package-readme.md
+++ b/package-readme.md
@@ -50,6 +50,18 @@ Package | Description
 
 Want to see your extension in the list above? Send a pull request or talk to us on Discord!
 
+## Natives
+
+DSharpPlus also provides a number of native libraries that power certain features or extensions:
+
+Package | Description
+:---:|:---:
+`DSharpPlus.Natives.Zstd` | Enables zstd compression for the gateway. DSharpPlus will pick up on this by default and use it.
+`DSharpPlus.Natives.Sodium` | Provides the required encryption support for VoiceNext and for `DSharpPlus.Http.AspNetCore`.
+`DSharpPlus.Natives.Opus` | Provides the native audio encoder for VoiceNext.
+
+These are simply native libraries packaged as nuget packages, so you can use them from anywhere, not only DSharpPlus bots. They provide the targets `{win, linux, linux-musl, osx}-{x64, arm64}`. Note that `x64` packages are built for `x86_64_v2`, which is any CPU newer than about 2008-2012: if you use an older CPU, you may need to build the native libraries yourself.
+
 ## I want to throw my money at you
 
 If you want to give us some money as a thank you gesture, you can do so using one of these links:

--- a/package-readme.md
+++ b/package-readme.md
@@ -4,7 +4,6 @@
 
 An unofficial .NET wrapper for the Discord API, the continuation of [DiscordSharp](https://github.com/suicvne/DiscordSharp).
 
-[![Nightly Build Status](https://github.com/DSharpPlus/DSharpPlus/actions/workflows/publish_nightly_master.yml/badge.svg?branch=master)](https://github.com/DSharpPlus/DSharpPlus/actions/workflows/build-commit.yml)
 [![Discord Server](https://img.shields.io/discord/379378609942560770.svg?label=Discord&color=506de2)](https://discord.gg/dsharpplus)
 [![NuGet](https://img.shields.io/nuget/v/DSharpPlus.svg?label=NuGet)](https://nuget.org/packages/DSharpPlus)
 [![NuGet Latest Nightly/Prerelease](https://img.shields.io/nuget/vpre/DSharpPlus?color=505050&label=NuGet%20Latest%20Nightly%2FPrerelease)](https://nuget.org/packages/DSharpPlus)

--- a/package-readme.md
+++ b/package-readme.md
@@ -18,44 +18,6 @@ The documentation for the latest nightly version is available at [dsharpplus.git
 1. Nightly versions are available on [Nuget](https://www.nuget.org/packages/DSharpPlus/) as a pre-release. These versions contain the latest features, improvements and bugfixes. You should, as a rule, use these versions: despite not being marked as stable, they are held to high standards of quality and merely represent the latest, most up-to-date state of the library.
 2. Stable releases are available on NuGet. Important bugfixes will be backported to the latest stable release. Stable versions roughly follow [romantic versioning](https://github.com/romversioning/romver): major versions indicate very major changes to both the library surface and internals, minor versions indicate major additions or breaking changes as necessary and in limited scope, and the third version number indicates hotfixes or small features as necessary.
 
-## Installing locally or from a pull request
-
-You can install the library locally from following sources:
-
-1. The library can be directly referenced from your csproj file. Cloning the repository and referencing the library is as easy as:
-
-    ```sh
-    git clone https://github.com/DSharpPlus/DSharpPlus.git DSharpPlus-Repo
-    # you can switch to a pull request using
-    gh pr <number>
-    git checkout <branch-name>
-    ```
-
-    Edit MyProject.csproj and add the following line:
-
-    ```xml
-    <ProjectReference Include="../DSharpPlus-Repo/DSharpPlus/DSharpPlus.csproj" />
-    ```
-
-    This belongs in the ItemGroup tag with the rest of your dependencies. The library should not be in the same directory or subdirectory as your project. This method should only be used if you're making local changes to the library.
-
-2. Every commit on a pull request is built into packages that can be manually downloaded from GitHub and referenced locally:
-
-    1. Navigate to the pull request you are interested in, for example <https://github.com/DSharpPlus/DSharpPlus/pull/2455>.
-    2. Click the checkmark next to the latest commit hash, then `Details`.
-    3. Click on `Summary` and scroll all the way down. There, an artifact of the format `DSharpPlus-PR-<PR number>-<Incrementing build number>` can be downloaded.
-    4. Unzip it and add the folder as a package source:
-        
-        Via command:
-        ```sh
-        dotnet add package <package-name> --source "path/to/your/package/folder"
-        ```
-
-        Via csproj, in your PropertyGroup:
-        ```xml
-        <RestoreAdditionalPackageSources>path/to/your/package/folder</RestoreAdditionalPackageSources>
-        ```
-
 ## Resources
 
 The following resources apply only for the latest stable version of the library.
@@ -67,14 +29,6 @@ The following resources apply only for the latest stable version of the library.
 ### Example bots
 
 * [Example by OoLunar](https://github.com/DSharpPlus/Example-Bots)
-
-## Contributing
-
-We're very glad about contributions! Pull requests should generally be made against the `master` branch, which tracks the latest development state of the library, or against a specific feature branch if you wish to collaborate on the feature. Please review the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
-
-By contributing to DSharpPlus, you agree to make your code available under the MIT License and that you can confer this license upon the code. Code from other people must be used in compliance with their license and clearly marked as such; AI-generated code cannot be submitted.
-
-We generally recommend you come talk to us first, in our [Discord server](https://discord.gg/dsharpplus) at **#lib-development** (the necessary role is available in onboarding or in Channels & Roles), to see whether we would take your changes as proposed before you do any unnecessary work. This is also where we can be reached about all sorts of questions regarding the library's development.
 
 ## Extensions
 


### PR DESCRIPTION
nuget packages don't really need to have contributing guidelines or how to build the library locally in there, do they

not sure how to label this. docs, technically, might fit?