### PR TITLE
Support setting Audit Log reasons when pinning/unpinning messages

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -650,24 +650,26 @@ public class DiscordMessage : SnowflakeObject, IEquatable<DiscordMessage>
     /// <summary>
     /// Pins the message in its channel.
     /// </summary>
+    /// <param name="reason">Reason for the Audit Log.</param>
     /// <returns></returns>
     /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="DiscordPermission.ManageMessages"/> permission.</exception>
     /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
     /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
     /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-    public async Task PinAsync()
-        => await this.Discord.ApiClient.PinMessageAsync(this.ChannelId, this.Id);
+    public async Task PinAsync(string? reason = null)
+        => await this.Discord.ApiClient.PinMessageAsync(this.ChannelId, this.Id, reason);
 
     /// <summary>
     /// Unpins the message in its channel.
     /// </summary>
+    /// <param name="reason">Reason for the Audit Log.</param>
     /// <returns></returns>
     /// <exception cref="Exceptions.UnauthorizedException">Thrown when the client does not have the <see cref="DiscordPermission.ManageMessages"/> permission.</exception>
     /// <exception cref="Exceptions.NotFoundException">Thrown when the member does not exist.</exception>
     /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
     /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
-    public async Task UnpinAsync()
-        => await this.Discord.ApiClient.UnpinMessageAsync(this.ChannelId, this.Id);
+    public async Task UnpinAsync(string? reason = null)
+        => await this.Discord.ApiClient.UnpinMessageAsync(this.ChannelId, this.Id, reason);
 
     /// <summary>
     /// Responds to the message. This produces a reply.

--- a/DSharpPlus/Net/Rest/DiscordRestApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordRestApiClient.cs
@@ -2867,9 +2867,16 @@ public sealed class DiscordRestApiClient
     public async ValueTask PinMessageAsync
     (
         ulong channelId,
-        ulong messageId
+        ulong messageId,
+        string reason
     )
     {
+        Dictionary<string, string> headers = [];
+        if (!string.IsNullOrWhiteSpace(reason))
+        {
+            headers[REASON_HEADER_NAME] = reason;
+        }
+
         string route = $"{Endpoints.CHANNELS}/{channelId}/{Endpoints.PINS}/:message_id";
         string url = $"{Endpoints.CHANNELS}/{channelId}/{Endpoints.PINS}/{messageId}";
 
@@ -2877,7 +2884,8 @@ public sealed class DiscordRestApiClient
         {
             Route = route,
             Url = url,
-            Method = HttpMethod.Put
+            Method = HttpMethod.Put,
+            Headers = headers
         };
 
         await this.rest.ExecuteRequestAsync(request);
@@ -2886,9 +2894,16 @@ public sealed class DiscordRestApiClient
     public async ValueTask UnpinMessageAsync
     (
         ulong channelId,
-        ulong messageId
+        ulong messageId,
+        string reason
     )
     {
+        Dictionary<string, string> headers = [];
+        if (!string.IsNullOrWhiteSpace(reason))
+        {
+            headers[REASON_HEADER_NAME] = reason;
+        }
+
         string route = $"{Endpoints.CHANNELS}/{channelId}/{Endpoints.PINS}/:message_id";
         string url = $"{Endpoints.CHANNELS}/{channelId}/{Endpoints.PINS}/{messageId}";
 
@@ -2896,7 +2911,8 @@ public sealed class DiscordRestApiClient
         {
             Route = route,
             Url = url,
-            Method = HttpMethod.Delete
+            Method = HttpMethod.Delete,
+            Headers = headers
         };
         await this.rest.ExecuteRequestAsync(request);
     }

--- a/DSharpPlus/Net/Rest/DiscordRestApiClient.cs
+++ b/DSharpPlus/Net/Rest/DiscordRestApiClient.cs
@@ -2868,7 +2868,7 @@ public sealed class DiscordRestApiClient
     (
         ulong channelId,
         ulong messageId,
-        string reason
+        string? reason = null
     )
     {
         Dictionary<string, string> headers = [];
@@ -2895,7 +2895,7 @@ public sealed class DiscordRestApiClient
     (
         ulong channelId,
         ulong messageId,
-        string reason
+        string? reason = null
     )
     {
         Dictionary<string, string> headers = [];


### PR DESCRIPTION
- [ ] This pull request was written by AI
- [ ] This pull request was assisted by AI, but you wrote the final code
- [x] This pull request did not involve AI in any way

# Summary
Adds support for providing an Audit Log reason when pinning and unpinning messages

# Details
Adds a `reason` parameter to `DiscordMessage.PinAsync` and `DiscordMessage.UnpinAsync` that can be used to set an Audit Log reason when pinning/unpinning

- [x] All features in this pull request were tested.