### PR TITLE
docs: fix misspellings in contributor guide and articles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,9 +119,9 @@ In addition to these, we also have several preferences:
   * Static constructor.
   * Public constructors.
   * Non-public constructors.
-  * Public methods (with the exception of methods overriden from `System.Object`).
+  * Public methods (with the exception of methods overridden from `System.Object`).
   * Non-public methods.
-  * Methods overriden from `System.Object`.
+  * Methods overridden from `System.Object`.
   * Public static methods.
   * Non-public static methods.
   * Operator overloads.

--- a/docs/articles/beyond_basics/interactions.md
+++ b/docs/articles/beyond_basics/interactions.md
@@ -9,7 +9,7 @@ This can happen in different ways. The most prominent case is "slash commands" b
 ## Recieving interactions
 Discord offers two ways to receive interactions: Through the gateway, and via an inbound HTTP webhook.
 Currently DSharpPlus only supports the first one but there are plans to also integrate webhooks.
-To recieve an interaction over the gateway you do not have to configure anything and simply register an EventHandler to the `InteractionCreated` event.
+To receive an interaction over the gateway you do not have to configure anything and simply register an EventHandler to the `InteractionCreated` event.
 
 In addition to that event we have some events that are filtered to provide some convienience:
 

--- a/docs/articles/commands/converters/custom_argument_converters.md
+++ b/docs/articles/commands/converters/custom_argument_converters.md
@@ -59,7 +59,7 @@ public class UlidArgumentConverter : ITextArgumentConverter<Ulid>, ISlashArgumen
 }
 ```
 
-Since there is no asynchronous operations occuring within the conversion methods, we use `Task.FromResult`. Another thing to note is that argument converters support constructor dependency injection. Lastly, you'll also notice the use of `Optional<T>` here. When executing an argument converter, there are three possible outcomes:
+Since there is no asynchronous operations occurring within the conversion methods, we use `Task.FromResult`. Another thing to note is that argument converters support constructor dependency injection. Lastly, you'll also notice the use of `Optional<T>` here. When executing an argument converter, there are three possible outcomes:
 
 1. The conversion was successful and the value is returned.
 2. The conversion was unsuccessful and the value is not returned.

--- a/docs/articles/migration/3x_to_4x.md
+++ b/docs/articles/migration/3x_to_4x.md
@@ -21,7 +21,7 @@ The client now supports proxies for both WebSocket and HTTP traffic. To proxy yo
 
 ### Intents
 
-Due to a change by Discord on their V8 endpoint which DSharpPlus targets, in order to recieve events, intents will have
+Due to a change by Discord on their V8 endpoint which DSharpPlus targets, in order to receive events, intents will have
 to be enabled in both the @DSharpPlus.DiscordConfiguration and the Discord Application Portal. We have an [article][0]
 that covers all that has to be done to set this up.
 


### PR DESCRIPTION
Fixes four misspellings in the documentation and contributor guide. Prose only — no code, identifiers, or API names touched.

| File | Fix |
|---|---|
| `CONTRIBUTING.md` (×2) | `overriden` → `overridden` |
| `docs/articles/beyond_basics/interactions.md` | `recieve` → `receive` |
| `docs/articles/migration/3x_to_4x.md` | `recieve` → `receive` |
| `docs/articles/commands/converters/custom_argument_converters.md` | `occuring` → `occurring` |
