### PR TITLE
Fixed DiscordMessageStickerPack object, so it does not throw an excep…

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessageStickerPack.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessageStickerPack.cs
@@ -11,10 +11,10 @@ public sealed class DiscordMessageStickerPack : SnowflakeObject
     /// <summary>
     /// Gets the stickers contained in this pack.
     /// </summary>
-    public IReadOnlyDictionary<ulong, DiscordMessageSticker> Stickers => this.stickers;
+    public IReadOnlyList<DiscordMessageSticker> Stickers => this.stickers;
 
     [JsonProperty("stickers")]
-    internal Dictionary<ulong, DiscordMessageSticker> stickers = [];
+    internal List<DiscordMessageSticker> stickers = [];
 
     /// <summary>
     /// Gets the name of this sticker pack.


### PR DESCRIPTION
…tion when deserializing the json response from Discord

Make sure you familiarize yourself with our contributing guidelines. (delete this line afterwards)

- [ ] This pull request was written by AI
- [ ] This pull request was assisted by AI, but you wrote the final code
- [X] This pull request did not involve AI in any way

# Summary
GetStickerPacksAsync() threw exception when used. Now it does not throw an exception.
The issue was with the json deserialization. The response from discord's API did not match the DiscordMessageStickerPack object.

# Details

Stack trace from my own application:

```
Newtonsoft.Json.JsonSerializationException: Cannot deserialize the current JSON array (e.g. [1,2,3]) into type 'System.Collections.Generic.Dictionary`2[System.UInt64,DSharpPlus.Entities.DiscordMessageSticker]' because the type requires a JSON object (e.g. {"name":"value"}) to deserialize correctly.
To fix this error either change the JSON to a JSON object (e.g. {"name":"value"}) or change the deserialized type to an array or a type that implements a collection interface (e.g. ICollection, IList) like List<T> that can be deserialized from a JSON array. JsonArrayAttribute can also be added to the type to force it to deserialize from a JSON array.
Path 'sticker_packs[0].stickers', line 1, position 216.
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureArrayContract(JsonReader reader, Type objectType, JsonContract contract)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)
   at Newtonsoft.Json.Linq.JToken.ToObject(Type objectType, JsonSerializer jsonSerializer)
   at Newtonsoft.Json.Linq.JToken.ToObject[T](JsonSerializer jsonSerializer)
   at DSharpPlus.Net.Serialization.DiscordJson.ToDiscordObject[T](JToken token) in /app/DSharpPlus-Repo/DSharpPlus/Net/Serialization/DiscordJson.cs:line 64
   at DSharpPlus.Net.DiscordApiClient.GetStickerPacksAsync() in /app/DSharpPlus-Repo/DSharpPlus/Net/Rest/DiscordApiClient.cs:line 868
   at LundBot.Services.WelcomeMessageService.GetWelcomeStickersAsync() in /app/src/Services/WelcomeMessageService.cs:line 126
   at LundBot.Services.Discord.DiscordInteractionService.HandleWelcomeInteractionAsync(DiscordUser user, DiscordChannel channel) in /app/src/Services/Discord/DiscordInteractionService.cs:line 101
   at LundBot.Services.Discord.DiscordInteractionService.HandleComponentInteractionAsync(ComponentInteractionCreateEventArgs e) in /app/src/Services/Discord/DiscordInteractionService.cs:line 87
   at LundBot.Services.BotService.OnComponentInteractionCreated(DiscordClient sender, ComponentInteractionCreateEventArgs e) in /app/src/Services/BotService.cs:line 107
```

# Changes proposed
Fixing the DiscordMessageStickerPack object.

# Notes
Any additional notes go here.

- [X] All features in this pull request were tested.

Proof of test:
<img width="247" height="980" alt="image" src="https://github.com/user-attachments/assets/6569764b-6163-49ab-b755-efcfbdbe60ef" />
