### PR TITLE
(try to) improve developer experience and docs on modal submissions

### DIFF
--- a/DSharpPlus/EventArgs/Interaction/IModalSubmission.cs
+++ b/DSharpPlus/EventArgs/Interaction/IModalSubmission.cs
@@ -3,12 +3,12 @@ using DSharpPlus.Entities;
 namespace DSharpPlus.EventArgs;
 
 /// <summary>
-/// Represents the values submitted to a component from a modal.
+/// Represents the values submitted to a component from a modal. Cast this object to a typed *ModalSubmission to access the submitted data.
 /// </summary>
 public interface IModalSubmission
 {
     /// <summary>
-    /// The type of component this submission represents.
+    /// The type of component this submission represents. Use <see cref="As"/> to cast this object accordingly to access the submitted data. 
     /// </summary>
     public DiscordComponentType ComponentType { get; }
 
@@ -16,4 +16,18 @@ public interface IModalSubmission
     /// The custom ID of this component.
     /// </summary>
     public string CustomId { get; }
+
+    /// <summary>
+    /// Casts this modal submission to its concrete type.
+    /// </summary>
+    public T? As<T>()
+        where T : class, IModalSubmission
+        => this as T;
+
+    /// <summary>
+    /// Checks whether this modal submission is of the specified concrete type.
+    /// </summary>
+    public bool Is<T>()
+        where T : class, IModalSubmission
+        => GetType().IsAssignableTo(typeof(T));
 }


### PR DESCRIPTION
i'm not sure how salvageable this is, but here goes.

- [x] This pull request did not involve AI in any way
- [x] All features in this pull request were tested.