### PR TITLE
Fix embed suppression/unsuppression in ModifyEmbedSuppressionAsync

### DIFF
--- a/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
+++ b/DSharpPlus/Entities/Channel/Message/DiscordMessage.cs
@@ -634,7 +634,7 @@ public class DiscordMessage : SnowflakeObject, IEquatable<DiscordMessage>
     /// <exception cref="Exceptions.BadRequestException">Thrown when an invalid parameter was provided.</exception>
     /// <exception cref="Exceptions.ServerErrorException">Thrown when Discord is unable to process the request.</exception>
     public async Task ModifyEmbedSuppressionAsync(bool hideEmbeds)
-        => await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, default, default, default, default, [], hideEmbeds ? DiscordMessageFlags.SuppressEmbeds : null, default);
+        => await this.Discord.ApiClient.EditMessageAsync(this.ChannelId, this.Id, default, default, default, default, [], hideEmbeds ? this.Flags | DiscordMessageFlags.SuppressEmbeds : this.Flags & ~DiscordMessageFlags.SuppressEmbeds, default);
 
     /// <summary>
     /// Deletes the message.


### PR DESCRIPTION
- [ ] This pull request was written by AI
- [ ] This pull request was assisted by AI, but you wrote the final code
- [x] This pull request did not involve AI in any way

# Summary
Fixes #2449. Fixes unsuppressing embeds with `DiscordMessage.ModifyEmbedSuppressionAsync`, and tweaks suppressing.

# Details
Changes `ModifyEmbedSuppressionAsync` to account for the message's current flags when modifying them. Previously D#+ would have always sent `{"flags":4}` when suppressing, and `{}` (which did nothing*) when unsuppressing. Now it will send the current flags in addition to (or without) `SUPPRESS_EMBEDS`. For example, when suppressing a message with the `HAS_SNAPSHOT` flag, D#+ will send `{"flags":16388}`: `HAS_SNAPSHOT` (16384) + `SUPPRESS_EMBEDS` (4). When unsuppressing the same message, it will send `{"flags":16384}`.

*but sometimes it would cause a BadRequestException to be thrown anyway (like when used on a message with `IS_COMPONENTS_V2` set), and that no longer happens with this change, so that's also a plus. Discord will ignore `SUPPRESS_EMBEDS` when it's invalid (like on a CV2 message) instead of sending back Bad Request

- [x] All features in this pull request were tested.